### PR TITLE
fix: NavView does not properly load content when launched in narrow mode

### DIFF
--- a/samples/Commerce/Commerce.Shared/Views/CommerceHomePage.xaml
+++ b/samples/Commerce/Commerce.Shared/Views/CommerceHomePage.xaml
@@ -43,6 +43,8 @@
 						<Setter Target="Tabs.Visibility"
 								Value="Collapsed" />
 						<Setter Target="NavView.IsPaneToggleButtonVisible"
+								Value="True" />
+						<Setter Target="NavView.IsPaneVisible"
 								Value="true" />
 						<Setter Target="NavView.PaneDisplayMode"
 								Value="Auto" />
@@ -56,6 +58,8 @@
 						<Setter Target="Tabs.Visibility"
 								Value="Collapsed" />
 						<Setter Target="NavView.IsPaneToggleButtonVisible"
+								Value="True" />
+						<Setter Target="NavView.IsPaneVisible"
 								Value="true" />
 						<Setter Target="NavView.PaneDisplayMode"
 								Value="Auto" />

--- a/src/Uno.Extensions.Navigation/Navigators/NavigationViewNavigator.cs
+++ b/src/Uno.Extensions.Navigation/Navigators/NavigationViewNavigator.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml.Controls;
 using Uno.Extensions.Navigation;
 using Uno.Extensions.Navigation.Controls;
 using Uno.Extensions.Navigation.Regions;
@@ -70,7 +71,8 @@ public class NavigationViewNavigator : ControlNavigator<Microsoft.UI.Xaml.Contro
         }
         finally
         {
-			if (Control.IsPaneVisible)
+			if (Control.IsPaneVisible &&
+				!(Control.PaneDisplayMode == NavigationViewPaneDisplayMode.LeftMinimal && !Control.IsPaneOpen))
 			{
 				await CurrentView.EnsureLoaded();
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

NavView does not load content initially when in narrow mode

## What is the new behavior?

NavView loads content correctly.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
