### PR TITLE
refactor: Add proper MaterialFlyoutPresenterStyle with latest Uno.Material and uncomment the MaterialToggleButtonIconStyle

### DIFF
--- a/samples/Commerce/Commerce.Shared/Commerce.Shared.projitems
+++ b/samples/Commerce/Commerce.Shared/Commerce.Shared.projitems
@@ -89,6 +89,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)MaterialFontsOverride.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Styles\FeedView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/samples/Commerce/Commerce.Shared/Views/CartDialog.xaml
+++ b/samples/Commerce/Commerce.Shared/Views/CartDialog.xaml
@@ -4,51 +4,9 @@
 		xmlns:local="using:Commerce"
 		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 		xmlns:nav="using:Uno.Extensions.Navigation.Controls"
-		Placement="Full">
-	<Flyout.FlyoutPresenterStyle>
-		<Style TargetType="FlyoutPresenter">
-			<Setter Property="HorizontalContentAlignment"
-					Value="Stretch" />
-			<Setter Property="VerticalContentAlignment"
-					Value="Stretch" />
-			<Setter Property="VerticalAlignment"
-					Value="Stretch" />
-			<Setter Property="HorizontalAlignment"
-					Value="Stretch" />
-			<Setter Property="MaxWidth"
-					Value="NaN" />
-			<Setter Property="MaxHeight"
-					Value="NaN" />
-			<Setter Property="Template">
-				<Setter.Value>
-					<ControlTemplate TargetType="FlyoutPresenter">
-						<Border Background="{TemplateBinding Background}"
-								HorizontalAlignment="Stretch"
-								VerticalAlignment="Stretch"
-								BackgroundSizing="OuterBorderEdge"
-								BorderBrush="{TemplateBinding BorderBrush}"
-								BorderThickness="{TemplateBinding BorderThickness}"
-								CornerRadius="{TemplateBinding CornerRadius}">
-							<Border.Transitions>
-								<TransitionCollection>
-									<PaneThemeTransition Edge="Bottom" />
-								</TransitionCollection>
-							</Border.Transitions>
-							<ContentPresenter Content="{TemplateBinding Content}"
-											  HorizontalAlignment="Stretch"
-											  VerticalAlignment="Stretch"
-											  ContentTemplate="{TemplateBinding ContentTemplate}"
-											  ContentTransitions="{TemplateBinding ContentTransitions}"
-											  HorizontalContentAlignment="Stretch"
-											  VerticalContentAlignment="Stretch" />
-						</Border>
-
-					</ControlTemplate>
-				</Setter.Value>
-			</Setter>
-		</Style>
-	</Flyout.FlyoutPresenterStyle>
-
+		Placement="Full"
+		FlyoutPresenterStyle="{StaticResource MaterialFlyoutPresenterStyle}">
+	
 	<Grid>
 		<ContentControl nav:Region.Attached="True"
 						HorizontalAlignment="Stretch"

--- a/samples/Commerce/Commerce.Shared/Views/FilterPopup.xaml
+++ b/samples/Commerce/Commerce.Shared/Views/FilterPopup.xaml
@@ -4,175 +4,145 @@
 		xmlns:local="using:Commerce"
 		xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-		xmlns:controls="using:Uno.Material.Controls"
+		xmlns:utu="using:Uno.Toolkit.UI.Controls"
+		xmlns:nav="using:Uno.Extensions.Navigation.Controls"
 		mc:Ignorable="d"
 		d:DesignHeight="300"
 		d:DesignWidth="400"
 		Placement="Full"
 		LightDismissOverlayMode="On"
-		xmlns:utu="using:Uno.Toolkit.UI.Controls"
-		xmlns:nav="using:Uno.Extensions.Navigation.Controls">
+		FlyoutPresenterStyle="{StaticResource MaterialFlyoutPresenterStyle}">
 
-	<Flyout.FlyoutPresenterStyle>
-		<Style TargetType="FlyoutPresenter">
-			<Setter Property="HorizontalContentAlignment"
-					Value="Center" />
-			<Setter Property="VerticalContentAlignment"
-					Value="Bottom" />
-			<Setter Property="VerticalAlignment"
-					Value="Bottom" />
-			<Setter Property="HorizontalAlignment"
-					Value="Center" />
-			<Setter Property="MinWidth"
-					Value="370" />
-			<Setter Property="MaxWidth"
-					Value="NaN" />
-			<Setter Property="Background"
-					Value="{StaticResource MaterialSurfaceBrush}" />
-			<Setter Property="Template">
-				<Setter.Value>
-					<ControlTemplate TargetType="FlyoutPresenter">
-						<Border MinWidth="{TemplateBinding MinWidth}"
-								Background="{TemplateBinding Background}"
-								HorizontalAlignment="Center"
-								VerticalAlignment="Bottom"
-								BackgroundSizing="OuterBorderEdge"
-								BorderBrush="{TemplateBinding BorderBrush}"
-								BorderThickness="{TemplateBinding BorderThickness}"
-								CornerRadius="{TemplateBinding CornerRadius}">
-							<Border.Transitions>
-								<TransitionCollection>
-									<PaneThemeTransition Edge="Bottom" />
-								</TransitionCollection>
-							</Border.Transitions>
-							<ScrollViewer x:Name="ScrollViewer"
-										  MinWidth="{TemplateBinding MinWidth}"
-										  ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
-										  HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
-										  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-										  VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
-										  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-										  AutomationProperties.AccessibilityView="Raw">
-								<ContentPresenter MinWidth="{TemplateBinding MinWidth}"
-												  Content="{TemplateBinding Content}"
-												  ContentTemplate="{TemplateBinding ContentTemplate}"
-												  ContentTransitions="{TemplateBinding ContentTransitions}"
-												  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-												  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-							</ScrollViewer>
-						</Border>
+	<UserControl>
+		<Grid>
+			<VisualStateManager.VisualStateGroups>
+				<VisualStateGroup>
+					<VisualState x:Name="Normal">
+						<VisualState.StateTriggers>
+							<AdaptiveTrigger MinWindowWidth="700" />
+						</VisualState.StateTriggers>
+						<VisualState.Setters>
+							<Setter Target="FlyoutRoot.MinWidth"
+									Value="370" />
+							<Setter Target="FlyoutRoot.HorizontalAlignment"
+									Value="Center" />
+							<Setter Target="FlyoutRoot.VerticalAlignment"
+									Value="Center" />
+						</VisualState.Setters>
+					</VisualState>
+				</VisualStateGroup>
+			</VisualStateManager.VisualStateGroups>
 
-					</ControlTemplate>
-				</Setter.Value>
-			</Setter>
-		</Style>
-	</Flyout.FlyoutPresenterStyle>
-	<utu:AutoLayout>
-		<utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
-			<utu:NavigationBar Content="Filters"
-							   x:Uid="Body_NavigationBar"
-							   utu:AutoLayout.CounterAlignment="Stretch"
-							   Style="{StaticResource MaterialRootModalNavigationBarStyle}">
-				<utu:NavigationBar.MainCommand>
-					<AppBarButton nav:Navigation.Request="-" />
-				</utu:NavigationBar.MainCommand>
-				<utu:NavigationBar.PrimaryCommands>
-					<AppBarButton Foreground="{StaticResource MaterialOnSurfaceBrush}">
-						<AppBarButton.Icon>
-							<BitmapIcon UriSource="ms-appx:///Assets/Icons/notifications.png"
-										ShowAsMonochrome="false" />
-						</AppBarButton.Icon>
-					</AppBarButton>
-					<AppBarButton Foreground="{StaticResource MaterialOnSurfaceBrush}">
-						<AppBarButton.Icon>
-							<BitmapIcon UriSource="ms-appx:///Assets/Icons/share.png"
-										ShowAsMonochrome="false" />
-						</AppBarButton.Icon>
-					</AppBarButton>
-				</utu:NavigationBar.PrimaryCommands>
-			</utu:NavigationBar>
-			<utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
-				<utu:AutoLayout Spacing="16"
-								Padding="16,16,16,16"
-								utu:AutoLayout.CounterAlignment="Stretch">
-					<TextBlock Foreground="{StaticResource MaterialOnBackgroundBrush}"
-							   x:Uid="Body_Categories"
-							   Text="Categories"
-							   Style="{StaticResource MaterialSubtitle2}" />
+			<utu:AutoLayout x:Name="FlyoutRoot"
+							Background="{StaticResource MaterialSurfaceBrush}">
+				<utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
+					<utu:NavigationBar Content="Filters"
+									   x:Uid="Body_NavigationBar"
+									   utu:AutoLayout.CounterAlignment="Stretch"
+									   Style="{StaticResource MaterialRootModalNavigationBarStyle}">
+						<utu:NavigationBar.MainCommand>
+							<AppBarButton nav:Navigation.Request="-" />
+						</utu:NavigationBar.MainCommand>
+						<utu:NavigationBar.PrimaryCommands>
+							<AppBarButton Foreground="{StaticResource MaterialOnSurfaceBrush}">
+								<AppBarButton.Icon>
+									<BitmapIcon UriSource="ms-appx:///Assets/Icons/notifications.png"
+												ShowAsMonochrome="false" />
+								</AppBarButton.Icon>
+							</AppBarButton>
+							<AppBarButton Foreground="{StaticResource MaterialOnSurfaceBrush}">
+								<AppBarButton.Icon>
+									<BitmapIcon UriSource="ms-appx:///Assets/Icons/share.png"
+												ShowAsMonochrome="false" />
+								</AppBarButton.Icon>
+							</AppBarButton>
+						</utu:NavigationBar.PrimaryCommands>
+					</utu:NavigationBar>
+					<utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
+						<utu:AutoLayout Spacing="16"
+										Padding="16,16,16,16"
+										utu:AutoLayout.CounterAlignment="Stretch">
+							<TextBlock Foreground="{StaticResource MaterialOnBackgroundBrush}"
+									   x:Uid="Body_Categories"
+									   Text="Categories"
+									   Style="{StaticResource MaterialSubtitle2}" />
+							<utu:AutoLayout Spacing="8"
+											Orientation="Horizontal">
+								<utu:Chip Content="Shoes"
+										  x:Uid="Body_Shoes"
+										  IsChecked="{Binding Filter.Shoes, Mode=TwoWay}"
+										  Style="{StaticResource MaterialOutlinedFilterChipStyle}" />
+								<utu:Chip Content="Accessories"
+										  x:Uid="Body_Accessproes"
+										  IsChecked="{Binding Filter.Accessories, Mode=TwoWay}"
+										  Style="{StaticResource MaterialOutlinedFilterChipStyle}" />
+								<utu:Chip Content="Headwear"
+										  x:Uid="Body_Headwear"
+										  IsChecked="{Binding Filter.Headwear, Mode=TwoWay}"
+										  Style="{StaticResource MaterialOutlinedFilterChipStyle}" />
+							</utu:AutoLayout>
+							<utu:AutoLayout Spacing="16"
+											Justify="SpaceBetween"
+											Orientation="Horizontal"
+											utu:AutoLayout.CounterAlignment="Stretch">
+								<TextBlock Foreground="{StaticResource MaterialOnBackgroundBrush}"
+										   x:Uid="Body_Body"
+										   Text="In stock only"
+										   utu:AutoLayout.CounterAlignment="Center"
+										   Style="{StaticResource MaterialSubtitle2}" />
+								<ToggleSwitch utu:AutoLayout.CounterAlignment="Center"
+											  Style="{StaticResource MaterialToggleSwitchStyle}" />
+							</utu:AutoLayout>
+							<utu:AutoLayout Spacing="16"
+											Padding="0,8,8,8"
+											Justify="SpaceBetween"
+											Orientation="Horizontal"
+											utu:AutoLayout.CounterAlignment="Stretch">
+								<TextBlock Foreground="{StaticResource MaterialOnBackgroundBrush}"
+										   x:Uid="Body_Body"
+										   Text="Order"
+										   utu:AutoLayout.CounterAlignment="Center"
+										   Style="{StaticResource MaterialSubtitle2}" />
+								<TextBlock Foreground="{StaticResource MaterialOnSurfaceMediumBrush}"
+										   TextAlignment="End"
+										   x:Uid="Body_Body"
+										   Text="Relevance"
+										   utu:AutoLayout.CounterAlignment="Center"
+										   Style="{StaticResource MaterialBody2}" />
+							</utu:AutoLayout>
+							<utu:AutoLayout Spacing="16"
+											Padding="0,8,8,8"
+											Justify="SpaceBetween"
+											Orientation="Horizontal"
+											utu:AutoLayout.CounterAlignment="Stretch">
+								<TextBlock Foreground="{StaticResource MaterialOnBackgroundBrush}"
+										   x:Uid="Body_Body"
+										   Text="Currency"
+										   utu:AutoLayout.CounterAlignment="Center"
+										   Style="{StaticResource MaterialSubtitle2}" />
+								<TextBlock Foreground="{StaticResource MaterialOnSurfaceMediumBrush}"
+										   TextAlignment="End"
+										   x:Uid="Body_Body"
+										   Text="CAD"
+										   utu:AutoLayout.CounterAlignment="Center"
+										   Style="{StaticResource MaterialBody2}" />
+							</utu:AutoLayout>
+						</utu:AutoLayout>
+					</utu:AutoLayout>
 					<utu:AutoLayout Spacing="8"
-									Orientation="Horizontal">
-						<utu:Chip Content="Shoes"
-								  x:Uid="Body_Shoes"
-								  IsChecked="{Binding Filter.Shoes, Mode=TwoWay}"
-								  Style="{StaticResource MaterialOutlinedFilterChipStyle}" />
-						<utu:Chip Content="Accessories"
-								  x:Uid="Body_Accessproes"
-								  IsChecked="{Binding Filter.Accessories, Mode=TwoWay}"
-								  Style="{StaticResource MaterialOutlinedFilterChipStyle}" />
-						<utu:Chip Content="Headwear"
-								  x:Uid="Body_Headwear"
-								  IsChecked="{Binding Filter.Headwear, Mode=TwoWay}"
-								  Style="{StaticResource MaterialOutlinedFilterChipStyle}" />
-					</utu:AutoLayout>
-					<utu:AutoLayout Spacing="16"
-									Justify="SpaceBetween"
+									Padding="16,16,16,16"
 									Orientation="Horizontal"
 									utu:AutoLayout.CounterAlignment="Stretch">
-						<TextBlock Foreground="{StaticResource MaterialOnBackgroundBrush}"
-								   x:Uid="Body_Body"
-								   Text="In stock only"
-								   utu:AutoLayout.CounterAlignment="Center"
-								   Style="{StaticResource MaterialSubtitle2}" />
-						<ToggleSwitch utu:AutoLayout.CounterAlignment="Center"
-									  Style="{StaticResource MaterialToggleSwitchStyle}" />
-					</utu:AutoLayout>
-					<utu:AutoLayout Spacing="16"
-									Padding="0,8,8,8"
-									Justify="SpaceBetween"
-									Orientation="Horizontal"
-									utu:AutoLayout.CounterAlignment="Stretch">
-						<TextBlock Foreground="{StaticResource MaterialOnBackgroundBrush}"
-								   x:Uid="Body_Body"
-								   Text="Order"
-								   utu:AutoLayout.CounterAlignment="Center"
-								   Style="{StaticResource MaterialSubtitle2}" />
-						<TextBlock Foreground="{StaticResource MaterialOnSurfaceMediumBrush}"
-								   TextAlignment="End"
-								   x:Uid="Body_Body"
-								   Text="Relevance"
-								   utu:AutoLayout.CounterAlignment="Center"
-								   Style="{StaticResource MaterialBody2}" />
-					</utu:AutoLayout>
-					<utu:AutoLayout Spacing="16"
-									Padding="0,8,8,8"
-									Justify="SpaceBetween"
-									Orientation="Horizontal"
-									utu:AutoLayout.CounterAlignment="Stretch">
-						<TextBlock Foreground="{StaticResource MaterialOnBackgroundBrush}"
-								   x:Uid="Body_Body"
-								   Text="Currency"
-								   utu:AutoLayout.CounterAlignment="Center"
-								   Style="{StaticResource MaterialSubtitle2}" />
-						<TextBlock Foreground="{StaticResource MaterialOnSurfaceMediumBrush}"
-								   TextAlignment="End"
-								   x:Uid="Body_Body"
-								   Text="CAD"
-								   utu:AutoLayout.CounterAlignment="Center"
-								   Style="{StaticResource MaterialBody2}" />
+						<Button Content="Apply"
+								x:Uid="Body_Apply"
+								utu:AutoLayout.PrimaryAlignment="Stretch"
+								Style="{StaticResource MaterialContainedButtonStyle}"
+								nav:Navigation.Request="-"
+								nav:Navigation.Data="{Binding Filter.Value}" />
 					</utu:AutoLayout>
 				</utu:AutoLayout>
 			</utu:AutoLayout>
-			<utu:AutoLayout Spacing="8"
-							Padding="16,16,16,16"
-							Orientation="Horizontal"
-							utu:AutoLayout.CounterAlignment="Stretch">
-				<Button Content="Apply"
-						x:Uid="Body_Apply"
-						utu:AutoLayout.PrimaryAlignment="Stretch"
-						Style="{StaticResource MaterialContainedButtonStyle}"
-						nav:Navigation.Request="-"
-						nav:Navigation.Data="{Binding Filter.Value}" />
-			</utu:AutoLayout>
-		</utu:AutoLayout>
-	</utu:AutoLayout>
+			
+		</Grid>
+	</UserControl>
 </Flyout>

--- a/samples/Commerce/Commerce.Shared/Views/ProductDetailsPage.xaml
+++ b/samples/Commerce/Commerce.Shared/Views/ProductDetailsPage.xaml
@@ -119,7 +119,7 @@
 										   Text="Reviews"
 										   Style="{StaticResource MaterialHeadline6}" />
 								<controls:RatingControl MaxRating="5"
-											   Value="{Binding Rating, Mode=TwoWay}" />
+														Value="{Binding Rating, Mode=TwoWay}" />
 							</utu:AutoLayout>
 						</utu:AutoLayout>
 					</DataTemplate>
@@ -175,14 +175,14 @@
 												<utu:AutoLayout Padding="16,0,0,16"
 																Orientation="Horizontal"
 																utu:AutoLayout.CounterAlignment="Stretch">
-													<ToggleButton utu:AutoLayout.CounterAlignment="Center">
-														<!--Style="{StaticResource MaterialToggleButtonIconStyle}">-->
+													<ToggleButton utu:AutoLayout.CounterAlignment="Center"
+																  Style="{StaticResource MaterialToggleButtonIconStyle}">
 														<ToggleButton.Content>
-															<PathIcon Data="{StaticResource Icon_more_horiz}" />
+															<PathIcon Data="{StaticResource Icon_more_vert}" />
 														</ToggleButton.Content>
-														<!--<um:ControlExtensions.AlternateContent>
-                                <PathIcon Data="{StaticResource Icon_more_vert}" />
-														</um:ControlExtensions.AlternateContent>-->
+														<um:ControlExtensions.AlternateContent>
+															<PathIcon Data="{StaticResource Icon_more_horiz}" />
+														</um:ControlExtensions.AlternateContent>
 													</ToggleButton>
 												</utu:AutoLayout>
 											</utu:AutoLayout>

--- a/samples/Commerce/UWP/Commerce.Droid/Commerce.Droid.csproj
+++ b/samples/Commerce/UWP/Commerce.Droid/Commerce.Droid.csproj
@@ -65,7 +65,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.3" />
     <PackageReference Include="Uno.Material">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="4.0.0-dev.5688" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.0-dev.5688" Condition="'$(Configuration)'=='Debug'" />

--- a/samples/Commerce/UWP/Commerce.Skia.Gtk/Commerce.Skia.Gtk.csproj
+++ b/samples/Commerce/UWP/Commerce.Skia.Gtk/Commerce.Skia.Gtk.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.0-dev.5688" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.Toolkit.UI" Version="0.1.0-dev.169" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material" Version="1.1.0-dev.57" />
+		<PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.3" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>

--- a/samples/Commerce/UWP/Commerce.Skia.WPF/Commerce.Skia.WPF.csproj
+++ b/samples/Commerce/UWP/Commerce.Skia.WPF/Commerce.Skia.WPF.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="System.Linq.Async" Version="4.0.0" />
 		<PackageReference Include="Uno.Toolkit.UI" Version="0.1.0-dev.169" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material" Version="1.1.0-dev.57" />
+		<PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.3" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>

--- a/samples/Commerce/UWP/Commerce.UWP/Commerce.Uwp.csproj
+++ b/samples/Commerce/UWP/Commerce.UWP/Commerce.Uwp.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.7.1-prerelease.211026002" />
     <PackageReference Include="Uno.Core" Version="4.0.0-dev.7" />
     <PackageReference Include="Uno.Material">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI.Material">
       <Version>0.1.0-dev.165</Version>

--- a/samples/Commerce/UWP/Commerce.Wasm/Commerce.Wasm.csproj
+++ b/samples/Commerce/UWP/Commerce.Wasm/Commerce.Wasm.csproj
@@ -83,7 +83,7 @@
 		<PackageReference Include="Uno.Toolkit.UI" Version="0.1.0-dev.169" />
 		<PackageReference Include="Uno.Toolkit.UI.Material" Version="0.1.0-dev.169" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material" Version="1.1.0-dev.57" />
+		<PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/samples/Commerce/UWP/Commerce.iOS/Commerce.iOS.csproj
+++ b/samples/Commerce/UWP/Commerce.iOS/Commerce.iOS.csproj
@@ -123,7 +123,7 @@
     <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.3.0-dev.1" />
     <PackageReference Include="System.Linq.Async" Version="4.0.0" />
     <PackageReference Include="Uno.Toolkit.UI" Version="0.1.0-dev.152" />
-    <PackageReference Include="Uno.Material" Version="1.1.0-dev.57" />
+    <PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
 	<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Commerce/UWP/Commerce.macOS/Commerce.macOS.csproj
+++ b/samples/Commerce/UWP/Commerce.macOS/Commerce.macOS.csproj
@@ -75,7 +75,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Uno.Toolkit.UI" Version="0.1.0-dev.169" />
     <PackageReference Include="Uno.Core" Version="4.0.1" />
-    <PackageReference Include="Uno.Material" Version="1.1.0-dev.57" />
+    <PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.3" />
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>

--- a/samples/Commerce/WinUI/Commerce.Droid/Commerce.Droid.csproj
+++ b/samples/Commerce/WinUI/Commerce.Droid/Commerce.Droid.csproj
@@ -75,7 +75,7 @@
 		</PackageReference>
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
 		<PackageReference Include="Uno.Material.WinUI">
-			<Version>1.1.0-dev.57</Version>
+			<Version>1.1.0-dev.64</Version>
 		</PackageReference>
 		<PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />

--- a/samples/Commerce/WinUI/Commerce.Skia.Gtk/Commerce.Skia.Gtk.csproj
+++ b/samples/Commerce/WinUI/Commerce.Skia.Gtk/Commerce.Skia.Gtk.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="Uno.Toolkit.WinUI" Version="0.1.0-dev.169" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="0.1.0-dev.169" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.57" />
+		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.64" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/samples/Commerce/WinUI/Commerce.Skia.WPF/Commerce.Skia.WPF.csproj
+++ b/samples/Commerce/WinUI/Commerce.Skia.WPF/Commerce.Skia.WPF.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="Uno.Toolkit.WinUI" Version="0.1.0-dev.169" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="0.1.0-dev.169" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.57" />
+		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.64" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
   <ItemGroup>

--- a/samples/Commerce/WinUI/Commerce.Wasm/Commerce.Wasm.csproj
+++ b/samples/Commerce/WinUI/Commerce.Wasm/Commerce.Wasm.csproj
@@ -52,7 +52,7 @@
 		<PackageReference Include="Uno.Toolkit.WinUI" Version="0.1.0-dev.169" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="0.1.0-dev.169" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.57" />
+		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.64" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/samples/Commerce/WinUI/Commerce.Windows.Desktop/Commerce.Windows.Desktop.csproj
+++ b/samples/Commerce/WinUI/Commerce.Windows.Desktop/Commerce.Windows.Desktop.csproj
@@ -31,7 +31,7 @@
 		<PackageReference Include="Uno.WinUI" Version="4.0.0-dev.5688" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
 		<PackageReference Include="Uno.Material.WinUI">
-			<Version>1.1.0-dev.57</Version>
+			<Version>1.1.0-dev.64</Version>
 		</PackageReference>
 		<PackageReference Include="Uno.Toolkit.WinUI.Material">
 			<Version>0.1.0-dev.169</Version>

--- a/samples/Commerce/WinUI/Commerce.iOS/Commerce.iOS.csproj
+++ b/samples/Commerce/WinUI/Commerce.iOS/Commerce.iOS.csproj
@@ -126,7 +126,7 @@
     </PackageReference>
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material.WinUI">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
 	<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>

--- a/samples/Commerce/WinUI/Commerce.macOS/Commerce.macOS.csproj
+++ b/samples/Commerce/WinUI/Commerce.macOS/Commerce.macOS.csproj
@@ -82,7 +82,7 @@
     </PackageReference>
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material.WinUI">
-      <Version>1.1.0-dev.57</Version>
+      <Version>1.1.0-dev.64</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #https://github.com/unoplatform/Uno.Themes/pull/688

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the new behavior?

Add proper MaterialFlyoutPresenterStyle with latest Uno.Material and uncomment the MaterialToggleButtonIconStyle


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

