### PR TITLE
fix: Add missing Uno.Toolkit.UI/WinUI.Material references

### DIFF
--- a/samples/Commerce/UWP/Commerce.Droid/Commerce.Droid.csproj
+++ b/samples/Commerce/UWP/Commerce.Droid/Commerce.Droid.csproj
@@ -70,7 +70,7 @@
     <PackageReference Include="Uno.UI" Version="4.0.8" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.8" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.Toolkit.UI" Version="1.0.0" />
-    <PackageReference Include="Uno.Toolkit.UI.Material" Version="0.1.0-dev.185" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.0.0" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.33" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/samples/Commerce/UWP/Commerce.Skia.Gtk/Commerce.Skia.Gtk.csproj
+++ b/samples/Commerce/UWP/Commerce.Skia.Gtk/Commerce.Skia.Gtk.csproj
@@ -17,7 +17,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Uno.UI.Skia.Gtk" Version="4.0.8" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.8" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.Toolkit.UI" Version="1.0.0" />
+    <PackageReference Include="Uno.Toolkit.UI" Version="1.0.0" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.0.0" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
 		<PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.3" />

--- a/samples/Commerce/UWP/Commerce.Skia.WPF/Commerce.Skia.WPF.csproj
+++ b/samples/Commerce/UWP/Commerce.Skia.WPF/Commerce.Skia.WPF.csproj
@@ -9,6 +9,7 @@
 		<PackageReference Include="Uno.UI.RemoteControl" Version="4.0.8" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="System.Linq.Async" Version="5.0.0" />
 		<PackageReference Include="Uno.Toolkit.UI" Version="1.0.0" />
+		<PackageReference Include="Uno.Toolkit.UI.Material" Version="1.0.0" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
 		<PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.3" />

--- a/samples/Commerce/UWP/Commerce.UWP/Commerce.Uwp.csproj
+++ b/samples/Commerce/UWP/Commerce.UWP/Commerce.Uwp.csproj
@@ -22,10 +22,8 @@
     <PackageReference Include="Uno.Material">
       <Version>1.1.0-dev.64</Version>
     </PackageReference>
-    <PackageReference Include="Uno.Toolkit.UI.Material">
-      <Version>1.0.0</Version>
-    </PackageReference>
     <PackageReference Include="Uno.Toolkit.UI" Version="1.0.0" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.0.0" />
     <PackageReference Include="Uno.UI" Version="4.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />

--- a/samples/Commerce/UWP/Commerce.Wasm/Commerce.Wasm.csproj
+++ b/samples/Commerce/UWP/Commerce.Wasm/Commerce.Wasm.csproj
@@ -81,7 +81,7 @@
 		<PackageReference Include="System.Linq.Async" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
 		<PackageReference Include="Uno.Toolkit.UI" Version="1.0.0" />
-		<PackageReference Include="Uno.Toolkit.UI.Material" Version="0.1.0-dev.185" />
+		<PackageReference Include="Uno.Toolkit.UI.Material" Version="1.0.0" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
 		<PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />

--- a/samples/Commerce/UWP/Commerce.iOS/Commerce.iOS.csproj
+++ b/samples/Commerce/UWP/Commerce.iOS/Commerce.iOS.csproj
@@ -123,6 +123,7 @@
     <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.3.0-dev.1" />
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="Uno.Toolkit.UI" Version="1.0.0" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.0.0" />
     <PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>

--- a/samples/Commerce/UWP/Commerce.macOS/Commerce.macOS.csproj
+++ b/samples/Commerce/UWP/Commerce.macOS/Commerce.macOS.csproj
@@ -74,6 +74,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Uno.Toolkit.UI" Version="1.0.0" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.0.0" />
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material" Version="1.1.0-dev.64" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.3" />

--- a/samples/Commerce/WinUI/Commerce.Droid/Commerce.Droid.csproj
+++ b/samples/Commerce/WinUI/Commerce.Droid/Commerce.Droid.csproj
@@ -70,9 +70,8 @@
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.0.8" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Uno.Toolkit.WinUI">
-      <Version>1.0.0</Version>
-    </PackageReference>
+    <PackageReference Include="Uno.Toolkit.WinUI" Version="1.0.0" />
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.0.0" />
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material.WinUI">
       <Version>1.1.0-dev.64</Version>

--- a/samples/Commerce/WinUI/Commerce.iOS/Commerce.iOS.csproj
+++ b/samples/Commerce/WinUI/Commerce.iOS/Commerce.iOS.csproj
@@ -121,9 +121,8 @@
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.3.0-dev.1" />
-    <PackageReference Include="Uno.Toolkit.WinUI">
-      <Version>1.0.0</Version>
-    </PackageReference>
+    <PackageReference Include="Uno.Toolkit.WinUI" Version="1.0.0" />
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.0.0" />
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material.WinUI">
       <Version>1.1.0-dev.64</Version>

--- a/samples/Commerce/WinUI/Commerce.macOS/Commerce.macOS.csproj
+++ b/samples/Commerce/WinUI/Commerce.macOS/Commerce.macOS.csproj
@@ -77,9 +77,8 @@
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Uno.Toolkit.WinUI">
-      <Version>1.0.0</Version>
-    </PackageReference>
+    <PackageReference Include="Uno.Toolkit.WinUI" Version="1.0.0" />
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.0.0" />
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material.WinUI">
       <Version>1.1.0-dev.64</Version>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Droid/MyExtensionsApp.Droid.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Droid/MyExtensionsApp.Droid.csproj
@@ -77,6 +77,7 @@
     <PackageReference Include="Uno.Material.WinUI">
       <Version>1.1.0-dev.64</Version>
     </PackageReference>
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.0.0" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0" />
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows.Desktop/MyExtensionsApp.Windows.Desktop.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows.Desktop/MyExtensionsApp.Windows.Desktop.csproj
@@ -31,7 +31,7 @@
 		<PackageReference Include="Uno.WinUI" Version="4.0.8" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
 		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.64" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.0.0" />
 		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.0.0" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.iOS/MyExtensionsApp.iOS.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.iOS/MyExtensionsApp.iOS.csproj
@@ -128,6 +128,7 @@
     <PackageReference Include="Uno.Material.WinUI">
       <Version>1.1.0-dev.64</Version>
     </PackageReference>
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.0.0" />
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.macOS/MyExtensionsApp.macOS.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.macOS/MyExtensionsApp.macOS.csproj
@@ -84,6 +84,7 @@
     <PackageReference Include="Uno.Material.WinUI">
       <Version>1.1.0-dev.64</Version>
     </PackageReference>
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.0.0" />
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/extensions/ExtensionsSampleApp/ExtensionsSampleApp.UWP/ExtensionsSampleApp.UWP.csproj
+++ b/src/extensions/ExtensionsSampleApp/ExtensionsSampleApp.UWP/ExtensionsSampleApp.UWP.csproj
@@ -27,13 +27,11 @@
     <PackageReference Include="Uno.Material">
       <Version>1.1.0-dev.13</Version>
     </PackageReference>
-    <PackageReference Include="Uno.Toolkit.UI.Material">
-      <Version>0.1.0-dev.124</Version>
-    </PackageReference>
     <PackageReference Include="Uno.UI" Version="4.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-    <PackageReference Include="Uno.Toolkit.UI" Version="0.1.0-dev.124" />
+    <PackageReference Include="Uno.Toolkit.UI" Version="1.0.0" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />


### PR DESCRIPTION
## PR Type

- Bugfix

## What is the current behavior?

Some Material styles are not taken into account on some platforms


## What is the new behavior?

Add missing Uno.Toolkit.UI.Material and Uno.Toolkit.WinUI.Material references in order to fix that.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
