### PR TITLE
fix: Remove ToogleSwitch workaround for wasm/skia as it's not needed anymore with latest Uno.Material

### DIFF
--- a/samples/Commerce/Commerce.Shared/App.xaml
+++ b/samples/Commerce/Commerce.Shared/App.xaml
@@ -33,11 +33,6 @@
 			
 			<x:Double x:Key="LandscapeMaxPageWidth">500</x:Double>
 
-			<!-- Workaround for https://github.com/unoplatform/uno/issues/5372 -->
-			<wasm:Style x:Key="MaterialToggleSwitchStyle"
-						TargetType="ToggleSwitch"
-						BasedOn="{StaticResource DefaultMaterialToggleSwitchStyle}" />
-
 			<!-- To override the default FlyoutLightDismissOverlayBackground resource -->
 			<SolidColorBrush x:Key="FlyoutLightDismissOverlayBackground"
 							 Color="{StaticResource MaterialOverlayColor}" />

--- a/samples/Commerce/UWP/Commerce.Droid/Commerce.Droid.csproj
+++ b/samples/Commerce/UWP/Commerce.Droid/Commerce.Droid.csproj
@@ -65,12 +65,12 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.3" />
     <PackageReference Include="Uno.Material">
-      <Version>1.1.0-dev.70</Version>
+      <Version>1.2.0-dev.6</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI" Version="4.0.9" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.9" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.Toolkit.UI" Version="1.1.0-dev.3" />
-    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.1.0-dev.3" />
+    <PackageReference Include="Uno.Toolkit.UI" Version="1.2.0-dev.1" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.2.0-dev.1" />
     <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/samples/Commerce/UWP/Commerce.Skia.Gtk/Commerce.Skia.Gtk.csproj
+++ b/samples/Commerce/UWP/Commerce.Skia.Gtk/Commerce.Skia.Gtk.csproj
@@ -17,10 +17,10 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Uno.UI.Skia.Gtk" Version="4.0.9" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.9" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.Toolkit.UI" Version="1.1.0-dev.3" />
-    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.1.0-dev.3" />
+    <PackageReference Include="Uno.Toolkit.UI" Version="1.2.0-dev.1" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.2.0-dev.1" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material" Version="1.1.0-dev.70" />
+		<PackageReference Include="Uno.Material" Version="1.2.0-dev.6" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.3" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>

--- a/samples/Commerce/UWP/Commerce.Skia.WPF/Commerce.Skia.WPF.csproj
+++ b/samples/Commerce/UWP/Commerce.Skia.WPF/Commerce.Skia.WPF.csproj
@@ -8,10 +8,10 @@
 		<PackageReference Include="Uno.UI.Skia.Wpf" Version="4.0.9" />
 		<PackageReference Include="Uno.UI.RemoteControl" Version="4.0.9" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="System.Linq.Async" Version="5.0.0" />
-		<PackageReference Include="Uno.Toolkit.UI" Version="1.1.0-dev.3" />
-		<PackageReference Include="Uno.Toolkit.UI.Material" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Toolkit.UI" Version="1.2.0-dev.1" />
+		<PackageReference Include="Uno.Toolkit.UI.Material" Version="1.2.0-dev.1" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material" Version="1.1.0-dev.70" />
+		<PackageReference Include="Uno.Material" Version="1.2.0-dev.6" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.3" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>

--- a/samples/Commerce/UWP/Commerce.UWP/Commerce.Uwp.csproj
+++ b/samples/Commerce/UWP/Commerce.UWP/Commerce.Uwp.csproj
@@ -20,10 +20,10 @@
     <PackageReference Include="Microsoft.UI.Xaml" Version="2.7.1-prerelease.211026002" />
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material">
-      <Version>1.1.0-dev.70</Version>
+      <Version>1.2.0-dev.6</Version>
     </PackageReference>
-    <PackageReference Include="Uno.Toolkit.UI" Version="1.1.0-dev.3" />
-    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.1.0-dev.3" />
+    <PackageReference Include="Uno.Toolkit.UI" Version="1.2.0-dev.1" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.2.0-dev.1" />
     <PackageReference Include="Uno.UI" Version="4.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />

--- a/samples/Commerce/UWP/Commerce.Wasm/Commerce.Wasm.csproj
+++ b/samples/Commerce/UWP/Commerce.Wasm/Commerce.Wasm.csproj
@@ -80,10 +80,10 @@
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.1.2" />
 		<PackageReference Include="System.Linq.Async" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-		<PackageReference Include="Uno.Toolkit.UI" Version="1.1.0-dev.3" />
-		<PackageReference Include="Uno.Toolkit.UI.Material" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Toolkit.UI" Version="1.2.0-dev.1" />
+		<PackageReference Include="Uno.Toolkit.UI.Material" Version="1.2.0-dev.1" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material" Version="1.1.0-dev.70" />
+		<PackageReference Include="Uno.Material" Version="1.2.0-dev.6" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/samples/Commerce/UWP/Commerce.iOS/Commerce.iOS.csproj
+++ b/samples/Commerce/UWP/Commerce.iOS/Commerce.iOS.csproj
@@ -122,9 +122,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.3.0-dev.1" />
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
-    <PackageReference Include="Uno.Toolkit.UI" Version="1.1.0-dev.3" />
-    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.1.0-dev.3" />
-    <PackageReference Include="Uno.Material" Version="1.1.0-dev.70" />
+    <PackageReference Include="Uno.Toolkit.UI" Version="1.2.0-dev.1" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.2.0-dev.1" />
+    <PackageReference Include="Uno.Material" Version="1.2.0-dev.6" />
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Commerce/UWP/Commerce.macOS/Commerce.macOS.csproj
+++ b/samples/Commerce/UWP/Commerce.macOS/Commerce.macOS.csproj
@@ -73,10 +73,10 @@
     <PackageReference Include="Uno.UI.RemoteControl" Version="4.0.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Uno.Toolkit.UI" Version="1.1.0-dev.3" />
-    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.1.0-dev.3" />
+    <PackageReference Include="Uno.Toolkit.UI" Version="1.2.0-dev.1" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.2.0-dev.1" />
     <PackageReference Include="Uno.Core" Version="4.0.1" />
-    <PackageReference Include="Uno.Material" Version="1.1.0-dev.70" />
+    <PackageReference Include="Uno.Material" Version="1.2.0-dev.6" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.3" />
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>

--- a/samples/Commerce/WinUI/Commerce.Droid/Commerce.Droid.csproj
+++ b/samples/Commerce/WinUI/Commerce.Droid/Commerce.Droid.csproj
@@ -70,11 +70,11 @@
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.0.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
-    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+    <PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material.WinUI">
-      <Version>1.1.0-dev.70</Version>
+      <Version>1.2.0-dev.6</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0" />
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />

--- a/samples/Commerce/WinUI/Commerce.Skia.Gtk/Commerce.Skia.Gtk.csproj
+++ b/samples/Commerce/WinUI/Commerce.Skia.Gtk/Commerce.Skia.Gtk.csproj
@@ -19,10 +19,10 @@
     <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.0.9" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.0.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.9" />
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.70" />
+		<PackageReference Include="Uno.Material.WinUI" Version="1.2.0-dev.6" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/samples/Commerce/WinUI/Commerce.Skia.WPF/Commerce.Skia.WPF.csproj
+++ b/samples/Commerce/WinUI/Commerce.Skia.WPF/Commerce.Skia.WPF.csproj
@@ -9,10 +9,10 @@
     <PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.0.9" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.0.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.9" />
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.70" />
+		<PackageReference Include="Uno.Material.WinUI" Version="1.2.0-dev.6" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
   <ItemGroup>

--- a/samples/Commerce/WinUI/Commerce.Wasm/Commerce.Wasm.csproj
+++ b/samples/Commerce/WinUI/Commerce.Wasm/Commerce.Wasm.csproj
@@ -55,10 +55,10 @@
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.9" />
     <PackageReference Include="Uno.Wasm.Bootstrap" Version="3.1.2" />
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.1.2" />
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.70" />
+		<PackageReference Include="Uno.Material.WinUI" Version="1.2.0-dev.6" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/samples/Commerce/WinUI/Commerce.Windows.Desktop/Commerce.Windows.Desktop.csproj
+++ b/samples/Commerce/WinUI/Commerce.Windows.Desktop/Commerce.Windows.Desktop.csproj
@@ -31,12 +31,12 @@
 		<PackageReference Include="Uno.WinUI" Version="4.0.9" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
 		<PackageReference Include="Uno.Material.WinUI">
-			<Version>1.1.0-dev.70</Version>
+			<Version>1.2.0-dev.6</Version>
 		</PackageReference>
 		<PackageReference Include="Uno.Toolkit.WinUI.Material">
-			<Version>1.1.0-dev.3</Version>
+			<Version>1.2.0-dev.1</Version>
 		</PackageReference>
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
 

--- a/samples/Commerce/WinUI/Commerce.iOS/Commerce.iOS.csproj
+++ b/samples/Commerce/WinUI/Commerce.iOS/Commerce.iOS.csproj
@@ -121,11 +121,11 @@
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.3.0-dev.1" />
-    <PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
-    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+    <PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material.WinUI">
-      <Version>1.1.0-dev.70</Version>
+      <Version>1.2.0-dev.6</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>

--- a/samples/Commerce/WinUI/Commerce.macOS/Commerce.macOS.csproj
+++ b/samples/Commerce/WinUI/Commerce.macOS/Commerce.macOS.csproj
@@ -77,11 +77,11 @@
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
-    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+    <PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material.WinUI">
-      <Version>1.1.0-dev.70</Version>
+      <Version>1.2.0-dev.6</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>

--- a/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.UI.csproj
+++ b/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.UI.csproj
@@ -11,7 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.UI" Version="4.0.9" />
-		<PackageReference Include="Uno.Toolkit.UI" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Toolkit.UI" Version="1.2.0-dev.1" />
 	</ItemGroup>
 
 	<Import Project="common.props" />

--- a/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.WinUI.csproj
+++ b/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.WinUI.csproj
@@ -17,7 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.WinUI" Version="4.0.9" />
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
 		<ProjectReference Include="..\Uno.Extensions.Navigation.UI\Uno.Extensions.Navigation.WinUI.csproj" />
 	</ItemGroup>
 

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Droid/MyExtensionsApp.Droid.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Droid/MyExtensionsApp.Droid.csproj
@@ -71,13 +71,13 @@
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Uno.Toolkit.WinUI">
-      <Version>1.1.0-dev.3</Version>
+      <Version>1.2.0-dev.1</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material.WinUI">
-      <Version>1.1.0-dev.70</Version>
+      <Version>1.2.0-dev.6</Version>
     </PackageReference>
-    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0" />
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.csproj
@@ -19,10 +19,10 @@
     <PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.0.9" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.0.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.9" />
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.70" />
+		<PackageReference Include="Uno.Material.WinUI" Version="1.2.0-dev.6" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.csproj
@@ -9,10 +9,10 @@
     <PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.0.9" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.0.9" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.9" />
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.70" />
+		<PackageReference Include="Uno.Material.WinUI" Version="1.2.0-dev.6" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
   <ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.csproj
@@ -49,10 +49,10 @@
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.0.9" />
     <PackageReference Include="Uno.Wasm.Bootstrap" Version="3.1.2" />
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.1.2" />
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.70" />
+		<PackageReference Include="Uno.Material.WinUI" Version="1.2.0-dev.6" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows.Desktop/MyExtensionsApp.Windows.Desktop.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows.Desktop/MyExtensionsApp.Windows.Desktop.csproj
@@ -30,9 +30,9 @@
 	<ItemGroup>
 		<PackageReference Include="Uno.WinUI" Version="4.0.9" />
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
-		<PackageReference Include="Uno.Material.WinUI" Version="1.1.0-dev.70" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.1.0-dev.3" />
+		<PackageReference Include="Uno.Material.WinUI" Version="1.2.0-dev.6" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="1.2.0-dev.1" />
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
 	</ItemGroup>
 

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.iOS/MyExtensionsApp.iOS.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.iOS/MyExtensionsApp.iOS.csproj
@@ -122,13 +122,13 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.OSLog " Version="1.3.0-dev.1" />
     <PackageReference Include="Uno.Toolkit.WinUI">
-      <Version>1.1.0-dev.3</Version>
+      <Version>1.2.0-dev.1</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material.WinUI">
-      <Version>1.1.0-dev.70</Version>
+      <Version>1.2.0-dev.6</Version>
     </PackageReference>
-    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.macOS/MyExtensionsApp.macOS.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.macOS/MyExtensionsApp.macOS.csproj
@@ -78,13 +78,13 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Uno.Toolkit.WinUI">
-      <Version>1.1.0-dev.3</Version>
+      <Version>1.2.0-dev.1</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core" Version="4.0.1" />
     <PackageReference Include="Uno.Material.WinUI">
-      <Version>1.1.0-dev.70</Version>
+      <Version>1.2.0-dev.6</Version>
     </PackageReference>
-    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.1.0-dev.3" />
+    <PackageReference Include="Uno.Toolkit.WinUI.Material" Version="1.2.0-dev.1" />
     <PackageReference Include="Uno.SourceGenerationTasks" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/extensions/ExtensionsSampleApp/ExtensionsSampleApp.UWP/ExtensionsSampleApp.UWP.csproj
+++ b/src/extensions/ExtensionsSampleApp/ExtensionsSampleApp.UWP/ExtensionsSampleApp.UWP.csproj
@@ -30,8 +30,8 @@
     <PackageReference Include="Uno.UI" Version="4.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-    <PackageReference Include="Uno.Toolkit.UI" Version="1.1.0-dev.3" />
-    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.1.0-dev.3" />
+    <PackageReference Include="Uno.Toolkit.UI" Version="1.2.0-dev.1" />
+    <PackageReference Include="Uno.Toolkit.UI.Material" Version="1.2.0-dev.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />


### PR DESCRIPTION
GitHub Issue (If applicable): #199 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

ToggleSwitch is not taking the correct Material Style for Wasm and Skia


## What is the new behavior?

ToggleSwitch is taking the correct Material Style for Wasm and Skia


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
