### PR TITLE
fix: Change Image Stretch UniformToFill to Uniform in order to match latest Uno Figma plugin changes (PR #321)

### DIFF
--- a/samples/Commerce/Commerce.Shared/Views/CartPage.xaml
+++ b/samples/Commerce/Commerce.Shared/Views/CartPage.xaml
@@ -64,7 +64,7 @@
 														<utu:AutoLayout Spacing="10"
 																		Padding="0,0,16,16">
 															<Image Source="{Binding Product.Photo}"
-																   Stretch="UniformToFill"
+																   Stretch="Uniform"
 																   utu:AutoLayout.PrimaryLength="56"
 																   utu:AutoLayout.CounterLength="56" />
 														</utu:AutoLayout>

--- a/samples/Commerce/Commerce.Shared/Views/DealsPage.xaml
+++ b/samples/Commerce/Commerce.Shared/Views/DealsPage.xaml
@@ -61,7 +61,7 @@
 									<DataTemplate>
 										<utu:AutoLayout Background="{StaticResource MaterialSurfaceBrush}">
 											<Image Source="{Binding Photo}"
-												   Stretch="UniformToFill"
+												   Stretch="Uniform"
 												   utu:AutoLayout.CounterAlignment="Stretch"
 												   utu:AutoLayout.PrimaryAlignment="Stretch" />
 											<utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">

--- a/samples/Commerce/Commerce.Shared/Views/ProductDetailsPage.xaml
+++ b/samples/Commerce/Commerce.Shared/Views/ProductDetailsPage.xaml
@@ -140,7 +140,7 @@
 												<utu:AutoLayout Spacing="10"
 																Padding="0,0,16,16">
 													<Image Source="{Binding Photo}"
-														   Stretch="UniformToFill"
+														   Stretch="Uniform"
 														   utu:AutoLayout.PrimaryLength="56"
 														   utu:AutoLayout.CounterLength="56" />
 												</utu:AutoLayout>

--- a/samples/Commerce/Commerce.Shared/Views/ProductsPage.xaml
+++ b/samples/Commerce/Commerce.Shared/Views/ProductsPage.xaml
@@ -161,7 +161,7 @@
 														<utu:AutoLayout Spacing="10"
 																		Padding="0,0,16,8">
 															<Image Source="{Binding Photo}"
-																   Stretch="UniformToFill"
+																   Stretch="Uniform"
 																   utu:AutoLayout.PrimaryLength="56"
 																   utu:AutoLayout.CounterLength="56" />
 														</utu:AutoLayout>

--- a/src/extensions/ExtensionsSampleApp/ExtensionsSampleApp.Shared/UnoCommerce/DealsPage.xaml
+++ b/src/extensions/ExtensionsSampleApp/ExtensionsSampleApp.Shared/UnoCommerce/DealsPage.xaml
@@ -20,7 +20,7 @@
                     <Image Source="{Binding Photo}"
                            HorizontalAlignment="Center"
                            VerticalAlignment="Center"
-                           Stretch="UniformToFill" />
+                           Stretch="Uniform" />
                 </Grid>
                 <StackPanel Grid.Row="1"
                             Margin="12">

--- a/src/extensions/ExtensionsSampleApp/ExtensionsSampleApp.Shared/UnoCommerce/ProductDetailsPage.xaml
+++ b/src/extensions/ExtensionsSampleApp/ExtensionsSampleApp.Shared/UnoCommerce/ProductDetailsPage.xaml
@@ -28,7 +28,7 @@
                       DataContext="{Binding Product}" Grid.Row="1">
             <StackPanel Margin="12">
                 <Border Height="300">
-                    <Image Source="{Binding Photo}" HorizontalAlignment="Center" VerticalAlignment="Center" Stretch="UniformToFill" />
+                    <Image Source="{Binding Photo}" HorizontalAlignment="Center" VerticalAlignment="Center" Stretch="Uniform" />
                 </Border>
                     
                 <TextBlock Text="{Binding Name}" FontSize="32" FontWeight="Bold" Margin="12"/>


### PR DESCRIPTION
GitHub Issue (If applicable): #201 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Images don't have the correct Stretch (UniformToFill)

## What is the new behavior?

Images use the correct Stretch for the wanted design (Uniform)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

