### PR TITLE
feat: Refactoring navigation logic

### DIFF
--- a/samples/Commerce/Commerce.Shared/Views/HomePage.xaml
+++ b/samples/Commerce/Commerce.Shared/Views/HomePage.xaml
@@ -95,13 +95,15 @@
 					</muxc:NavigationViewItem.Icon>
 				</muxc:NavigationViewItem>
 				<muxc:NavigationViewItem Content="Cart"
-										 uen:Navigation.Request="!Cart">
+										 uen:Navigation.Request="!Cart"
+										 SelectsOnInvoked="False">
 					<muxc:NavigationViewItem.Icon>
 						<PathIcon Data="{StaticResource Icon_shopping_cart}" />
 					</muxc:NavigationViewItem.Icon>
 				</muxc:NavigationViewItem>
 				<muxc:NavigationViewItem Content="Add"
-										 uen:Navigation.Request="../../AddProduct">
+										 uen:Navigation.Request="../../AddProduct"
+										 SelectsOnInvoked="False">
 					<muxc:NavigationViewItem.Icon>
 						<PathIcon Data="{StaticResource Icon_shopping_cart}" />
 					</muxc:NavigationViewItem.Icon>

--- a/samples/Commerce/Commerce.Shared/Views/ProductsPage.xaml
+++ b/samples/Commerce/Commerce.Shared/Views/ProductsPage.xaml
@@ -147,7 +147,7 @@
 										  ItemsSource="{Binding Data}"
 										  SelectionMode="None"
 										  IsItemClickEnabled="True"
-										  uen:Navigation.Request="+Details">
+										  uen:Navigation.Request="Details">
 									<ListView.ItemsPanel>
 										<ItemsPanelTemplate>
 											<ItemsStackPanel Orientation="Vertical" />

--- a/samples/Commerce/Commerce.Shared/Views/ProductsPage.xaml
+++ b/samples/Commerce/Commerce.Shared/Views/ProductsPage.xaml
@@ -147,7 +147,7 @@
 										  ItemsSource="{Binding Data}"
 										  SelectionMode="None"
 										  IsItemClickEnabled="True"
-										  uen:Navigation.Request="./Details">
+										  uen:Navigation.Request="+Details">
 									<ListView.ItemsPanel>
 										<ItemsPanelTemplate>
 											<ItemsStackPanel Orientation="Vertical" />

--- a/samples/Playground/Playground/Playground/Playground.Shared/ViewModels/FourthViewModel.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/ViewModels/FourthViewModel.cs
@@ -15,7 +15,7 @@ namespace Playground.ViewModels
 
 		public async Task NavigateToFifth()
 		{
-			await _navigator.NavigateViewModelAsync<FifthViewModel>(this, Schemes.Nested);
+			await _navigator.NavigateViewModelAsync<FifthViewModel>(this);
 		}
 	}
 }

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
@@ -28,10 +28,15 @@
 			<Button Content="MessageDialog Codebehind"
 					Click="MessageDialogCodebehindClick" />
 			<TextBlock x:Name="MessageDialogResultText" />
+			<Button Content="MessageDialog Codebehind (cancel after 2s)"
+					Click="MessageDialogCodebehindCancelClick" />
+			<TextBlock x:Name="MessageDialogCancelResultText" />
 			<Button uen:Navigation.Request="!Simple"
 					Content="SimpleDialog Nav Request" />
 			<Button Content="SimpleDialog Codebehind"
 					Click="SimpleDialogCodebehindClick" />
+			<Button Content="SimpleDialog Codebehind (cancel after 2s)"
+					Click="SimpleDialogCodebehindCancelClick" />
 			<TextBlock x:Name="SimpleDialogResultText" />
 			<Button uen:Navigation.Request="!Complex/ComplexDialogFirst"
 					Content="Complex Dialog Nav Request" />

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
@@ -26,13 +26,28 @@ namespace Playground.Views
 			var messageDialogResult = await showDialog.Result;
 			MessageDialogResultText.Text = $"Message dialog result: {messageDialogResult.SomeOrDefault()?.Label}";
 		}
+
+		private async void MessageDialogCodebehindCancelClick(object sender, RoutedEventArgs args)
+		{
+			var cancelSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+			var showDialog = await Navigator.ShowMessageDialogAsync(this, "This is Content", "This is title", cancellation: cancelSource.Token);
+			var messageDialogResult = await showDialog.Result;
+			MessageDialogCancelResultText.Text = $"Message dialog result: {messageDialogResult.SomeOrDefault()?.Label}";
+		}
+
 		private async void SimpleDialogCodebehindClick(object sender, RoutedEventArgs args)
 		{
 			var showDialog = await Navigator.NavigateViewForResultAsync<SimpleDialog,object>(this, Schemes.Dialog);
 			var dialogResult = await showDialog.Result;
 			SimpleDialogResultText.Text = $"Dialog result: {dialogResult.SomeOrDefault()?.ToString()}";
 		}
-
+		private async void SimpleDialogCodebehindCancelClick(object sender, RoutedEventArgs args)
+		{
+			var cancelSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+			var showDialog = await Navigator.NavigateViewForResultAsync<SimpleDialog, object>(this, Schemes.Dialog, cancellation: cancelSource.Token);
+			var dialogResult = await showDialog.Result;
+			SimpleDialogResultText.Text = $"Dialog result: {dialogResult.SomeOrDefault()?.ToString()}";
+		}
 		public void Inject(INavigator entity) => Navigator = entity;
 	}
 }

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/FourthPage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/FourthPage.xaml.cs
@@ -42,7 +42,7 @@ namespace Playground.Views
 
 		private void FifthPageClick(object sender, RoutedEventArgs args)
 		{
-			Navigator.NavigateViewAsync<FifthPage>(this, Schemes.Nested);
+			Navigator.NavigateViewAsync<FifthPage>(this);
 		}
 
 		public void Inject(INavigator entity)

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/VisualStatesPage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/VisualStatesPage.xaml
@@ -18,7 +18,7 @@
 					</VisualState.StateTriggers>
 					<VisualState.Setters>
 						<Setter Target="NextButton.(uen:Navigation.Request)"
-								Value="./Fifth" />
+								Value="Fifth" />
 						<Setter Target="NextButton.Content"
 								Value="Next - Fifth" />
 					</VisualState.Setters>

--- a/src/Uno.Extensions.Navigation.Toolkit/Controls/TabBarItemRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/Controls/TabBarItemRequestHandler.cs
@@ -1,7 +1,4 @@
-﻿using Uno.Extensions.Navigation.UI;
-using Uno.Toolkit.UI;
-
-namespace Uno.Extensions.Navigation.Toolkit.Controls;
+﻿namespace Uno.Extensions.Navigation.Toolkit.Controls;
 
 public class TabBarItemRequestHandler : ActionRequestHandlerBase<TabBarItem>
 {

--- a/src/Uno.Extensions.Navigation.Toolkit/Controls/TabBarItemRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/Controls/TabBarItemRequestHandler.cs
@@ -7,6 +7,7 @@ public class TabBarItemRequestHandler : ActionRequestHandlerBase<TabBarItem>
 {
 	public TabBarItemRequestHandler(IRouteResolver routes) : base(routes)
 	{
+		DefaultScheme = Schemes.ChangeContent;
 	}
 
 	public override IRequestBinding? Bind(FrameworkElement view)

--- a/src/Uno.Extensions.Navigation.Toolkit/GlobalUsings.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/GlobalUsings.cs
@@ -1,21 +1,36 @@
 ﻿global using System;
+global using System.Collections.Generic;
 global using System.Linq;
+global using System.Text;
+global using System.Threading;
 global using System.Threading.Tasks;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Hosting;
 global using Microsoft.Extensions.Logging;
+global using Windows.Foundation;
+global using Windows.UI.Popups;
+global using Uno.Extensions.Navigation.Navigators;
+global using Uno.Extensions.Navigation.Regions;
+global using Uno.Extensions.Navigation.Toolkit.Controls;
+global using Uno.Extensions.Navigation.Toolkit.Navigators;
+global using Uno.Extensions.Navigation.UI;
+global using Uno.Toolkit.UI;
 
 #if WINUI
-global using Microsoft.UI.Xaml;
-global using Microsoft.UI.Xaml.Controls;
-global using Microsoft.UI.Xaml.Controls.Primitives;
-global using Microsoft.UI.Xaml.Markup;
-global using Microsoft.UI.Xaml.Data;
-global using Microsoft.UI.Xaml.Media;
+	global using Microsoft.UI.Dispatching;
+	global using Microsoft.UI.Xaml;
+	global using Microsoft.UI.Xaml.Controls;
+	global using Microsoft.UI.Xaml.Controls.Primitives;
+	global using Microsoft.UI.Xaml.Navigation;
+	global using Microsoft.UI.Xaml.Markup;
+	global using Microsoft.UI.Xaml.Data;
+	global using Microsoft.UI.Xaml.Media;
 #else
+global using Windows.System;
 global using Windows.UI.Xaml;
 global using Windows.UI.Xaml.Controls;
 global using Windows.UI.Xaml.Controls.Primitives;
+global using Windows.UI.Xaml.Navigation;
 global using Windows.UI.Xaml.Markup;
 global using Windows.UI.Xaml.Data;
 global using Windows.UI.Xaml.Media;

--- a/src/Uno.Extensions.Navigation.Toolkit/Navigators/TabBarNavigator.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/Navigators/TabBarNavigator.cs
@@ -1,111 +1,43 @@
-﻿using Uno.Extensions.Navigation;
-using Uno.Extensions.Navigation.UI;
-using Uno.Toolkit.UI;
-using Uno.Extensions.Navigation.Regions;
-using Uno.Extensions.Navigation.Navigators;
+﻿namespace Uno.Extensions.Navigation.Toolkit.Navigators;
 
-
-namespace Uno.Extensions.Navigation.Toolkit.Navigators;
-
-public class TabBarNavigator : ControlNavigator<TabBar>
+public class TabBarNavigator : SelectorNavigator<TabBar>
 {
-	public override void ControlInitialize()
-	{
-		if (Control is not null)
-		{
-			Control.SelectionChanged += ControlSelectionChanged;
-		}
-	}
-
-	protected override bool SchemeIsSupported(Route route) =>
-		base.SchemeIsSupported(route) ||
-		// "../" (change content) Add support for changing current content
-		route.IsChangeContent();
-
-	protected override bool CanNavigateToRoute(Route route) =>
-		base.CanNavigateToRoute(route) &&
-		(FindByPath(RouteResolver.Find(route)?.Path) is not null);
-
-	private async void ControlSelectionChanged(TabBar sender, TabBarSelectionChangedEventArgs args)
-	{
-		var tbi = args.NewItem as TabBarItem;
-		if (tbi is null)
-		{
-			return;
-		}
-		await tbi.EnsureLoaded();
-		var tabName = tbi.GetName() ?? tbi.Name;
-		var nav = Region.Navigator();
-		if (nav is null)
-		{
-			return;
-		}
-
-		await nav.NavigateRouteAsync(tbi, tabName, scheme: Schemes.ChangeContent);
-	}
-
 	public TabBarNavigator(
-		ILogger<TabBarNavigator> logger,
-		IRegion region,
-		IRouteResolver routeResolver,
-		RegionControlProvider controlProvider)
-		: base(logger, region, routeResolver, controlProvider.RegionControl as TabBar)
+	ILogger<TabBarNavigator> logger,
+	IRegion region,
+	IRouteResolver routeResolver,
+	RegionControlProvider controlProvider)
+	: base(logger, region, routeResolver, controlProvider)
 	{
 	}
 
-	protected override async Task<string?> Show(string? path, Type? viewType, object? data)
+	protected override FrameworkElement? SelectedItem
 	{
-		if (Control is null)
+		get => Control?.SelectedItem as FrameworkElement;
+		set
 		{
-			return null;
-		}
-
-		Control.SelectionChanged -= ControlSelectionChanged;
-		try
-		{
-			if (int.TryParse(path, out var index))
+			if (Control is not null)
 			{
-				Control.SelectedIndex = index;
-				return path;
+				Control.SelectedItem = value;
 			}
-			else
-			{
-				if (Control.ItemsPanelRoot is null)
-				{
-					return default;
-				}
-
-				var item = FindByPath(path);
-				if (item is not null)
-				{
-					var idx = Control.IndexFromContainer(item);
-					if (Control.SelectedIndex != idx)
-					{
-						Control.SelectedIndex = idx;
-						await (item as FrameworkElement).EnsureLoaded();
-					}
-					return path;
-				}
-
-				return default;
-			}
-		}
-		finally
-		{
-			Control.SelectionChanged += ControlSelectionChanged;
 		}
 	}
 
-	private TabBarItem? FindByPath(string? path)
+	protected override IEnumerable<FrameworkElement>? Items => Control?.Items.OfType<FrameworkElement>();
+
+	protected override Action? AttachSelectionChanged(Action<FrameworkElement, FrameworkElement?> selectionChanged)
 	{
-		if (string.IsNullOrWhiteSpace(path) || Control is null)
+		var control = Control;
+		if (control is null)
 		{
 			return default;
 		}
 
-		var item = (from tbi in Control.Items.OfType<TabBarItem>()
-					where tbi.GetName() == path || tbi.Name == path
-					select tbi).FirstOrDefault();
-		return item;
+		TypedEventHandler<TabBar, TabBarSelectionChangedEventArgs> handler =
+			(nv, args) => selectionChanged(nv, args.NewItem as FrameworkElement);
+
+		control.SelectionChanged += handler;
+		return () => control.SelectionChanged -= handler;
+
 	}
 }

--- a/src/Uno.Extensions.Navigation.Toolkit/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/ServiceCollectionExtensions.cs
@@ -1,9 +1,4 @@
-﻿using Uno.Extensions.Navigation.Toolkit.Controls;
-using Uno.Extensions.Navigation.Toolkit.Navigators;
-using Uno.Extensions.Navigation.UI;
-using Uno.Toolkit.UI;
-
-namespace Uno.Extensions.Navigation.Toolkit;
+﻿namespace Uno.Extensions.Navigation.Toolkit;
 
 public static class ServiceCollectionExtensions
 {

--- a/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
@@ -9,6 +9,7 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 		RouteResolver = routes;
 	}
 
+	protected string DefaultScheme { get; init; } = Schemes.None;
 
 	protected IRequestBinding? BindAction<TElement, TEventHandler>(
 		TElement view,
@@ -63,6 +64,7 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 				resultType = routeMap?.ResultData;
 			}
 
+			var scheme = path.HasScheme() ? Schemes.None: DefaultScheme;
 
 			if (data is not null ||
 				resultType is not null)
@@ -70,7 +72,8 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 
 				if (resultType is not null)
 				{
-					var response = await nav.NavigateRouteForResultAsync(element, path, Schemes.Current, data, resultType: resultType);
+					
+					var response = await nav.NavigateRouteForResultAsync(element, path, scheme, data, resultType: resultType);
 					if (binding is not null &&
 					binding.ParentBinding.Mode == BindingMode.TwoWay)
 					{
@@ -87,13 +90,13 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 				}
 				else
 				{
-					await nav.NavigateRouteAsync(element, path, Schemes.Current, data);
+					await nav.NavigateRouteAsync(element, path, scheme, data);
 
 				}
 			}
 			else
 			{
-				await nav.NavigateRouteAsync(element, path, Schemes.Current);
+				await nav.NavigateRouteAsync(element, path, scheme);
 			}
 		};
 

--- a/src/Uno.Extensions.Navigation.UI/Controls/NavigationViewItemRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/NavigationViewItemRequestHandler.cs
@@ -7,6 +7,7 @@ public class NavigationViewItemRequestHandler : ActionRequestHandlerBase<Navigat
 {
 	public NavigationViewItemRequestHandler(IRouteResolver routes) : base(routes)
 	{
+		DefaultScheme = Schemes.ChangeContent;
 	}
 
 	public override IRequestBinding? Bind(FrameworkElement view)

--- a/src/Uno.Extensions.Navigation.UI/Controls/SelectorRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/SelectorRequestHandler.cs
@@ -21,7 +21,7 @@ public class SelectorRequestHandler : ControlRequestHandlerBase<Selector>
 				return;
 			}
 
-			await nav.NavigateRouteAsync(sender, path, Schemes.Current, navdata);
+			await nav.NavigateRouteAsync(sender, path, Schemes.None, navdata);
 		};
 
 		SelectionChangedEventHandler selectionAction = async (actionSender, actionArgs) =>

--- a/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
@@ -34,14 +34,15 @@ public static class FrameworkElementExtensions
 		Windows.ApplicationModel.Core.CoreApplication.MainView.DispatcherQueue;
 #endif
 
-	public static async Task EnsureLoaded(this FrameworkElement? element)
+	public static async Task<bool> EnsureLoaded(this FrameworkElement? element)
 	{
 		if (element is null)
 		{
-			return;
+			return false;
 		}
 
 		var dispatcher = element.GetDispatcher();
+		var success = true;
 		if (dispatcher is not null)
 		{
 			var completion = new TaskCompletionSource<bool>();
@@ -57,7 +58,7 @@ public static class FrameworkElementExtensions
 						{
 							if (timeoutToken.IsCancellationRequested)
 							{
-								completion.TrySetCanceled(timeoutToken);
+								completion.SetResult(false);
 							}
 							else
 							{
@@ -65,7 +66,7 @@ public static class FrameworkElementExtensions
 							}
 						}
 					});
-			await completion.Task;
+			success = await completion.Task;
 		}
 
 
@@ -76,6 +77,8 @@ public static class FrameworkElementExtensions
 		// By yielding here, we avoid such situation from happening.
 		await Task.Yield();
 #endif
+
+		return success;
 	}
 	private static Task EnsureElementLoaded(this FrameworkElement? element, CancellationToken? timeoutToken = null)
 	{

--- a/src/Uno.Extensions.Navigation.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Navigation.UI/GlobalUsings.cs
@@ -9,6 +9,10 @@ global using Microsoft.Extensions.Hosting;
 global using Microsoft.Extensions.Logging;
 global using Windows.Foundation;
 global using Windows.UI.Popups;
+global using Uno.Extensions.Navigation;
+global using Uno.Extensions.Navigation.Navigators;
+global using Uno.Extensions.Navigation.Regions;
+global using Uno.Extensions.Navigation.UI;
 
 #if WINUI
 	global using Microsoft.UI.Dispatching;
@@ -20,7 +24,7 @@ global using Windows.UI.Popups;
 	global using Microsoft.UI.Xaml.Data;
 	global using Microsoft.UI.Xaml.Media;
 #else
-	global using Windows.System;
+global using Windows.System;
 	global using Windows.UI.Xaml;
 	global using Windows.UI.Xaml.Controls;
 	global using Windows.UI.Xaml.Controls.Primitives;

--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -172,9 +172,6 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 	{
 		var dialogService = Region.Services?.GetService<INavigatorFactory>()?.CreateService(Region, request);
 
-		//// Trim dialog scheme to prevent recursion when we call Navigate
-		//request = request with { Route = request.Route with { Scheme = Schemes.None } };
-
 		var dialogResponse = await (dialogService?.NavigateAsync(request) ?? Task.FromResult<NavigationResponse?>(default));
 
 		return dialogResponse;

--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -144,9 +144,6 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 	}
 
 	protected virtual bool SchemeIsSupported(Route route) =>
-		// "" (current) Has been removed to force navigation to be explicit (eg either ../ or ./)
-		// route.IsCurrent() ||					
-
 		// "./" (nested) by default all navigators should be able to forward requests
 		// to child if the Base matches a named child
 		(

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ContentDialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ContentDialogNavigator.cs
@@ -59,7 +59,7 @@ public class ContentDialogNavigator : DialogNavigator
 		}
 
 
-		if (request.Cancellation.HasValue)
+		if (request.Cancellation.HasValue && request.Cancellation.CanBeCanceled)
 		{
 			request.Cancellation.Value.Register(() =>
 			{

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ContentDialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ContentDialogNavigator.cs
@@ -59,6 +59,14 @@ public class ContentDialogNavigator : DialogNavigator
 		}
 
 
+		if (request.Cancellation.HasValue)
+		{
+			request.Cancellation.Value.Register(() =>
+			{
+				showTask.Cancel();
+			});
+		}
+
 		return showTask;
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ContentDialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ContentDialogNavigator.cs
@@ -13,6 +13,10 @@ public class ContentDialogNavigator : DialogNavigator
 	{
 	}
 
+	protected override bool CanNavigateToRoute(Route route) =>
+			base.CanNavigateToRoute(route) &&
+			(RouteResolver.Find(route)?.View?.IsSubclassOf(typeof(ContentDialog)) ?? false);
+
 	protected override async Task<IAsyncInfo?> DisplayDialog(NavigationRequest request, Type? viewType, object? viewModel)
 	{
 		var route = request.Route;

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ContentDialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ContentDialogNavigator.cs
@@ -59,7 +59,8 @@ public class ContentDialogNavigator : DialogNavigator
 		}
 
 
-		if (request.Cancellation.HasValue && request.Cancellation.CanBeCanceled)
+		if (request.Cancellation.HasValue &&
+			request.Cancellation.Value.CanBeCanceled)
 		{
 			request.Cancellation.Value.Register(() =>
 			{

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
@@ -177,7 +177,7 @@ public abstract class ControlNavigator : Navigator
 
 	protected virtual void UpdateRoute(Route? route)
 	{
-		Route = route is not null ? new Route(Schemes.Current, route.Base, null, route.Data) : null;
+		Route = route is not null ? new Route(Schemes.None, route.Base, null, route.Data) : null;
 	}
 
 	protected object? CreateViewModel(IServiceProvider services, Route route, RouteMap? mapping)

--- a/src/Uno.Extensions.Navigation.UI/Navigators/DialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/DialogNavigator.cs
@@ -16,7 +16,10 @@ public abstract class DialogNavigator : ControlNavigator
     {
     }
 
-    protected override bool CanNavigateToRoute(Route route) => base.CanNavigateToRoute(route) || route.IsBackOrCloseNavigation();
+	protected override bool SchemeIsSupported(Route route) =>
+			base.SchemeIsSupported(route) ||
+			// "-" (back or close) Add closing 
+			route.IsBackOrCloseNavigation();
 
     protected override async Task<Route?> ExecuteRequestAsync(NavigationRequest request)
     {

--- a/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
@@ -17,7 +17,13 @@ public class FlyoutNavigator : ControlNavigator
 	{
 	}
 
-	protected override bool CanNavigateToRoute(Route route) => base.CanNavigateToRoute(route) || route.IsBackOrCloseNavigation();
+	protected override bool SchemeIsSupported(Route route) =>
+			base.SchemeIsSupported(route) ||
+			// "-" (back or close) Add closing 
+			route.IsBackOrCloseNavigation();
+
+	protected override bool CanNavigateToRoute(Route route) =>
+		base.CanNavigateToRoute(route);
 
 	protected override async Task<Route?> ExecuteRequestAsync(NavigationRequest request)
 	{
@@ -112,7 +118,7 @@ public class FlyoutNavigator : ControlNavigator
 		await flyoutElement.EnsureLoaded();
 
 
-		if (flyoutElement is not null)
+		if (flyoutElement is not null && flyoutElement.Parent is not null)
 		{
 			flyoutElement.SetInstance(null); // Clear region off the flyout element
 			flyoutElement.Parent.SetInstance(Region); // Set region on parent (now that it will be not null)

--- a/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
@@ -35,6 +35,19 @@ public class FrameNavigator : ControlNavigator<Frame>
 		}
 	}
 
+	protected override bool SchemeIsSupported(Route route) =>
+		base.SchemeIsSupported(route) ||
+		route.IsFrameNavigation() ||
+		(
+			route.IsInternal &&
+				(
+					// Where a FrameView is injected, a changecontent route can flow to the framenavigator
+					route.IsChangeContent() ||
+					// Where a FrameView is injected, a dialog route can flow to the framenavigator
+					route.IsDialog()
+				)
+		); 
+
 	protected override bool CanNavigateToRoute(Route route)
 	{
 		if(Control is null)
@@ -42,8 +55,7 @@ public class FrameNavigator : ControlNavigator<Frame>
 			return false;
 		}
 
-		var baseCanNavigate = base.CanNavigateToRoute(route) || route.IsFrameNavigation();
-		if (!baseCanNavigate)
+		if (!base.CanNavigateToRoute(route))
 		{
 			return false;
 		}

--- a/src/Uno.Extensions.Navigation.UI/Navigators/MessageDialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/MessageDialogNavigator.cs
@@ -45,7 +45,8 @@ public class MessageDialogNavigator : DialogNavigator
 				TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.DenyChildAttach,
 				TaskScheduler.FromCurrentSynchronizationContext());
 
-		if (request.Cancellation.HasValue)
+		if (request.Cancellation.HasValue &&
+			request.Cancellation.Value.CanBeCanceled)
 		{
 			request.Cancellation.Value.Register(() =>
 			{

--- a/src/Uno.Extensions.Navigation.UI/Navigators/MessageDialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/MessageDialogNavigator.cs
@@ -13,6 +13,15 @@ public class MessageDialogNavigator : DialogNavigator
 	{
 	}
 
+	protected override bool SchemeIsSupported(Route route) =>
+			base.SchemeIsSupported(route) ||
+			// "-" (back or close) Add closing 
+			route.IsBackOrCloseNavigation();
+
+	protected override bool CanNavigateToRoute(Route route) =>
+		base.CanNavigateToRoute(route) &&
+		(RouteResolver.Find(route)?.View == typeof(MessageDialog));
+
 	protected override async Task<IAsyncInfo?> DisplayDialog(NavigationRequest request, Type? viewType, object? viewModel)
 	{
 		var route = request.Route;

--- a/src/Uno.Extensions.Navigation.UI/Navigators/MessageDialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/MessageDialogNavigator.cs
@@ -44,6 +44,15 @@ public class MessageDialogNavigator : DialogNavigator
 				CancellationToken.None,
 				TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.DenyChildAttach,
 				TaskScheduler.FromCurrentSynchronizationContext());
+
+		if (request.Cancellation.HasValue)
+		{
+			request.Cancellation.Value.Register(() =>
+			{
+				showTask.Cancel();
+			});
+		}
+
 		return showTask;
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/Navigators/NavigationViewNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/NavigationViewNavigator.cs
@@ -1,87 +1,43 @@
-﻿using Uno.Extensions.Navigation;
-using Uno.Extensions.Navigation.UI;
-using Uno.Extensions.Navigation.Regions;
+﻿namespace Uno.Extensions.Navigation.Navigators;
 
-namespace Uno.Extensions.Navigation.Navigators;
-
-public class NavigationViewNavigator : ControlNavigator<Microsoft.UI.Xaml.Controls.NavigationView>
+public class NavigationViewNavigator : SelectorNavigator<Microsoft.UI.Xaml.Controls.NavigationView>
 {
-	protected override FrameworkElement? CurrentView => Control?.SelectedItem as FrameworkElement;
-
-	public override void ControlInitialize()
-	{
-		if (Control is not null)
-		{
-			Control.SelectionChanged += ControlSelectionChanged;
-		}
-	}
-
-	protected override bool SchemeIsSupported(Route route) =>
-		base.SchemeIsSupported(route) ||
-		// "../" (change content) Add support for changing current content
-		route.IsChangeContent();
-
-	protected override bool CanNavigateToRoute(Route route) =>
-		base.CanNavigateToRoute(route) &&
-		(FindByPath(RouteResolver.Find(route)?.Path) is not null);
-
-	private void ControlSelectionChanged(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs args)
-	{
-		var tbi = args.SelectedItem as FrameworkElement;
-
-		var path = tbi?.GetName() ?? tbi?.Name;
-		if (path is not null &&
-			!string.IsNullOrEmpty(path))
-		{
-			Region.Navigator()?.NavigateRouteAsync(sender, path, scheme: Schemes.ChangeContent);
-		}
-	}
-
 	public NavigationViewNavigator(
-		ILogger<NavigationViewNavigator> logger,
-		IRegion region,
-		IRouteResolver routeResolver,
-		RegionControlProvider controlProvider)
-		: base(logger, region, routeResolver, controlProvider.RegionControl as Microsoft.UI.Xaml.Controls.NavigationView)
+	ILogger<NavigationViewNavigator> logger,
+	IRegion region,
+	IRouteResolver routeResolver,
+	RegionControlProvider controlProvider)
+	: base(logger, region, routeResolver, controlProvider)
 	{
 	}
 
-	protected override async Task<string?> Show(string? path, Type? viewType, object? data)
+	protected override FrameworkElement? SelectedItem
 	{
-		if (Control is null)
+		get => Control?.SelectedItem as FrameworkElement;
+		set
 		{
-			return null;
-		}
-
-		Control.SelectionChanged -= ControlSelectionChanged;
-		try
-		{
-			var item = FindByPath(path);
-			if (item != null)
+			if (Control is not null)
 			{
-				Control.SelectedItem = item;
+				Control.SelectedItem = value;
 			}
-
-			// Don't return path, as we need for path to be passed down to children
-			return default;
-		}
-		finally
-		{
-			await (Control.Content as FrameworkElement).EnsureLoaded();
-			Control.SelectionChanged += ControlSelectionChanged;
 		}
 	}
 
-	private FrameworkElement? FindByPath(string? path)
+	protected override IEnumerable<FrameworkElement>? Items => Control?.MenuItems.OfType<FrameworkElement>();
+
+	protected override Action? AttachSelectionChanged(Action<FrameworkElement, FrameworkElement?> selectionChanged)
 	{
-		if(string.IsNullOrWhiteSpace(path) || Control is null)
+		var control = Control;
+		if(control is null)
 		{
 			return default;
 		}
 
-		var item = (from mi in Control.MenuItems.OfType<FrameworkElement>()
-					where (mi.GetName() ?? mi.Name) == path
-					select mi).FirstOrDefault();
-		return item;
+		TypedEventHandler<Microsoft.UI.Xaml.Controls.NavigationView, Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs> handler =
+			(nv, args) => selectionChanged(nv, args.SelectedItem as FrameworkElement);
+
+		control.SelectionChanged += handler;
+		return () => control.SelectionChanged -= handler;
+
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/Navigators/PopupNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/PopupNavigator.cs
@@ -16,8 +16,13 @@ public class PopupNavigator : ControlNavigator<Popup>
     {
     }
 
+	protected override bool SchemeIsSupported(Route route) =>
+			base.SchemeIsSupported(route) ||
+			route.Scheme == Schemes.None ||
+			// "-" (back or close) Add closing 
+			route.IsBackOrCloseNavigation();
 
-    public override void ControlInitialize()
+	public override void ControlInitialize()
     {
         base.ControlInitialize();
 

--- a/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
@@ -1,0 +1,120 @@
+﻿
+namespace Uno.Extensions.Navigation.Navigators;
+
+public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
+where TControl : class
+{
+	protected abstract FrameworkElement SelectedItem { get; set; }
+
+	protected abstract Action? AttachSelectionChanged(Action<FrameworkElement, FrameworkElement?> selectionChanged);
+
+	protected abstract IEnumerable<FrameworkElement>? Items { get; }
+
+	protected override FrameworkElement? CurrentView => SelectedItem;
+
+	private Action? DetachSelectionChanged { get; set; }
+	public override void ControlInitialize()
+	{
+		if (Control is not null)
+		{
+			DetachSelectionChanged = AttachSelectionChanged(SelectionChanged);
+		}
+	}
+
+	protected override bool SchemeIsSupported(Route route) =>
+		base.SchemeIsSupported(route) ||
+		// "../" (change content) Add support for changing current content
+		route.IsChangeContent();
+
+	protected override bool CanNavigateToRoute(Route route) =>
+		base.CanNavigateToRoute(route) &&
+		(FindByPath(RouteResolver.Find(route)?.Path) is not null);
+
+	//private void ControlSelectionChanged(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs args)
+	//{
+	//	var tbi = args.SelectedItem as FrameworkElement;
+
+	//	var path = tbi?.GetName() ?? tbi?.Name;
+	//	if (path is not null &&
+	//		!string.IsNullOrEmpty(path))
+	//	{
+	//		Region.Navigator()?.NavigateRouteAsync(sender, path, scheme: Schemes.ChangeContent);
+	//	}
+	//}
+
+	private async void SelectionChanged(FrameworkElement sender, FrameworkElement? selectedItem)
+	{
+		await selectedItem.EnsureLoaded();
+
+		var path = selectedItem?.GetName() ?? selectedItem?.Name;
+		if (path is null ||
+			string.IsNullOrEmpty(path))
+		{
+			return;
+		}
+
+			var nav = Region.Navigator();
+		if (nav is null)
+		{
+			return;
+		}
+
+		await nav.NavigateRouteAsync(sender, path, scheme: Schemes.ChangeContent);
+	}
+
+
+	protected SelectorNavigator(
+		ILogger logger,
+		IRegion region,
+		IRouteResolver routeResolver,
+		RegionControlProvider controlProvider)
+		: base(logger, region, routeResolver, controlProvider.RegionControl as TControl)
+	{
+	}
+
+	protected override async Task<string?> Show(string? path, Type? viewType, object? data)
+	{
+		if (Control is null)
+		{
+			return null;
+		}
+
+		DetachSelectionChanged?.Invoke();
+		try
+		{
+			var item = FindByPath(path);
+			if (item != null)
+			{
+				SelectedItem = item;
+			}
+
+			// Don't return path, as we need for path to be passed down to children
+			return default;
+		}
+		finally
+		{
+			await SelectedItem.EnsureLoaded();
+			DetachSelectionChanged = AttachSelectionChanged(SelectionChanged);
+		}
+	}
+
+	private FrameworkElement? FindByPath(string? path)
+	{
+		if (string.IsNullOrWhiteSpace(path) || Control is null)
+		{
+			return default;
+		}
+
+		var items = Items;
+
+		if (items == null)
+		{
+			return null;
+		}
+
+		var item = (from mi in Items
+					where (mi.GetName() ?? mi.Name) == path
+					select mi).FirstOrDefault();
+		return item;
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/RouteExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteExtensions.cs
@@ -7,31 +7,31 @@ public static class RouteExtensions
 	private static Regex nonAlphaRegex = new Regex(@"([^a-zA-Z0-9])+");
 	private static Regex alphaRegex = new Regex(@"([a-zA-Z0-9])+");
 
-	public static bool EmptyScheme(this Route route) => string.IsNullOrWhiteSpace(route.Scheme);
-
-	public static bool IsCurrent(this Route route) => route.Scheme == Schemes.Current;
-
 	public static bool IsBackOrCloseNavigation(this Route route) =>
-	route.Scheme
-		.TrimStart(Schemes.Parent) // Handle eg ../-  which is still a back navigation
-		.StartsWith(Schemes.NavigateBack);
+		route.Scheme
+			.StartsWith(Schemes.NavigateBack);
 
 	public static bool IsFrameNavigation(this Route route) =>
+		route.Scheme == Schemes.None || // We want to make forward navigation between frames simple, so don't require +
 		route.Scheme.StartsWith(Schemes.NavigateForward) ||
 		route.Scheme.StartsWith(Schemes.NavigateBack);
 
+	public static bool IsInternal(this Route route) => route.IsInternal;
+
 	public static bool IsRoot(this Route route) => route.Scheme.StartsWith(Schemes.Root);
+
+	public static bool IsChangeContent(this Route route) =>
+		(route.Scheme.StartsWith(Schemes.ChangeContent) && !route.IsParent()) ||
+		(route.Scheme==Schemes.None && route.IsInternal);
 
 	public static bool IsParent(this Route route) => route.Scheme.StartsWith(Schemes.Parent);
 
-	public static bool IsNested(this Route route, bool checkIfLastScheme = false) => checkIfLastScheme ?
-		route.Scheme == Schemes.Nested :
-		route.Scheme.StartsWith(Schemes.Nested);
+	public static bool IsNested(this Route route) => route.Scheme.StartsWith(Schemes.Nested);
 
 	public static bool IsDialog(this Route route) => route.Scheme.StartsWith(Schemes.Dialog);
 
-
-	public static bool IsLast(this Route route) => string.IsNullOrWhiteSpace(route?.Path);
+	public static bool IsLast(this Route route) => route.Next().IsEmpty();
+		//string.IsNullOrWhiteSpace(route?.Path);
 
 	public static Route Last(this Route route)
 	{
@@ -46,9 +46,9 @@ public static class RouteExtensions
 	}
 
 	public static bool IsEmpty(this Route route) => route is not null ?
-		(route.Scheme == Schemes.Current || route.Scheme == Schemes.Nested) &&
+		(route.Scheme == Schemes.None || route.Scheme == Schemes.ChangeContent || route.Scheme == Schemes.Nested) &&
 		string.IsNullOrWhiteSpace(route.Base) :
-		false;
+		true;
 
 	// eg -/NextPage
 	public static bool FrameIsRooted(this Route route) => route?.Scheme.EndsWith(Schemes.Root + string.Empty) ?? false;
@@ -220,7 +220,7 @@ public static class RouteExtensions
 		var routeBase = path.ExtractBase(out var nextScheme, out var nextPath);
 		if (nextScheme == Schemes.Root)
 		{
-			nextScheme = Schemes.Current;
+			nextScheme = Schemes.None;
 		}
 		return route with { Scheme = nextScheme, Base = routeBase, Path = nextPath };
 	}
@@ -243,15 +243,20 @@ public static class RouteExtensions
 
 	public static string NextPath(this Route route)
 	{
-		route.Path.ExtractBase(out var nextScheme, out var nextPath);
+		route.Path.ExtractBase(out var _, out var nextPath);
 		return nextPath;
 	}
 	public static string NextScheme(this Route route)
 	{
-		route.Path.ExtractBase(out var nextScheme, out var nextPath);
+		route.Path.ExtractBase(out var nextScheme, out var _);
 		return nextScheme;
 	}
 
+	public static bool HasScheme(this string path)
+	{
+		var _ = ExtractBase(path, out var scheme, out var _);
+		return !string.IsNullOrWhiteSpace(scheme);
+	}
 	public static string? ExtractBase(this string? path, out string nextScheme, out string nextPath)
 	{
 		nextPath = path ?? string.Empty;
@@ -399,7 +404,7 @@ public static class RouteExtensions
 			return route;
 		}
 
-		var separator = nextRoute.Scheme == Schemes.Current ? Schemes.Separator : string.Empty;
+		var separator = nextRoute.Scheme == Schemes.None ? Schemes.Separator : string.Empty;
 
 
 		var child = nextRoute;
@@ -407,7 +412,7 @@ public static class RouteExtensions
 		{
 			child = child with
 			{
-				Scheme = Schemes.Current,
+				Scheme = Schemes.None,
 				Base = regionName,
 				Path = (string.IsNullOrWhiteSpace(child.Scheme) ?
 							Schemes.Separator :

--- a/src/Uno.Extensions.Navigation.UI/RouteExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteExtensions.cs
@@ -12,7 +12,8 @@ public static class RouteExtensions
 			.StartsWith(Schemes.NavigateBack);
 
 	public static bool IsFrameNavigation(this Route route) =>
-		route.Scheme == Schemes.None || // We want to make forward navigation between frames simple, so don't require +
+		// We want to make forward navigation between frames simple, so don't require +
+		route.Scheme == Schemes.None || 
 		route.Scheme.StartsWith(Schemes.NavigateForward) ||
 		route.Scheme.StartsWith(Schemes.NavigateBack);
 
@@ -31,7 +32,6 @@ public static class RouteExtensions
 	public static bool IsDialog(this Route route) => route.Scheme.StartsWith(Schemes.Dialog);
 
 	public static bool IsLast(this Route route) => route.Next().IsEmpty();
-		//string.IsNullOrWhiteSpace(route?.Path);
 
 	public static Route Last(this Route route)
 	{

--- a/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
@@ -44,9 +44,7 @@ public class RouteResolver : IRouteResolver
 	{
 		if (
 			path is null ||
-			string.IsNullOrWhiteSpace(path) ||
-			path == Schemes.Parent ||
-			path == Schemes.Current)
+			string.IsNullOrWhiteSpace(path))
 		{
 			return null;
 		}

--- a/src/Uno.Extensions.Navigation.UI/ServiceProviderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ServiceProviderExtensions.cs
@@ -86,15 +86,15 @@ public static class ServiceProviderExtensions
 			var start = () => Task.CompletedTask;
 			if (initialView is not null)
 			{
-				start = () => nav.NavigateViewAsync(cc, initialView);
+				start = () => nav.NavigateViewAsync(cc, initialView, scheme:Schemes.ChangeContent);
 			}
 			else if (initialViewModel is not null)
 			{
-				start = () => nav.NavigateViewModelAsync(cc, initialViewModel);
+				start = () => nav.NavigateViewModelAsync(cc, initialViewModel, scheme: Schemes.ChangeContent);
 			}
 			else
 			{
-				start = () => nav.NavigateRouteAsync(cc, initialRoute ?? string.Empty);
+				start = () => nav.NavigateRouteAsync(cc, initialRoute ?? string.Empty, scheme: Schemes.ChangeContent);
 			}
 			services.Startup(start);
 		}

--- a/src/Uno.Extensions.Navigation/Route.cs
+++ b/src/Uno.Extensions.Navigation/Route.cs
@@ -3,6 +3,8 @@
 #pragma warning disable SA1313 // Parameter names should begin with lower-case letter
 public record Route(string Scheme, string? Base = null, string? Path = null, IDictionary<string, object>? Data = null)
 {
+	internal  bool IsInternal { get; set; }
+
 	public static Route Empty => new Route(Schemes.None, null, null, null);
 
 	public static Route PageRoute<TPage>() => PageRoute(typeof(TPage));

--- a/src/Uno.Extensions.Navigation/Schemes.cs
+++ b/src/Uno.Extensions.Navigation/Schemes.cs
@@ -5,9 +5,9 @@ public static class Schemes
 	public const string Separator = "/";
 	public const string Root = "/";
 	public const string None = "";
-	public const string Current = "";
 	public const string Nested = "./";
-	public const string Parent = "../";
+	public const string ChangeContent = "../";
+	public const string Parent = "../../";
 	public const string Dialog = "!";
 	public const string NavigateBack = "-";
 	public const string NavigateForward = "+";


### PR DESCRIPTION
GitHub Issue (If applicable): #
https://github.com/unoplatform/uno.extensions/issues/268

## PR Overview

The different navigation schemes and behaviours were quite confusing. This PR attempts to provide more consistency which should make documenting navigation easier. 

# Supported schemes
```
/ Forward request to the root region
../ Change content (Container regions) or selection (Selector regions)
../../ Forward request to parent region
./ Forward request to child region
+ (or no scheme) Navigate to a page (Frame based region)
! Open a dialog or flyout eg !Cart
- Back (Frame region), Close (Dialog/Flyout) or respond to navigation
```

One of the big changes is that the INavigator implementations have a SchemeIsSupported method that will restrict the schemes that are handled. If they experience a scheme they don't recognise, the request will be forwarded to the parent region. 
There's still a CanNavigateToRoute method which carried our more specific checks (and runs on UI thread). It may be possible to eliminate/merge this with the SchemeIsSupported as they have similar function

This PR also introduces a flag "IsInternal" on the Route which is used to prevent requests being sent up the region hierarchy multiple times. Once a request has been forwarded to the correct INavigator interface, it should only be passed down to child regions, never back up to parent regions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)




