### PR TITLE
feat: Detach Navigation from App Startup

### DIFF
--- a/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.cs
@@ -131,7 +131,7 @@ namespace Playground
 
 			// Option 1: Ad-hoc hosting of Navigation
 			var f = new Frame();
-			f.AttachServices(Host.Services);
+			f.AttachServiceProvider(Host.Services);
 			_window.Content = f;
 			f.Navigate(typeof(MainPage));
 
@@ -143,7 +143,7 @@ namespace Playground
 			//	HorizontalContentAlignment = HorizontalAlignment.Stretch,
 			//	VerticalContentAlignment = VerticalAlignment.Stretch
 			//};
-			//root.AttachServices(Host.Services);
+			//root.AttachServiceProvider(Host.Services);
 			//_window.Content = root;
 			//root.Host(initialRoute: "Shell");
 

--- a/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.cs
@@ -12,6 +12,7 @@ using Uno.Extensions.Hosting;
 using Uno.Extensions.Logging;
 using Uno.Extensions.Navigation;
 using Uno.Extensions.Navigation.Toolkit;
+using Uno.Extensions.Navigation.UI;
 using Uno.Extensions.Serialization;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
@@ -122,14 +123,35 @@ namespace Playground
 			_window = Window.Current;
 #endif
 
-			_window.Content = Host.Services.NavigationHost(
-				// Option 1: This requires Shell to be the first RouteMap - best for perf as no reflection required
-				// initialRoute: ""
-				// Option 2: Specify route name
-				// initialRoute: "Shell"
-				// Option 3: Specify the view model. To avoid reflection, you can still define a routemap
-				initialViewModel: typeof(ShellViewModel)
-				);
+			// Option 1: Ad-hoc hosting of Navigation
+			var f = new Frame();
+			f.AttachServices(Host.Services);
+			_window.Content = f;
+			f.Navigate(typeof(MainPage));
+
+			// Option 2: Ad-hoc hosting using root content control
+			//var root = new ContentControl
+			//{
+			//	HorizontalAlignment = HorizontalAlignment.Stretch,
+			//	VerticalAlignment = VerticalAlignment.Stretch,
+			//	HorizontalContentAlignment = HorizontalAlignment.Stretch,
+			//	VerticalContentAlignment = VerticalAlignment.Stretch
+			//};
+			//root.AttachServices(Host.Services);
+			//_window.Content = root;
+			//root.Host(initialRoute: "Shell");
+
+			// Option 3: Default hosting
+			//_window.Content = Host.Services.NavigationHost(
+			//	// Option 1: This requires Shell to be the first RouteMap - best for perf as no reflection required
+			//	// initialRoute: ""
+			//	// Option 2: Specify route name
+			//	// initialRoute: "Shell"
+			//	// Option 3: Specify the view model. To avoid reflection, you can still define a routemap
+			//	initialViewModel: typeof(ShellViewModel)
+			//	);
+
+
 			_window.Activate();
 
 			await Task.Run(()=>Host.StartAsync());

--- a/samples/Playground/Playground/Playground/Playground.Shared/Playground.Shared.projitems
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Playground.Shared.projitems
@@ -25,6 +25,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)ViewModels\FourthViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModels\HomeViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModels\ShellViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Views\AlternatePage.xaml.cs">
+      <DependentUpon>AlternatePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Views\ComplexDialog.xaml.cs">
       <DependentUpon>ComplexDialog.xaml</DependentUpon>
     </Compile>
@@ -46,6 +49,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Views\HomePage.xaml.cs">
       <DependentUpon>HomePage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Views\MainPage.xaml.cs">
+      <DependentUpon>MainPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Views\SecondPage.xaml.cs">
       <DependentUpon>SecondPage.xaml</DependentUpon>
     </Compile>
@@ -64,6 +70,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)_Compat\IsExternalInit.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)Views\AlternatePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Views\ComplexDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -89,6 +99,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Views\HomePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Views\MainPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/samples/Playground/Playground/Playground/Playground.Shared/Playground.Shared.shproj
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Playground.Shared.shproj
@@ -14,5 +14,11 @@
     <_Globbed_Compile Remove="Models\AppInfo.cs" />
     <_Globbed_Compile Remove="Services\SimpleStartupService.cs" />
     <_Globbed_Compile Remove="ViewModels\HomeViewModel.cs" />
+    <_Globbed_Compile Remove="Views\AlternatePage.xaml.cs" />
+    <_Globbed_Compile Remove="Views\MainPage.xaml.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <_Globbled_Page Remove="Views\AlternatePage.xaml" />
+    <_Globbled_Page Remove="Views\MainPage.xaml" />
   </ItemGroup>
 </Project>

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/AlternatePage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/AlternatePage.xaml
@@ -18,7 +18,7 @@
 						VerticalAlignment="Stretch"
 						HorizontalContentAlignment="Stretch"
 						VerticalContentAlignment="Stretch"
-						uen:Region.Host="Shell" />
+						uen:Region.Attached="true" />
 		<StackPanel Orientation="Horizontal"
 					Grid.Row="1">
 			<Button Content="Back to Main"

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/AlternatePage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/AlternatePage.xaml
@@ -1,0 +1,28 @@
+﻿<Page
+    x:Class="Playground.Views.AlternatePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Playground.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<ContentControl HorizontalAlignment="Stretch"
+						VerticalAlignment="Stretch"
+						HorizontalContentAlignment="Stretch"
+						VerticalContentAlignment="Stretch"
+						uen:Region.Host="Shell" />
+		<StackPanel Orientation="Horizontal"
+					Grid.Row="1">
+			<Button Content="Back to Main"
+					Click="BackClick" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/AlternatePage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/AlternatePage.xaml.cs
@@ -1,0 +1,16 @@
+﻿namespace Playground.Views
+{
+	public sealed partial class AlternatePage : Page
+    {
+        public AlternatePage()
+        {
+            this.InitializeComponent();
+        }
+
+		private void BackClick(object sender, RoutedEventArgs e)
+		{
+			this.Frame.GoBack();
+		}
+
+	}
+}

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/MainPage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/MainPage.xaml
@@ -1,0 +1,28 @@
+﻿<Page x:Class="Playground.Views.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Playground.Views"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  mc:Ignorable="d"
+	  NavigationCacheMode="Required"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<ContentControl HorizontalAlignment="Stretch"
+						VerticalAlignment="Stretch"
+						HorizontalContentAlignment="Stretch"
+						VerticalContentAlignment="Stretch"
+						uen:Region.Host="Shell" />
+		<StackPanel Orientation="Horizontal"
+					Grid.Row="1">
+			<Button Content="Alternate Host"
+					Click="AlternateClick" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/MainPage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/MainPage.xaml
@@ -18,7 +18,7 @@
 						VerticalAlignment="Stretch"
 						HorizontalContentAlignment="Stretch"
 						VerticalContentAlignment="Stretch"
-						uen:Region.Host="Shell" />
+						uen:Region.Attached="true" />
 		<StackPanel Orientation="Horizontal"
 					Grid.Row="1">
 			<Button Content="Alternate Host"

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/MainPage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/MainPage.xaml.cs
@@ -1,0 +1,15 @@
+﻿namespace Playground.Views
+{
+	public sealed partial class MainPage : Page
+    {
+        public MainPage()
+        {
+            this.InitializeComponent();
+        }
+
+		private void AlternateClick(object sender, RoutedEventArgs e)
+		{
+			this.Frame.Navigate(typeof(AlternatePage));
+		}
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/DependencyObjectExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/DependencyObjectExtensions.cs
@@ -16,7 +16,12 @@ public static class DependencyObjectExtensions
         return element.ServiceForControl(true, element => element.GetInstance());
     }
 
-    public static IRegion? FindParentRegion(this FrameworkElement element, out string routeName)
+	public static IServiceProvider? FindServiceProvider(this FrameworkElement element)
+	{
+		return element.ServiceForControl(true, element => element.GetServiceProvider());
+	}
+
+	public static IRegion? FindParentRegion(this FrameworkElement element, out string routeName)
     {
         var name = element?.GetName() ?? string.Empty;
 

--- a/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
@@ -6,7 +6,7 @@ namespace Uno.Extensions.Navigation;
 
 public static class FrameworkElementExtensions
 {
-	public static void AttachServices(this FrameworkElement element, IServiceProvider services)
+	public static void AttachServiceProvider(this FrameworkElement element, IServiceProvider services)
 	{
 		element.SetServiceProvider(services);
 	}

--- a/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
@@ -35,15 +35,15 @@ public static class FrameworkElementExtensions
 			var start = () => Task.CompletedTask;
 			if (initialView is not null)
 			{
-				start = () => nav.NavigateViewAsync(root, initialView, scheme: Schemes.ChangeContent);
+				start = () => nav.NavigateViewAsync(root, initialView, qualifier: Qualifiers.ChangeContent);
 			}
 			else if (initialViewModel is not null)
 			{
-				start = () => nav.NavigateViewModelAsync(root, initialViewModel, scheme: Schemes.ChangeContent);
+				start = () => nav.NavigateViewModelAsync(root, initialViewModel, qualifier: Qualifiers.ChangeContent);
 			}
 			else
 			{
-				start = () => nav.NavigateRouteAsync(root, initialRoute ?? string.Empty, scheme: Schemes.ChangeContent);
+				start = () => nav.NavigateRouteAsync(root, initialRoute ?? string.Empty, qualifier: Qualifiers.ChangeContent);
 			}
 			elementRegion.Services?.Startup(start);
 		}

--- a/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
@@ -27,7 +27,6 @@ public static class FrameworkElementExtensions
 
 		// Create the Root region
 		var elementRegion = new NavigationRegion(root, services);
-		root.SetInstance(elementRegion);
 
 		var nav = elementRegion.Navigator();
 		if (nav is not null)
@@ -49,7 +48,7 @@ public static class FrameworkElementExtensions
 		}
 	}
 
-	private static async Task Startup(this IServiceProvider services, Func<Task> afterStartup)
+	public static async Task Startup(this IServiceProvider services, Func<Task> afterStartup)
 	{
 		var startupServices = services.GetServices<IHostedService>().Select(x => x as IStartupService).Where(x => x is not null)
 								.Union(services.GetServices<IStartupService>()).ToArray();

--- a/src/Uno.Extensions.Navigation.UI/IRouteNotifier.cs
+++ b/src/Uno.Extensions.Navigation.UI/IRouteNotifier.cs
@@ -2,6 +2,6 @@
 
 public interface IRouteNotifier
 {
-	event EventHandler RouteChanged;
+	event EventHandler<RouteChangedEventArgs> RouteChanged;
 }
 

--- a/src/Uno.Extensions.Navigation.UI/IRouteUpdater.cs
+++ b/src/Uno.Extensions.Navigation.UI/IRouteUpdater.cs
@@ -2,8 +2,8 @@
 
 internal interface IRouteUpdater
 {
-	void StartNavigation();
+	void StartNavigation(IRegion region);
 
-	void EndNavigation();
+	void EndNavigation(IRegion region);
 }
 

--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -33,7 +33,7 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 		if (Logger.IsEnabled(LogLevel.Information)) Logger.LogInformation($"Pre-navigation: - {Region.Root().ToString()}");
 		try
 		{
-			RouteUpdater?.StartNavigation();
+			RouteUpdater?.StartNavigation(Region);
 
 			request = InitialiseRequest(request);
 
@@ -119,7 +119,7 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 		{
 			if (Logger.IsEnabled(LogLevel.Information)) Logger.LogInformation($"Post-navigation: {Region.Root().ToString()}");
 			if (Logger.IsEnabled(LogLevel.Information)) Logger.LogInformation($"Post-navigation (route): {Region.Root().GetRoute()}");
-			RouteUpdater?.EndNavigation();
+			RouteUpdater?.EndNavigation(Region);
 		}
 	}
 

--- a/src/Uno.Extensions.Navigation.UI/Region.cs
+++ b/src/Uno.Extensions.Navigation.UI/Region.cs
@@ -46,15 +46,6 @@ public static class Region
 			typeof(Region),
 			new PropertyMetadata(null));
 
-	public static readonly DependencyProperty HostProperty =
-	   DependencyProperty.RegisterAttached(
-		   "Host",
-		   typeof(string),
-		   typeof(FrameworkElementExtensions),
-		   new PropertyMetadata(null, HostPropertyChanged));
-
-	
-
 	private static void AttachedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 	{
 		if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
@@ -72,7 +63,6 @@ public static class Region
 	{
 		var existingRegion = Region.GetInstance(element);
 		var region = existingRegion ?? new NavigationRegion(element);
-		element.SetInstance(region);
 	}
 
 	public static void SetInstance(this DependencyObject element, IRegion? value)
@@ -157,23 +147,5 @@ public static class Region
 	public static IServiceProvider GetServiceProvider(this DependencyObject element)
 	{
 		return (IServiceProvider)element.GetValue(ServiceProviderProperty);
-	}
-
-	private static async void HostPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
-	{
-		if (dependencyObject is FrameworkElement element)
-		{
-			await element.HostAsync(initialRoute: args.NewValue as string);
-		}
-	}
-
-	public static void SetHost(this DependencyObject element, string value)
-	{
-		element.SetValue(HostProperty, value);
-	}
-
-	public static string GetHost(this DependencyObject element)
-	{
-		return (string)element.GetValue(HostProperty);
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/Region.cs
+++ b/src/Uno.Extensions.Navigation.UI/Region.cs
@@ -8,36 +8,52 @@ public static class Region
 	   DependencyProperty.RegisterAttached(
 		   "Instance",
 		   typeof(IRegion),
-		   typeof(Navigation),
+		   typeof(Region),
 		   new PropertyMetadata(null));
 
 	public static readonly DependencyProperty AttachedProperty =
 		DependencyProperty.RegisterAttached(
 			"Attached",
 			typeof(bool),
-			typeof(Navigation),
+			typeof(Region),
 			new PropertyMetadata(false, AttachedChanged));
 
 	public static readonly DependencyProperty ParentProperty =
 		DependencyProperty.RegisterAttached(
 			"Parent",
 			typeof(FrameworkElement),
-			typeof(Navigation),
+			typeof(Region),
 			new PropertyMetadata(null));
 
 	public static readonly DependencyProperty NameProperty =
 		DependencyProperty.RegisterAttached(
 			"Name",
 			typeof(string),
-			typeof(Navigation),
+			typeof(Region),
 			new PropertyMetadata(null));
 
 	public static readonly DependencyProperty NavigatorProperty =
 		DependencyProperty.RegisterAttached(
 			"Navigator",
 			typeof(string),
-			typeof(Navigation),
+			typeof(Region),
 			new PropertyMetadata(null));
+
+	public static readonly DependencyProperty ServiceProviderProperty =
+		DependencyProperty.RegisterAttached(
+			"ServiceProvider",
+			typeof(IServiceProvider),
+			typeof(Region),
+			new PropertyMetadata(null));
+
+	public static readonly DependencyProperty HostProperty =
+	   DependencyProperty.RegisterAttached(
+		   "Host",
+		   typeof(string),
+		   typeof(FrameworkElementExtensions),
+		   new PropertyMetadata(null, HostPropertyChanged));
+
+	
 
 	private static void AttachedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 	{
@@ -131,5 +147,33 @@ public static class Region
 	public static string GetNavigator(this FrameworkElement element)
 	{
 		return (string)element.GetValue(NavigatorProperty);
+	}
+
+	public static void SetServiceProvider(this DependencyObject element, IServiceProvider value)
+	{
+		element.SetValue(ServiceProviderProperty, value);
+	}
+
+	public static IServiceProvider GetServiceProvider(this DependencyObject element)
+	{
+		return (IServiceProvider)element.GetValue(ServiceProviderProperty);
+	}
+
+	private static async void HostPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+	{
+		if (dependencyObject is FrameworkElement element)
+		{
+			await element.HostAsync(initialRoute: args.NewValue as string);
+		}
+	}
+
+	public static void SetHost(this DependencyObject element, string value)
+	{
+		element.SetValue(HostProperty, value);
+	}
+
+	public static string GetHost(this DependencyObject element)
+	{
+		return (string)element.GetValue(HostProperty);
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/RouteChangedEventArgs.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteChangedEventArgs.cs
@@ -1,0 +1,12 @@
+﻿namespace Uno.Extensions.Navigation;
+
+public class RouteChangedEventArgs : EventArgs
+{
+	public IRegion Region { get; }
+
+	public RouteChangedEventArgs(IRegion region)
+	{
+		Region = region;
+	}
+}
+

--- a/src/Uno.Extensions.Navigation.UI/RouteNotifier.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteNotifier.cs
@@ -5,7 +5,7 @@ namespace Uno.Extensions.Navigation;
 
 public class RouteNotifier : IRouteNotifier, IRouteUpdater
 {
-	public event EventHandler? RouteChanged;
+	public event EventHandler<RouteChangedEventArgs>? RouteChanged;
 
 	private ILogger Logger { get; }
 	public RouteNotifier(ILogger<RouteNotifier> logger)
@@ -13,27 +13,38 @@ public class RouteNotifier : IRouteNotifier, IRouteUpdater
 		Logger = logger;
 	}
 
-	private int runningNavigations;
+	private IDictionary<IRegion, int> runningNavigations = new Dictionary<IRegion, int>();
+	private IDictionary<IRegion, Stopwatch> timers = new Dictionary<IRegion, Stopwatch>();
 
-	private Stopwatch Timer { get; } = new();
-
-	public void StartNavigation()
+	public void StartNavigation(IRegion region)
 	{
-		if(runningNavigations == 0)
+		region = region.Root();
+
+		if (!runningNavigations.TryGetValue(region, out var count) ||
+			count == 0)
 		{
-			Timer.Restart();
+			runningNavigations[region] = 1;
+			var timer = new Stopwatch();
+			timers[region] = timer;
+			timer.Start();
 		}
-		runningNavigations++;
+		else
+		{
+			runningNavigations[region] = runningNavigations[region] + 1;
+			timers[region].Restart();
+		}
 	}
 
-	public void EndNavigation()
+	public void EndNavigation(IRegion region)
 	{
-		runningNavigations--;
-		if (runningNavigations == 0)
+		region = region.Root();
+		runningNavigations[region] = runningNavigations[region] - 1;
+
+		if (runningNavigations[region] == 0)
 		{
-			Timer.Stop();
-			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Elapsed navigation: {Timer.ElapsedMilliseconds}");
-			RouteChanged?.Invoke(this, EventArgs.Empty);
+			timers[region].Stop();
+			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Elapsed navigation: {timers[region].ElapsedMilliseconds}");
+			RouteChanged?.Invoke(this, new RouteChangedEventArgs(region));
 		}
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
@@ -15,7 +15,9 @@ public class RouteResolver : IRouteResolver
 
 		if (maps is not null)
 		{
-			First = maps.FirstOrDefault();
+			// Set the first routemap to be either the first with IsDefault, if
+			// if none have IsDefault then just return the first
+			First = maps.FirstOrDefault(x=>x.IsDefault)?? maps.FirstOrDefault();
 			maps.Flatten().ForEach(route => Mappings[route.Path] = route);
 		}
 

--- a/src/Uno.Extensions.Navigation/Route.cs
+++ b/src/Uno.Extensions.Navigation/Route.cs
@@ -11,7 +11,7 @@ public record Route(string Qualifier, string? Base = null, string? Path = null, 
 
 	public static Route PageRoute(Type pageType) => PageRoute(pageType.Name);
 
-	public static Route PageRoute(string path) => new Route(Qualifiers.NavigateForward, path, null, null);
+	public static Route PageRoute(string path) => new Route(Qualifiers.None, path, null, null);
 
 	public static Route NestedRoute<TView>() => NestedRoute(typeof(TView));
 

--- a/src/Uno.Extensions.Navigation/Schemes.cs
+++ b/src/Uno.Extensions.Navigation/Schemes.cs
@@ -10,6 +10,5 @@ public static class Qualifiers
 	public const string Parent = "../../";
 	public const string Dialog = "!";
 	public const string NavigateBack = "-";
-	public const string NavigateForward = "+";
 	public const string ClearBackStack = "-/";
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #275 

## PR Type

What kind of change does this PR introduce?
- Feature
- 
## What is the current behavior?

Navigation is setup in app.xaml.cs using the NavigationHost method to define the root element of the application.

## What is the new behavior?

The NavigationHost method is still supported. However, it's now possible to attach navigation to any page by adding a ContentControl and setting the Region.Host property eg

```csharp
    <ContentControl uen:Region.Host="Shell" />
```

The string is the name of the route to load by default. The Host property can be set to "" in order to use the first route in the routemap table.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
