### PR TITLE
chore: Trimming/Updating LinkerConfig for commerce app and templates 

### DIFF
--- a/samples/Commerce/Commerce.Shared/App.xaml.cs
+++ b/samples/Commerce/Commerce.Shared/App.xaml.cs
@@ -287,21 +287,21 @@ namespace Commerce
 #endif
 
 
-#if __WASM__
-				// Note: This is a hack to avoid error being thrown when loading products async
-				await Task.Delay(1000).ConfigureAwait(false);
-				CoreApplication.MainView?.DispatcherQueue.TryEnqueue(() =>
-				{
-					var href = WebAssemblyRuntime.InvokeJS("window.location.href");
-					var url = new UriBuilder(href);
-					url.Query = route.Query();
-					url.Path = route.FullPath()?.Replace("+", "/");
-					var webUri = url.Uri.OriginalString;
-					var js = $"window.history.pushState(\"{webUri}\",\"\", \"{webUri}\");";
-					Console.WriteLine($"JS:{js}");
-					var result = WebAssemblyRuntime.InvokeJS(js);
-				});
-#endif
+//#if __WASM__
+//				// Note: This is a hack to avoid error being thrown when loading products async
+//				await Task.Delay(1000).ConfigureAwait(false);
+//				CoreApplication.MainView?.DispatcherQueue.TryEnqueue(() =>
+//				{
+//					var href = WebAssemblyRuntime.InvokeJS("window.location.href");
+//					var url = new UriBuilder(href);
+//					url.Query = route.Query();
+//					url.Path = route.FullPath()?.Replace("+", "/");
+//					var webUri = url.Uri.OriginalString;
+//					var js = $"window.history.pushState(\"{webUri}\",\"\", \"{webUri}\");";
+//					Console.WriteLine($"JS:{js}");
+//					var result = WebAssemblyRuntime.InvokeJS(js);
+//				});
+//#endif
 			}
 			catch (Exception ex)
 			{

--- a/samples/Commerce/Commerce.Shared/App.xaml.cs
+++ b/samples/Commerce/Commerce.Shared/App.xaml.cs
@@ -95,7 +95,9 @@ namespace Commerce
 
 
 					// Enable navigation, including registering views and viewmodels
-					.UseNavigation(RegisterRoutes)
+					.UseNavigation(
+						RegisterRoutes,
+						config => config with { AddressBarUpdateEnabled = true })
 
 					// Add navigation support for toolkit controls such as TabBar and NavigationView
 					.UseToolkitNavigation()
@@ -176,7 +178,7 @@ namespace Commerce
 					Title: "Forgot your password!",
 					DelayUserInput: true,
 					DefaultButtonIndex: 1,
-					Buttons:new DialogAction[]
+					Buttons: new DialogAction[]
 					{
 						new(Label: "Yeh!",Id:"Y"),
 						new(Label: "Nah", Id:"N")

--- a/samples/Commerce/Commerce.Shared/App.xaml.cs
+++ b/samples/Commerce/Commerce.Shared/App.xaml.cs
@@ -8,20 +8,14 @@ using Commerce.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Uno.Extensions;
 using Uno.Extensions.Configuration;
 using Uno.Extensions.Hosting;
 using Uno.Extensions.Logging;
 using Uno.Extensions.Navigation;
-using Uno.Extensions.Navigation.UI;
 using Uno.Extensions.Navigation.Regions;
 using Uno.Extensions.Navigation.Toolkit;
 using Uno.Extensions.Serialization;
-using Uno.Foundation;
 using Commerce.Views;
-using Uno.Extensions.Logging.Serilog;
-using Uno.Extensions.Navigation.UI.Controls;
-using Uno.Extensions.Navigation.Toolkit.Controls;
 
 #if WINUI
 using Windows.ApplicationModel;
@@ -36,11 +30,8 @@ using Window = Microsoft.UI.Xaml.Window;
 using CoreApplication = Windows.ApplicationModel.Core.CoreApplication;
 #else
 using Windows.ApplicationModel;
-using Windows.ApplicationModel.Activation;
-using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 using LaunchActivatedEventArgs = Windows.ApplicationModel.Activation.LaunchActivatedEventArgs;
 using Window = Windows.UI.Xaml.Window;
@@ -286,22 +277,6 @@ namespace Commerce
 				});
 #endif
 
-
-//#if __WASM__
-//				// Note: This is a hack to avoid error being thrown when loading products async
-//				await Task.Delay(1000).ConfigureAwait(false);
-//				CoreApplication.MainView?.DispatcherQueue.TryEnqueue(() =>
-//				{
-//					var href = WebAssemblyRuntime.InvokeJS("window.location.href");
-//					var url = new UriBuilder(href);
-//					url.Query = route.Query();
-//					url.Path = route.FullPath()?.Replace("+", "/");
-//					var webUri = url.Uri.OriginalString;
-//					var js = $"window.history.pushState(\"{webUri}\",\"\", \"{webUri}\");";
-//					Console.WriteLine($"JS:{js}");
-//					var result = WebAssemblyRuntime.InvokeJS(js);
-//				});
-//#endif
 			}
 			catch (Exception ex)
 			{

--- a/samples/Commerce/UWP/Commerce.Wasm/LinkerConfig.xml
+++ b/samples/Commerce/UWP/Commerce.Wasm/LinkerConfig.xml
@@ -1,35 +1,7 @@
 <linker>
   <assembly fullname="Commerce.Wasm" />
 	<assembly fullname="Uno.UI" />
-	<assembly fullname="Uno.Extensions.Core" />
-	<assembly fullname="Uno.Extensions.Configuration" />
-	<assembly fullname="Uno.Extensions.Hosting" />
-	<assembly fullname="Uno.Extensions.Hosting.UWP.Wasm" />
-	<assembly fullname="Uno.Extensions.Http" />
-	<!--<assembly fullname="Uno.Extensions.Http.Refit" />-->
-	<assembly fullname="Uno.Extensions.Localization" />
-	<assembly fullname="Uno.Extensions.Logging" />
-	<assembly fullname="Uno.Extensions.Logging.Serilog" />
-	<assembly fullname="Uno.Extensions.Logging.UWP.Wasm" />
-	<assembly fullname="Uno.Extensions.Navigation" />
-	<assembly fullname="Uno.Extensions.Navigation.Toolkit.UI" />
-	<assembly fullname="Uno.Extensions.Navigation.UI" />
-	<assembly fullname="Uno.Extensions.Serialization" />
-	<assembly fullname="Uno.Extensions.Reactive" />
-	<assembly fullname="Uno.Extensions.Reactive.UI" />
-	<assembly fullname="Uno.Extensions.Serialization" />
-	<assembly fullname="Uno.Extensions.Serialization.Http" />
-	<assembly fullname="Uno.Extensions.Serialization.Refit" />
-	<assembly fullname="Serilog.Sinks.Console" />
-	<assembly fullname="Serilog.Sinks.Debug" />
-	<assembly fullname="Serilog.Sinks.File" />
-	<assembly fullname="Microsoft.Extensions.Options" />
-	<assembly fullname="Microsoft.Extensions.Hosting" />
-	<assembly fullname="Microsoft.Extensions.Logging" />
-	<assembly fullname="Microsoft.Extensions.Logging.Configuration" />
-	<assembly fullname="Microsoft.Extensions.Logging.Console" />
-	<assembly fullname="Microsoft.Extensions.Logging.Debug" />
-	<assembly fullname="Microsoft.Extensions.Logging.EventSource" />
+
 
   <assembly fullname="System.Core">
 	<!-- This is required by JSon.NET and any expression.Compile caller -->

--- a/samples/Commerce/WinUI/Commerce.Wasm/LinkerConfig.xml
+++ b/samples/Commerce/WinUI/Commerce.Wasm/LinkerConfig.xml
@@ -1,35 +1,7 @@
 <linker>
   <assembly fullname="Commerce.Wasm" />
  	<assembly fullname="Uno.WinUI" />
-	<assembly fullname="Uno.Extensions.Core" />
-	<assembly fullname="Uno.Extensions.Configuration" />
-	<assembly fullname="Uno.Extensions.Hosting" />
-	<assembly fullname="Uno.Extensions.Hosting.WinUI.Wasm" />
-	<assembly fullname="Uno.Extensions.Http" />
-	<!--<assembly fullname="Uno.Extensions.Http.Refit" />-->
-	<assembly fullname="Uno.Extensions.Localization" />
-	<assembly fullname="Uno.Extensions.Logging" />
-	<assembly fullname="Uno.Extensions.Logging.Serilog" />
-	<assembly fullname="Uno.Extensions.Logging.WinUI.Wasm" />
-	<assembly fullname="Uno.Extensions.Navigation" />
-	<assembly fullname="Uno.Extensions.Navigation.Toolkit.WinUI" />
-	<assembly fullname="Uno.Extensions.Navigation.WinUI" />
-	<assembly fullname="Uno.Extensions.Serialization" />
-	<assembly fullname="Uno.Extensions.Reactive" />
-	<assembly fullname="Uno.Extensions.Reactive.WinUI" />
-	<assembly fullname="Uno.Extensions.Serialization" />
-	<assembly fullname="Uno.Extensions.Serialization.Http" />
-	<assembly fullname="Uno.Extensions.Serialization.Refit" />
-	<assembly fullname="Serilog.Sinks.Console" />
-	<assembly fullname="Serilog.Sinks.Debug" />
-	<assembly fullname="Serilog.Sinks.File" />
-	<assembly fullname="Microsoft.Extensions.Options" />
-	<assembly fullname="Microsoft.Extensions.Hosting" />
-	<assembly fullname="Microsoft.Extensions.Logging" />
-	<assembly fullname="Microsoft.Extensions.Logging.Configuration" />
-	<assembly fullname="Microsoft.Extensions.Logging.Console" />
-	<assembly fullname="Microsoft.Extensions.Logging.Debug" />
-	<assembly fullname="Microsoft.Extensions.Logging.EventSource" />
+
 
   <assembly fullname="System.Core">
 	<!-- This is required by JSon.NET and any expression.Compile caller -->

--- a/src/Uno.Extensions.Hosting.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Hosting.UI/GlobalUsings.cs
@@ -15,4 +15,6 @@ global using Microsoft.Extensions.Options;
 global using Uno.Extensions.Storage;
 global using Uno.Extensions.Hosting.Internal;
 global using Windows.Storage;
+global using Windows.ApplicationModel.Core;
+
 

--- a/src/Uno.Extensions.Hosting.UI/UnoHost.cs
+++ b/src/Uno.Extensions.Hosting.UI/UnoHost.cs
@@ -18,12 +18,16 @@ public static class UnoHost
 				{
 					services.AddSingleton(appHost);
 				}
+				if (ctx.HostingEnvironment is IHasAddressBar addressBarHost)
+				{
+					services.AddSingleton(addressBarHost);
+				}
 				services.AddSingleton<IStorageProxy, StorageProxy>();
 			})
 #if __WASM__
 				.ConfigureHostConfiguration(config =>
 				{
-					if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("UNO_BOOTSTRAP_MONO_RUNTIME_MODE")))
+					if (Foundation.WebAssemblyRuntime.IsWebAssembly)
 					{
 						var href = Foundation.WebAssemblyRuntime.InvokeJS("window.location.href");
 						var appsettingsPrefix = new Dictionary<string, string>

--- a/src/Uno.Extensions.Hosting/IHasAddressBar.cs
+++ b/src/Uno.Extensions.Hosting/IHasAddressBar.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Uno.Extensions.Hosting;
+
+public interface IHasAddressBar
+{
+	Task UpdateAddressBar(Uri applicationUri);
+}

--- a/src/Uno.Extensions.Navigation.UI/BrowserAddressBarService.cs
+++ b/src/Uno.Extensions.Navigation.UI/BrowserAddressBarService.cs
@@ -1,0 +1,61 @@
+﻿using Uno.Extensions.Hosting;
+
+namespace Uno.Extensions.Navigation;
+
+internal class BrowserAddressBarService : IHostedService
+{
+	private readonly IRouteNotifier _notifier;
+	private readonly IHasAddressBar? _addressbarHost;
+	public BrowserAddressBarService(
+		IRouteNotifier notifier,
+		IHasAddressBar? host = null)
+	{
+		_notifier = notifier;
+		_addressbarHost = host;
+	}
+
+
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
+		if (_addressbarHost is not null)
+		{
+			_notifier.RouteChanged += RouteChanged;
+		}
+
+		return Task.CompletedTask;
+	}
+
+	public Task StopAsync(CancellationToken cancellationToken)
+	{
+		if (_addressbarHost is not null)
+		{
+			_notifier.RouteChanged -= RouteChanged;
+		}
+
+		return Task.CompletedTask;
+	}
+
+
+	private async void RouteChanged(object sender, RouteChangedEventArgs e)
+	{
+		try
+		{
+			var rootRegion = e.Region.Root();
+			var route = rootRegion.GetRoute();
+			if (route is null)
+			{
+				return;
+			}
+
+			var url = new UriBuilder();
+			url.Query = route.Query();
+			url.Path = route.FullPath()?.Replace("+", "/");
+			await _addressbarHost!.UpdateAddressBar(url.Uri);
+
+		}
+		catch (Exception ex)
+		{
+			Console.WriteLine("Error: " + ex.Message);
+		}
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/BrowserAddressBarService.cs
+++ b/src/Uno.Extensions.Navigation.UI/BrowserAddressBarService.cs
@@ -6,18 +6,21 @@ internal class BrowserAddressBarService : IHostedService
 {
 	private readonly IRouteNotifier _notifier;
 	private readonly IHasAddressBar? _addressbarHost;
+	private readonly NavigationConfig? _config;
 	public BrowserAddressBarService(
 		IRouteNotifier notifier,
+		NavigationConfig? config,
 		IHasAddressBar? host = null)
 	{
 		_notifier = notifier;
 		_addressbarHost = host;
+		_config = config;
 	}
 
 
 	public Task StartAsync(CancellationToken cancellationToken)
 	{
-		if (_addressbarHost is not null)
+		if (_addressbarHost is not null && (_config?.AddressBarUpdateEnabled??true))
 		{
 			_notifier.RouteChanged += RouteChanged;
 		}

--- a/src/Uno.Extensions.Navigation.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/HostBuilderExtensions.cs
@@ -4,12 +4,13 @@ public static class HostBuilderExtensions
 {
 	public static IHostBuilder UseNavigation(
 			this IHostBuilder builder,
-			Action<IViewRegistry, IRouteRegistry>? viewRouteBuilder = null)
+			Action<IViewRegistry, IRouteRegistry>? viewRouteBuilder = null,
+						Func<NavigationConfig, NavigationConfig>? configure = null)
 	{
 		return builder
 			.ConfigureServices(sp =>
 			{
-				_ = sp.AddNavigation(viewRouteBuilder);
+				_ = sp.AddNavigation(configure, viewRouteBuilder);
 			});
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Uno.Extensions.Navigation.Navigators;
+﻿using Microsoft.Extensions.Options;
+using Uno.Extensions.Navigation.Navigators;
 using Uno.Extensions.Navigation.Regions;
 using Uno.Extensions.Navigation.UI;
 using Uno.Extensions.Navigation.UI.Controls;
@@ -10,13 +11,29 @@ public static class ServiceCollectionExtensions
 {
 	public static IServiceCollection AddNavigation(
 		this IServiceCollection services,
+		Func<NavigationConfig, NavigationConfig>? configure = null,
 		Action<IViewRegistry, IRouteRegistry>? routeBuilder = null)
 	{
+		var navConfig = new NavigationConfig();
+		navConfig = (configure?.Invoke(navConfig)) ?? navConfig;
+
 		var views = new ViewRegistry();
 		var routes = new RouteRegistry(services, views);
 		routeBuilder?.Invoke(views, routes);
 
 		return services
+					.AddSingleton<NavigationConfig>(sp =>
+					{
+						var config = new NavigationConfig(RouteResolver: typeof(RouteResolverDefault), AddressBarUpdateEnabled: true);
+						//RouteResolver: typeof(RouteResolverDefault), AddressBarUpdateEnabled: true
+						var inputConfig = sp.GetService<IOptions<NavigationConfig>>()?.Value;
+						config = config with
+						{
+							RouteResolver = (navConfig?.RouteResolver) ?? (inputConfig?.RouteResolver) ?? config.RouteResolver,
+							AddressBarUpdateEnabled = (navConfig?.AddressBarUpdateEnabled) ?? (inputConfig?.AddressBarUpdateEnabled) ?? config.AddressBarUpdateEnabled,
+						};
+						return config;
+					})
 					.AddScoped<IInstanceRepository, InstanceRepository>()
 					.AddSingleton<IResponseNavigatorFactory, ResponseNavigatorFactory>()
 
@@ -48,8 +65,13 @@ public static class ServiceCollectionExtensions
 					.AddSingleton<IViewResolver, ViewResolver>()
 
 					.AddSingleton<IRouteRegistry>(routes)
+					.AddSingleton<RouteResolver>()
 					.AddSingleton<RouteResolverDefault>()
-					.AddSingleton<IRouteResolver>(sp => sp.GetRequiredService<RouteResolverDefault>())
+					.AddSingleton<IRouteResolver>(sp =>
+					{
+						var config = sp.GetRequiredService<NavigationConfig>();
+						return (sp.GetRequiredService(config.RouteResolver!) as IRouteResolver)!;
+					})
 
 					.AddSingleton<IResolver, Resolver>()
 

--- a/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class ServiceCollectionExtensions
 					.AddSingleton<RouteNotifier>()
 					.AddSingleton<IRouteNotifier>(sp => sp.GetRequiredService<RouteNotifier>())
 					.AddSingleton<IRouteUpdater>(sp => sp.GetRequiredService<RouteNotifier>())
+					.AddHostedService<BrowserAddressBarService>()
 					.AddScoped<Navigator>()
 
 					.AddTransient<Flyout, NavigationFlyout>()

--- a/src/Uno.Extensions.Navigation/NavigationConfig.cs
+++ b/src/Uno.Extensions.Navigation/NavigationConfig.cs
@@ -1,0 +1,6 @@
+﻿namespace Uno.Extensions.Navigation;
+
+public record NavigationConfig (Type? RouteResolver = null, bool? AddressBarUpdateEnabled=null)
+{
+	public NavigationConfig(): this(null,null) { }
+}

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions-net6/MyExtensionsApp.Wasm/LinkerConfig.xml
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions-net6/MyExtensionsApp.Wasm/LinkerConfig.xml
@@ -1,4 +1,5 @@
 <linker>
+  <assembly fullname="MyExtensionsApp" />
   <assembly fullname="MyExtensionsApp.Wasm" />
   <assembly fullname="Uno.UI" />
   <assembly fullname="Microsoft.Extensions.Options" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.UI/App.xaml.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.UI/App.xaml.cs
@@ -173,22 +173,6 @@ public sealed partial class App : Application
 			});
 #endif
 
-
-#if __WASM__
-			// Note: This is a hack to avoid error being thrown when loading products async
-			await Task.Delay(1000).ConfigureAwait(false);
-			CoreApplication.MainView?.DispatcherQueue.TryEnqueue(() =>
-			{
-				var href = WebAssemblyRuntime.InvokeJS("window.location.href");
-				var url = new UriBuilder(href);
-				url.Query = route?.Query();
-				url.Path = route?.FullPath()?.Replace("+", "/");
-				var webUri = url.Uri.OriginalString;
-				var js = $"window.history.pushState(\"{webUri}\",\"\", \"{webUri}\");";
-				Console.WriteLine($"JS:{js}");
-				var result = WebAssemblyRuntime.InvokeJS(js);
-			});
-#endif
 		}
 		catch (Exception ex)
 		{

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/LinkerConfig.xml
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/LinkerConfig.xml
@@ -1,4 +1,5 @@
 <linker>
+  <assembly fullname="MyExtensionsApp" />
   <assembly fullname="MyExtensionsApp.Wasm" />
   <assembly fullname="Uno.UI" />
   <assembly fullname="Microsoft.Extensions.Options" />


### PR DESCRIPTION
GitHub Issue (If applicable): #318

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

LinkerConfig file for extensions template wasn't picking up the netstandard class library that was added for viewmodels, services etc

## What is the new behavior?

LinkerConfig includes the netstandard library
Also, removed excess linkerconfig assemblies from commerce sample


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
