### PR TITLE
fix: Wrapping UI related actions with dispatcher

### DIFF
--- a/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.cs
@@ -217,7 +217,8 @@ namespace Playground
 						new ViewMap<PanelVisibilityPage>(),
 						new ViewMap<VisualStatesPage>(),
 						new ViewMap<AdHocPage, AdHocViewModel>(),
-						new ViewMap<AuthTokenDialog, AuthTokenViewModel>()
+						new ViewMap<AuthTokenDialog, AuthTokenViewModel>(),
+						new ViewMap<BasicFlyout>()
 				);
 
 
@@ -247,7 +248,8 @@ namespace Playground
 						{
 							new RouteMap("ComplexDialogFirst",View: views.FindByView<ComplexDialogFirstPage>()),
 							new RouteMap("ComplexDialogSecond",View: views.FindByView<ComplexDialogSecondPage>(), DependsOn: "ComplexDialogFirst")
-						})
+						}),
+						new RouteMap("Basic",View: views.FindByView<BasicFlyout>())
 					}),
 					new RouteMap("PanelVisibility",View: views.FindByView<PanelVisibilityPage>(), DependsOn: "Home"),
 					new RouteMap("VisualStates",View: views.FindByView<VisualStatesPage>(), DependsOn: "Home"),

--- a/samples/Playground/Playground/Playground/Playground.Shared/Playground.Shared.projitems
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Playground.Shared.projitems
@@ -44,6 +44,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Views\AuthTokenDialog.xaml.cs">
       <DependentUpon>AuthTokenDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Views\BasicFlyout.xaml.cs">
+      <DependentUpon>BasicFlyout.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Views\CodeBehindPage.xaml.cs">
       <DependentUpon>CodeBehindPage.xaml</DependentUpon>
     </Compile>
@@ -116,6 +119,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Views\AuthTokenDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Views\BasicFlyout.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/samples/Playground/Playground/Playground/Playground.Shared/Playground.Shared.shproj
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Playground.Shared.shproj
@@ -24,6 +24,7 @@
     <_Globbed_Compile Remove="Views\AdHocPage.xaml.cs" />
     <_Globbed_Compile Remove="Views\AlternatePage.xaml.cs" />
     <_Globbed_Compile Remove="Views\AuthTokenDialog.xaml.cs" />
+    <_Globbed_Compile Remove="Views\BasicFlyout.xaml.cs" />
     <_Globbed_Compile Remove="Views\CodeBehindPage.xaml.cs" />
     <_Globbed_Compile Remove="Views\ContentControlPage.xaml.cs" />
     <_Globbed_Compile Remove="Views\MainPage.xaml.cs" />
@@ -37,6 +38,7 @@
     <_Globbled_Page Remove="Views\AdHocPage.xaml" />
     <_Globbled_Page Remove="Views\AlternatePage.xaml" />
     <_Globbled_Page Remove="Views\AuthTokenDialog.xaml" />
+    <_Globbled_Page Remove="Views\BasicFlyout.xaml" />
     <_Globbled_Page Remove="Views\CodeBehindPage.xaml" />
     <_Globbled_Page Remove="Views\ContentControlPage.xaml" />
     <_Globbled_Page Remove="Views\MainPage.xaml" />

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/BasicFlyout.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/BasicFlyout.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="Playground.Views.BasicFlyout"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Playground.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<TextBlock Text="Shown in Flyout" />
+	</Grid>
+</Page>

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/BasicFlyout.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/BasicFlyout.xaml.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Playground.Views;
+
+public sealed partial class BasicFlyout : Page
+{
+	public BasicFlyout()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
@@ -40,6 +40,10 @@
 			<TextBlock x:Name="SimpleDialogResultText" />
 			<Button uen:Navigation.Request="!Complex/ComplexDialogFirst"
 					Content="Complex Dialog Nav Request" />
+			<Button uen:Navigation.Request="!Basic"
+					Content="Flyout from Xaml" />
+			<Button Content="Flyout from Background Thread"
+					Click="FlyoutFromBackgroundClick" />
 		</StackPanel>
 	</Grid>
 </Page>

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
@@ -58,4 +58,13 @@ public sealed partial class DialogsPage : Page, IInjectable<INavigator>
 		SimpleDialogResultText.Text = $"Dialog result: {dialogResult.SomeOrDefault()?.ToString()}";
 	}
 	public void Inject(INavigator entity) => Navigator = entity;
+
+	private void FlyoutFromBackgroundClick(object sender, RoutedEventArgs e)
+	{
+		Task.Run(() =>
+		{
+			// Note: Passing object in as sender to make sure navigation doesn't use the sender when showing flyout
+			Navigator.NavigateRouteAsync(new object(), "!Basic");
+		});
+	}
 }

--- a/src/Uno.Extensions.Navigation.UI/DispatcherQueueExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/DispatcherQueueExtensions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Uno.Extensions;
 
-public static class DispatcherQueueHelpers
+public static class DispatcherQueueExtensions
 {
 	public static Task Run(this DispatcherQueue dispatcher, Func<Task> action)
 	{

--- a/src/Uno.Extensions.Navigation.UI/DispatcherQueueHelpers.cs
+++ b/src/Uno.Extensions.Navigation.UI/DispatcherQueueHelpers.cs
@@ -1,0 +1,31 @@
+﻿namespace Uno.Extensions;
+
+public static class DispatcherQueueHelpers
+{
+	public static Task Run(this DispatcherQueue dispatcher, Func<Task> action)
+	{
+		return dispatcher.Run(async () =>
+		{
+			await action();
+			return true;
+		});
+	}
+
+	public static async Task<TResult> Run<TResult>(this DispatcherQueue dispatcher, Func<Task<TResult>> actionWithResult)
+	{
+		var completion = new TaskCompletionSource<TResult>();
+		dispatcher.TryEnqueue(async () =>
+						{
+							try
+							{
+								var result = await actionWithResult();
+								completion.SetResult(result);
+							}
+							catch (Exception ex)
+							{
+								completion.SetException(ex);
+							}
+						});
+		return await completion.Task;
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -395,8 +395,16 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 		// Append Internal qualifier to avoid requests being sent back to parent
 		request = request with { Route = request.Route with { IsInternal = true } };
 
+		var dispatcher = this.GetDispatcher();
+		var navigators = await dispatcher.Run(async () =>
+		{
+			return (from child in children
+					let nav = child.Navigator()
+					select nav).ToList();
+		});
+
 		var tasks = new List<Task<NavigationResponse?>>();
-		foreach (var region in children)
+		foreach (var region in navigators)
 		{
 			tasks.Add(region.NavigateAsync(request));
 		}

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
@@ -142,19 +142,15 @@ public abstract class ControlNavigator : Navigator
 
 	private async Task<NavigationResponse?> ControlCoreNavigateAsync(NavigationRequest request)
 	{
-		var completion = new TaskCompletionSource<NavigationResponse?>();
-		GetDispatcher().TryEnqueue(async () =>
+		return await GetDispatcher().Run(async () =>
 		{
 			if (CanNavigateToRoute(request.Route))
 			{
-				var response = await ControlNavigateAsync(request);
-				completion.SetResult(response);
-				return;
+				return await ControlNavigateAsync(request);
 			}
-			completion.SetResult(default);
-		});
 
-		return await completion.Task;
+			return default;
+		});
 	}
 
 	public virtual void ControlInitialize()

--- a/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
@@ -39,13 +39,13 @@ public class FlyoutNavigator : ControlNavigator
 		}
 		else
 		{
-			if(Flyout is not null)
+			if (Flyout is not null)
 			{
 				return Route.Empty;
 			}
 
 			var mapping = Resolver.Routes.Find(route);
-			injectedFlyout = !(mapping?.View?.RenderView?.IsSubclassOf(typeof(Flyout))??false);
+			injectedFlyout = !(mapping?.View?.RenderView?.IsSubclassOf(typeof(Flyout)) ?? false);
 			var viewModel = CreateViewModel(Region.Services, request, route, mapping);
 			Flyout = await DisplayFlyout(request, mapping?.View?.RenderView, viewModel, injectedFlyout);
 		}
@@ -107,6 +107,11 @@ public class FlyoutNavigator : ControlNavigator
 		if (flyoutHost is null)
 		{
 			flyoutHost = Region.View;
+
+			if (flyoutHost is null)
+			{
+				flyoutHost = Window.Content as FrameworkElement;
+			}
 		}
 
 		flyout?.ShowAt(flyoutHost);


### PR DESCRIPTION
GitHub Issue (If applicable): #323

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Launching flyout from background thread (eg from a reactive command) causes exception when child navigators are created 

## What is the new behavior?

Flyouts use the Window.DispatcherQueue and child navigation switches to UI thread to retrieve the region navigators

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
