### PR TITLE
fix: Attaching event handler to closed event so that navigation returns correctly

### DIFF
--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
@@ -59,12 +59,14 @@ public sealed partial class DialogsPage : Page, IInjectable<INavigator>
 	}
 	public void Inject(INavigator entity) => Navigator = entity;
 
-	private void FlyoutFromBackgroundClick(object sender, RoutedEventArgs e)
+	private async void FlyoutFromBackgroundClick(object sender, RoutedEventArgs e)
 	{
-		Task.Run(() =>
+		var response = await Task.Run(async () =>
 		{
 			// Note: Passing object in as sender to make sure navigation doesn't use the sender when showing flyout
-			Navigator.NavigateRouteAsync(new object(), "!Basic");
+			return await Navigator.NavigateRouteForResultAsync<string>(new object(), "!Basic");
 		});
+
+		var result = await response.Result;
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #368

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Tap outside of flyout doesn't return result to navigation

## What is the new behavior?

Tap outside of flyout returns a "None" result to navigation

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
