### PR TITLE
fix: Fix type load issue of evtRegToken on Win-WinUI

### DIFF
--- a/src/Uno.Extensions.Reactive.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Reactive.UI/GlobalUsings.cs
@@ -22,7 +22,7 @@ global using CurrentChangingEventArgs = Windows.UI.Xaml.Data.CurrentChangingEven
 global using CurrentChangedEventHandler = System.EventHandler<object?>;
 #endif
 
-#if WINUI && (WINDOWS || (NET6_0_OR_GREATER && (__IOS__ || __ANDROID__)))
+#if WINUI && NET5_0_OR_GREATER
 global using WinRT;
 #else
 global using System.Runtime.InteropServices.WindowsRuntime;

--- a/src/Uno.Extensions.Reactive.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Reactive.UI/GlobalUsings.cs
@@ -6,6 +6,9 @@ global using Microsoft.UI.Xaml.Data;
 global using Microsoft.UI.Xaml.Media;
 global using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
 global using DispatcherQueueHandler = Microsoft.UI.Dispatching.DispatcherQueueHandler;
+global using CurrentChangingEventHandler = Microsoft.UI.Xaml.Data.CurrentChangingEventHandler;
+global using CurrentChangingEventArgs = Microsoft.UI.Xaml.Data.CurrentChangingEventArgs;
+global using CurrentChangedEventHandler = System.EventHandler<object?>;
 #else
 global using Windows.UI.Xaml;
 global using Windows.UI.Xaml.Controls;
@@ -14,4 +17,13 @@ global using Windows.UI.Xaml.Data;
 global using Windows.UI.Xaml.Media;
 global using DispatcherQueue = Windows.System.DispatcherQueue;
 global using DispatcherQueueHandler = Windows.System.DispatcherQueueHandler;
+global using CurrentChangingEventHandler = Windows.UI.Xaml.Data.CurrentChangingEventHandler;
+global using CurrentChangingEventArgs = Windows.UI.Xaml.Data.CurrentChangingEventArgs;
+global using CurrentChangedEventHandler = System.EventHandler<object?>;
+#endif
+
+#if WINUI && (WINDOWS || (NET6_0_OR_GREATER && (__IOS__ || __ANDROID__)))
+global using WinRT;
+#else
+global using System.Runtime.InteropServices.WindowsRuntime;
 #endif

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.CollectionView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.CollectionView.cs
@@ -117,7 +117,7 @@ partial class BindableListFeed<T> : ICollectionView, INotifyCollectionChanged
 	}
 
 	/// <inheritdoc />
-	public event EventHandler<object>? CurrentChanged
+	public event CurrentChangedEventHandler CurrentChanged
 	{
 		add => _items.AddCurrentChangedHandler(value);
 		remove => _items.RemoveCurrentChangedHandler(value);

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
@@ -14,17 +13,9 @@ using Uno.Extensions.Reactive.Dispatching;
 using Uno.Extensions.Reactive.Utils;
 
 #if WINUI
-using CurrentChangingEventHandler = Microsoft.UI.Xaml.Data.CurrentChangingEventHandler;
-using CurrentChangedEventHandler = System.EventHandler<object>;
 using ISchedulersProvider = System.Func<Microsoft.UI.Dispatching.DispatcherQueue?>;
-#elif HAS_WINDOWS_UI || HAS_UMBRELLA_UI || true
-using CurrentChangingEventHandler = Windows.UI.Xaml.Data.CurrentChangingEventHandler;
-using CurrentChangedEventHandler = System.EventHandler<object>;
-using ISchedulersProvider = System.Func<Windows.System.DispatcherQueue?>;
 #else
-using CurrentChangingEventHandler = System.ComponentModel.CurrentChangingEventHandler;
-using CurrentChangingEventArgs = System.ComponentModel.CurrentChangingEventArgs;
-using CurrentChangedEventHandler = System.EventHandler;
+using ISchedulersProvider = System.Func<Windows.System.DispatcherQueue?>;
 #endif
 
 namespace Uno.Extensions.Reactive.Bindings.Collections
@@ -207,7 +198,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 		public ICollectionView GetForCurrentThread()
 			=> _holder.Value.View;
 
-		#region ICollectionView
+#region ICollectionView
 		/// <inheritdoc />
 		public IEnumerator<object> GetEnumerator()
 			=> GetForCurrentThread().GetEnumerator();
@@ -340,7 +331,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 			add => _holder.Value.GetFacet<SelectionFacet>().AddCurrentChangingHandler(value!);
 			remove => _holder.Value.GetFacet<SelectionFacet>().RemoveCurrentChangingHandler(value!);
 		}
-		#endregion
+#endregion
 
 		internal EventRegistrationToken AddVectorChangedHandler(VectorChangedEventHandler<object?>? handler)
 			=> _holder.Value.GetFacet<CollectionChangedFacet>().AddVectorChangedHandler(handler!);

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionChangedFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionChangedFacet.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
 using Windows.Foundation.Collections;
 using Uno.Extensions;

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/FlatCollectionChangedFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/FlatCollectionChangedFacet.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
 using Windows.Foundation.Collections;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions.Collections;
-using Uno.Extensions;
 using Uno.Logging;
 using _CollectionChanged = Uno.Extensions.Collections.RichNotifyCollectionChangedEventArgs;
 

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/SelectionFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/SelectionFacet.cs
@@ -1,22 +1,8 @@
 ﻿using System;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
 using Windows.Foundation.Collections;
 
-#if WINUI
-using CurrentChangingEventHandler = Microsoft.UI.Xaml.Data.CurrentChangingEventHandler;
-using CurrentChangingEventArgs = Microsoft.UI.Xaml.Data.CurrentChangingEventArgs;
-using CurrentChangedEventHandler = System.EventHandler<object?>;
-#elif HAS_WINDOWS_UI || HAS_UMBRELLA_UI || true
-using CurrentChangingEventHandler = Windows.UI.Xaml.Data.CurrentChangingEventHandler;
-using CurrentChangingEventArgs = Windows.UI.Xaml.Data.CurrentChangingEventArgs;
-using CurrentChangedEventHandler = System.EventHandler<object?>;
-#else
-using CurrentChangingEventHandler = System.ComponentModel.CurrentChangingEventHandler;
-using CurrentChangingEventArgs = System.ComponentModel.CurrentChangingEventArgs;
-using CurrentChangedEventHandler = System.EventHandler;
-#endif
 
 namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets
 {

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
@@ -3,22 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets;
-
-#if WINUI
-using CurrentChangingEventHandler = Microsoft.UI.Xaml.Data.CurrentChangingEventHandler;
-using CurrentChangedEventHandler = System.EventHandler<object?>;
-#elif HAS_WINDOWS_UI || HAS_UMBRELLA_UI || true
-using CurrentChangingEventHandler = Windows.UI.Xaml.Data.CurrentChangingEventHandler;
-using CurrentChangedEventHandler = System.EventHandler<object?>;
-#else
-using CurrentChangingEventHandler = System.ComponentModel.CurrentChangingEventHandler;
-using CurrentChangingEventArgs = System.ComponentModel.CurrentChangingEventArgs;
-using CurrentChangedEventHandler = System.EventHandler;
-#endif
 
 namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 {

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/FlatView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/FlatView.cs
@@ -10,20 +10,6 @@ using Uno.Extensions.Collections;
 using Uno.Extensions.Collections.Facades.Composite;
 using Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets;
 
-#if WINUI
-using CurrentChangingEventHandler = Microsoft.UI.Xaml.Data.CurrentChangingEventHandler;
-using CurrentChangingEventArgs = Microsoft.UI.Xaml.Data.CurrentChangingEventArgs;
-using CurrentChangedEventHandler = System.EventHandler<object?>;
-#elif HAS_WINDOWS_UI || HAS_UMBRELLA_UI || true
-using CurrentChangingEventHandler = Windows.UI.Xaml.Data.CurrentChangingEventHandler;
-using CurrentChangingEventArgs = Windows.UI.Xaml.Data.CurrentChangingEventArgs;
-using CurrentChangedEventHandler = System.EventHandler<object?>;
-#else
-using CurrentChangingEventHandler = System.ComponentModel.CurrentChangingEventHandler;
-using CurrentChangingEventArgs = System.ComponentModel.CurrentChangingEventArgs;
-using CurrentChangedEventHandler = System.EventHandler;
-#endif
-
 namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 {
 	/// <summary>

--- a/src/Uno.Extensions.Reactive.UI/_Compat/EventRegistrationToken.cs
+++ b/src/Uno.Extensions.Reactive.UI/_Compat/EventRegistrationToken.cs
@@ -1,29 +1,94 @@
-﻿#if NET6_0_OR_GREATER && (__IOS__ || __ANDROID__)
-#nullable disable // Matches the WinRT API
+﻿#nullable disable // Matches the WinRT API
+#if NET6_0_OR_GREATER && (__IOS__ || __ANDROID__)
+#define IS_NET6_MOBILE
+#endif
+#if WINDOWS && WINUI
+#define IS_WINDOWS_WINUI 
+#endif
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
+#if WINUI && (WINDOWS || IS_NET6_MOBILE)
+namespace WinRT;
+#else
 namespace System.Runtime.InteropServices.WindowsRuntime;
+#endif
 
-internal record struct EventRegistrationToken(Delegate Delegate);
+#if IS_NET6_MOBILE
+internal record struct EventRegistrationToken(long Value);
+#endif
 
+#if IS_NET6_MOBILE || IS_WINDOWS_WINUI
 internal class EventRegistrationTokenTable<THandler>
 	where THandler : Delegate
 {
+	private readonly List<long> _handlersTokenIds = new();
+	private readonly List<WeakReference<THandler>> _handlers = new();
+
+	private long _nextTokenId;
+
 	public EventRegistrationToken AddEventHandler(THandler handler)
 	{
-		InvocationList = (THandler)Delegate.Combine(InvocationList, handler);
-		return default;
+		var token = new EventRegistrationToken(_nextTokenId++);
+		var weakHandler = new WeakReference<THandler>(handler);
+
+		_handlersTokenIds.Add(token.Value);
+		_handlers.Add(weakHandler);
+
+		return token;
 	}
 
 	public void RemoveEventHandler(EventRegistrationToken token)
-		=> RemoveEventHandler(token.Delegate as THandler);
+	{
+		var index = _handlersTokenIds.IndexOf(token.Value);
+		if (index >=0)
+		{
+			_handlersTokenIds.RemoveAt(index);
+			_handlers.RemoveAt(index);
+		}
+	}
 
 	public void RemoveEventHandler(THandler handler)
-		=> InvocationList = (THandler)Delegate.Remove(InvocationList, handler);
+	{
+		var index = _handlers.FindIndex(weakHandler => weakHandler.TryGetTarget(out var h) && h == handler);
+		if (index >= 0)
+		{
+			_handlersTokenIds.RemoveAt(index);
+			_handlers.RemoveAt(index);
+		}
+	}
 
-	public THandler InvocationList { get; private set; }
+	public THandler InvocationList
+	{
+		get
+		{
+			var activeHandlers = new THandler[_handlers.Count];
+			var activeHandlersCount = 0;
+			for (var i = 0; i < _handlers.Count; )
+			{
+				if (_handlers[i].TryGetTarget(out var handler))
+				{
+					activeHandlers[activeHandlersCount++] = handler;
+					i++;
+				}
+				else
+				{
+					_handlersTokenIds.RemoveAt(i);
+					_handlers.RemoveAt(i);
+				}
+			}
+
+			if (activeHandlersCount is 0)
+			{
+				return null;
+			}
+
+			Array.Resize(ref activeHandlers, activeHandlersCount);
+
+			return (THandler)Delegate.Combine(activeHandlers);
+		}
+	}
 }
 #endif

--- a/src/Uno.Extensions.Reactive.UI/_Compat/EventRegistrationToken.cs
+++ b/src/Uno.Extensions.Reactive.UI/_Compat/EventRegistrationToken.cs
@@ -1,26 +1,39 @@
-﻿#nullable disable // Matches the WinRT API
-#if NET6_0_OR_GREATER && (__IOS__ || __ANDROID__)
-#define IS_NET6_MOBILE
+﻿#if NET5_0_OR_GREATER
+#nullable disable // Matches the WinRT API
+
+
+#if __ANDROID__ || __IOS__
+// Both types are missing on NET6_MOBILE, for UWP and WinUI
+// Note: They are added only to share code, they are actually not exposed publicly
+
+#define NEEDS_EVT_TOKEN
+#define NEEDS_EVT_TOKEN_TABLE
+
+#elif WINUI
+// Types might be in old interop.WinRun namespace, but we want to match the WinUI API and use the WinRT namespace.
+
+#if !WINDOWS // net6-win is the only platform that defines the WinRT.EvtRegToken (but not the table)
+#define NEEDS_EVT_TOKEN
 #endif
-#if WINDOWS && WINUI
-#define IS_WINDOWS_WINUI 
+#define NEEDS_EVT_TOKEN_TABLE // Type might be in old interop.WinRun namespace, but we want to match the WinUI API and use the WinRT namespace
+
 #endif
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
-#if WINUI && (WINDOWS || IS_NET6_MOBILE)
+#if WINUI 
 namespace WinRT;
 #else
 namespace System.Runtime.InteropServices.WindowsRuntime;
 #endif
 
-#if IS_NET6_MOBILE
+#if NEEDS_EVT_TOKEN
 internal record struct EventRegistrationToken(long Value);
 #endif
 
-#if IS_NET6_MOBILE || IS_WINDOWS_WINUI
+#if NEEDS_EVT_TOKEN_TABLE
 internal class EventRegistrationTokenTable<THandler>
 	where THandler : Delegate
 {
@@ -91,4 +104,5 @@ internal class EventRegistrationTokenTable<THandler>
 		}
 	}
 }
+#endif
 #endif

--- a/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
@@ -13,7 +13,7 @@ public static class ListState
 {
 	#region Operators
 	/// <summary>
-	/// Adds an items into the state
+	/// Adds an item into a list state
 	/// </summary>
 	/// <typeparam name="T">The type of the items in the list.</typeparam>
 	/// <param name="state">The list state onto which the item should be added.</param>
@@ -22,5 +22,41 @@ public static class ListState
 	/// <returns></returns>
 	public static ValueTask AddAsync<T>(this IListState<T> state, T item, CancellationToken ct)
 		=> state.UpdateValue(items => items.SomeOrDefault(ImmutableList<T>.Empty).Add(item), ct);
+
+	/// <summary>
+	/// Removes all matching items from a list state.
+	/// </summary>
+	/// <typeparam name="T">The type of the items in the list.</typeparam>
+	/// <param name="state">The list state onto which the item should be added.</param>
+	/// <param name="match">Predicate to determine which items should be removed.</param>
+	/// <param name="ct">A token to abort the async add operation.</param>
+	/// <returns></returns>
+	public static ValueTask RemoveAllAsync<T>(this IListState<T> state, Predicate<T> match, CancellationToken ct)
+		=> state.UpdateValue(itemsOpt => itemsOpt.Map(items => items.RemoveAll(match)), ct);
+
+	/// <summary>
+	/// Updates all matching items from a list state.
+	/// </summary>
+	/// <typeparam name="T">The type of the items in the list.</typeparam>
+	/// <param name="state">The list state onto which the item should be added.</param>
+	/// <param name="match">Predicate to determine which items should be removed.</param>
+	/// <param name="updater">How to update items.</param>
+	/// <param name="ct">A token to abort the async add operation.</param>
+	/// <returns></returns>
+	public static ValueTask UpdateAsync<T>(this IListState<T> state, Predicate<T> match, Func<T, T> updater, CancellationToken ct)
+		=> state.UpdateValue(
+			itemsOpt => itemsOpt.Map(items =>
+			{
+				var updated = items;
+				foreach (var item in items)
+				{
+					if (match(item))
+					{
+						updated = items.Replace(item, updater(item));
+					}
+				}
+				return updated;
+			}),
+			ct);
 	#endregion
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## Bugfix
Fix type load issue of evtRegToken on Win-WinUI

## What is the current behavior?
On Windows - WinUI, BindableCollection fails due to a type load exception of the EvtRegTokenTable missing

## What is the new behavior?
🙃

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
