### PR TITLE
fix: Make sure to go in None state if source is null or empty

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_FeedToListFeedAdapter.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_FeedToListFeedAdapter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Operators;
+
+[TestClass]
+public class Given_FeedToListFeedAdapter : FeedTests
+{
+	[TestMethod]
+	public async Task When_Null_Then_None()
+	{
+		var source = Feed.Async(async ct => default(IImmutableList<int>)!);
+		var sut = source.AsListFeed();
+		var result = await sut.Record();
+
+		result.Should().Be(r => r
+			.Message(Changed.Data, Data.None, Error.No, Progress.Final)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_Empty_Then_None()
+	{
+		var source = Feed.Async(async ct => ImmutableList<int>.Empty as IImmutableList<int>);
+		var sut = source.AsListFeed();
+		var result = await sut.Record();
+
+		result.Should().Be(r => r
+			.Message(Changed.Data, Data.None, Error.No, Progress.Final)
+		);
+	}
+}

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.Extensions.cs
@@ -145,8 +145,7 @@ public static partial class ListFeed
 	/// <returns>The source data stream of list of the given <see cref="IListFeed{T}"/>.</returns>
 	public static IFeed<IImmutableList<TItem>> AsFeed<TItem>(
 		this IListFeed<TItem> source)
-		=> source is FeedToListFeedAdapter<TItem> adapter
-			? adapter.Source
-			: AttachedProperty.GetOrCreate(source, typeof(TItem), (s, _) => new ListFeedToFeedAdapter<TItem>(s));
+		// Note: DO NOT unwrap FeedToListFeedAdapter, as it adds some behavior
+		=> AttachedProperty.GetOrCreate(source, typeof(TItem), (s, _) => new ListFeedToFeedAdapter<TItem>(s));
 	#endregion
 }

--- a/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
+++ b/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
@@ -30,10 +30,16 @@ internal record FeedToListFeedAdapter<T>(IFeed<IImmutableList<T>> Source) : ILis
 	{
 		var updated = current.With(parentMsg!);
 
-		if (parentMsg!.Changes.Contains(MessageAxis.Data, out var changeSet))
+		if (parentMsg.Changes.Contains(MessageAxis.Data, out var changeSet))
 		{
 			var error = default(Exception);
 			var updatedData = parentMsg.Current.Data;
+
+			if (updatedData.IsSome(out var items) && items is null or { Count: 0 })
+			{
+				updatedData = Option<IImmutableList<T>>.None();
+			}
+
 			if (changeSet is not CollectionChangeSet)
 			{
 				try // As we might invoke the app Equality implementation, we make sure to try / catch it


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## Bugfix
Make sure to go in None state if source is null or empty

## What is the current behavior?
If source feed produces a `Some(null)` or `Some(Empty)`, the  `ListFeed` stays in `Some` 

## What is the new behavior?
When source feed produces a `Some(null)` or `Some(Empty)`, the `FeedToListFeedAdapter` converts its to a `None`

