### PR TITLE
fix: Null ref when no binding path

### DIFF
--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/NavigationViewPage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/NavigationViewPage.xaml
@@ -11,6 +11,10 @@
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition />
+		</Grid.RowDefinitions>
 		<muxc:NavigationView uen:Region.Attached="true">
 			<muxc:NavigationView.MenuItems>
 				<muxc:NavigationViewItem Content="Products"
@@ -46,6 +50,31 @@
 							uen:Navigation.Request="Deals" />
 				</StackPanel>
 			</Grid>
+		</muxc:NavigationView>
+		<muxc:NavigationView Grid.Row="1"
+							 uen:Region.Attached="true">
+			<muxc:NavigationView.MenuItems>
+				<muxc:NavigationViewItem Content="Third"
+										 SelectsOnInvoked="False"
+										 uen:Navigation.Request="./Third"
+										 uen:Navigation.Data="{Binding }">
+					<muxc:NavigationViewItem.DataContext>
+						<x:String>Third Page</x:String>
+					</muxc:NavigationViewItem.DataContext>
+				</muxc:NavigationViewItem>
+
+				<muxc:NavigationViewItem Content="Fourth"
+										 SelectsOnInvoked="False"
+										 uen:Navigation.Request="./Fourth"
+										 uen:Navigation.Data="{Binding }">
+					<muxc:NavigationViewItem.DataContext>
+						<x:String>Fourth Page</x:String>
+					</muxc:NavigationViewItem.DataContext>
+
+				</muxc:NavigationViewItem>
+			</muxc:NavigationView.MenuItems>
+			<Grid uen:Region.Attached="True"
+				  uen:Region.Navigator="Visibility" />
 		</muxc:NavigationView>
 	</Grid>
 </Page>

--- a/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
@@ -38,7 +38,7 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 				binding.DataItem is not null)
 			{
 				var dataObject = binding.DataItem;
-				var bindingPathSegments = binding.ParentBinding.Path.Path.Split('.').ToArray();
+				var bindingPathSegments = binding.ParentBinding.Path?.Path?.Split('.').ToArray() ?? Array.Empty<string>();
 				for (int i = 0; i < bindingPathSegments.Length; i++)
 				{
 					var prop = dataObject.GetType().GetProperty(bindingPathSegments[i]);


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Exception is raised when the Binding path for the Navigation Data attached property is null

## What is the new behavior?

Null reference is correctly handled

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
