### PR TITLE
fix: Overflow when navigating to nested regions

### DIFF
--- a/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.cs
@@ -254,8 +254,12 @@ namespace Playground
 						new RouteMap("NavContent", View: views.FindByViewModel<NavContentViewModel>(),
 						Nested: new[]
 						{
-							new RouteMap("Tab1", IsDefault:true),
-							new RouteMap("Tab2")
+							new RouteMap("NavContentTabs", IsDefault:true,
+										Nested: new[]
+										{
+											new RouteMap("Tab1", IsDefault:true),
+											new RouteMap("Tab2")
+										}),
 						}),
 						new RouteMap("NavContentSecond", View: views.FindByView<NavContentSecondPage>(), DependsOn:"NavContent")
 					}),

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/NavContentPage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/NavContentPage.xaml
@@ -11,7 +11,8 @@
 	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	NavigationCacheMode="Required"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-	<Grid uen:Region.Attached="True">
+	<Grid uen:Region.Attached="True"
+		  uen:Region.Name="NavContentTabs">
 		<Grid.RowDefinitions>
 			<RowDefinition />
 			<RowDefinition Height="Auto" />


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Navigating to tabs within a navigation view item causes infinite loop due to responsenavigator not being cleared

## What is the new behavior?

Responsenavigator is cleared before navigating to tabs

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
