### PR TITLE
feat: Adding support for non-dismiss flyouts

### DIFF
--- a/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.cs
@@ -237,7 +237,8 @@ namespace Playground
 						new ViewMap<VisualStatesPage>(),
 						new ViewMap<AdHocPage, AdHocViewModel>(),
 						new ViewMap<AuthTokenDialog, AuthTokenViewModel>(),
-						new ViewMap<BasicFlyout, BasicViewModel>(),
+						new FlyoutViewMap<BasicFlyout, BasicViewModel>(),
+						new FlyoutViewMap<NonDismissFlyout>(AutoDismiss: false),
 						confirmDialog
 				);
 
@@ -282,7 +283,8 @@ namespace Playground
 							new RouteMap("ComplexDialogFirst",View: views.FindByView<ComplexDialogFirstPage>()),
 							new RouteMap("ComplexDialogSecond",View: views.FindByView<ComplexDialogSecondPage>(), DependsOn: "ComplexDialogFirst")
 						}),
-						new RouteMap("Basic",View: views.FindByView<BasicFlyout>())
+						new RouteMap("Basic",View: views.FindByView<BasicFlyout>()),
+						new RouteMap("NonDismiss",View: views.FindByView<NonDismissFlyout>())
 					}),
 					new RouteMap("PanelVisibility",View: views.FindByView<PanelVisibilityPage>()),
 					new RouteMap("VisualStates",View: views.FindByView<VisualStatesPage>()),

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
@@ -48,6 +48,8 @@
 					Click="FlyoutFromBackgroundClick" />
 			<Button Content="Flyout from Background Thread requesting data"
 					Click="FlyoutFromBackgroundRequestingDataClick" />
+			<Button uen:Navigation.Request="!NonDismiss"
+					Content="Non-dismis Flyout from Xaml" />
 		</StackPanel>
 	</Grid>
 </Page>

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/NonDismissFlyout.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/NonDismissFlyout.xaml
@@ -1,0 +1,19 @@
+﻿<Page
+    x:Class="Playground.Views.NonDismissFlyout"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Playground.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  xmlns:ui="using:Uno.Toolkit.UI"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<TextBlock Text="Shown in Flyout" />
+
+		<Button Content="Close"
+				uen:Navigation.Request="-" VerticalAlignment="Bottom" />
+	</Grid>
+</Page>

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/NonDismissFlyout.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/NonDismissFlyout.xaml.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Playground.Views;
+
+public sealed partial class NonDismissFlyout : Page
+{
+	public NonDismissFlyout()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/FlyoutViewMap.cs
+++ b/src/Uno.Extensions.Navigation.UI/FlyoutViewMap.cs
@@ -1,0 +1,33 @@
+﻿namespace Uno.Extensions.Navigation;
+
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
+public record FlyoutAttributes(
+	bool AutoDismiss = true
+)
+{
+}
+
+
+public record FlyoutViewMap<TFlyout>(
+	bool AutoDismiss = true,
+	Type? ViewModel = null,
+	DataMap? Data = null,
+	Type? ResultData = null
+) : ViewMap<TFlyout>(
+		ViewModel,
+		Data,
+		ResultData,
+		new FlyoutAttributes(AutoDismiss)
+		)
+{
+}
+
+public record FlyoutViewMap<TFlyout,TViewModel>(
+	bool AutoDismiss = true,
+	DataMap? Data = null,
+	Type? ResultData = null
+) : FlyoutViewMap<TFlyout>(AutoDismiss,typeof(TViewModel), Data, ResultData)
+{
+}
+#pragma warning restore SA1313 // Parameter names should begin with lower-case letter
+


### PR DESCRIPTION
GitHub Issue (If applicable): #394

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Unable to stop flyouts from being closed if user taps outside of flyout

## What is the new behavior?

Flyouts can remain open until navigation closes them

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
