### PR TITLE
feat: Applying dialog qualifier for appropriate view types

### DIFF
--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
@@ -26,7 +26,7 @@
 		</ui:NavigationBar>
 		<StackPanel Grid.Row="1">
 			<Button Content="MessageDialog XAML"
-					uen:Navigation.Request="!Confirm" />
+					uen:Navigation.Request="Confirm" />
 			<Button Content="Localized MessageDialog XAML"
 					uen:Navigation.Request="!LocalizedConfirm" />
 			<Button Content="MessageDialog Codebehind"
@@ -35,7 +35,7 @@
 			<Button Content="MessageDialog Codebehind (cancel after 2s)"
 					Click="MessageDialogCodebehindCancelClick" />
 			<TextBlock x:Name="MessageDialogCancelResultText" />
-			<Button uen:Navigation.Request="!Simple"
+			<Button uen:Navigation.Request="Simple"
 					Content="SimpleDialog Nav Request" />
 			<Button Content="SimpleDialog Codebehind"
 					Click="SimpleDialogCodebehindClick" />

--- a/src/Uno.Extensions.Navigation.UI/NavigatorExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigatorExtensions.cs
@@ -29,8 +29,9 @@ public static class NavigatorExtensions
                 { RouteConstants.PickerItemsSource, itemsSource },
                 { RouteConstants.PickerItemTemplate, itemTemplate }
             };
+		var resolver = service.GetResolver();
 
-		var req = (Qualifiers.Dialog + typeof(Picker).Name).AsRequest(sender, data, cancellation, typeof(TSource));
+		var req = (Qualifiers.Dialog + typeof(Picker).Name).AsRequest(resolver, sender, data, cancellation, typeof(TSource));
 		if(req is null)
 		{
 			return default;

--- a/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
@@ -69,7 +69,25 @@ public class RouteResolver : IRouteResolver
 			IsDefault: drm.IsDefault,
 			DependsOn: drm.DependsOn,
 			Init: drm.Init,
+			IsDialogViewType: () =>
+			{
+				return IsDialogViewType(viewFunc?.Invoke());
+			},
 			Nested: ResolveViewMaps(drm.Nested));
+	}
+
+	private static bool IsDialogViewType(Type? viewType = null)
+	{
+		if(viewType is null)
+		{
+			return false;;
+		}
+
+		return viewType == typeof(MessageDialog) ||
+			viewType == typeof(ContentDialog) ||
+			viewType.IsSubclassOf(typeof(ContentDialog)) ||
+			viewType == typeof(Flyout) ||
+			viewType.IsSubclassOf(typeof(Flyout));
 	}
 
 

--- a/src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs
@@ -3,11 +3,11 @@ namespace Uno.Extensions.Navigation;
 
 public static class NavigationRequestExtensions
 {
-	public static NavigationRequest? AsRequest(this string path, object sender, object? data, CancellationToken cancellationToken, Type? resultType = null)
+	public static NavigationRequest? AsRequest(this string path, IRouteResolver? resolver, object sender, object? data, CancellationToken cancellationToken, Type? resultType = null)
 	{
-		if(resultType is null)
+		if (resultType is null)
 		{
-			return AsRequest(path, sender, data, cancellationToken);
+			return AsRequest(path, resolver, sender, data, cancellationToken);
 		}
 
 		var navMethods = typeof(NavigationRequestExtensions)
@@ -20,21 +20,21 @@ public static class NavigationRequestExtensions
 		return nav;
 	}
 
-	public static NavigationRequest AsRequest<TResult>(this string path, object sender, object? data = null, CancellationToken cancellationToken = default)
-    {
-		var request = new NavigationRequest<TResult>(sender, path.AsRoute(data), cancellationToken);
+	public static NavigationRequest AsRequest<TResult>(this string path, IRouteResolver? resolver, object sender, object? data = null, CancellationToken cancellationToken = default)
+	{
+		var request = new NavigationRequest<TResult>(sender, path.AsRoute(data, resolver), cancellationToken);
 		return request;
 	}
 
-	public static NavigationRequest AsRequest(this string path, object sender, object? data = null, CancellationToken cancellationToken = default)
-    {
-        var request = new NavigationRequest(sender, path.AsRoute(data), cancellationToken);
-        return request;
-    }
+	public static NavigationRequest AsRequest(this string path, IRouteResolver? resolver, object sender, object? data = null, CancellationToken cancellationToken = default)
+	{
+		var request = new NavigationRequest(sender, path.AsRoute(data, resolver), cancellationToken);
+		return request;
+	}
 
 	public static bool SameRouteBase(this NavigationRequest request, NavigationRequest newRequest)
 	{
-		if(request?.Route is null || newRequest?.Route is null)
+		if (request?.Route is null || newRequest?.Route is null)
 		{
 			return false;
 		}

--- a/src/Uno.Extensions.Navigation/RouteInfo.cs
+++ b/src/Uno.Extensions.Navigation/RouteInfo.cs
@@ -13,6 +13,7 @@ public record RouteInfo(
 	bool IsDefault = false,
 	string DependsOn = "",
 	Func<NavigationRequest, NavigationRequest>? Init = null,
+	Func<bool>? IsDialogViewType = null,
 	params RouteInfo[] Nested)
 {
 	public Type? RenderView => View?.Invoke();


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Navigation request has to include the dialog qualifier ! for messagedialog, contentdialog and flyout

## What is the new behavior?

Qualifier can be omitted for known view types (eg MessageDialog, ContentDialog and Flyout)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
