### PR TITLE
fix: Wasm logging not working

### DIFF
--- a/src/Uno.Extensions.Logging/Uno.Extensions.Logging.UWP.csproj
+++ b/src/Uno.Extensions.Logging/Uno.Extensions.Logging.UWP.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'!=''">$(UnoTargetFrameworkOverride)</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'==''">netstandard2.0;netstandard2.1;net5.0;xamarinios10;xamarinmac20;monoandroid11.0</TargetFrameworks>
-				<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);uap10.0.18362;net6.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);uap10.0.18362;net6.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(UnoExtensionsDisableNet6)'=='' and '$(UnoExtensionsDisableNet6Mobile)'==''">$(TargetFrameworks);net6.0-ios;net6.0-android</TargetFrameworks>
 
 	</PropertyGroup>
@@ -17,6 +17,10 @@
 			<PackagePath>buildTransitive</PackagePath>
 			<Pack>true</Pack>
 		</Content>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Uno.UI" Version="4.1.9" />
 	</ItemGroup>
 
 

--- a/src/Uno.Extensions.Logging/Uno.Extensions.Logging.WinUI.csproj
+++ b/src/Uno.Extensions.Logging/Uno.Extensions.Logging.WinUI.csproj
@@ -26,6 +26,9 @@
 		<PackageReference Include="uno.extensions.logging.oslog" Version="1.3.0" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<PackageReference Include="Uno.WinUI" Version="4.1.9" />
+	</ItemGroup>
 
 	<Import Project="common.props"/>
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Logging in wasm wasn't working because the uno-runtime specific libraries weren't being included in the Logging.UWP and Logging.WinUI packaged

## What is the new behavior?

Referencing Uno.UI and Uno.WinUI fixes the issue as the uno-runtimes folder is created and populated as part of creating the nuget package

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
