### PR TITLE
feat: Adding support for localizing message dialog

### DIFF
--- a/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.host.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.host.cs
@@ -92,6 +92,18 @@ public sealed partial class App : Application
 				}
 			);
 
+		var localizedDialog = new LocalizableMessageDialogViewMap(
+				Content: localizer => "[localized]Confirm this message?",
+				Title: localizer => "[localized]Confirm?",
+				DelayUserInput: true,
+				DefaultButtonIndex: 1,
+				Buttons: new LocalizableDialogAction[]
+				{
+								new(LabelProvider: localizer=> localizer["Y"],Id:"Y"),
+								new(LabelProvider: localizer=> localizer["N"], Id:"N")
+				}
+			);
+
 
 		views.Register(
 					// Option 1: Specify ShellView in order to customise the shell
@@ -121,7 +133,8 @@ public sealed partial class App : Application
 					new ViewMap<AdHocPage, AdHocViewModel>(),
 					new ViewMap<AuthTokenDialog, AuthTokenViewModel>(),
 					new ViewMap<BasicFlyout, BasicViewModel>(),
-					confirmDialog
+					confirmDialog,
+					localizedDialog
 			);
 
 
@@ -174,7 +187,8 @@ public sealed partial class App : Application
 					{
 						new RouteMap("Auth", View: views.FindByView<AuthTokenDialog>())
 					}),
-					new RouteMap("Confirm", View: confirmDialog)
+					new RouteMap("Confirm", View: confirmDialog),
+					new RouteMap("LocalizedConfirm", View: localizedDialog)
 			}));
 	}
 }

--- a/samples/Playground/Playground/Playground/Playground.Shared/Strings/en/Resources.resw
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Strings/en/Resources.resw
@@ -126,4 +126,10 @@
   <data name="HomePage_AppName.Text" xml:space="preserve">
     <value>Playground</value>
   </data>
+  <data name="N" xml:space="preserve">
+    <value>N - English</value>
+  </data>
+  <data name="Y" xml:space="preserve">
+    <value>Y - English</value>
+  </data>
 </root>

--- a/samples/Playground/Playground/Playground/Playground.Shared/Strings/fr/Resources.resw
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Strings/fr/Resources.resw
@@ -126,4 +126,10 @@
   <data name="HomePage_AppName.Text" xml:space="preserve">
     <value>Playground - French</value>
   </data>
+  <data name="N" xml:space="preserve">
+    <value>N - French</value>
+  </data>
+  <data name="Y" xml:space="preserve">
+    <value>Y - French</value>
+  </data>
 </root>

--- a/samples/Playground/Playground/Playground/Playground.Shared/ViewModels/HomeViewModel.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/ViewModels/HomeViewModel.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Globalization;
 using Microsoft.Extensions.Localization;
 using Uno.Extensions.Localization;
 
@@ -16,15 +17,16 @@ public class HomeViewModel
 	{
 		_localization = localization;
 		Platform = appInfo.Value.Platform;
+		SupportedCultures = _localization.Value?.Cultures?.AsCultures() ?? new[] { "en-US".AsCulture() }; 
 
-		var language = localizer[_localization.Value.CurrentCulture ?? "en"];
+		var language = localizer[_localization.Value?.CurrentCulture ?? "en"];
 	}
 
-	public string[] SupportedCultures => _localization.Value?.Cultures ?? new[] { "en-US" };
+	public CultureInfo[] SupportedCultures { get; }
 
-	public string SelectedCulture {
-		get => _localization.Value?.CurrentCulture?? _localization.Value?.Cultures?.FirstOrDefault()??"en-US";
-		set => _localization.Update(settings => settings.CurrentCulture = value);
+	public CultureInfo SelectedCulture {
+		get => SupportedCultures.FirstOrDefault(x=>x.Name == _localization.Value?.CurrentCulture)?? SupportedCultures.First();
+		set => _localization.Update(settings => settings.CurrentCulture = value.Name);
 	}
 
 }

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
@@ -27,6 +27,8 @@
 		<StackPanel Grid.Row="1">
 			<Button Content="MessageDialog XAML"
 					uen:Navigation.Request="!Confirm" />
+			<Button Content="Localized MessageDialog XAML"
+					uen:Navigation.Request="!LocalizedConfirm" />
 			<Button Content="MessageDialog Codebehind"
 					Click="MessageDialogCodebehindClick" />
 			<TextBlock x:Name="MessageDialogResultText" />

--- a/samples/Playground/Playground/Playground/Playground.Shared/appsettings.development.json
+++ b/samples/Playground/Playground/Playground/Playground.Shared/appsettings.development.json
@@ -1,9 +1,5 @@
 ﻿{
   "AppInfo": {
     "Title": "Uno Commerce App - Dev"
-  },
-  "ToDoTaskListEndpoint": {
-    "Url": "https://graph.microsoft.com/v1.0/me",
-    "UseNativeHandler": true
   }
 }

--- a/samples/Playground/Playground/Playground/Playground.Shared/appsettings.json
+++ b/samples/Playground/Playground/Playground/Playground.Shared/appsettings.json
@@ -2,6 +2,10 @@
   "AppInfo": {
     "Title": "Uno Commerce App"
   },
+  "ToDoTaskListEndpoint": {
+    "Url": "https://graph.microsoft.com/v1.0/me",
+    "UseNativeHandler": true
+  },
   "LocalizationSettings": {
     "Cultures": [ "en", "es", "fr" ]
   }

--- a/src/Uno.Extensions.Localization/LocalizationService.cs
+++ b/src/Uno.Extensions.Localization/LocalizationService.cs
@@ -24,14 +24,11 @@ public class LocalizationService : IHostedService
 
 	private IDisposable? _settingsListener;
 
-	private CultureInfo[] SupportedCultures =>
-		_settings?.CurrentValue?.Cultures?.Select((string c) => new CultureInfo(c)).ToArray() ??
-		new[] { new CultureInfo(DefaultCulture) };
+	private CultureInfo[] SupportedCultures { get; }
 
 	private CultureInfo CurrentCulture =>
-		(_settings?.CurrentValue?.CurrentCulture != null) ?
-		new CultureInfo(_settings.CurrentValue.CurrentCulture) :
-		(SupportedCultures?.FirstOrDefault() ?? new CultureInfo(DefaultCulture));
+		_settings?.CurrentValue?.CurrentCulture?.AsCulture() ??
+		SupportedCultures.First();
 
 	public LocalizationService(
 		ILogger<LocalizationService> logger,
@@ -39,6 +36,7 @@ public class LocalizationService : IHostedService
 	{
 		_logger = logger;
 		_settings = settings;
+		SupportedCultures = settings.CurrentValue?.Cultures?.AsCultures() ?? new[] { DefaultCulture.AsCulture() };
 	}
 
 	public Task StartAsync(CancellationToken cancellationToken)
@@ -84,6 +82,8 @@ public class LocalizationService : IHostedService
 
 	private CultureInfo? PickSupportedCulture(CultureInfo culture)
 	{
-		return SupportedCultures.FirstOrDefault(supported => supported.TwoLetterISOLanguageName == culture.TwoLetterISOLanguageName);
+		return
+			SupportedCultures.FirstOrDefault(supported => supported.Name == culture.Name) ??
+			SupportedCultures.FirstOrDefault(supported => supported.TwoLetterISOLanguageName == culture.TwoLetterISOLanguageName);
 	}
 }

--- a/src/Uno.Extensions.Localization/LocalizationSettingsExtensions.cs
+++ b/src/Uno.Extensions.Localization/LocalizationSettingsExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Globalization;
+using System.Linq;
+
+namespace Uno.Extensions.Localization;
+
+public static class LocalizationSettingsExtensions
+{
+	public static CultureInfo[] AsCultures(this string[] cultures)
+	{
+		return cultures.Select(c => c.AsCulture()).ToArray();
+	}
+
+	public static CultureInfo AsCulture(this string culture)
+	{
+		return CultureInfo.GetCultures(CultureTypes.AllCultures)
+					.FirstOrDefault(cu => cu.Name == culture);
+	}
+}

--- a/src/Uno.Extensions.Localization/Uno.Extensions.Localization.csproj
+++ b/src/Uno.Extensions.Localization/Uno.Extensions.Localization.csproj
@@ -12,4 +12,8 @@
 	<ItemGroup>
 		<PackageReference Include="Uno.UI" Version="4.1.9" />
 	</ItemGroup>
+
+	<ItemGroup>
+	  <SourceGeneratorInput Remove="LocalizationSettingsExtensions.cs" />
+	</ItemGroup>
 </Project>

--- a/src/Uno.Extensions.Localization/Uno.Extensions.Localization.csproj
+++ b/src/Uno.Extensions.Localization/Uno.Extensions.Localization.csproj
@@ -12,8 +12,4 @@
 	<ItemGroup>
 		<PackageReference Include="Uno.UI" Version="4.1.9" />
 	</ItemGroup>
-
-	<ItemGroup>
-	  <SourceGeneratorInput Remove="LocalizationSettingsExtensions.cs" />
-	</ItemGroup>
 </Project>

--- a/src/Uno.Extensions.Navigation.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Navigation.UI/GlobalUsings.cs
@@ -6,6 +6,7 @@ global using System.Threading;
 global using System.Threading.Tasks;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Hosting;
+global using Microsoft.Extensions.Localization;
 global using Microsoft.Extensions.Logging;
 global using Microsoft.Extensions.Options;
 global using Windows.Foundation;

--- a/src/Uno.Extensions.Navigation.UI/MessageDialogViewMap.cs
+++ b/src/Uno.Extensions.Navigation.UI/MessageDialogViewMap.cs
@@ -1,35 +1,35 @@
 ﻿namespace Uno.Extensions.Navigation;
 
 #pragma warning disable SA1313 // Parameter names should begin with lower-case letter
-public record MessageDialogAttributes(
-	string? Content = null,
-	string? Title = null,
+internal record MessageDialogAttributes(
+	Func<IStringLocalizer?, string?>? ContentProvider = default,
+	Func<IStringLocalizer?, string?>? TitleProvider = default,
 	bool DelayUserInput = false,
 	int DefaultButtonIndex = 0,
 	int CancelButtonIndex = 0,
-	DialogAction[]? Buttons = null
+	LocalizableDialogAction[]? Buttons = default
 )
 {
 }
 
 
 public record MessageDialogViewMap(
-	string? Content = null,
-	string? Title = null,
+	string? Content = default,
+	string? Title = default,
 	bool DelayUserInput = false,
 	int DefaultButtonIndex = 0,
 	int CancelButtonIndex = 0,
-	DialogAction[]? Buttons = null,
-	Type? ViewModel = null,
-	DataMap? Data = null,
-	Type? ResultData = null
+	DialogAction[]? Buttons = default,
+	Type? ViewModel = default,
+	DataMap? Data = default,
+	Type? ResultData = default
 ) : ViewMap<MessageDialog>(
 		ViewModel,
 		Data,
 		ResultData,
 		new MessageDialogAttributes(
-			Content,
-			Title,
+			ContentProvider: _ => Content,
+			TitleProvider: _ => Title,
 			DelayUserInput,
 			DefaultButtonIndex,
 			CancelButtonIndex,
@@ -38,18 +38,28 @@ public record MessageDialogViewMap(
 {
 }
 
-public record MessageDialogViewMap<TViewModel>(
-	string? Content = null,
-	string? Title = null,
+public record LocalizableMessageDialogViewMap(
+	Func<IStringLocalizer?, string?>? Content = default,
+	Func<IStringLocalizer?, string?>? Title = default,
 	bool DelayUserInput = false,
 	int DefaultButtonIndex = 0,
 	int CancelButtonIndex = 0,
-	DialogAction[]? Buttons = null,
-	DataMap? Data = null,
-	Type? ResultData = null
-) : MessageDialogViewMap(
-	Content,Title,DelayUserInput,DefaultButtonIndex, CancelButtonIndex, Buttons,
-	typeof(TViewModel), Data, ResultData)
+	LocalizableDialogAction[]? Buttons = default,
+	Type? ViewModel = default,
+	DataMap? Data = default,
+	Type? ResultData = default
+) : ViewMap<MessageDialog>(
+		ViewModel,
+		Data,
+		ResultData,
+		new MessageDialogAttributes(
+			ContentProvider: Content,
+			TitleProvider: Title,
+			DelayUserInput,
+			DefaultButtonIndex,
+			CancelButtonIndex,
+			Buttons)
+		)
 {
 }
 

--- a/src/Uno.Extensions.Navigation.UI/common.props
+++ b/src/Uno.Extensions.Navigation.UI/common.props
@@ -14,6 +14,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="6.0.4" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Uno.Core" Version="4.0.1" />
 	</ItemGroup>
 

--- a/src/Uno.Extensions.Navigation/GlobalUsings.cs
+++ b/src/Uno.Extensions.Navigation/GlobalUsings.cs
@@ -2,6 +2,7 @@
 global using System.Collections.Generic;
 global using System.Linq;
 global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.Localization;
 global using System.Threading;
 global using System.Threading.Tasks;
 global using System.Reflection; 

--- a/src/Uno.Extensions.Navigation/Uno.Extensions.Navigation.csproj
+++ b/src/Uno.Extensions.Navigation/Uno.Extensions.Navigation.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'!=''">$(UnoTargetFrameworkOverride)</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'==''">netstandard2.0;netstandard2.1;net5.0;xamarinios10;xamarinmac20;monoandroid11.0</TargetFrameworks>
-				<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);uap10.0.18362;net6.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);uap10.0.18362;net6.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(UnoExtensionsDisableNet6)'=='' and '$(UnoExtensionsDisableNet6Mobile)'==''">$(TargetFrameworks);net6.0-ios;net6.0-android</TargetFrameworks>
 
 	</PropertyGroup>
@@ -15,6 +15,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="6.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Navigation/ViewMap.cs
+++ b/src/Uno.Extensions.Navigation/ViewMap.cs
@@ -38,7 +38,15 @@ public record ViewMap<TView, TViewModel>(
 {
 }
 
-public record DialogAction(string? Label = "", Action? Action = null, object? Id = null) { }
+public record LocalizableDialogAction(Func<IStringLocalizer?, string?>? LabelProvider = default, Action? Action = null, object? Id = null) { }
+
+public record DialogAction(string? Label = default, Action? Action = null, object? Id = null)
+	: LocalizableDialogAction(
+		LabelProvider: _ => Label,
+		Action,
+		Id
+		)
+{ }
 
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Unable to localize strings used in messagedialog with navigation

## What is the new behavior?

Added LocalizableMessageDialogViewMap

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
