### PR TITLE
fix: Ignoring null values when serializing json

### DIFF
--- a/src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ServiceCollectionExtensions
 			.AddSingleton(sp => new JsonSerializerOptions
 			{
 				NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString,
+				DefaultIgnoreCondition= System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
 				AllowTrailingCommas = true
 			})
 			.AddSingleton<SystemTextJsonSerializer>()


### PR DESCRIPTION
GitHub Issue (If applicable): #407

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

null values are written when serializing object to json

## What is the new behavior?

null values are ignored

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
