### PR TITLE
feat: Adjusting messagedialog to return dialogresult.Id instead of whole DialogResult

### DIFF
--- a/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.host.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/App.xaml.host.cs
@@ -100,8 +100,8 @@ public sealed partial class App : Application
 				DefaultButtonIndex: 1,
 				Buttons: new LocalizableDialogAction[]
 				{
-								new(LabelProvider: localizer=> localizer["Y"],Id:"Y"),
-								new(LabelProvider: localizer=> localizer["N"], Id:"N")
+								new(LabelProvider: localizer=> localizer!["Y"],Id:"Y"),
+								new(LabelProvider: localizer=> localizer!["N"], Id:"N")
 				}
 			);
 

--- a/samples/Playground/Playground/Playground/Playground.Shared/ViewModels/HomeViewModel.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/ViewModels/HomeViewModel.cs
@@ -19,7 +19,7 @@ public class HomeViewModel
 	{
 		_localization = localization;
 		Platform = appInfo.Value.Platform;
-		SupportedCultures = _localization.Value?.Cultures?.AsCultures() ?? new[] { "en-US".AsCulture() }; 
+		SupportedCultures = _localization.Value?.Cultures?.AsCultures() ?? new[] { "en-US".AsCulture()! }; 
 
 		var language = localizer[_localization.Value?.CurrentCulture ?? "en"];
 

--- a/samples/Playground/Playground/Playground/Playground.Shared/ViewModels/VMViewModel.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/ViewModels/VMViewModel.cs
@@ -79,12 +79,6 @@ public class VMViewModel
 	// Show MessageDialog
 	public async void ShowMessageDialogAsyncClick(object sender, RoutedEventArgs args)
 	{
-		var response = await Navigator.ShowMessageDialogAsync(this, "Sample content", "Sample title");
-		if (response is null)
-		{
-			return;
-		}
-
-		var result = await response.Result;
+		var result = await Navigator.ShowMessageDialogAsync<string>(this, content:"Sample content", title:"Sample title").AsResult();
 	}
 }

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/CodeBehindPage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/CodeBehindPage.xaml.cs
@@ -92,7 +92,7 @@ public sealed partial class CodeBehindPage : Page, IInjectable<INavigator>
 	// Show MessageDialog
 	public async void ShowMessageDialogAsyncClick(object sender, RoutedEventArgs args)
 	{
-		var result = await Navigator!.ShowMessageDialogAsync(this, "Sample content", "Sample title").AsResult();
+		var result = await Navigator!.ShowMessageDialogAsync<string>(this, content: "Sample content", title: "Sample title").AsResult();
 	}
 }
 

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
@@ -12,25 +12,15 @@ public sealed partial class DialogsPage : Page, IInjectable<INavigator>
 
 	private async void MessageDialogCodebehindClick(object sender, RoutedEventArgs args)
 	{
-		var showDialog = await Navigator!.ShowMessageDialogAsync(this, "This is Content", "This is title");
-		if(showDialog is null)
-		{
-			return;
-		}
-		var messageDialogResult = await showDialog.Result;
-		MessageDialogResultText.Text = $"Message dialog result: {messageDialogResult.SomeOrDefault()?.Label}";
+		var messageDialogResult = await Navigator!.ShowMessageDialogAsync<string>(this, content: "This is Content", title:"This is title").AsResult();
+		MessageDialogResultText.Text = $"Message dialog result: {messageDialogResult}";
 	}
 
 	private async void MessageDialogCodebehindCancelClick(object sender, RoutedEventArgs args)
 	{
 		var cancelSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-		var showDialog = await Navigator!.ShowMessageDialogAsync(this, "This is Content", "This is title", cancellation: cancelSource.Token);
-		if (showDialog is null)
-		{
-			return;
-		}
-		var messageDialogResult = await showDialog.Result;
-		MessageDialogCancelResultText.Text = $"Message dialog result: {messageDialogResult.SomeOrDefault()?.Label}";
+		var messageDialogResult = await Navigator!.ShowMessageDialogAsync<string>(this, content:"This is Content", title:"This is title", cancellation: cancelSource.Token).AsResult();
+		MessageDialogCancelResultText.Text = $"Message dialog result: {messageDialogResult}";
 	}
 
 	private async void SimpleDialogCodebehindClick(object sender, RoutedEventArgs args)

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/FlyoutsPopupsDrawerPage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/FlyoutsPopupsDrawerPage.xaml.cs
@@ -15,12 +15,12 @@ public sealed partial class FlyoutsPopupsDrawerPage : Page
 
 	private async void OpenDrawerResponseClick(object sender, RoutedEventArgs e)
 	{
-		var result = await this.Navigator().NavigateRouteForResultAsync<Widget>(this, "MyDrawer/Show").AsResult();
-		await this.Navigator().ShowMessageDialogAsync(this, $"Widget: {result.SomeOrDefault()?.Name}");
+		var result = await this.Navigator()!.NavigateRouteForResultAsync<Widget>(this, "MyDrawer/Show").AsResult();
+		await this.Navigator()!.ShowMessageDialogAsync(this, content: $"Widget: {result.SomeOrDefault()?.Name}");
 	}
 
 	private async void CloseDrawerWithResultClick(object sender, RoutedEventArgs e)
 	{
-		await (sender as FrameworkElement).Navigator().NavigateBackWithResultAsync(this, data: new Widget { Name = "Drawer Widget" });
+		await (sender as FrameworkElement)!.Navigator()!.NavigateBackWithResultAsync(this, data: new Widget { Name = "Drawer Widget" });
 	}
 }

--- a/src/Uno.Extensions.Localization/LocalizationService.cs
+++ b/src/Uno.Extensions.Localization/LocalizationService.cs
@@ -36,7 +36,7 @@ public class LocalizationService : IHostedService
 	{
 		_logger = logger;
 		_settings = settings;
-		SupportedCultures = settings.CurrentValue?.Cultures?.AsCultures() ?? new[] { DefaultCulture.AsCulture() };
+		SupportedCultures = settings.CurrentValue?.Cultures?.AsCultures() ?? new[] { DefaultCulture.AsCulture()! };
 	}
 
 	public Task StartAsync(CancellationToken cancellationToken)

--- a/src/Uno.Extensions.Localization/LocalizationSettingsExtensions.cs
+++ b/src/Uno.Extensions.Localization/LocalizationSettingsExtensions.cs
@@ -7,10 +7,13 @@ public static class LocalizationSettingsExtensions
 {
 	public static CultureInfo[] AsCultures(this string[] cultures)
 	{
-		return cultures.Select(c => c.AsCulture()).ToArray();
+		return (from c in cultures
+				let cult = c.AsCulture()
+				where cult is not null
+				select cult).ToArray();
 	}
 
-	public static CultureInfo AsCulture(this string culture)
+	public static CultureInfo? AsCulture(this string culture)
 	{
 		return CultureInfo.GetCultures(CultureTypes.AllCultures)
 					.FirstOrDefault(cu => cu.Name == culture);

--- a/src/Uno.Extensions.Navigation.UI/Navigators/MessageDialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/MessageDialogNavigator.cs
@@ -78,16 +78,13 @@ public class MessageDialogNavigator : DialogNavigator
 					if (result.Status != TaskStatus.Canceled)
 					{
 						var msgResult = result.Result;
-						var dialogAction = msgResult is not null ?
-											(buttons.FirstOrDefault(b => b.Id == msgResult.Id) ?? new DialogAction(Label: msgResult.Label, Id: msgResult.Id)) :
-											default;
-						if (dialogAction is not null)
+						if (msgResult is not null)
 						{
-							navigation?.NavigateBackWithResultAsync(request.Sender, data: Option.Some(dialogAction));
+							navigation?.NavigateBackWithResultAsync(request.Sender, data: Option.Some(msgResult.Id ?? msgResult.Label));
 						}
 						else
 						{
-							navigation?.NavigateBackWithResultAsync(request.Sender, data: Option.None<DialogAction>());
+							navigation?.NavigateBackWithResultAsync(request.Sender, data: Option.None<object>());
 						}
 
 					}

--- a/src/Uno.Extensions.Navigation/NavigationResponseExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigationResponseExtensions.cs
@@ -15,12 +15,12 @@ public static class NavigationResponseExtensions
 
 	public static NavigationResultResponse<TResult>? AsResultResponse<TResult>(this NavigationResponse response)
     {
-        if (response is NavigationResultResponse<TResult> resultResponse)
-        {
-            return resultResponse;
-        }
+		if (response is NavigationResultResponse genericResultResponse)
+		{
+			return genericResultResponse.AsResultResponse<TResult>();
+		}
 
-        return null;
+		return null;
     }
 
 	public static async ValueTask<Option<TResult>> AsResult<TResult>(this Task<NavigationResultResponse<TResult>?> navigationResponse)

--- a/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
@@ -210,29 +210,45 @@ public static class NavigatorExtensions
 		return service.NavigateAsync((Qualifiers.NavigateBack + string.Empty).WithQualifier(qualifier).AsRequest(resolver, sender, data, cancellation));
 	}
 
-	public static async Task<NavigationResultResponse<DialogAction>?> ShowMessageDialogAsync(
+	public static async Task<NavigationResponse?> ShowMessageDialogAsync(
 		this INavigator service,
 		object sender,
-		string content,
-		string? title = null,
-		bool delayInput = false,
-		uint defaultCommandIndex = 0,
-		uint cancelCommandIndex = 0,
-		DialogAction[]? commands = null,
+		string? route = default,
+		string? content = default,
+		string? title = default,
+		bool? delayInput = default,
+		uint? defaultCommandIndex = default,
+		uint? cancelCommandIndex = default,
+		DialogAction[]? commands = default,
+		CancellationToken cancellation = default)
+	{
+		return await service.ShowMessageDialogAsync<object>(sender, route, content, title, delayInput, defaultCommandIndex, cancelCommandIndex, commands, cancellation);
+	}
+
+	public static async Task<NavigationResultResponse<TResult>?> ShowMessageDialogAsync<TResult>(
+		this INavigator service,
+		object sender,
+		string? route = default,
+		string? content = default,
+		string? title = default,
+		bool? delayInput = default,
+		uint? defaultCommandIndex = default,
+		uint? cancelCommandIndex = default,
+		DialogAction[]? commands = default,
 		CancellationToken cancellation = default)
 	{
 		var resolver = service.GetResolver();
 		var data = new Dictionary<string, object>()
 			{
 				{ RouteConstants.MessageDialogParameterTitle, title! },
-				{ RouteConstants.MessageDialogParameterContent, content },
-				{ RouteConstants.MessageDialogParameterOptions, delayInput },
-				{ RouteConstants.MessageDialogParameterDefaultCommand, defaultCommandIndex },
-				{ RouteConstants.MessageDialogParameterCancelCommand, cancelCommandIndex },
+				{ RouteConstants.MessageDialogParameterContent, content! },
+				{ RouteConstants.MessageDialogParameterOptions, delayInput! },
+				{ RouteConstants.MessageDialogParameterDefaultCommand, defaultCommandIndex! },
+				{ RouteConstants.MessageDialogParameterCancelCommand, cancelCommandIndex! },
 				{ RouteConstants.MessageDialogParameterCommands, commands! }
 			};
 
-		var result = await service.NavigateAsync((Qualifiers.Dialog + RouteConstants.MessageDialogUri).AsRequest<DialogAction>(resolver, sender, data, cancellation));
-		return result?.AsResultResponse<DialogAction>();
+		var result = await service.NavigateAsync((route ?? (Qualifiers.Dialog + RouteConstants.MessageDialogUri)).AsRequest<object>(resolver, sender, data, cancellation));
+		return result?.AsResultResponse<TResult>();
 	}
 }


### PR DESCRIPTION
…ole dialogresult

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

ShowMessageDialogAsync returns a DialogAction

## What is the new behavior?

ShowMessageDialogAsync returns the DialogAction.Id (or Label if Id not provided) and can be cast to the appropriate entity type - cleans up using messagedialog to get a result


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
