### PR TITLE
fix: Remove the default nullable for Action<ILoggingBuilder> parameter to avoid ambiguous call for HostBuilderExtensions.UseLogging methods

### DIFF
--- a/src/Uno.Extensions.Logging/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Logging/HostBuilderExtensions.cs
@@ -8,9 +8,9 @@ public static class HostBuilderExtensions
 {
 	public static IHostBuilder UseLogging(
 		this IHostBuilder hostBuilder,
-		Action<ILoggingBuilder>? configure = default)
+		Action<ILoggingBuilder> configure)
 	{
-		return hostBuilder.UseLogging((context, builder) => configure?.Invoke(builder));
+		return hostBuilder.UseLogging((context, builder) => configure.Invoke(builder));
 	}
 	public static IHostBuilder UseLogging(
 		this IHostBuilder hostBuilder,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Remove the default nullable for Action<ILoggingBuilder> parameter to avoid ambiguous call for HostBuilderExtensions.UseLogging methods
