### PR TITLE
feat: Simplifying messagedialog and extending GetDataAsync

### DIFF
--- a/samples/Playground/Playground/Playground/Playground.Shared/ViewModels/VMViewModel.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/ViewModels/VMViewModel.cs
@@ -79,6 +79,6 @@ public class VMViewModel
 	// Show MessageDialog
 	public async void ShowMessageDialogAsyncClick(object sender, RoutedEventArgs args)
 	{
-		var result = await Navigator.ShowMessageDialogAsync<string>(this, content:"Sample content", title:"Sample title").AsResult();
+		var result = await Navigator.ShowMessageDialogAsync<string>(this, content:"Sample content", title:"Sample title");
 	}
 }

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/CodeBehindPage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/CodeBehindPage.xaml.cs
@@ -92,7 +92,7 @@ public sealed partial class CodeBehindPage : Page, IInjectable<INavigator>
 	// Show MessageDialog
 	public async void ShowMessageDialogAsyncClick(object sender, RoutedEventArgs args)
 	{
-		var result = await Navigator!.ShowMessageDialogAsync<string>(this, content: "Sample content", title: "Sample title").AsResult();
+		var result = await Navigator!.ShowMessageDialogAsync<string>(this, content: "Sample content", title: "Sample title");
 	}
 }
 

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml
@@ -31,6 +31,10 @@
 					uen:Navigation.Request="!LocalizedConfirm" />
 			<Button Content="MessageDialog Codebehind"
 					Click="MessageDialogCodebehindClick" />
+			<Button Content="MessageDialog Codebehind (route)"
+					Click="MessageDialogCodebehindRouteClick" />
+			<Button Content="MessageDialog Codebehind (route override)"
+					Click="MessageDialogCodebehindRouteOverrideClick" />
 			<TextBlock x:Name="MessageDialogResultText" />
 			<Button Content="MessageDialog Codebehind (cancel after 2s)"
 					Click="MessageDialogCodebehindCancelClick" />

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
@@ -12,14 +12,14 @@ public sealed partial class DialogsPage : Page, IInjectable<INavigator>
 
 	private async void MessageDialogCodebehindClick(object sender, RoutedEventArgs args)
 	{
-		var messageDialogResult = await Navigator!.ShowMessageDialogAsync<string>(this, content: "This is Content", title:"This is title").AsResult();
+		var messageDialogResult = await Navigator!.ShowMessageDialogAsync<string>(this, content: "This is Content", title:"This is title");
 		MessageDialogResultText.Text = $"Message dialog result: {messageDialogResult}";
 	}
 
 	private async void MessageDialogCodebehindCancelClick(object sender, RoutedEventArgs args)
 	{
 		var cancelSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-		var messageDialogResult = await Navigator!.ShowMessageDialogAsync<string>(this, content:"This is Content", title:"This is title", cancellation: cancelSource.Token).AsResult();
+		var messageDialogResult = await Navigator!.ShowMessageDialogAsync<string>(this, content:"This is Content", title:"This is title", cancellation: cancelSource.Token);
 		MessageDialogCancelResultText.Text = $"Message dialog result: {messageDialogResult}";
 	}
 

--- a/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
+++ b/samples/Playground/Playground/Playground/Playground.Shared/Views/DialogsPage.xaml.cs
@@ -16,6 +16,16 @@ public sealed partial class DialogsPage : Page, IInjectable<INavigator>
 		MessageDialogResultText.Text = $"Message dialog result: {messageDialogResult}";
 	}
 
+	private async void MessageDialogCodebehindRouteClick(object sender, RoutedEventArgs args)
+	{
+		var messageDialogResult = await Navigator!.ShowMessageDialogAsync<string>(this, route:"LocalizedConfirm");
+		MessageDialogResultText.Text = $"Message dialog result: {messageDialogResult}";
+	}
+private async void MessageDialogCodebehindRouteOverrideClick(object sender, RoutedEventArgs args)
+	{
+		var messageDialogResult = await Navigator!.ShowMessageDialogAsync<string>(this, route:"LocalizedConfirm", content:"Override content", title:"Override title");
+		MessageDialogResultText.Text = $"Message dialog result: {messageDialogResult}";
+	}
 	private async void MessageDialogCodebehindCancelClick(object sender, RoutedEventArgs args)
 	{
 		var cancelSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));

--- a/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
@@ -210,7 +210,7 @@ public static class NavigatorExtensions
 		return service.NavigateAsync((Qualifiers.NavigateBack + string.Empty).WithQualifier(qualifier).AsRequest(resolver, sender, data, cancellation));
 	}
 
-	public static async Task<NavigationResponse?> ShowMessageDialogAsync(
+	public static async Task ShowMessageDialogAsync(
 		this INavigator service,
 		object sender,
 		string? route = default,
@@ -222,10 +222,10 @@ public static class NavigatorExtensions
 		DialogAction[]? commands = default,
 		CancellationToken cancellation = default)
 	{
-		return await service.ShowMessageDialogAsync<object>(sender, route, content, title, delayInput, defaultCommandIndex, cancelCommandIndex, commands, cancellation);
+		await service.ShowMessageDialogAsync<object>(sender, route, content, title, delayInput, defaultCommandIndex, cancelCommandIndex, commands, cancellation);
 	}
 
-	public static async Task<NavigationResultResponse<TResult>?> ShowMessageDialogAsync<TResult>(
+	public static async Task<TResult?> ShowMessageDialogAsync<TResult>(
 		this INavigator service,
 		object sender,
 		string? route = default,
@@ -248,7 +248,13 @@ public static class NavigatorExtensions
 				{ RouteConstants.MessageDialogParameterCommands, commands! }
 			};
 
-		var result = await service.NavigateAsync((route ?? (Qualifiers.Dialog + RouteConstants.MessageDialogUri)).AsRequest<object>(resolver, sender, data, cancellation));
-		return result?.AsResultResponse<TResult>();
+		var response = await service.NavigateAsync((route ?? (Qualifiers.Dialog + RouteConstants.MessageDialogUri)).AsRequest<object>(resolver, sender, data, cancellation));
+		if(response?.AsResultResponse<TResult>() is { } resultResponse &&
+			resultResponse.Result is not null)
+		{
+			var result = await resultResponse.Result;
+			return result.SomeOrDefault();
+		};
+		return default;
 	}
 }

--- a/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
@@ -183,6 +183,12 @@ public static class NavigatorExtensions
 		return result.SomeOrDefault();
 	}
 
+	public static async Task<TResult?> GetDataAsync<TResult>(this INavigator service, object sender, string route, string qualifier = Qualifiers.None, CancellationToken cancellation = default)
+	{
+		var result = await service.NavigateRouteForResultAsync<TResult>(sender, route, qualifier, cancellation: cancellation).AsResult();
+		return result.SomeOrDefault();
+	}
+
 	public static async Task<TResult?> GetDataAsync<TViewModel, TResult>(this INavigator service, object sender, string qualifier = Qualifiers.None, CancellationToken cancellation = default)
 	{
 		var result = await service.NavigateViewModelForResultAsync<TViewModel, TResult>(sender, qualifier, cancellation: cancellation).AsResult();
@@ -249,7 +255,7 @@ public static class NavigatorExtensions
 			};
 
 		var response = await service.NavigateAsync((route ?? (Qualifiers.Dialog + RouteConstants.MessageDialogUri)).AsRequest<object>(resolver, sender, data, cancellation));
-		if(response?.AsResultResponse<TResult>() is { } resultResponse &&
+		if (response?.AsResultResponse<TResult>() is { } resultResponse &&
 			resultResponse.Result is not null)
 		{
 			var result = await resultResponse.Result;

--- a/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
@@ -223,12 +223,12 @@ public static class NavigatorExtensions
 		string? content = default,
 		string? title = default,
 		bool? delayInput = default,
-		uint? defaultCommandIndex = default,
-		uint? cancelCommandIndex = default,
-		DialogAction[]? commands = default,
+		int? defaultButtonIndex = default,
+		int? cancelButtonIndex = default,
+		DialogAction[]? buttons = default,
 		CancellationToken cancellation = default)
 	{
-		await service.ShowMessageDialogAsync<object>(sender, route, content, title, delayInput, defaultCommandIndex, cancelCommandIndex, commands, cancellation);
+		await service.ShowMessageDialogAsync<object>(sender, route, content, title, delayInput, defaultButtonIndex, cancelButtonIndex, buttons, cancellation);
 	}
 
 	public static async Task<TResult?> ShowMessageDialogAsync<TResult>(
@@ -238,9 +238,9 @@ public static class NavigatorExtensions
 		string? content = default,
 		string? title = default,
 		bool? delayInput = default,
-		uint? defaultCommandIndex = default,
-		uint? cancelCommandIndex = default,
-		DialogAction[]? commands = default,
+		int? defaultButtonIndex = default,
+		int? cancelButtonIndex = default,
+		DialogAction[]? buttons = default,
 		CancellationToken cancellation = default)
 	{
 		var resolver = service.GetResolver();
@@ -249,9 +249,9 @@ public static class NavigatorExtensions
 				{ RouteConstants.MessageDialogParameterTitle, title! },
 				{ RouteConstants.MessageDialogParameterContent, content! },
 				{ RouteConstants.MessageDialogParameterOptions, delayInput! },
-				{ RouteConstants.MessageDialogParameterDefaultCommand, defaultCommandIndex! },
-				{ RouteConstants.MessageDialogParameterCancelCommand, cancelCommandIndex! },
-				{ RouteConstants.MessageDialogParameterCommands, commands! }
+				{ RouteConstants.MessageDialogParameterDefaultCommand, defaultButtonIndex! },
+				{ RouteConstants.MessageDialogParameterCancelCommand, cancelButtonIndex! },
+				{ RouteConstants.MessageDialogParameterCommands, buttons! }
 			};
 
 		var response = await service.NavigateAsync((route ?? (Qualifiers.Dialog + RouteConstants.MessageDialogUri)).AsRequest<object>(resolver, sender, data, cancellation));


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

ShowMessageDialogAsync required the AsResult extension and then SomeOrDefault just to get the returned value
GetDataAsync doesn't support specifying a route string

## What is the new behavior?

ShowMessageDialogAsync returns the selected value
GetDataAsync has an overload that takes a route string

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
