### PR TITLE
feat(feed): Support of pessimistic update messaging system

### DIFF
--- a/src/Uno.Extensions.Reactive.Messaging/EntityChange.cs
+++ b/src/Uno.Extensions.Reactive.Messaging/EntityChange.cs
@@ -4,7 +4,7 @@ using System.Linq;
 namespace Uno.Extensions.Reactive.Messaging;
 
 /// <summary>
-/// Defines the possible of updates on an entity
+/// Defines possible types of updates for an entity
 /// </summary>
 public enum EntityChange
 {

--- a/src/Uno.Extensions.Reactive.Messaging/EntityChange.cs
+++ b/src/Uno.Extensions.Reactive.Messaging/EntityChange.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive.Messaging;
+
+/// <summary>
+/// Defines the possible of updates on an entity
+/// </summary>
+public enum EntityChange
+{
+	/// <summary>
+	/// An entity has been created.
+	/// </summary>
+	Created,
+
+	/// <summary>
+	/// A new version of an entity is available.
+	/// </summary>
+	Updated,
+
+	/// <summary>
+	/// An entity has been removed.
+	/// </summary>
+	Deleted,
+}

--- a/src/Uno.Extensions.Reactive.Messaging/EntityMessage.cs
+++ b/src/Uno.Extensions.Reactive.Messaging/EntityMessage.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Linq;
+using CommunityToolkit.Mvvm.Messaging;
+
+namespace Uno.Extensions.Reactive.Messaging;
+
+/// <summary>
+/// A message that can be send through <see cref="IMessenger"/> to indicate that a changed has been successfully made on an entity.
+/// </summary>
+/// <typeparam name="T">The type of the updated entity.</typeparam>
+/// <param name="Change">The type of the change.</param>
+/// <param name="Value">The updated entity.</param>
+public record EntityMessage<T>(EntityChange Change, T Value);

--- a/src/Uno.Extensions.Reactive.Messaging/EntityMessage.cs
+++ b/src/Uno.Extensions.Reactive.Messaging/EntityMessage.cs
@@ -5,7 +5,7 @@ using CommunityToolkit.Mvvm.Messaging;
 namespace Uno.Extensions.Reactive.Messaging;
 
 /// <summary>
-/// A message that can be send through <see cref="IMessenger"/> to indicate that a changed has been successfully made on an entity.
+/// A message that can be sent through <see cref="IMessenger"/> to indicate that a change has been successfully made on an entity.
 /// </summary>
 /// <typeparam name="T">The type of the updated entity.</typeparam>
 /// <param name="Change">The type of the change.</param>

--- a/src/Uno.Extensions.Reactive.Messaging/MessengerExtensions.cs
+++ b/src/Uno.Extensions.Reactive.Messaging/MessengerExtensions.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Threading;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Logging;
+using Uno.Extensions.Reactive.Utils;
+
+namespace Uno.Extensions.Reactive.Messaging;
+
+/// <summary>
+/// Set of extensions to bind an <see cref="IMessenger"/> with an <see cref="IState{T}"/>.
+/// </summary>
+public static class MessengerExtensions
+{
+	/// <summary>
+	/// Listen for <see cref="EntityMessage{TEntity}"/> on the given <paramref name="messenger"/> and updates the <paramref name="state"/> accordingly.
+	/// </summary>
+	/// <typeparam name="TEntity">Type of the value of teh state.</typeparam>
+	/// <typeparam name="TKey">Type of the identifier that uniquely identifies a <typeparamref name="TEntity"/>.</typeparam>
+	/// <param name="messenger">The messenger to listen for <see cref="EntityMessage{TEntity}"/></param>
+	/// <param name="state">The state to update.</param>
+	/// <param name="keySelector">A selector to get a unique identifier of a <typeparamref name="TEntity"/>.</param>
+	/// <returns>A disposable that can be used to unbind the state from the messenger.</returns>
+	public static IDisposable Observe<TEntity, TKey>(this IMessenger messenger, IState<TEntity> state, Func<TEntity, TKey> keySelector)
+		=> AttachedProperty.GetOrCreate(state, keySelector, messenger, (s, ks, msg) => new Recipient<IState<TEntity>, TEntity, TKey>(s, msg, ks, StateExtensions.Update));
+
+	/// <summary>
+	/// Listen for <see cref="EntityMessage{TEntity}"/> on the given <paramref name="messenger"/> and updates the <paramref name="listState"/> accordingly.
+	/// </summary>
+	/// <typeparam name="TEntity">Type of the value of teh state.</typeparam>
+	/// <typeparam name="TKey">Type of the identifier that uniquely identifies a <typeparamref name="TEntity"/>.</typeparam>
+	/// <param name="messenger">The messenger to listen for <see cref="EntityMessage{TEntity}"/></param>
+	/// <param name="listState">The list state to update.</param>
+	/// <param name="keySelector">A selector to get a unique identifier of a <typeparamref name="TEntity"/>.</param>
+	/// <returns>A disposable that can be used to unbind the state from the messenger.</returns>
+	public static IDisposable Observe<TEntity, TKey>(this IMessenger messenger, IListState<TEntity> listState, Func<TEntity, TKey> keySelector)
+		=> AttachedProperty.GetOrCreate(listState, keySelector, messenger, (s, ks, msg) => new Recipient<IListState<TEntity>, TEntity, TKey>(s, msg, ks, StateExtensions.Update));
+
+	/// <summary>
+	/// Listen for <see cref="EntityMessage{TEntity}"/> on the given <paramref name="messenger"/>, matches it with another value and updates the <paramref name="state"/> accordingly.
+	/// </summary>
+	/// <typeparam name="TOther">Type of the other value to validate.</typeparam>
+	/// <typeparam name="TEntity">Type of the value of teh state.</typeparam>
+	/// <typeparam name="TKey">Type of the identifier that uniquely identifies a <typeparamref name="TEntity"/>.</typeparam>
+	/// <param name="messenger">The messenger to listen for <see cref="EntityMessage{TEntity}"/></param>
+	/// <param name="state">The state to update.</param>
+	/// <param name="other">The other value to validate with the updated entity using <paramref name="predicate"/>.</param>
+	/// <param name="predicate">A predicted used with the updated entity to confirm that the change should by applied to the <paramref name="state"/>.</param>
+	/// <param name="keySelector">A selector to get a unique identifier of a <typeparamref name="TEntity"/>.</param>
+	/// <returns>A disposable that can be used to unbind the state from the messenger.</returns>
+	public static IDisposable Observe<TOther, TEntity, TKey>(
+		this IMessenger messenger,
+		IState<TEntity> state,
+		IFeed<TOther> other,
+		Func<TOther, TEntity, bool> predicate,
+		Func<TEntity, TKey> keySelector)
+	{
+		return AttachedProperty.GetOrCreate(
+			state,
+			keySelector,
+			(other, predicate, messenger),
+			CreateRecipient);
+
+		static Recipient<IState<TEntity>, TEntity, TKey> CreateRecipient(
+			IState<TEntity> state,
+			Func<TEntity, TKey> keySelector,
+			(IFeed<TOther> other, Func<TOther, TEntity, bool> predicate, IMessenger messenger) config)
+			=> new(state, config.messenger, keySelector, If<IState<TEntity>, TOther, TEntity, TKey>(config.other, config.predicate, StateExtensions.Update));
+	}
+
+	/// <summary>
+	/// Listen for <see cref="EntityMessage{TEntity}"/> on the given <paramref name="messenger"/>, matches it with another value and updates the <paramref name="listState"/> accordingly.
+	/// </summary>
+	/// <typeparam name="TOther">Type of the other value to validate.</typeparam>
+	/// <typeparam name="TEntity">Type of the value of teh state.</typeparam>
+	/// <typeparam name="TKey">Type of the identifier that uniquely identifies a <typeparamref name="TEntity"/>.</typeparam>
+	/// <param name="messenger">The messenger to listen for <see cref="EntityMessage{TEntity}"/></param>
+	/// <param name="listState">The list state to update.</param>
+	/// <param name="other">The other value to validate with the updated entity using <paramref name="predicate"/>.</param>
+	/// <param name="predicate">A predicted used with the updated entity to confirm that the change should by applied to the <paramref name="listState"/>.</param>
+	/// <param name="keySelector">A selector to get a unique identifier of a <typeparamref name="TEntity"/>.</param>
+	/// <returns>A disposable that can be used to unbind the state from the messenger.</returns>
+	public static IDisposable Observe<TOther, TEntity, TKey>(
+		this IMessenger messenger,
+		IListState<TEntity> listState,
+		IFeed<TOther> other,
+		Func<TOther, TEntity, bool> predicate,
+		Func<TEntity, TKey> keySelector)
+	{
+		return AttachedProperty.GetOrCreate(
+			listState,
+			keySelector,
+			(other, predicate, messenger),
+			CreateRecipient);
+
+		static Recipient<IListState<TEntity>, TEntity, TKey> CreateRecipient(
+			IListState<TEntity> state,
+			Func<TEntity, TKey> keySelector,
+			(IFeed<TOther> other, Func<TOther, TEntity, bool> predicate, IMessenger messenger) config)
+			=> new(state, config.messenger, keySelector, If<IListState<TEntity>, TOther, TEntity, TKey>(config.other, config.predicate, StateExtensions.Update));
+	}
+
+	private static AsyncAction<TState, EntityMessage<TEntity>, Func<TEntity, TKey>> If<TState, TOther, TEntity, TKey>(
+		IFeed<TOther> other,
+		Func<TOther, TEntity, bool> predicate,
+		AsyncAction<TState, EntityMessage<TEntity>, Func<TEntity, TKey>> update)
+		=> async (state, message, keySelector, ct) =>
+		{
+			using var _ = SourceContext.GetOrCreate(other).AsCurrent();
+
+			if ((await other.Option(ct)).IsSome(out var master) && predicate(master, message.Value))
+			{
+				await update(state, message, keySelector, ct);
+			}
+		};
+
+	private sealed class Recipient<TState, TEntity, TKey> : IRecipient<EntityMessage<TEntity>>, IDisposable
+		where TState : class
+	{
+		private readonly CancellationTokenSource _ct = new();
+		private readonly TState _state;
+		private readonly IMessenger _messenger;
+		private readonly Func<TEntity, TKey> _keySelector;
+		private readonly AsyncAction<TState, EntityMessage<TEntity>, Func<TEntity, TKey>> _update;
+
+		public Recipient(
+			TState state,
+			IMessenger messenger,
+			Func<TEntity, TKey> keySelector,
+			AsyncAction<TState, EntityMessage<TEntity>, Func<TEntity, TKey>> update)
+		{
+			_state = state;
+			_messenger = messenger;
+			_keySelector = keySelector;
+			_update = update;
+
+			messenger.Register(this);
+		}
+
+		/// <inheritdoc />
+		public async void Receive(EntityMessage<TEntity> msg)
+		{
+			try
+			{
+				await _update(_state, msg, _keySelector, _ct.Token);
+			}
+			catch (OperationCanceledException) when (_ct.IsCancellationRequested)
+			{
+			}
+			catch (Exception e)
+			{
+				if (this.Log().IsEnabled(LogLevel.Error))
+				{
+					this.Log().Error(e, "Failed to apply update message.");
+				}
+			}
+		}
+
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			_messenger.Unregister<EntityMessage<TEntity>>(this);
+			_ct.Cancel(throwOnFirstException: false);
+			_ct.Dispose();
+		}
+	}
+}

--- a/src/Uno.Extensions.Reactive.Messaging/MessengerExtensions.cs
+++ b/src/Uno.Extensions.Reactive.Messaging/MessengerExtensions.cs
@@ -16,7 +16,7 @@ public static class MessengerExtensions
 	/// <summary>
 	/// Listen for <see cref="EntityMessage{TEntity}"/> on the given <paramref name="messenger"/> and updates the <paramref name="state"/> accordingly.
 	/// </summary>
-	/// <typeparam name="TEntity">Type of the value of teh state.</typeparam>
+	/// <typeparam name="TEntity">Type of the value of the state.</typeparam>
 	/// <typeparam name="TKey">Type of the identifier that uniquely identifies a <typeparamref name="TEntity"/>.</typeparam>
 	/// <param name="messenger">The messenger to listen for <see cref="EntityMessage{TEntity}"/></param>
 	/// <param name="state">The state to update.</param>
@@ -28,7 +28,7 @@ public static class MessengerExtensions
 	/// <summary>
 	/// Listen for <see cref="EntityMessage{TEntity}"/> on the given <paramref name="messenger"/> and updates the <paramref name="listState"/> accordingly.
 	/// </summary>
-	/// <typeparam name="TEntity">Type of the value of teh state.</typeparam>
+	/// <typeparam name="TEntity">Type of the value of the state.</typeparam>
 	/// <typeparam name="TKey">Type of the identifier that uniquely identifies a <typeparamref name="TEntity"/>.</typeparam>
 	/// <param name="messenger">The messenger to listen for <see cref="EntityMessage{TEntity}"/></param>
 	/// <param name="listState">The list state to update.</param>
@@ -41,7 +41,7 @@ public static class MessengerExtensions
 	/// Listen for <see cref="EntityMessage{TEntity}"/> on the given <paramref name="messenger"/>, matches it with another value and updates the <paramref name="state"/> accordingly.
 	/// </summary>
 	/// <typeparam name="TOther">Type of the other value to validate.</typeparam>
-	/// <typeparam name="TEntity">Type of the value of teh state.</typeparam>
+	/// <typeparam name="TEntity">Type of the value of the state.</typeparam>
 	/// <typeparam name="TKey">Type of the identifier that uniquely identifies a <typeparamref name="TEntity"/>.</typeparam>
 	/// <param name="messenger">The messenger to listen for <see cref="EntityMessage{TEntity}"/></param>
 	/// <param name="state">The state to update.</param>
@@ -73,7 +73,7 @@ public static class MessengerExtensions
 	/// Listen for <see cref="EntityMessage{TEntity}"/> on the given <paramref name="messenger"/>, matches it with another value and updates the <paramref name="listState"/> accordingly.
 	/// </summary>
 	/// <typeparam name="TOther">Type of the other value to validate.</typeparam>
-	/// <typeparam name="TEntity">Type of the value of teh state.</typeparam>
+	/// <typeparam name="TEntity">Type of the value of the state.</typeparam>
 	/// <typeparam name="TKey">Type of the identifier that uniquely identifies a <typeparamref name="TEntity"/>.</typeparam>
 	/// <param name="messenger">The messenger to listen for <see cref="EntityMessage{TEntity}"/></param>
 	/// <param name="listState">The list state to update.</param>

--- a/src/Uno.Extensions.Reactive.Messaging/StateExtensions.cs
+++ b/src/Uno.Extensions.Reactive.Messaging/StateExtensions.cs
@@ -27,6 +27,11 @@ public static class StateExtensions
 				var updatedEntityKey = keySelector(message.Value);
 				await state.UpdateValue(current => current.IsSome(out var entity) && AreKeyEquals(updatedEntityKey, keySelector(entity)) ? message.Value : current, ct);
 				break;
+
+			case EntityChange.Deleted:
+				var removedEntityKey = keySelector(message.Value);
+				await state.UpdateValue(current => current.IsSome(out var entity) && AreKeyEquals(removedEntityKey, keySelector(entity)) ? Option<TEntity>.None() : current, ct);
+				break;
 		}
 
 		static bool AreKeyEquals(TKey left, TKey right)

--- a/src/Uno.Extensions.Reactive.Messaging/StateExtensions.cs
+++ b/src/Uno.Extensions.Reactive.Messaging/StateExtensions.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Uno.Extensions.Reactive.Messaging;
+
+/// <summary>
+/// Set of extensions to update an <see cref="IState{T}"/> from messaging structures.
+/// </summary>
+public static class StateExtensions
+{
+	/// <summary>
+	/// Updates a state using an <see cref="EntityMessage{TEntity}"/>.
+	/// </summary>
+	/// <typeparam name="TEntity">Type of the value of teh state.</typeparam>
+	/// <typeparam name="TKey">Type of the identifier that uniquely identifies a <typeparamref name="TEntity"/>.</typeparam>
+	/// <param name="state">The state to update.</param>
+	/// <param name="message">The update message to apply.</param>
+	/// <param name="keySelector">A selector to get a unique identifier of a <typeparamref name="TEntity"/>.</param>
+	/// <param name="ct">A cancellation token to abort the async operation</param>
+	/// <returns>An async operation of the update.</returns>
+	public static async ValueTask Update<TEntity, TKey>(this IState<TEntity> state, EntityMessage<TEntity> message, Func<TEntity, TKey> keySelector, CancellationToken ct)
+	{
+		switch (message.Change)
+		{
+			case EntityChange.Updated:
+				var updatedEntityKey = keySelector(message.Value);
+				await state.UpdateValue(current => current.IsSome(out var entity) && AreKeyEquals(updatedEntityKey, keySelector(entity)) ? message.Value : current, ct);
+				break;
+		}
+
+		static bool AreKeyEquals(TKey left, TKey right)
+			=> left?.Equals(right) ?? right is null;
+	}
+
+	/// <summary>
+	/// Updates a state using an <see cref="EntityMessage{TEntity}"/>.
+	/// </summary>
+	/// <typeparam name="TEntity">Type of the value of teh state.</typeparam>
+	/// <typeparam name="TKey">Type of the identifier that uniquely identifies a <typeparamref name="TEntity"/>.</typeparam>
+	/// <param name="listState">The state to update.</param>
+	/// <param name="message">The update message to apply.</param>
+	/// <param name="keySelector">A selector to get a unique identifier of a <typeparamref name="TEntity"/>.</param>
+	/// <param name="ct">A cancellation token to abort the async operation</param>
+	/// <returns>An async operation of the update.</returns>
+	public static async ValueTask Update<TEntity, TKey>(this IListState<TEntity> listState, EntityMessage<TEntity> message, Func<TEntity, TKey> keySelector, CancellationToken ct)
+	{
+		switch (message.Change)
+		{
+			case EntityChange.Created:
+				await listState.AddAsync(message.Value, ct);
+				break;
+
+			case EntityChange.Deleted:
+				var removedItemKey = keySelector(message.Value);
+				await listState.RemoveAllAsync(item => AreKeyEquals(removedItemKey, keySelector(item)), ct);
+				break;
+
+			case EntityChange.Updated:
+				var updatedItemKey = keySelector(message.Value);
+				await listState.UpdateAsync(item => AreKeyEquals(updatedItemKey, keySelector(item)), _ => message.Value, ct);
+				break;
+		}
+
+		static bool AreKeyEquals(TKey left, TKey right)
+			=> left?.Equals(right) ?? right is null;
+	}
+}

--- a/src/Uno.Extensions.Reactive.Messaging/Uno.Extensions.Reactive.Messaging.csproj
+++ b/src/Uno.Extensions.Reactive.Messaging/Uno.Extensions.Reactive.Messaging.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Uno.Extensions.Reactive.Messaging/Uno.Extensions.Reactive.Messaging.csproj
+++ b/src/Uno.Extensions.Reactive.Messaging/Uno.Extensions.Reactive.Messaging.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.0.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.Extensions.Reactive\Uno.Extensions.Reactive.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="..\Uno.Extensions.Core\_Compat\**\*.cs" Link="_Compat\%(RecursiveDir)%(Filename)%(Extension)" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.Extensions.Reactive.Tests/Messaging/Given_Messaging.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Messaging/Given_Messaging.cs
@@ -1,0 +1,264 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Messaging;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Messaging;
+
+[TestClass]
+public class Given_Messaging : FeedTests
+{
+	[TestMethod]
+	public async Task When_Created_Then_StateNotUpdated()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var state = State<MyEntity>.Empty(this);
+
+		messenger.Observe(state, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Created, new(42)));
+
+		var result = await state.Option(CT);
+		result.Should().Be(Option<MyEntity>.None());
+	}
+
+	[TestMethod]
+	public async Task When_Updated_Then_StateUpdated()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var state = State.Value(this, () => new MyEntity(42));
+
+		messenger.Observe(state, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Updated, new(42, 1)));
+
+		var result = await state;
+		result.Should().BeEquivalentTo(new MyEntity(42, 1));
+	}
+
+	[TestMethod]
+	public async Task When_Deleted_Then_StateUpdated()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var state = State.Value(this, () => new MyEntity(42));
+
+		messenger.Observe(state, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Deleted, new(42, 1)));
+
+		var result = await state.Option(CT);
+		result.Should().Be(Option<MyEntity>.None());
+	}
+
+	[TestMethod]
+	public async Task When_Created_Then_ListStateUpdated()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var state = ListState<MyEntity>.Empty(this);
+
+		messenger.Observe(state, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Created, new(42)));
+
+		var result = await state;
+		result.Should().BeEquivalentTo(Items(42));
+	}
+
+	[TestMethod]
+	public async Task When_Updated_Then_ListStateUpdated()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var state = ListState<MyEntity>.Value(this, () => Items(42));
+
+		messenger.Observe(state, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Updated, new(42, 1)));
+
+		var result = await state;
+		result.Should().BeEquivalentTo(Items((42, 1)));
+	}
+
+	[TestMethod]
+	public async Task When_Deleted_Then_ListStateUpdated()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var state = ListState<MyEntity>.Value(this, () => Items(42));
+
+		messenger.Observe(state, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Deleted, new(42, 1)));
+
+		var result = await state;
+		result.Should().BeEmpty();
+	}
+
+	[TestMethod]
+	public async Task When_CreatedUsingOther_Then_StateNotUpdated()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var other = State.Value(this, () => 0);
+		var state = State<MyEntity>.Empty(this);
+
+		messenger.Observe(state, other, (o, e) => true, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Created, new(42)));
+
+		var result = await state.Option(CT);
+		result.Should().Be(Option<MyEntity>.None());
+	}
+
+	[TestMethod]
+	public async Task When_UpdatedUsingOther_Then_StateUpdatedIfMatchOther()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var other = State.Value(this, () => 1);
+		var state = State.Value(this, () => new MyEntity(42));
+
+		messenger.Observe(state, other, (o, e) => e.Version == o, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Updated, new(42, 1)));
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Updated, new(42, 2)));
+
+		var result = await state;
+		result.Should().BeEquivalentTo(new MyEntity(42, 1));
+	}
+
+	[TestMethod]
+	public async Task When_DeletedUsingOther_Then_StateUpdatedIfMatchOther()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var other = State.Value(this, () => 2);
+		var state = State.Value(this, () => new MyEntity(42));
+
+		messenger.Observe(state, other, (o, e) => e.Version == o, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Deleted, new(42, 1)));
+		var intermediate = await state;
+		intermediate.Should().BeEquivalentTo(new MyEntity(42));
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Deleted, new(42, 2)));
+		var result = await state.Option(CT);
+		result.Should().Be(Option<MyEntity>.None());
+	}
+
+	[TestMethod]
+	public async Task When_CreatedUsingOther_Then_ListStateUpdatedIfMatchOther()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var other = State.Value(this, () => 1);
+		var state = ListState<MyEntity>.Empty(this);
+
+		messenger.Observe(state, other, (o, e) => e.Version == o, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Created, new(42, 1)));
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Created, new(43, 2)));
+
+		var result = await state;
+		result.Should().BeEquivalentTo(Items((42, 1)));
+	}
+
+	[TestMethod]
+	public async Task When_UpdatedUsingOther_Then_ListStateUpdatedIfMatchOther()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var other = State.Value(this, () => 1);
+		var state = ListState<MyEntity>.Value(this, () => Items((42, 0), (43, 1)));
+
+		messenger.Observe(state, other, (o, e) => e.Version == o, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Updated, new(42, 1)));
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Updated, new(43, 2)));
+
+		var result = await state;
+		result.Should().BeEquivalentTo(Items((42, 1), (43, 1)));
+	}
+
+	[TestMethod]
+	public async Task When_DeletedUsingOther_Then_ListStateUpdatedIfMatchOther()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var other = State.Value(this, () => 1);
+		var state = ListState<MyEntity>.Value(this, () => Items((42, 0), (43, 1)));
+
+		messenger.Observe(state, other, (o, e) => e.Version == o, i => i.Key);
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Deleted, new(42, 1)));
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Deleted, new(43, 2)));
+
+		var result = await state;
+		result.Should().BeEquivalentTo(Items((43, 1)));
+	}
+
+	[TestMethod]
+	public async Task When_DisposedAndUpdated_Then_StateNotUpdated()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var state = State.Value(this, () => new MyEntity(42));
+
+		messenger.Observe(state, i => i.Key).Dispose();
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Updated, new(42, 1)));
+
+		var result = await state;
+		result.Should().BeEquivalentTo(new MyEntity(42));
+	}
+
+	[TestMethod]
+	public async Task When_DisposedAndUpdated_Then_ListStateNotUpdated()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var state = ListState<MyEntity>.Value(this, () => Items(42));
+
+		messenger.Observe(state, i => i.Key).Dispose();
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Updated, new(42, 1)));
+
+		var result = await state;
+		result.Should().BeEquivalentTo(Items(42));
+	}
+
+	[TestMethod]
+	public async Task When_DisposedAndUpdatedUsingOther_Then_StateNotUpdated()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var other = State.Value(this, () => 1);
+		var state = State.Value(this, () => new MyEntity(42));
+
+		messenger.Observe(state, other, (o, e) => e.Version == o, i => i.Key).Dispose();
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Updated, new(42, 1)));
+
+		var result = await state;
+		result.Should().BeEquivalentTo(new MyEntity(42));
+	}
+
+	[TestMethod]
+	public async Task When_DisposedAndUpdatedUsingOther_Then_ListStateNotUpdated()
+	{
+		var messenger = new WeakReferenceMessenger();
+		var other = State.Value(this, () => 1);
+		var state = ListState<MyEntity>.Value(this, () => Items((42, 0), (43, 1)));
+
+		messenger.Observe(state, other, (o, e) => e.Version == o, i => i.Key).Dispose();
+
+		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Updated, new(42, 1)));
+
+		var result = await state;
+		result.Should().BeEquivalentTo(Items((42, 0), (43, 1)));
+	}
+
+	private static IImmutableList<MyEntity> Items(params int[] items)
+		=> items.Select(i => new MyEntity(i)).ToImmutableList();
+
+	private static IImmutableList<MyEntity> Items(params (int key, int version)[] items)
+		=> items.Select(i => new MyEntity(i.key, i.version)).ToImmutableList();
+
+	private record MyEntity(int Key, int Version = 0);
+}

--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_CombineFeed.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_CombineFeed.cs
@@ -24,8 +24,8 @@ namespace Uno.Reactive.Tests.Operators
 
 			var sut = Feed.Combine(feed1, feed2).Record();
 
-			await feed1.Update(msg => msg.With().Data(42), CT);
-			await feed2.Update(msg => msg.With().Data(43), CT);
+			await feed1.UpdateMessage(msg => msg.With().Data(42), CT);
+			await feed2.UpdateMessage(msg => msg.With().Data(43), CT);
 
 			sut.Should().Be(r => r
 				.Message(Changed.None, Data.Undefined, Error.No, Progress.Final)

--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_StateExecute.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_StateExecute.cs
@@ -123,7 +123,7 @@ public class Given_StateExecute : FeedTests
 
 		state.Execute(async (list, ct) => result.Add(list));
 
-		await state.UpdateValue(_ => Option.None<IImmutableList<int>>(), CT);
+		await state.UpdateData(_ => Option.None<IImmutableList<int>>(), CT);
 
 		result.Single().Should().NotBeNull().And.BeEquivalentTo(ImmutableList<int>.Empty);
 	}

--- a/src/Uno.Extensions.Reactive.Tests/Uno.Extensions.Reactive.Tests.csproj
+++ b/src/Uno.Extensions.Reactive.Tests/Uno.Extensions.Reactive.Tests.csproj
@@ -27,8 +27,13 @@
 	<Import Project="..\Uno.Extensions.Reactive.Generator\buildTransitive\Uno.Extensions.Reactive.props" />
 
 	<ItemGroup>
+		<ProjectReference Include="..\Uno.Extensions.Reactive.Messaging\Uno.Extensions.Reactive.Messaging.csproj" />
 		<ProjectReference Include="..\Uno.Extensions.Reactive.Testing\Uno.Extensions.Reactive.Testing.csproj" />
 		<ProjectReference Include="..\Uno.Extensions.Reactive.UI\Uno.Extensions.Reactive.UI.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="..\Uno.Extensions.Core\_Compat\**\*.cs" Link="_Compat\%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
 </Project>

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Bindable.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Bindable.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Uno.Extensions.Reactive.Core;
-using Uno.Logging;
+using Uno.Extensions.Reactive.Logging;
 
 namespace Uno.Extensions.Reactive.Bindings;
 
@@ -144,9 +144,9 @@ public class Bindable<T> : IBindable, INotifyPropertyChanged, IFeed<T>
 		catch (Exception error)
 		{
 			this.Log().Error(
+				error,
 				$"Synchronization from View to ViewModel of '{_property}' failed. "
-				+ "(This is a temporary error, it will be retried on next change from the View.)",
-				error);
+				+ "(This is a temporary error, it will be retried on next change from the View.)");
 		}
 	}
 

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
@@ -75,12 +75,12 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 	}
 
 	/// <inheritdoc />
-	ValueTask IListState<T>.Update(Func<Message<IImmutableList<T>>, MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
-		=> _state.Update(updater, ct);
+	ValueTask IListState<T>.UpdateMessage(Func<Message<IImmutableList<T>>, MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
+		=> _state.UpdateMessage(updater, ct);
 
 	/// <inheritdoc />
-	ValueTask IState<IImmutableList<T>>.Update(Func<Message<IImmutableList<T>>, MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
-		=> _state.Update(updater, ct);
+	ValueTask IState<IImmutableList<T>>.UpdateMessage(Func<Message<IImmutableList<T>>, MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
+		=> _state.UpdateMessage(updater, ct);
 
 	/// <inheritdoc />
 	public async ValueTask DisposeAsync()

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableViewModelBase.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableViewModelBase.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 using Uno.Extensions.Reactive.Core;
 using Uno.Extensions.Reactive.Dispatching;
 using Uno.Extensions.Reactive.Events;
+using Uno.Extensions.Reactive.Logging;
 using Uno.Extensions.Reactive.Utils;
-using Uno.Logging;
 
 namespace Uno.Extensions.Reactive.Bindings;
 
@@ -138,18 +138,18 @@ public abstract partial class BindableViewModelBase : IBindable, INotifyProperty
 					catch (Exception error)
 					{
 						this.Log().Error(
+							error,
 							$"Synchronization from ViewModel to View of '{propertyName}' failed."
-							+ "(This is a final error, changes made in the VM are no longer propagated to the View.)",
-							error);
+							+ "(This is a final error, changes made in the VM are no longer propagated to the View.)");
 					}
 				});
 			}
 			catch (Exception error)
 			{
 				this.Log().Error(
+					error,
 					$"Synchronization from ViewModel to View of '{propertyName}' failed."
-					+ "(This is a final error, changes made in the VM are no longer propagated to the View.)",
-					error);
+					+ "(This is a final error, changes made in the VM are no longer propagated to the View.)");
 			}
 		}
 

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableViewModelBase.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableViewModelBase.cs
@@ -165,7 +165,7 @@ public abstract partial class BindableViewModelBase : IBindable, INotifyProperty
 			// Here we also make sure to leave the UI thread so no matter the implementation of the State,
 			// we won't raise the State updated callbacks on the UI Thread.
 			await Task
-				.Run(async () => await stateImpl.Update(DoUpdate, ct).ConfigureAwait(false), ct)
+				.Run(async () => await stateImpl.UpdateMessage(DoUpdate, ct).ConfigureAwait(false), ct)
 				.ConfigureAwait(false);
 
 			MessageBuilder<TProperty> DoUpdate(Message<TProperty> msg)

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataLayerChangesBuffer.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataLayerChangesBuffer.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading;
 using Uno.Extensions.Collections;
 using Uno.Extensions.Collections.Tracking;
-using Uno.Logging;
+using Uno.Extensions.Reactive.Logging;
 
 namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data;
 

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionChangedFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionChangedFacet.cs
@@ -3,8 +3,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading;
 using Windows.Foundation.Collections;
-using Uno.Extensions;
-using Uno.Logging;
+using Uno.Extensions.Reactive.Logging;
 
 namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets
 {
@@ -106,7 +105,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 				}
 				catch (Exception e)
 				{
-					sender.Log().Error("Failed to notify collection changed", e);
+					sender.Log().Error(e, "Failed to notify collection changed");
 				}
 			}
 		}
@@ -141,7 +140,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 				}
 				catch (Exception e)
 				{
-					sender.Log().Error("Failed to notify collection changed", e);
+					sender.Log().Error(e, "Failed to notify collection changed");
 				}
 			}
 		}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionFacet.cs
@@ -3,15 +3,13 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Windows.Foundation.Collections;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions.Collections;
 using Uno.Extensions.Collections.Tracking;
 using Uno.Extensions.Collections.Facades.Differential;
-using Uno.Extensions;
-using Uno.Logging;
+using Uno.Extensions.Reactive.Logging;
 
 namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets
 {

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/FlatCollectionChangedFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/FlatCollectionChangedFacet.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using Windows.Foundation.Collections;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions.Collections;
-using Uno.Logging;
+using Uno.Extensions.Reactive.Logging;
 using _CollectionChanged = Uno.Extensions.Collections.RichNotifyCollectionChangedEventArgs;
 
 namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/PaginationFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/PaginationFacet.cs
@@ -2,8 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.Foundation;
-using Uno.Extensions;
-using Uno.Logging;
+using Uno.Extensions.Reactive.Logging;
 
 namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets
 {

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Input.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Input.cs
@@ -24,8 +24,8 @@ internal sealed class Input<T> : IInput<T>
 		=> _state.GetSource(context, ct);
 
 	/// <inheritdoc />
-	public ValueTask Update(Func<Message<T>, MessageBuilder<T>> updater, CancellationToken ct)
-		=> _state.Update(msg => updater(msg).Set(BindableViewModelBase.BindingSource, this), ct);
+	public ValueTask UpdateMessage(Func<Message<T>, MessageBuilder<T>> updater, CancellationToken ct)
+		=> _state.UpdateMessage(msg => updater(msg).Set(BindableViewModelBase.BindingSource, this), ct);
 
 	/// <inheritdoc />
 	public ValueTask DisposeAsync()

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Commands/Command.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Commands/Command.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.ComponentModel;
-using System.ComponentModel.Design;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using Uno.Extensions;
 using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Logging;
 using Uno.Extensions.Reactive.Utils;
-using Uno.Logging;
 
 namespace Uno.Extensions.Reactive;
 
@@ -21,7 +19,7 @@ public static class Command
 	/// <remarks>By default, this will log the error.</remarks>
 	/// <remarks>This is designed to be a "last chance" handler, you should handle exceptions in each command.</remarks>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
-	public static Action<Exception> DefaultErrorHandler { get; set; } = e => typeof(AsyncCommand).Log().Error("Failed to execute command.", e);
+	public static Action<Exception> DefaultErrorHandler { get; set; } = e => typeof(AsyncCommand).Log().Error(e, "Failed to execute command.");
 
 	/// <summary>
 	/// Creates a command from an async method

--- a/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.WinUI.csproj
+++ b/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.WinUI.csproj
@@ -11,8 +11,6 @@
 		<EnableDefaultPageItems>false</EnableDefaultPageItems>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 		<PackageId>Uno.Extensions.Reactive.WinUI</PackageId>
-		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
-		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 	</PropertyGroup>
 
 	<Import Project="common.props" />

--- a/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.csproj
+++ b/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.csproj
@@ -15,5 +15,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.UI" Version="4.1.9" />
+		<PackageReference Include="System.Collections.Immutable" Version="1.3.1" /><!-- Fix version to avoid transient resolution of muliple system packages on UWP -->
 	</ItemGroup>
 </Project>

--- a/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.csproj
+++ b/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.csproj
@@ -8,8 +8,6 @@
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'==''">netstandard2.0;xamarinios10;xamarinmac20;monoandroid11.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);uap10.0.18362</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkOverride)'=='' and '$(UnoExtensionsDisableNet6)'=='' and '$(UnoExtensionsDisableNet6Mobile)'==''">$(TargetFrameworks);net6.0-ios;net6.0-android</TargetFrameworks>
-
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageId>Uno.Extensions.Reactive.UI</PackageId>
 	</PropertyGroup>
 	

--- a/src/Uno.Extensions.Reactive.UI/Utils/Events/EventManager.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/Events/EventManager.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Uno;
-using Uno.Extensions;
-using Uno.Logging;
 
 namespace Uno.Extensions.Reactive.Events;
 

--- a/src/Uno.Extensions.Reactive.UI/Utils/SmoothVisualState/SmoothVisualStateManager.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/SmoothVisualState/SmoothVisualStateManager.cs
@@ -4,9 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
-using Windows.UI.Core;
-using Uno.Logging;
+using Uno.Extensions.Reactive.Logging;
 
 namespace Uno.Extensions.Reactive.UI;
 
@@ -130,7 +128,7 @@ public class SmoothVisualStateManager : VisualStateManager
 					catch (OperationCanceledException) { }
 					catch (Exception error)
 					{
-						_owner.Log().Error("Failed to defer go-to-state", error);
+						_owner.Log().Error(error, "Failed to defer go-to-state");
 					}
 				};
 				timer.Start();

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Logging;
 using Uno.Extensions.Reactive.Utils;
-using Uno.Logging;
 
 namespace Uno.Extensions.Reactive.UI;
 
@@ -284,7 +284,7 @@ public partial class FeedView : Control
 			}
 			catch (Exception error)
 			{
-				this.Log().Error("Subscription to feed failed, view will no longer render updates made by the VM.", error);
+				this.Log().Error(error, "Subscription to feed failed, view will no longer render updates made by the VM.");
 			}
 		}
 
@@ -304,7 +304,7 @@ public partial class FeedView : Control
 			}
 			catch (Exception error)
 			{
-				this.Log().Error("Failed to change visual state.", error);
+				this.Log().Error(error, "Failed to change visual state.");
 			}
 		}
 

--- a/src/Uno.Extensions.Reactive.UI/common.props
+++ b/src/Uno.Extensions.Reactive.UI/common.props
@@ -8,14 +8,14 @@
 		<NoWarn Condition="$(Configuration)=='Debug'">$(NoWarn);1591</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<WarningsAsErrors />
-	  <AssemblyName>Uno.Extensions.Reactive.UI</AssemblyName>
+		<AssemblyName>Uno.Extensions.Reactive.UI</AssemblyName>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
+		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 	</PropertyGroup>
   
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-		<PackageReference Include="Uno.Foundation.Logging" Version="4.1.9" />
-		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<PackageReference Include="Uno.Core.Extensions.Logging" Version="4.0.1" />
 	</ItemGroup>
   
 	<ItemGroup>

--- a/src/Uno.Extensions.Reactive/AssemblyInfo.cs
+++ b/src/Uno.Extensions.Reactive/AssemblyInfo.cs
@@ -2,3 +2,5 @@
 
 [assembly: InternalsVisibleTo("Uno.Extensions.Reactive.Tests")]
 [assembly: InternalsVisibleTo("Uno.Extensions.Reactive.UI")]
+[assembly: InternalsVisibleTo("Uno.Extensions.Reactive.WinUI")]
+[assembly: InternalsVisibleTo("Uno.Extensions.Reactive.Messaging")]

--- a/src/Uno.Extensions.Reactive/Core/IListState.cs
+++ b/src/Uno.Extensions.Reactive/Core/IListState.cs
@@ -20,5 +20,6 @@ public interface IListState<T> : IListFeed<T>, IAsyncDisposable
 	/// <param name="updater">The update method to apply to the current message.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	ValueTask Update(Func<Message<IImmutableList<T>>, MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct);
+	/// <remarks>This is the raw way to update a state, you should consider using the <see cref="ListState.Update{T}"/> method instead.</remarks>
+	ValueTask UpdateMessage(Func<Message<IImmutableList<T>>, MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct);
 }

--- a/src/Uno.Extensions.Reactive/Core/IState.cs
+++ b/src/Uno.Extensions.Reactive/Core/IState.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,5 +20,6 @@ public interface IState<T> : IFeed<T>, IAsyncDisposable
 	/// <param name="updater">The update method to apply to the current message.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	ValueTask Update(Func<Message<T>, MessageBuilder<T>> updater, CancellationToken ct);
+	/// <remarks>This is the raw way to update a state, you should consider using the <see cref="State.Update{T}"/> method instead.</remarks>
+	ValueTask UpdateMessage(Func<Message<T>, MessageBuilder<T>> updater, CancellationToken ct);
 }

--- a/src/Uno.Extensions.Reactive/Core/Internal/ListStateImpl.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/ListStateImpl.cs
@@ -16,8 +16,8 @@ internal record ListStateImpl<T>(IState<IImmutableList<T>> implementation) : Fee
 	public SourceContext Context => ((IStateImpl)implementation).Context;
 
 	/// <inheritdoc />
-	public ValueTask Update(Func<Message<IImmutableList<T>>, MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
-		=> implementation.Update(updater, ct);
+	public ValueTask UpdateMessage(Func<Message<IImmutableList<T>>, MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
+		=> implementation.UpdateMessage(updater, ct);
 
 	/// <inheritdoc />
 	public ValueTask DisposeAsync()

--- a/src/Uno.Extensions.Reactive/Core/Internal/StateImpl.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/StateImpl.cs
@@ -136,7 +136,7 @@ internal sealed class StateImpl<T> : IState<T>, IFeed<T>, IAsyncDisposable, ISta
 	}
 
 	/// <inheritdoc />
-	public ValueTask Update(Func<Message<T>, MessageBuilder<T>> updater, CancellationToken ct)
+	public ValueTask UpdateMessage(Func<Message<T>, MessageBuilder<T>> updater, CancellationToken ct)
 		=> UpdateCore(msg => updater(msg), ct);
 
 	private async ValueTask UpdateCore(Func<Message<T>, Message<T>> updater, CancellationToken ct)

--- a/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -50,6 +51,21 @@ static partial class ListState
 	/// <returns>A ValueTask to track the async update.</returns>
 	public static ValueTask UpdateData<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, IImmutableList<T>> updater, CancellationToken ct)
 		=> state.UpdateMessage(m => m.With().Data(updater(m.Current.Data)), ct);
+
+	/// <summary>
+	/// [DEPRECATED] Use UpdateData instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static ValueTask UpdateValue<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
+		=> state.UpdateMessage(m => m.With().Data(updater(m.Current.Data)), ct);
+
+	/// <summary>
+	/// [DEPRECATED] Use UpdateData instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static ValueTask UpdateValue<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, IImmutableList<T>> updater, CancellationToken ct)
+		=> state.UpdateMessage(m => m.With().Data(updater(m.Current.Data)), ct);
+
 
 	#region Operators
 	/// <summary>

--- a/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
@@ -9,6 +9,48 @@ namespace Uno.Extensions.Reactive;
 
 static partial class ListState
 {
+	/// <summary>
+	/// Updates the value of a state
+	/// </summary>
+	/// <typeparam name="T">Type of the value of the state.</typeparam>
+	/// <param name="state">The state to update.</param>
+	/// <param name="updater">The update method to apply to the current value.</param>
+	/// <param name="ct">A cancellation to cancel the async operation.</param>
+	/// <returns>A ValueTask to track the async update.</returns>
+	public static ValueTask Update<T>(this IListState<T> state, Func<IImmutableList<T>, IImmutableList<T>> updater, CancellationToken ct)
+		where T : notnull
+		=> state.UpdateMessage(
+			m =>
+			{
+				var updatedValue = updater(m.Current.Data.SomeOrDefault() ?? ImmutableList<T>.Empty);
+				var updatedData = updatedValue is null or {Count: 0} ? Option<IImmutableList<T>>.None() : Option.Some(updatedValue);
+
+				return m.With().Data(updatedData);
+			},
+			ct);
+
+	/// <summary>
+	/// Updates the value of a list state
+	/// </summary>
+	/// <typeparam name="T">Type of the items of the list state.</typeparam>
+	/// <param name="state">The list state to update.</param>
+	/// <param name="updater">The update method to apply to the current list.</param>
+	/// <param name="ct">A cancellation to cancel the async operation.</param>
+	/// <returns>A ValueTask to track the async update.</returns>
+	public static ValueTask UpdateData<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
+		=> state.UpdateMessage(m => m.With().Data(updater(m.Current.Data)), ct);
+
+	/// <summary>
+	/// Updates the value of a list state
+	/// </summary>
+	/// <typeparam name="T">Type of the items of the list state.</typeparam>
+	/// <param name="state">The list state to update.</param>
+	/// <param name="updater">The update method to apply to the current list.</param>
+	/// <param name="ct">A cancellation to cancel the async operation.</param>
+	/// <returns>A ValueTask to track the async update.</returns>
+	public static ValueTask UpdateData<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, IImmutableList<T>> updater, CancellationToken ct)
+		=> state.UpdateMessage(m => m.With().Data(updater(m.Current.Data)), ct);
+
 	#region Operators
 	/// <summary>
 	/// Adds an item into a list state
@@ -19,7 +61,7 @@ static partial class ListState
 	/// <param name="ct">A token to abort the async add operation.</param>
 	/// <returns></returns>
 	public static ValueTask AddAsync<T>(this IListState<T> state, T item, CancellationToken ct)
-		=> state.UpdateValue(items => items.SomeOrDefault(ImmutableList<T>.Empty).Add(item), ct);
+		=> state.UpdateData(items => items.SomeOrDefault(ImmutableList<T>.Empty).Add(item), ct);
 
 	/// <summary>
 	/// Removes all matching items from a list state.
@@ -30,7 +72,7 @@ static partial class ListState
 	/// <param name="ct">A token to abort the async add operation.</param>
 	/// <returns></returns>
 	public static ValueTask RemoveAllAsync<T>(this IListState<T> state, Predicate<T> match, CancellationToken ct)
-		=> state.UpdateValue(itemsOpt => itemsOpt.Map(items => items.RemoveAll(match)), ct);
+		=> state.UpdateData(itemsOpt => itemsOpt.Map(items => items.RemoveAll(match)), ct);
 
 	/// <summary>
 	/// Updates all matching items from a list state.
@@ -42,7 +84,7 @@ static partial class ListState
 	/// <param name="ct">A token to abort the async add operation.</param>
 	/// <returns></returns>
 	public static ValueTask UpdateAsync<T>(this IListState<T> state, Predicate<T> match, Func<T, T> updater, CancellationToken ct)
-		=> state.UpdateValue(
+		=> state.UpdateData(
 			itemsOpt => itemsOpt.Map(items =>
 			{
 				var updated = items;

--- a/src/Uno.Extensions.Reactive/Core/ListState.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.T.cs
@@ -78,6 +78,18 @@ public static class ListState<T>
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="valueProvider">The provider of the initial value of the state.</param>
 	/// <returns>A feed that encapsulate the source.</returns>
+	public static IListState<T> Value<TOwner>(TOwner owner, Func<ImmutableList<T>> valueProvider)
+		where TOwner : class
+	// Note: We force the usage of delegate so 2 properties which are doing State.Value(this, () => 42) will effectively have 2 distinct states.
+		=> AttachedProperty.GetOrCreate(owner, valueProvider, (o, v) => SourceContext.GetOrCreate(o).CreateListState(Option<IImmutableList<T>>.Some(v())));
+
+	/// <summary>
+	/// Gets or creates a list state from a static initial list of items.
+	/// </summary>
+	/// <typeparam name="TOwner">Type of the owner of the state.</typeparam>
+	/// <param name="owner">The owner of the state.</param>
+	/// <param name="valueProvider">The provider of the initial value of the state.</param>
+	/// <returns>A feed that encapsulate the source.</returns>
 	public static IListState<T> Value<TOwner>(TOwner owner, Func<IImmutableList<T>> valueProvider)
 		where TOwner : class
 		// Note: We force the usage of delegate so 2 properties which are doing State.Value(this, () => 42) will effectively have 2 distinct states.

--- a/src/Uno.Extensions.Reactive/Core/State.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/State.Extensions.cs
@@ -43,6 +43,13 @@ partial class State
 		=> state.UpdateMessage(m => m.With().Data(updater(m.Current.Data)), ct);
 
 	/// <summary>
+	/// [DEPRECATED] Use UpdateData instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static ValueTask UpdateValue<T>(this IState<T> state, Func<Option<T>, Option<T>> updater, CancellationToken ct)
+		=> state.UpdateMessage(m => m.With().Data(updater(m.Current.Data)), ct);
+
+	/// <summary>
 	/// Sets the value of a state
 	/// </summary>
 	/// <typeparam name="T">Type of the value of the state.</typeparam>

--- a/src/Uno.Extensions.Reactive/Core/State.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/State.Extensions.cs
@@ -19,30 +19,28 @@ partial class State
 	/// <param name="updater">The update method to apply to the current value.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask UpdateValue<T>(this IState<T> state, Func<Option<T>, Option<T>> updater, CancellationToken ct)
-		=> state.Update(m => m.With().Data(updater(m.Current.Data)), ct);
+	public static ValueTask Update<T>(this IState<T> state, Func<T?, T?> updater, CancellationToken ct)
+		where T : notnull
+		=> state.UpdateMessage(
+			m =>
+			{
+				var updatedValue = updater(m.Current.Data.SomeOrDefault());
+				var updatedData = updatedValue is null ? Option<T>.None() : Option.Some(updatedValue);
+
+				return m.With().Data(updatedData);
+			},
+			ct);
 
 	/// <summary>
-	/// Updates the value of a list state
+	/// Updates the value of a state
 	/// </summary>
-	/// <typeparam name="T">Type of the items of the list state.</typeparam>
-	/// <param name="state">The list state to update.</param>
-	/// <param name="updater">The update method to apply to the current list.</param>
+	/// <typeparam name="T">Type of the value of the state.</typeparam>
+	/// <param name="state">The state to update.</param>
+	/// <param name="updater">The update method to apply to the current value.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask UpdateValue<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
-		=> state.Update(m => m.With().Data(updater(m.Current.Data)), ct);
-
-	/// <summary>
-	/// Updates the value of a list state
-	/// </summary>
-	/// <typeparam name="T">Type of the items of the list state.</typeparam>
-	/// <param name="state">The list state to update.</param>
-	/// <param name="updater">The update method to apply to the current list.</param>
-	/// <param name="ct">A cancellation to cancel the async operation.</param>
-	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask UpdateValue<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, IImmutableList<T>> updater, CancellationToken ct)
-		=> state.Update(m => m.With().Data(updater(m.Current.Data)), ct);
+	public static ValueTask UpdateData<T>(this IState<T> state, Func<Option<T>, Option<T>> updater, CancellationToken ct)
+		=> state.UpdateMessage(m => m.With().Data(updater(m.Current.Data)), ct);
 
 	/// <summary>
 	/// Sets the value of a state
@@ -54,7 +52,7 @@ partial class State
 	/// <returns>A ValueTask to track the async update.</returns>
 	public static ValueTask Set<T>(this IState<T> state, T? value, CancellationToken ct)
 		where T : struct
-		=> state.Update(m => m.With().Data(value is null ? Option<T>.None() : Option.Some(value.Value)), ct);
+		=> state.UpdateMessage(m => m.With().Data(value is null ? Option<T>.None() : Option.Some(value.Value)), ct);
 
 	/// <summary>
 	/// Sets the value of a state
@@ -63,8 +61,8 @@ partial class State
 	/// <param name="value">The value to set.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask Set(this IState<string> state, Option<string> value, CancellationToken ct)
-		=> state.Update(m => m.With().Data(value), ct);
+	public static ValueTask Set(this IState<string> state, string? value, CancellationToken ct)
+		=> state.UpdateMessage(m => m.With().Data(value is { Length: > 0 } ? value : Option<string>.None()), ct);
 
 	/// <summary>
 	/// Execute an async callback each time the state is being updated.

--- a/src/Uno.Extensions.Reactive/Utils/Logging/LogExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/Logging/LogExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -8,12 +9,47 @@ namespace Uno.Extensions.Reactive.Logging;
 internal static class LogExtensions
 {
 	private static ILoggerProvider? _provider;
+	private static bool _boundToUnoLogger;
+	private static ILoggerFactory? _unoLogger;
+
+	private static ILoggerFactory? FindUnoAmbientLogger()
+	{
+		if (!_boundToUnoLogger)
+		{
+			_boundToUnoLogger = true;
+			try
+			{
+				_unoLogger = Type
+					.GetType("Uno.Extensions.LogExtensionPoint, Uno.Core.Extensions.Logging.Singleton", throwOnError: false)
+					?.GetProperty("AmbientLoggerFactory", BindingFlags.Public | BindingFlags.Static)
+					?.GetValue(null) as ILoggerFactory;
+			}
+			catch (Exception e)
+			{
+				Console.Error.WriteLine($"Failed to bind to uno ambient logger: {e}");
+			}
+		}
+
+		return _unoLogger;
+	}
 
 	public static void SetProvider(ILoggerProvider provider)
 		=> _provider = provider;
 
 	public static ILogger Log<T>(this T owner)
 		=> Holder<T>.Logger;
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static void Trace(this ILogger logger, string message)
+		=> logger.LogTrace(0, message);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static void Debug(this ILogger logger, string message)
+		=> logger.LogDebug(0, message);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static void Info(this ILogger logger, string message)
+		=> logger.LogInformation(0, message);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static void Warn(this ILogger logger, string message)
@@ -29,6 +65,6 @@ internal static class LogExtensions
 
 	private static class Holder<T>
 	{
-		public static ILogger Logger { get; } = _provider?.CreateLogger(typeof(T).FullName) ?? NullLogger.Instance;
+		public static ILogger Logger { get; } = _provider?.CreateLogger(typeof(T).FullName) ?? FindUnoAmbientLogger()?.CreateLogger(typeof(T).FullName) ?? NullLogger.Instance;
 	}
 }

--- a/src/Uno.Extensions.sln
+++ b/src/Uno.Extensions.sln
@@ -98,6 +98,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Extensions.Templates", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Extensions.Logging.UWP.Wasm", "Uno.Extensions.Logging\Uno.Extensions.Logging.UWP.Wasm.csproj", "{ABEE641A-A845-468F-A877-1F8BC9AB4D34}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Reactive.Messaging", "Uno.Extensions.Reactive.Messaging\Uno.Extensions.Reactive.Messaging.csproj", "{B54E4D85-188D-4B19-93B0-2248FFAA6144}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -256,6 +258,10 @@ Global
 		{ABEE641A-A845-468F-A877-1F8BC9AB4D34}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ABEE641A-A845-468F-A877-1F8BC9AB4D34}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ABEE641A-A845-468F-A877-1F8BC9AB4D34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B54E4D85-188D-4B19-93B0-2248FFAA6144}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B54E4D85-188D-4B19-93B0-2248FFAA6144}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B54E4D85-188D-4B19-93B0-2248FFAA6144}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B54E4D85-188D-4B19-93B0-2248FFAA6144}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -296,6 +302,7 @@ Global
 		{BFA2A242-D9AE-4FD3-935B-12F8FC08AF20} = {6B956AB1-06A6-4BEC-9467-E7B593A89E34}
 		{0F3C7D7A-C57C-41C0-86B9-34C9B5A1643A} = {6B956AB1-06A6-4BEC-9467-E7B593A89E34}
 		{ABEE641A-A845-468F-A877-1F8BC9AB4D34} = {DFA5C025-922C-4408-8489-D45786D0C5AA}
+		{B54E4D85-188D-4B19-93B0-2248FFAA6144} = {6B956AB1-06A6-4BEC-9467-E7B593A89E34}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E7B035D-9A64-4D95-89AA-9D4653F17C42}


### PR DESCRIPTION
https://github.com/unoplatform/uno.extensions/issues/411

## Feature
Support of pessimistic update messaging system

## What is the current behavior?
Update of states needs to be manually wired

## What is the new behavior?
Reactive.Messaging package now offer a easy way to update a state when an update is made.
Currently this supports only pessimistic updates.
