### PR TITLE
fix(feed): Use our own EvtRegToken for all platforms where it's possible

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_CombineFeed.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_CombineFeed.cs
@@ -1,17 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Uno.Extensions;
-using Uno.Extensions.Reactive;
 using Uno.Extensions.Reactive.Core;
 using Uno.Extensions.Reactive.Testing;
-using Uno.Extensions.Reactive.Tests.Sources;
 
-namespace Uno.Reactive.Tests.Operators
+namespace Uno.Extensions.Reactive.Tests.Operators
 {
 	[TestClass]
 	public class Given_CombineFeed : FeedTests

--- a/src/Uno.Extensions.Reactive.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Reactive.UI/GlobalUsings.cs
@@ -25,5 +25,5 @@ global using CurrentChangedEventHandler = System.EventHandler<object?>;
 #if USE_EVENT_TOKEN
 global using System.Runtime.InteropServices.WindowsRuntime;
 #else
-global using Uno.Reactive.UI._Compat;
+global using Uno.Extensions.Reactive.UI._Compat;
 #endif

--- a/src/Uno.Extensions.Reactive.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Reactive.UI/GlobalUsings.cs
@@ -22,8 +22,8 @@ global using CurrentChangingEventArgs = Windows.UI.Xaml.Data.CurrentChangingEven
 global using CurrentChangedEventHandler = System.EventHandler<object?>;
 #endif
 
-#if WINUI && NET5_0_OR_GREATER
-global using WinRT;
-#else
+#if USE_EVENT_TOKEN
 global using System.Runtime.InteropServices.WindowsRuntime;
+#else
+global using Uno.Reactive.UI._Compat;
 #endif

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
@@ -198,7 +198,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 		public ICollectionView GetForCurrentThread()
 			=> _holder.Value.View;
 
-#region ICollectionView
+		#region ICollectionView
 		/// <inheritdoc />
 		public IEnumerator<object> GetEnumerator()
 			=> GetForCurrentThread().GetEnumerator();
@@ -331,29 +331,34 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 			add => _holder.Value.GetFacet<SelectionFacet>().AddCurrentChangingHandler(value!);
 			remove => _holder.Value.GetFacet<SelectionFacet>().RemoveCurrentChangingHandler(value!);
 		}
-#endregion
+		#endregion
 
 		internal EventRegistrationToken AddVectorChangedHandler(VectorChangedEventHandler<object?>? handler)
 			=> _holder.Value.GetFacet<CollectionChangedFacet>().AddVectorChangedHandler(handler!);
 		internal void RemoveVectorChangedHandler(VectorChangedEventHandler<object?>? handler)
 			=> _holder.Value.GetFacet<CollectionChangedFacet>().RemoveVectorChangedHandler(handler!);
+#if USE_EVENT_TOKEN
 		internal void RemoveVectorChangedHandler(EventRegistrationToken token)
 			=> _holder.Value.GetFacet<CollectionChangedFacet>().RemoveVectorChangedHandler(token);
+#endif
 
 		internal EventRegistrationToken AddCurrentChangedHandler(CurrentChangedEventHandler? handler)
 			=> _holder.Value.GetFacet<SelectionFacet>().AddCurrentChangedHandler(handler!);
 		internal void RemoveCurrentChangedHandler(CurrentChangedEventHandler? handler)
 			=> _holder.Value.GetFacet<SelectionFacet>().RemoveCurrentChangedHandler(handler!);
+#if USE_EVENT_TOKEN
 		internal void RemoveCurrentChangedHandler(EventRegistrationToken token)
 			=> _holder.Value.GetFacet<SelectionFacet>().RemoveCurrentChangedHandler(token);
+#endif
 
 		internal EventRegistrationToken AddCurrentChangingHandler(CurrentChangingEventHandler? handler)
 			=> _holder.Value.GetFacet<SelectionFacet>().AddCurrentChangingHandler(handler!);
 		internal void RemoveCurrentChangingHandler(CurrentChangingEventHandler? handler)
 			=> _holder.Value.GetFacet<SelectionFacet>().RemoveCurrentChangingHandler(handler!);
+#if USE_EVENT_TOKEN
 		internal void RemoveCurrentChangingHandler(EventRegistrationToken token)
 			=> _holder.Value.GetFacet<SelectionFacet>().RemoveCurrentChangingHandler(token);
-
+#endif
 
 		/// <summary>
 		/// Gets some extended properties for this collection

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionChangedFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionChangedFacet.cs
@@ -44,11 +44,13 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 			return token;
 		}
 
+#if USE_EVENT_TOKEN
 		public void RemoveVectorChangedHandler(EventRegistrationToken value, bool lowPriority = false)
 		{
 			(lowPriority ? _lowPriorityVectorChanged : _normalPriorityVectorChanged).RemoveEventHandler(value);
 			UpdateVectorChanged();
 		}
+#endif
 
 		public void RemoveVectorChangedHandler(VectorChangedEventHandler<object?> value, bool lowPriority = false)
 		{
@@ -63,11 +65,13 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 			return token;
 		}
 
+#if USE_EVENT_TOKEN
 		public void RemoveCollectionChangedHandler(EventRegistrationToken value, bool lowPriority = false)
 		{
 			(lowPriority ? _lowPriorityCollectionChanged : _normalPriorityCollectionChanged).RemoveEventHandler(value);
 			UpdateCollectionChanged();
 		}
+#endif
 
 		public void RemoveCollectionChangedHandler(NotifyCollectionChangedEventHandler value, bool lowPriority = false)
 		{

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/SelectionFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/SelectionFacet.cs
@@ -36,8 +36,10 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 		public EventRegistrationToken AddCurrentChangedHandler(CurrentChangedEventHandler value)
 			=> _currentChanged.AddEventHandler(value);
 
+#if USE_EVENT_TOKEN
 		public void RemoveCurrentChangedHandler(EventRegistrationToken value)
 			=> _currentChanged.RemoveEventHandler(value);
+#endif
 
 		public void RemoveCurrentChangedHandler(CurrentChangedEventHandler value)
 			=> _currentChanged.RemoveEventHandler(value);
@@ -45,8 +47,10 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 		public EventRegistrationToken AddCurrentChangingHandler(CurrentChangingEventHandler value)
 			=> _currentChanging.AddEventHandler(value);
 
+#if USE_EVENT_TOKEN
 		public void RemoveCurrentChangingHandler(EventRegistrationToken value)
 			=> _currentChanging.RemoveEventHandler(value);
+#endif
 
 		public void RemoveCurrentChangingHandler(CurrentChangingEventHandler value)
 			=> _currentChanging.RemoveEventHandler(value);

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
@@ -76,7 +76,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 		/// <inheritdoc />
 		public event CurrentChangingEventHandler CurrentChanging
 		{
-#if WINDOWS_UWP
+#if USE_EVENT_TOKEN
 			add => _selection?.AddCurrentChangingHandler(value) ?? default(EventRegistrationToken);
 #else
 			add => _selection?.AddCurrentChangingHandler(value);
@@ -87,7 +87,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 		/// <inheritdoc />
 		public event CurrentChangedEventHandler CurrentChanged
 		{
-#if WINDOWS_UWP
+#if USE_EVENT_TOKEN
 			add => _selection?.AddCurrentChangedHandler(value) ?? default(EventRegistrationToken);
 #else
 			add => _selection?.AddCurrentChangedHandler(value);

--- a/src/Uno.Extensions.Reactive.UI/_Compat/EventRegistrationToken.cs
+++ b/src/Uno.Extensions.Reactive.UI/_Compat/EventRegistrationToken.cs
@@ -8,7 +8,7 @@ using System.Linq;
 namespace Uno.Extensions.Reactive.UI._Compat;
 
 // The EventRegsitrationToken is use only in WinRT for native events.
-// On all other platforms, in order to share teh code, we have our own implementation where the EventRegistrationToken is nothing.
+// On all other platforms, in order to share the code, we have our own implementation where the EventRegistrationToken is nothing.
 // Note: Even if on some platforms the EventRegistrationToken and the EventRegistrationTokenTable appears as present,
 //		 and compilation of the Reactive.UI package succeeds, the resolution of the type at runtime might fail (TypeLoadException).
 //		 So to avoid any crash at runtime, we prefer to always use our how version (except on UWP which needs it)!

--- a/src/Uno.Extensions.Reactive.UI/_Compat/EventRegistrationToken.cs
+++ b/src/Uno.Extensions.Reactive.UI/_Compat/EventRegistrationToken.cs
@@ -10,7 +10,7 @@ namespace Uno.Extensions.Reactive.UI._Compat;
 // The EventRegsitrationToken is use only in WinRT for native events.
 // On all other platforms, in order to share teh code, we have our own implementation where the EventRegistrationToken is nothing.
 // Note: Even if on some platforms the EventRegistrationToken and the EventRegistrationTokenTable appears as present,
-//		 and compilation of the Reactive.UI package succeed, the resolution of the type at runtime might fail (TypeLoadException).
+//		 and compilation of the Reactive.UI package succeeds, the resolution of the type at runtime might fail (TypeLoadException).
 //		 So to avoid any crash at runtime, we prefer to always use our how version (except on UWP which needs it)!
 
 internal record struct EventRegistrationToken;

--- a/src/Uno.Extensions.Reactive.UI/common.props
+++ b/src/Uno.Extensions.Reactive.UI/common.props
@@ -13,7 +13,11 @@
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 	</PropertyGroup>
-  
+
+	<PropertyGroup Condition="'$(IsUWP)'=='true'">
+		<DefineConstants>$(DefineConstants);USE_EVENT_TOKEN</DefineConstants>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
 	</ItemGroup>


### PR DESCRIPTION

## Bugfix
Fix `TypeLoadException` in ToDo app

## What is the current behavior?
We can get a `TypeLoadException` when using the reactive.WinUI packages as we tried to rely on framework's  `EventRegsitrationTokenTable` which might be missing on some runtime.

## What is the new behavior?
We use our own implementation everywhere except UWP

