### PR TITLE
fix: Only navigate if data (ie selected item) is not null

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Controls/NavigationViewRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/NavigationViewRequestHandler.cs
@@ -43,6 +43,10 @@ public class NavigationViewRequestHandler : ControlRequestHandlerBase<Navigation
 			}
 
 			var data = sender.GetData() ?? sender.SelectedItem;
+			if (data is null)
+			{
+				return;
+			}
 
 			await action(sender, data);
 		};
@@ -61,6 +65,10 @@ public class NavigationViewRequestHandler : ControlRequestHandlerBase<Navigation
 			}
 
 			var data = sender.GetData() ?? actionArgs.InvokedItem;
+			if (data is null)
+			{
+				return;
+			}
 
 			await action(sender, data);
 		};
@@ -72,6 +80,11 @@ public class NavigationViewRequestHandler : ControlRequestHandlerBase<Navigation
 		{
 			viewList.ItemInvoked += clickAction;
 			viewList.SelectionChanged += selectionAction;
+
+			if (viewList.SelectedItem is not null)
+			{
+				action(viewList, viewList.SelectedItem);
+			}
 		};
 
 		disconnect = () =>


### PR DESCRIPTION
GitHub Issue (If applicable): #475

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Navigation is trigged on selectionchanged even when selecteditem is null

## What is the new behavior?

Navigation only triggered when selecteditem is not null
Also, navigation is triggered on bind if selecteditem is not null (default selection)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
