### PR TITLE
fix: Changing CurrentCulture to use set instead of init

### DIFF
--- a/src/Uno.Extensions.Localization/LocalizationSettings.cs
+++ b/src/Uno.Extensions.Localization/LocalizationSettings.cs
@@ -2,5 +2,5 @@
 
 public record LocalizationSettings
 {
-	public string? CurrentCulture { get; init; }
+	public string? CurrentCulture { get; set; }
 }


### PR DESCRIPTION
Fix issue with ToDo app where LocalizationSettings can't be set due to set_CurrentCulture method not found exception