### PR TITLE
feat(feeds): Add ability for a SourceContext to send reqests to feeds subscribed using that context

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Core/Given_CompositeRequestSource.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Given_CompositeRequestSource.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Core;
+
+[TestClass]
+public class Given_CompositeRequestSource : FeedTests
+{
+	[TestMethod]
+	public async Task When_Add_Then_Composed()
+	{
+		var sut = new CompositeRequestSource();
+		var src1 = new RequestSource();
+		var src2 = new RequestSource();
+		var ct1 = CancellationTokenSource.CreateLinkedTokenSource(CT);
+		var ct2 = CancellationTokenSource.CreateLinkedTokenSource(CT);
+		var rq1 = new TestRequest();
+		var rq2 = new TestRequest();
+
+		var resultTask = sut.Take(2).ToListAsync(CT);
+		
+		sut.Add(src1, ct1.Token);
+		sut.Add(src2, ct2.Token);
+
+		src1.Send(rq1);
+		src2.Send(rq2);
+
+		var result = await resultTask;
+
+		result.Should().BeEquivalentTo(new[] { rq1, rq2 });
+	}
+
+	[TestMethod]
+	public async Task When_AddAndCancel_Then_NoLongerComposed()
+	{
+		var sut = new CompositeRequestSource();
+		var src1 = new RequestSource();
+		var src2 = new RequestSource();
+		var ct1 = CancellationTokenSource.CreateLinkedTokenSource(CT);
+		var ct2 = CancellationTokenSource.CreateLinkedTokenSource(CT);
+		var rq1 = new TestRequest();
+		var rq2 = new TestRequest();
+
+		var resultTask = sut.Take(1).ToListAsync(CT);
+
+		sut.Add(src1, ct1.Token);
+		sut.Add(src2, ct2.Token);
+
+		ct1.Cancel();
+
+		src1.Send(rq1);
+		src2.Send(rq2);
+
+		var result = await resultTask;
+
+		result.Should().BeEquivalentTo(new[] { rq2 });
+	}
+
+	[TestMethod]
+	public async Task When_Disposed_Then_EnumerationCompletes()
+	{
+		var sut = new CompositeRequestSource();
+
+		var resultTask = sut.ToListAsync(CT);
+
+		sut.Dispose();
+
+		resultTask.IsCompleted.Should().BeTrue();
+	}
+
+	[TestMethod]
+	public async Task When_DisposedAndSendOnSource_Then_DoesNotThrow()
+	{
+		var sut = new CompositeRequestSource();
+		var src1 = new RequestSource();
+		var src2 = new RequestSource();
+		var ct1 = CancellationTokenSource.CreateLinkedTokenSource(CT);
+		var ct2 = CancellationTokenSource.CreateLinkedTokenSource(CT);
+		var rq1 = new TestRequest();
+		var rq2 = new TestRequest();
+
+		var resultTask = sut.Take(1).ToListAsync(CT);
+
+		sut.Add(src1, ct1.Token);
+		sut.Add(src2, ct2.Token);
+
+		sut.Dispose();
+
+		src1.Send(rq1);
+		src2.Send(rq2);
+
+		resultTask.IsCompleted.Should().BeTrue();
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Core/Given_NoneRequestSource.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Given_NoneRequestSource.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Core;
+
+[TestClass]
+public class Given_NoneRequestSource : FeedTests
+{
+	[TestMethod]
+	public void When_Enumerate_Then_CompletesSync()
+	{
+		var sut = new NoneRequestSource();
+		var result = sut.ToListAsync(CT).IsCompleted;
+
+		result.Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void When_Dispose()
+	{
+		new NoneRequestSource().Dispose();
+	}
+
+	[TestMethod]
+	public void When_Send()
+	{
+		new NoneRequestSource().Send(new TestRequest());
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Core/Given_RequestSource.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Given_RequestSource.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Core;
+
+[TestClass]
+public class Given_RequestSource : FeedTests
+{
+	[TestMethod]
+	public async Task When_Send_Then_Forwarded()
+	{
+		var sut = new RequestSource();
+		var rq = new TestRequest();
+
+		var resultTask = sut.Take(1).ToListAsync(CT);
+
+		sut.Send(rq);
+
+		var result = await resultTask;
+
+		result.Should().BeEquivalentTo(new[] { rq });
+	}
+
+	[TestMethod]
+	public async Task When_Disposed_Then_EnumerationCompletes()
+	{
+		var sut = new RequestSource();
+
+		var resultTask = sut.ToListAsync(CT);
+
+		sut.Dispose();
+
+		resultTask.IsCompleted.Should().BeTrue();
+	}
+
+	[TestMethod]
+	[ExpectedException(typeof(InvalidOperationException))]
+	public async Task When_DisposedAndSend_Then_Throws()
+	{
+		var sut = new CompositeRequestSource();
+		var rq = new TestRequest();
+
+		sut.Dispose();
+		sut.Send(rq);
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Core/TestRequest.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/TestRequest.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using Uno.Extensions.Reactive.Core;
+
+namespace Uno.Extensions.Reactive.Tests.Core;
+
+internal record TestRequest(int? _id = null) : IContextRequest
+{
+	private static int _nextId;
+
+	public int Id { get; } = _id ?? Interlocked.Increment(ref _nextId);
+}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableViewModelBase.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableViewModelBase.cs
@@ -118,7 +118,7 @@ public abstract partial class BindableViewModelBase : IBindable, INotifyProperty
 
 				// We run the update sync in setup, no matter the thread
 				updated(initialValue);
-				var source = stateImpl.GetSource();
+				var source = stateImpl.GetSource(CancellationToken.None);
 				var dispatcher = await _dispatcher.GetFirstResolved(CancellationToken.None);
 
 				dispatcher.TryEnqueue(async () =>

--- a/src/Uno.Extensions.Reactive/AssemblyInfo.cs
+++ b/src/Uno.Extensions.Reactive/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Uno.Extensions.Reactive.Tests")]
+[assembly: InternalsVisibleTo("Uno.Extensions.Reactive.Testing")]
 [assembly: InternalsVisibleTo("Uno.Extensions.Reactive.UI")]
 [assembly: InternalsVisibleTo("Uno.Extensions.Reactive.WinUI")]
 [assembly: InternalsVisibleTo("Uno.Extensions.Reactive.Messaging")]

--- a/src/Uno.Extensions.Reactive/Core/Axes/MessageAxisExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/MessageAxisExtensions.cs
@@ -74,7 +74,7 @@ public static class MessageAxisExtensions
 	public static TBuilder Data<TBuilder, T>(this TBuilder builder, Option<T> data)
 		where TBuilder : IMessageBuilder<T>
 	{
-		builder[MessageAxis.Data] = MessageAxis.Data.ToMessageValue(data);
+		builder.Set(MessageAxis.Data, MessageAxis.Data.ToMessageValue(data));
 
 		return builder;
 	}
@@ -86,10 +86,10 @@ public static class MessageAxisExtensions
 	/// <param name="data">The data to set.</param>
 	/// <param name="changeSet">The changes made from the previous value</param>
 	/// <returns>The <paramref name="builder"/> for fluent building.</returns>
-	internal static TBuilder Data<TBuilder, T>(this TBuilder builder, Option<T> data, IChangeSet changeSet)
+	internal static TBuilder Data<TBuilder, T>(this TBuilder builder, Option<T> data, IChangeSet? changeSet)
 		where TBuilder : IMessageBuilder<T>
 	{
-		builder[MessageAxis.Data] = MessageAxis.Data.ToMessageValue(data);
+		builder.Set(MessageAxis.Data, MessageAxis.Data.ToMessageValue(data), changeSet);
 
 		return builder;
 	}
@@ -106,7 +106,7 @@ public static class MessageAxisExtensions
 	[EditorBrowsable(EditorBrowsableState.Advanced)] // Create dedicated extension methods
 	public static T? Get<TBuilder, T>(this TBuilder builder, MessageAxis<T> axis)
 		where TBuilder : IMessageBuilder
-		=> axis.FromMessageValue(builder[axis]);
+		=> axis.FromMessageValue(builder.Get(axis).value);
 
 	/// <summary>
 	/// Gets a metadata of an <see cref="MessageEntry{T}"/>
@@ -130,7 +130,7 @@ public static class MessageAxisExtensions
 	public static TBuilder Set<TBuilder, T>(this TBuilder builder, MessageAxis<T> axis, T? value)
 		where TBuilder : IMessageBuilder
 	{
-		builder[axis] = axis.ToMessageValue(value);
+		builder.Set(axis, axis.ToMessageValue(value));
 		return builder;
 	}
 	#endregion
@@ -177,8 +177,22 @@ public static class MessageAxisExtensions
 	public static TBuilder IsTransient<TBuilder>(this TBuilder builder, bool isTransient)
 		where TBuilder : IMessageBuilder
 	{
-		builder[MessageAxis.Progress] = MessageAxis.Progress.ToMessageValue(isTransient);
+		builder.Set(MessageAxis.Progress, MessageAxis.Progress.ToMessageValue(isTransient));
 
+		return builder;
+	}
+
+	/// <summary>
+	/// Fluently applies an additional configuration action on a message builder.
+	/// </summary>
+	/// <typeparam name="TBuilder">Type of the builder to configure.</typeparam>
+	/// <param name="builder">The builder to configure.</param>
+	/// <param name="configure">The addition configure operation to apply on the builder.</param>
+	/// <returns></returns>
+	internal static TBuilder Apply<TBuilder>(this TBuilder builder, Action<TBuilder>? configure)
+		where TBuilder : IMessageBuilder
+	{
+		configure?.Invoke(builder);
 		return builder;
 	}
 }

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/IContextRequest.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/IContextRequest.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive.Core;
+
+/// <summary>
+/// Flag interface for a request that can be sent by a <see cref="SourceContext"/>.
+/// </summary>
+internal interface IContextRequest
+{
+}

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/IRequestSource.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/IRequestSource.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive.Core;
+
+/// <summary>
+/// A source of <see cref="IContextRequest"/> that can be used with a <see cref="SourceContext"/>.
+/// </summary>
+internal interface IRequestSource : IAsyncEnumerable<IContextRequest>, IDisposable
+{
+	/// <summary>
+	/// Send a new request.
+	/// </summary>
+	/// <param name="request">The request to send.</param>
+	public void Send(IContextRequest request);
+}

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSource.Composite.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSource.Composite.cs
@@ -16,7 +16,16 @@ internal sealed class CompositeRequestSource : IRequestSource
 	/// <param name="other">The source to add.</param>
 	/// <param name="ct">A cancellation token that can be used to remove the given source.</param>
 	public void Add(IRequestSource other, CancellationToken ct)
-		=> other.ForEachAsync(_subject.SetNext, ct);
+		=> other.ForEachAsync(
+			req =>
+			{
+				// There is kind of a bug in the ForEach, which wait for the **next** item before checking the CT
+				if (ct is not { IsCancellationRequested: true })
+				{
+					_subject.SetNext(req);
+				}
+			},
+			ct);
 
 	/// <inheritdoc />
 	public IAsyncEnumerator<IContextRequest> GetAsyncEnumerator(CancellationToken cancellationToken)

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSource.Composite.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSource.Composite.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Uno.Extensions.Reactive.Utils;
+
+namespace Uno.Extensions.Reactive.Core;
+
+internal sealed class CompositeRequestSource : IRequestSource
+{
+	private readonly AsyncEnumerableSubject<IContextRequest> _subject = new();
+
+	/// <summary>
+	/// Adds a new source to this composite source.
+	/// </summary>
+	/// <param name="other">The source to add.</param>
+	/// <param name="ct">A cancellation token that can be used to remove the given source.</param>
+	public void Add(IRequestSource other, CancellationToken ct)
+		=> other.ForEachAsync(_subject.SetNext, ct);
+
+	/// <inheritdoc />
+	public IAsyncEnumerator<IContextRequest> GetAsyncEnumerator(CancellationToken cancellationToken)
+		=> _subject.GetAsyncEnumerator(cancellationToken);
+
+	/// <inheritdoc />
+	public void Send(IContextRequest request)
+		=> _subject.SetNext(request);
+
+	/// <inheritdoc />
+	public void Dispose()
+		=> _subject.TryComplete();
+}

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSource.None.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSource.None.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions.Reactive.Logging;
+
+namespace Uno.Extensions.Reactive.Core;
+
+internal sealed class NoneRequestSource : IRequestSource
+{
+	/// <inheritdoc />
+	public async IAsyncEnumerator<IContextRequest> GetAsyncEnumerator(CancellationToken cancellationToken)
+	{
+		yield break;
+	}
+
+	/// <inheritdoc />
+	public void Send(IContextRequest request)
+	{
+		if (this.Log().IsEnabled(LogLevel.Warning))
+		{
+			this.Log().Warn($"Attempt to send a {request?.GetType()} message on the None SourceContext");
+		}
+	}
+
+	/// <inheritdoc />
+	public void Dispose()
+	{
+	}
+}

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSource.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSource.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Uno.Extensions.Reactive.Utils;
+
+namespace Uno.Extensions.Reactive.Core;
+
+internal sealed class RequestSource : IRequestSource
+{
+	private readonly AsyncEnumerableSubject<IContextRequest> _subject = new();
+
+	/// <inheritdoc />
+	public IAsyncEnumerator<IContextRequest> GetAsyncEnumerator(CancellationToken cancellationToken)
+		=> _subject.GetAsyncEnumerator(cancellationToken);
+
+	/// <inheritdoc />
+	public void Send(IContextRequest request)
+		=> _subject.SetNext(request);
+
+	/// <inheritdoc />
+	public void Dispose()
+		=> _subject.TryComplete();
+}

--- a/src/Uno.Extensions.Reactive/Core/IMessageBuilder.cs
+++ b/src/Uno.Extensions.Reactive/Core/IMessageBuilder.cs
@@ -11,10 +11,10 @@ namespace Uno.Extensions.Reactive;
 public interface IMessageBuilder
 {
 	/// <summary>
-	/// Gets or sets the raw value of a message axis.
+	/// Gets the raw value of a message axis.
 	/// </summary>
-	/// <param name="axis">The axis to get or set.</param>
-	/// <returns>The raw value of the axis.</returns>
+	/// <param name="axis">The axis to set.</param>
+	/// <returns>The raw value of the axis among the changes made to that value compared to the previous value.</returns>
 	/// <remarks>
 	/// This gives access to raw <see cref="MessageAxisValue"/> for extensibility but it should not be used directly.
 	/// Prefer to use dedicated extensions methods to access to values.
@@ -24,5 +24,18 @@ public interface IMessageBuilder
 	/// it will instead return <see cref="MessageAxisValue.Unset"/>.
 	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)] // Use dedicated extensions methods
-	MessageAxisValue this[MessageAxis axis] { get; set; }
+	(MessageAxisValue value, IChangeSet? changes) Get(MessageAxis axis);
+
+	/// <summary>
+	/// Sets the raw value of a message axis.
+	/// </summary>
+	/// <param name="axis">The axis to set.</param>
+	/// <param name="value">The raw value of the axis.</param>
+	/// <param name="changes">The changes made compared to the previous value of the axis.</param>
+	/// <remarks>
+	/// This gives access to raw <see cref="MessageAxisValue"/> for extensibility but it should not be used directly.
+	/// Prefer to use dedicated extensions methods to access to values.
+	/// </remarks>
+	[EditorBrowsable(EditorBrowsableState.Never)] // Use dedicated extensions methods
+	void Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes = null);
 }

--- a/src/Uno.Extensions.Reactive/Core/Internal/IStateStore.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/IStateStore.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive.Core;
+
+/// <summary>
+/// A cache of <see cref="IState{T}"/> used by a <see cref="SourceContext"/>.
+/// </summary>
+internal interface IStateStore : IAsyncDisposable
+{
+	/// <summary>
+	/// Get or create a <see cref="IState{T}"/> for a given feed.
+	/// </summary>
+	/// <typeparam name="TSource">Type of the source feed.</typeparam>
+	/// <typeparam name="TState">The requested type of state.</typeparam>
+	/// <param name="source">The source feed.</param>
+	/// <param name="factory">Factory to build the state is not present yet in the cache.</param>
+	/// <returns>The state wrapping the given feed</returns>
+	/// <exception cref="ObjectDisposedException">This store has been disposed.</exception>
+	TState GetOrCreateState<TSource, TState>(TSource source, Func<SourceContext, TSource, TState> factory)
+		where TSource : class
+		where TState : IStateImpl, IAsyncDisposable;
+
+	/// <summary>
+	/// Create a <see cref="IState{T}"/> for a given value.
+	/// </summary>
+	/// <typeparam name="T">Type of the value of items.</typeparam>
+	/// <param name="initialValue">The initial value of the state</param>
+	/// <returns>The list state wrapping the given list feed</returns>
+	/// <exception cref="ObjectDisposedException">This store has been disposed.</exception>
+	IState<T> CreateState<T>(Option<T> initialValue);
+}

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageAxisUpdate.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageAxisUpdate.cs
@@ -11,10 +11,13 @@ internal class MessageAxisUpdate
 
 	public MessageAxisValue Value { get; set; }
 
-	public MessageAxisUpdate(MessageAxis axis, MessageAxisValue value)
+	public IChangeSet? Changes { get; }
+
+	public MessageAxisUpdate(MessageAxis axis, MessageAxisValue value, IChangeSet? changes = null)
 	{
 		Axis = axis;
 		Value = value;
+		Changes = changes;
 	}
 
 	public MessageAxisValue GetValue(MessageAxisValue parent, MessageAxisValue current)

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.CurrentMessage.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.CurrentMessage.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Uno.Extensions.Reactive.Core;
 
-internal sealed partial class MessageManager<TParent, TResult>
+internal partial class MessageManager<TParent, TResult>
 {
 	public struct CurrentMessage
 	{

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.Message.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.Message.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive.Core;
+
+internal partial class MessageManager<TParent, TResult>
+{
+	partial class UpdateTransaction
+	{
+		public readonly struct CurrentMessage
+		{
+			private readonly UpdateTransaction _transaction;
+
+			internal CurrentMessage(UpdateTransaction transaction)
+			{
+				_transaction = transaction;
+			}
+
+			public Message<TParent>? Parent => _transaction.Parent;
+
+			public Message<TResult> Local => _transaction.Local;
+
+			public MessageBuilder With()
+				=> new(_transaction._transientUpdates, new MessageManager<TParent, TResult>.CurrentMessage(_transaction._owner).With());
+
+			public MessageBuilder With(Message<TParent>? updatedParent)
+				=> new(_transaction._transientUpdates, new MessageManager<TParent, TResult>.CurrentMessage(_transaction._owner).With(updatedParent));
+		}
+
+		/// <summary>
+		/// A <see cref="MessageBuilder{TParent, TResult}"/> dedicated for <see cref="UpdateTransaction"/>
+		/// that allows to set transient value only for the lifetime of the transaction.
+		/// </summary>
+		internal readonly struct MessageBuilder : IMessageBuilder<TResult>
+		{
+			private readonly Dictionary<MessageAxis, MessageAxisUpdate> _transientUpdates;
+
+			public MessageBuilder(
+				Dictionary<MessageAxis, MessageAxisUpdate> transientUpdates,
+				MessageBuilder<TParent, TResult> inner)
+			{
+				_transientUpdates = transientUpdates;
+				Inner = inner;
+			}
+
+			/// <summary>
+			/// The wrapped message builder
+			/// </summary>
+			internal MessageBuilder<TParent, TResult> Inner { get; }
+
+			/// <summary>
+			/// Temporarily sets the raw value of an axis for the lifetime of the current transaction.
+			/// Value will be automatically roll-backed at the end of the transaction.
+			/// </summary>
+			/// <param name="axis">The axis to set.</param>
+			/// <param name="value">The raw value of the axis.</param>
+			/// <remarks>
+			/// This gives access to raw <see cref="MessageAxisValue"/> for extensibility but it should not be used directly.
+			/// Prefer to use dedicated extensions methods to access to values.
+			/// </remarks>
+			public void SetTransient(MessageAxis axis, MessageAxisValue value)
+				=> _transientUpdates[axis] = new MessageAxisUpdate(axis, value);
+
+			/// <inheritdoc />
+			(MessageAxisValue value, IChangeSet? changes) IMessageBuilder.Get(MessageAxis axis)
+				=> (Get(axis), default);
+
+			/// <inheritdoc />
+			public void Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes = null)
+				=> Inner.Set(axis, value, changes);
+
+			private MessageAxisValue Get(MessageAxis axis)
+			{
+				var parentValue = Inner.Parent?.Current[axis] ?? MessageAxisValue.Unset;
+				var localValue = Inner.Local.Current[axis];
+				if (_transientUpdates.TryGetValue(axis, out var updater)
+					|| Inner.GetResult().updates.TryGetValue(axis, out updater))
+				{
+					return updater.GetValue(parentValue, localValue);
+				}
+				else
+				{
+					return parentValue;
+				}
+			}
+
+			public MessageBuilder Apply(Action<MessageBuilder<TParent, TResult>>? configure)
+			{
+				configure?.Invoke(Inner);
+				return this;
+			}
+		}
+	}
+}

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.cs
@@ -8,7 +8,7 @@ namespace Uno.Extensions.Reactive.Core;
 
 internal partial class MessageManager<TParent, TResult>
 {
-	public class UpdateTransaction : IDisposable
+	public sealed partial class UpdateTransaction : IDisposable
 	{
 		private readonly MessageManager<TParent, TResult> _owner;
 		private readonly Dictionary<MessageAxis, MessageAxisUpdate> _transientUpdates;
@@ -30,12 +30,12 @@ internal partial class MessageManager<TParent, TResult>
 
 		public Message<TResult> Local => _owner.Current;
 
-		public UpdateTransaction(MessageManager<TParent, TResult> owner, CancellationToken ct)
+		internal UpdateTransaction(MessageManager<TParent, TResult> owner, CancellationToken ct)
 			: this(owner, new(), ct)
 		{
 		}
 
-		public UpdateTransaction(MessageManager<TParent, TResult> owner, Dictionary<MessageAxis, MessageAxisUpdate> existingUpdates, CancellationToken ct)
+		internal UpdateTransaction(MessageManager<TParent, TResult> owner, Dictionary<MessageAxis, MessageAxisUpdate> existingUpdates, CancellationToken ct)
 		{
 			_owner = owner;
 			_transientUpdates = existingUpdates;
@@ -43,49 +43,26 @@ internal partial class MessageManager<TParent, TResult>
 			_ctSubscription = ct.Register(Dispose);
 		}
 
-		public void TransientSet(MessageAxis axis, object value)
+		public void Update<TState>(Func<CurrentMessage, TState, MessageBuilder> updater, TState state)
 		{
 			if (_state != State.Active)
 			{
 				return;
 			}
 
+			// Note: We alter the '_transientUpdates' in the 'updater' delegate so we are thread safe thanks to the _owner._gate
+			//		 The '_transientUpdates' is made accessible through the SetTransient method of the MessageBuilder dedicated to transaction.
 			_owner.Update(
-				(m, @params) =>
-				{
-					// We alter the _transientUpdates in the 'updater' delegate so we are thread safe thanks to the _owner._gate
-					_transientUpdates[@params.axis] = new MessageAxisUpdate(@params.axis, new MessageAxisValue(@params.value));
-
-					return m.With();
-				},
-				(axis, value),
+				(m, @params) => @params.updater(new CurrentMessage(@params.that), @params.state).Inner,
+				(that: this, updater, state),
 				_ct);
 		}
 
-		public void TransientSetWithFinalParentUpdate(MessageAxis axis, object value, Message<TParent>? parentMsg)
-		{
-			if (_state != State.Active)
-			{
-				return;
-			}
-
-			_owner.Update(
-				(m, @params) =>
-				{
-					// We alter the _transientUpdates in the 'updater' delegate so we are thread safe thanks to the _owner._gate
-					_transientUpdates[@params.axis] = new MessageAxisUpdate(@params.axis, new MessageAxisValue(@params.value));
-
-					return m.With(@params.parentMsg);
-				},
-				(axis, value, parentMsg),
-				_ct);
-		}
-
-		public void Commit(Func<CurrentMessage, MessageBuilder<TParent, TResult>> resultUpdater)
+		public void Commit<TState>(Updater<TState> resultUpdater, TState state)
 		{
 			if (Interlocked.CompareExchange(ref _state, State.Committed, State.Active) == State.Active)
 			{
-				_owner.EndUpdate(this, resultUpdater);
+				_owner.EndUpdate(this, resultUpdater, state);
 			}
 
 			Dispose();

--- a/src/Uno.Extensions.Reactive/Core/Internal/StateStore.None.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/StateStore.None.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Uno.Extensions.Reactive.Core;
+
+internal class NoneStateStore : IStateStore
+{
+	/// <inheritdoc />
+	public TState GetOrCreateState<TSource, TState>(TSource source, Func<SourceContext, TSource, TState> factory)
+		where TSource : class
+		where TState : IStateImpl, IAsyncDisposable
+		=> throw new InvalidOperationException("Cannot create a state on SourceContext.None");
+
+	/// <inheritdoc />
+	public IState<T> CreateState<T>(Option<T> initialValue)
+		=> throw new InvalidOperationException("Cannot create a state on SourceContext.None");
+
+	/// <inheritdoc />
+	public async ValueTask DisposeAsync()
+	{
+	}
+}

--- a/src/Uno.Extensions.Reactive/Core/Internal/StateStore.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/StateStore.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions.Reactive.Utils;
+
+namespace Uno.Extensions.Reactive.Core;
+
+internal class StateStore : IStateStore
+{
+	private readonly SourceContext _owner;
+	private Dictionary<object, IAsyncDisposable>? _states = new();
+
+	public StateStore(SourceContext owner)
+	{
+		_owner = owner;
+	}
+
+	public TState GetOrCreateState<TSource, TState>(TSource source, Func<SourceContext, TSource, TState> factory)
+		where TSource : class
+		where TState : IStateImpl, IAsyncDisposable
+	{
+		var states = _states;
+		if (states is null)
+		{
+			throw new ObjectDisposedException(nameof(SourceContext));
+		}
+
+		if (source is TState state && state.Context.States == this)
+		{
+			return state;
+		}
+
+		lock (states)
+		{
+			state = states.TryGetValue(source, out var existing)
+				? (TState)existing
+				: (TState)(states[source] = factory(_owner, source));
+		}
+
+		if (_states is null) // The context has been disposed while we where creating the State ...
+		{
+			_ = state.DisposeAsync();
+			throw new ObjectDisposedException(nameof(SourceContext));
+		}
+
+		return state;
+	}
+
+	public IState<T> CreateState<T>(Option<T> initialValue)
+	{
+		var states = _states;
+		if (states is null)
+		{
+			throw new ObjectDisposedException(nameof(SourceContext));
+		}
+
+		IState<T> state;
+		lock (states)
+		{
+			// Note: we use the **boxed** initialValue as key for the states cache,
+			//		 but it's only to have a key, it's not expected to be retrieved,
+			//		 we keep it only for dispose.
+			states[initialValue] = state = new StateImpl<T>(_owner, initialValue);
+		}
+
+		if (_states is null) // The context has been disposed while we where creating the State ...
+		{
+			_ = state.DisposeAsync();
+			throw new ObjectDisposedException(nameof(SourceContext));
+		}
+
+		return state;
+	}
+
+	/// <inheritdoc />
+	public async ValueTask DisposeAsync()
+	{
+		var states = Interlocked.Exchange(ref _states, null);
+		if (states is null or { Count: 0 })
+		{
+			return; // already disposed
+		}
+
+		Task disposeAsync;
+		lock (states)
+		{
+			disposeAsync = CompositeAsyncDisposable.DisposeAll(states.Values);
+		}
+
+		await disposeAsync.ConfigureAwait(false);
+	}
+}

--- a/src/Uno.Extensions.Reactive/Operators/SelectAsyncFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/SelectAsyncFeed.cs
@@ -58,7 +58,7 @@ internal sealed class SelectAsyncFeed<TArg, TResult> : IFeed<TResult>
 							case OptionType.Some:
 								var previousProjection = projectionToken;
 								projectionToken = CancellationTokenSource.CreateLinkedTokenSource(ct);
-								projection = InvokeAsync(message, parentMsg, async ct2 => await _projection((TArg)data, ct2), context, projectionToken.Token);
+								projection = InvokeAsync(message, parentMsg, async ct2 => await _projection((TArg)data, ct2), null, context, projectionToken.Token);
 
 								// We prefer to cancel the previous projection only AFTER so we are able to keep existing transient axes (cf. message.BeginTransaction)
 								// This will not cause any concurrency issue since a transaction cannot push message updates as soon it's not the current.

--- a/src/Uno.Extensions.Reactive/Sources/AsyncFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/AsyncFeed.cs
@@ -50,7 +50,7 @@ internal sealed class AsyncFeed<T> : IFeed<T>
 
 		Triggers(ct)
 			.ForEachAwaitWithCancellationAsync(
-				async (_, ct) => await InvokeAsync(message, null, _dataProvider, context, ct),
+				async (_, ct) => await InvokeAsync(message, null, _dataProvider, null, context, ct),
 				ConcurrencyMode.IgnoreNew, // If _refresh is triggered multiple times, we want to refresh only once.
 				continueOnError: true,
 				ct)


### PR DESCRIPTION
Base work for https://github.com/unoplatform/uno.extensions/issues/410 and https://github.com/unoplatform/uno.extensions/issues/372

## Feature
Create a "control/command channel" from the view to the source feed.

## What is the current behavior?
View only consume the data coming from the business sources

## What is the new behavior?
Consumer is now able to send request to the feeds that it is subscribed to

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ _Tests are coming in a next PR that uses it for refresh_
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
