### PR TITLE
feat: Allowing for httphandler chaining

### DIFF
--- a/src/Uno.Extensions.Http/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Http/ServiceCollectionExtensions.cs
@@ -8,97 +8,97 @@ using Microsoft.Extensions.Http;
 
 namespace Uno.Extensions.Http
 {
-    public static class ServiceCollectionExtensions
-    {
-        private static char[] InterfaceNamePrefix = new[] { 'i', 'I' };
+	public static class ServiceCollectionExtensions
+	{
+		private static char[] InterfaceNamePrefix = new[] { 'i', 'I' };
 
-        public static T Conditional<T>(
-            this T builder,
-            bool predicate,
-            Func<T, T> configureBuilder)
-        {
-            return (configureBuilder is not null && predicate) ? configureBuilder(builder) : builder;
-        }
+		public static T Conditional<T>(
+			this T builder,
+			bool predicate,
+			Func<T, T> configureBuilder)
+		{
+			return (configureBuilder is not null && predicate) ? configureBuilder(builder) : builder;
+		}
 
-        public static IServiceCollection AddClient<TClient, TImplementation>(
-             this IServiceCollection services,
-             HostBuilderContext context,
-             string? name = null,
-             Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>? configure = null
-         )
-            where TClient : class
-            where TImplementation : class, TClient
-        {
-            Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder> httpClientFactory = (s, c) => s.AddHttpClient<TClient, TImplementation>();
+		public static IServiceCollection AddClient<TClient, TImplementation>(
+			 this IServiceCollection services,
+			 HostBuilderContext context,
+			 string? name = null,
+			 Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>? configure = null
+		 )
+			where TClient : class
+			where TImplementation : class, TClient
+		{
+			Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder> httpClientFactory = (s, c) => s.AddHttpClient<TClient, TImplementation>();
 
-            return services.AddClient<TClient>(context, name, httpClientFactory, configure);
-        }
+			return services.AddClient<TClient>(context, name, httpClientFactory, configure);
+		}
 
-        public static IServiceCollection AddClient<TClient, TImplementation>(
-             this IServiceCollection services,
-             HostBuilderContext context,
-             EndpointOptions options,
-             string? name = null,
-             Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>? configure = null
-         )
-            where TClient : class
-            where TImplementation : class, TClient
-        {
-            Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder> httpClientFactory = (s, c) => s.AddHttpClient<TClient, TImplementation>();
+		public static IServiceCollection AddClient<TClient, TImplementation>(
+			 this IServiceCollection services,
+			 HostBuilderContext context,
+			 EndpointOptions options,
+			 string? name = null,
+			 Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>? configure = null
+		 )
+			where TClient : class
+			where TImplementation : class, TClient
+		{
+			Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder> httpClientFactory = (s, c) => s.AddHttpClient<TClient, TImplementation>();
 
-            return services.AddClient<TClient>(context, options, name, httpClientFactory, configure);
-        }
+			return services.AddClient<TClient>(context, options, name, httpClientFactory, configure);
+		}
 
-        public static IServiceCollection AddClient<TInterface>(
-             this IServiceCollection services,
-             HostBuilderContext context,
-             string? name = null,
-             Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>? httpClientFactory = null,
-             Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>? configure = null
-         )
-             where TInterface : class
-        {
-            name ??= typeof(TInterface).IsInterface ? typeof(TInterface).Name.TrimStart(InterfaceNamePrefix) : typeof(TInterface).Name;
-            var options = ConfigurationBinder.Get<EndpointOptions>(context.Configuration.GetSection(name));
+		public static IServiceCollection AddClient<TInterface>(
+			 this IServiceCollection services,
+			 HostBuilderContext context,
+			 string? name = null,
+			 Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>? httpClientFactory = null,
+			 Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>? configure = null
+		 )
+			 where TInterface : class
+		{
+			name ??= typeof(TInterface).IsInterface ? typeof(TInterface).Name.TrimStart(InterfaceNamePrefix) : typeof(TInterface).Name;
+			var options = ConfigurationBinder.Get<EndpointOptions>(context.Configuration.GetSection(name));
 
-            return services.AddClient<TInterface>(context, options, name, httpClientFactory, configure);
-        }
+			return services.AddClient<TInterface>(context, options, name, httpClientFactory, configure);
+		}
 
-        public static IServiceCollection AddClient<TInterface>(
-              this IServiceCollection services,
-              HostBuilderContext context,
-              EndpointOptions options,
-              string? name = null,
-              Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>? httpClientFactory = null,
-              Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>? configure = null
-          )
-              where TInterface : class
-        {
-            name ??= typeof(TInterface).IsInterface ? typeof(TInterface).Name.TrimStart(InterfaceNamePrefix) : typeof(TInterface).Name;
+		public static IServiceCollection AddClient<TInterface>(
+			  this IServiceCollection services,
+			  HostBuilderContext context,
+			  EndpointOptions options,
+			  string? name = null,
+			  Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>? httpClientFactory = null,
+			  Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>? configure = null
+		  )
+			  where TInterface : class
+		{
+			name ??= typeof(TInterface).IsInterface ? typeof(TInterface).Name.TrimStart(InterfaceNamePrefix) : typeof(TInterface).Name;
 
-            if (httpClientFactory is null)
-            {
-                httpClientFactory = (s, c) => s.AddHttpClient(name);
-            }
+			if (httpClientFactory is null)
+			{
+				httpClientFactory = (s, c) => s.AddHttpClient(name);
+			}
 
-            var httpClientBuilder = httpClientFactory(services, context);
+			var httpClientBuilder = httpClientFactory(services, context);
 
-            _ = httpClientBuilder
-                .Conditional(
-                    options.UseNativeHandler,
-                    builder => builder.ConfigurePrimaryAndInnerHttpMessageHandler<HttpMessageHandler>())
-                .ConfigureHttpClient((serviceProvider, client) =>
-                {
-                    if (options.Url is not null)
-                    {
-                        client.BaseAddress = new Uri(options.Url);
-                    }
-                })
-                .Conditional(
-                    configure is not null,
-                    builder => configure?.Invoke(builder, options) ?? builder);
-            return services;
-        }
+			_ = httpClientBuilder
+				.Conditional(
+					options.UseNativeHandler,
+					builder => builder.ConfigurePrimaryAndInnerHttpMessageHandler<HttpMessageHandler>())
+				.ConfigureHttpClient((serviceProvider, client) =>
+				{
+					if (options.Url is not null)
+					{
+						client.BaseAddress = new Uri(options.Url);
+					}
+				})
+				.Conditional(
+					configure is not null,
+					builder => configure?.Invoke(builder, options) ?? builder);
+			return services;
+		}
 
 
 		public static IHttpClientBuilder ConfigurePrimaryAndInnerHttpMessageHandler<THandler>(this IHttpClientBuilder builder) where THandler : HttpMessageHandler
@@ -115,6 +115,11 @@ namespace Uno.Extensions.Http
 					var innerHandler = b.Services.GetRequiredService<THandler>() as HttpMessageHandler;
 					if (b.PrimaryHandler is DelegatingHandler delegatingHandler)
 					{
+						if (delegatingHandler.InnerHandler is not null &&
+								innerHandler is DelegatingHandler innerDelegating)
+						{
+							innerDelegating.InnerHandler = delegatingHandler.InnerHandler;
+						}
 						delegatingHandler.InnerHandler = innerHandler;
 						innerHandler = delegatingHandler;
 					}
@@ -126,18 +131,18 @@ namespace Uno.Extensions.Http
 		}
 
 		public static IHttpClientBuilder AddTypedHttpClient<TClient>(
-            this IServiceCollection services,
-            Func<HttpClient, IServiceProvider, TClient> factory)
-           where TClient : class
-        {
-            return services
-                .AddHttpClient(typeof(TClient).FullName ?? string.Empty)
-                .AddTypedClient(factory);
-        }
+			this IServiceCollection services,
+			Func<HttpClient, IServiceProvider, TClient> factory)
+		   where TClient : class
+		{
+			return services
+				.AddHttpClient(typeof(TClient).FullName ?? string.Empty)
+				.AddTypedClient(factory);
+		}
 
-        public static IServiceCollection AddNativeHandler(this IServiceCollection services)
-        {
-            return services.AddTransient<HttpMessageHandler>(s =>
+		public static IServiceCollection AddNativeHandler(this IServiceCollection services)
+		{
+			return services.AddTransient<HttpMessageHandler>(s =>
 #if __IOS__
                 new NSUrlSessionHandler()
 #elif __ANDROID__
@@ -151,7 +156,7 @@ namespace Uno.Extensions.Http
 #else
 				new HttpClientHandler()
 #endif
-            );
-        }
-    }
+			);
+		}
+	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #N/A

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Only a single httphandler can be added as an innerhandler

## What is the new behavior?

Multiple levels of innerhandlers can be set

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
