### PR TITLE
Make the CollectionAnalyzer trully generic and fix support of ImmutableList<T> which are not IList

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.Immutable.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.Immutable.cs
@@ -1,0 +1,2221 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Collections.Tracking;
+using Uno.Extensions.Reactive.Tests._Utils;
+using static Uno.Extensions.Collections.CollectionChanged;
+
+namespace Uno.Extensions.Reactive.Tests.Collections.Tracking;
+
+[TestClass]
+public partial class Given_CollectionAnalyzer_Immutable
+{
+	private IEqualityComparer<MyClass> ItemComparer { get; } = FuncEqualityComparer<MyClass>.Create(c => c.Value);
+
+	[TestMethod]
+	public void When_Add_ValueType()
+	{
+		FromInt(0, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirst_ValueType()
+	{
+		FromInt(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstSome_ValueType()
+	{
+		FromInt(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLast_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSome_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSomeAndMove_ValueType()
+	{
+		FromInt(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Move_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLast_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedSome_ValueType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromInt(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_Remove_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLast_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Add_ReferenceType()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2}, new[] {0, 2}, 0),
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddSome_ReferenceType()
+	{
+		FromObj(0, 3)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 3}, new[] {0, 3}, 0),
+				AddSome(new[] {1, 2}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 2, 4)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2, 4}, new[] {0, 2, 4}, 0),
+				Add(1, 1),
+				Add(3, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirst_ReferenceType()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 0),
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstSome_ReferenceType()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 0),
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(1, 2, 4)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2, 4}, new[] {1, 2, 4}, 0),
+				Add(0, 0),
+				Add(3, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLast_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSome_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 2, 3)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2, 3}, new[] {0, 2, 3}, 0),
+				Add(1, 1),
+				Add(4, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSomeAndMove_ReferenceType()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 4}, new[] {0, 1, 4}, 0),
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Move_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedSome_ReferenceType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 1, 2, 3, 4}, 0),
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 0, 1, 2, 3}, new[] {0, 1, 0, 1, 2, 3}, 0),
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 2, 3}, new[] {0, 1, 2, 3, 2, 3}, 0),
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_Remove_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(2, 2, 2),
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(3, 3, 3),
+				RemoveSome(new[] {1, 2}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(2, 2, 2),
+				Replace(4, 4, 4),
+				Remove(1, 1),
+				Remove(3, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 1),
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 2),
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(1, 2, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 1),
+				Replace(4, 4, 4),
+				Remove(0, 0),
+				Remove(3, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(0, 0, 0),
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 2),
+				Remove(1, 1),
+				Remove(4, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace((0, 0), (0, 1), 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {(0, 1), (1, 1)}, 0)
+			);
+	}
+
+
+	[TestMethod]
+	public void When_Update_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(1, (1, 1), 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {(1, 1), (2, 1)}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(3, (3, 1), 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {(2, 1), (3, 1)}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_Add_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSomeAndMove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Move_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_Remove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+
+	[TestMethod]
+	public void When_Update_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Add_ValueType()
+	{
+		FromInt(0, 2)
+			.To(0, 1, 2)
+			.With()
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirst_ValueType()
+	{
+		FromInt(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirstSome_ValueType()
+	{
+		FromInt(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLast_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSome_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSomeAndMove_ValueType()
+	{
+		FromInt(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Move_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLast_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedSome_ValueType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromInt(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Remove_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLast_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Add_ReferenceType()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2}, new[] {0, 2}, 0),
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirst_ReferenceType()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 0),
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirstSome_ReferenceType()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 0),
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLast_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSome_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSomeAndMove_ReferenceType()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 4}, new[] {0, 1, 4}, 0),
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Move_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3 }, new[] { 0, 1, 2, 3 }, 0),
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] { 0, 1, 2, 3, 4 }, 0),
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] { 0, 1, 2, 3, 4 }, 0),
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3 }, new[] { 0, 1, 2, 3 }, 0),
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3, 4 }, new[] { 0, 1, 2, 3, 4 }, 0),
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedSome_ReferenceType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3, 1, 2, 3, 4 }, new[] { 0, 1, 2, 3, 1, 2, 3, 4 }, 0),
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 0, 1, 2, 3}, new[] {0, 1, 0, 1, 2, 3}, 0),
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 2, 3}, new[] {0, 1, 2, 3, 2, 3}, 0),
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Remove_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(2, 2, 2),
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 1, 2 }, new[] { 1, 2 }, 1),
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 2, 3 }, new[] { 2, 3 }, 2),
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace((0, 0), (0, 1), 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {(0, 1), (1, 1)}, 0)
+			);
+	}
+
+
+	[TestMethod]
+	public void When_WithVisitor_Update_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(1, (1, 1), 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {(1, 1), (2, 1)}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(3, (3, 1), 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {(2, 1), (3, 1)}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Add_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSomeAndMove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Move_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Remove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+
+	[TestMethod]
+	public void When_WithVisitor_Update_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void Scenario_1()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2)
+			.With(ItemComparer, null)
+			.ShouldBe(
+				Remove(1, 1),
+				RemoveSome(new[] {3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_2()
+	{
+		FromObj(0, 1, 2, 3, 4, 5, 6, 7)
+			.To(10, 11, 2, 13, 14, 0, 1, 3, 4, 5)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				AddSome(new[] {10, 11}, 0),
+				Move(2, 4, 2),
+				AddSome(new[] {13, 14}, 3),
+				RemoveSome(new[] {6, 7}, 10)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_2_WithUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4, 5, 6, 7)
+			.To(10, 11, (2, 1), 13, 14, (0, 1), (1, 1), (3, 1), (4, 1), (5, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3, 4, 5 }, new[] { (0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1) }, 0),
+				AddSome(new[] {10, 11}, 0),
+				Move((2, 1), 4, 2),
+				AddSome(new[] {13, 14}, 3),
+				RemoveSome(new[] {6, 7}, 10)
+			);
+	}
+
+
+	[TestMethod]
+	public void Scenario_3_MoveMultipleWithUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4, 5)
+			.To(6, (1, 1), (2, 1), (3, 1), (5, 1), (0, 1), (4, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4, 5}, new[] {(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)}, 0),
+				Add(6, 0),
+				MoveSome(new[] {(1, 1), (2, 1), (3, 1)}, 2, 1),
+				Move((5, 1), 6, 4)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_4_ReOrder()
+	{
+		FromObj(0, 1, 2, 3, 4, 5)
+			.To(5, 4, 3, 2, 1, 0)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Move(5, 5, 0),
+				Move(4, 5, 1),
+				Move(3, 5, 2),
+				Move(2, 5, 3),
+				Move(1, 5, 4)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_4_ReOrderWithMixedMoves()
+	{
+		FromObj(0, 1, 2, 3, 4, 5, 42)
+			.To(42, 0, 1, 5, 4, 3, 2)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Move(42, 6, 0),
+				Move(5, 6, 3),
+				Move(4, 6, 4),
+				Move(3, 6, 5)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_4_ReOrderWithMixedMoves2()
+	{
+		/*
+		*	 0   1   2   3   4   5   6
+		*
+		*	 0   1  (42) 2   3   4   5
+		*  [42] 0   1   2   3   4  (5)
+		*   42 [5]  0   1   2   3  (4)
+		*   42  5  [4]  0   1   2  (3)
+		*   42  5   4  [3]  0   1  (2)
+		*   42  5   4   3  [2]  0  (1)
+		*   42  5   4   3   2  [1]  0
+		*/
+
+
+		FromObj(0, 1, 42, 2, 3, 4, 5)
+			.To(42, 5, 4, 3, 2, 1, 0)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Move(42, 2, 0),
+				Move(5, 6, 1),
+				Move(4, 6, 2),
+				Move(3, 6, 3),
+				Move(2, 6, 4),
+				Move(1, 6, 5)
+			);
+	}
+
+	private static ImmutableListCollectionTrackerTester<MyClass> FromObj(params MyClass[] items)
+		=> new(ImmutableList.Create(items), null);
+
+	private static ImmutableListCollectionTrackerTester<int> FromInt(params int[] items)
+		=> new(ImmutableList.Create(items), null);
+
+	internal class ImmutableListCollectionTrackerTester<T> : CollectionTrackerTester<IImmutableList<T>, T>
+	{
+		/// <inheritdoc />
+		public ImmutableListCollectionTrackerTester(IImmutableList<T> previous, IImmutableList<T>? updated)
+			: base(previous, updated)
+		{
+		}
+
+		/// <inheritdoc />
+		protected override IImmutableList<T> Create(T[] items)
+			=> ImmutableList.Create(items);
+
+		/// <inheritdoc />
+		protected override IEnumerable<T> AsEnumerable(IImmutableList<T> collection)
+			=> collection;
+
+		/// <inheritdoc />
+		protected override CollectionUpdater GetUpdater(CollectionAnalyzer<T> analyzer, IImmutableList<T> previous, IImmutableList<T> updated, ICollectionUpdaterVisitor visitor)
+			=> analyzer.GetUpdater(previous, updated, visitor);
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.ImmutableNonIList.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.ImmutableNonIList.cs
@@ -1,0 +1,2301 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Collections.Tracking;
+using Uno.Extensions.Reactive.Tests._Utils;
+using static Uno.Extensions.Collections.CollectionChanged;
+
+namespace Uno.Extensions.Reactive.Tests.Collections.Tracking;
+
+[TestClass]
+public partial class Given_CollectionAnalyzer_ImmutableNonIList
+{
+	private IEqualityComparer<MyClass> ItemComparer { get; } = FuncEqualityComparer<MyClass>.Create(c => c.Value);
+
+	[TestMethod]
+	public void When_Add_ValueType()
+	{
+		FromInt(0, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirst_ValueType()
+	{
+		FromInt(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstSome_ValueType()
+	{
+		FromInt(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLast_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSome_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSomeAndMove_ValueType()
+	{
+		FromInt(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Move_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLast_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedSome_ValueType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromInt(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_Remove_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLast_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Add_ReferenceType()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2}, new[] {0, 2}, 0),
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddSome_ReferenceType()
+	{
+		FromObj(0, 3)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 3}, new[] {0, 3}, 0),
+				AddSome(new[] {1, 2}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 2, 4)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2, 4}, new[] {0, 2, 4}, 0),
+				Add(1, 1),
+				Add(3, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirst_ReferenceType()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 0),
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstSome_ReferenceType()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 0),
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(1, 2, 4)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2, 4}, new[] {1, 2, 4}, 0),
+				Add(0, 0),
+				Add(3, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLast_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSome_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 2, 3)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2, 3}, new[] {0, 2, 3}, 0),
+				Add(1, 1),
+				Add(4, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSomeAndMove_ReferenceType()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 4}, new[] {0, 1, 4}, 0),
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Move_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedSome_ReferenceType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 1, 2, 3, 4}, 0),
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 0, 1, 2, 3}, new[] {0, 1, 0, 1, 2, 3}, 0),
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 2, 3}, new[] {0, 1, 2, 3, 2, 3}, 0),
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_Remove_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(2, 2, 2),
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(3, 3, 3),
+				RemoveSome(new[] {1, 2}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(2, 2, 2),
+				Replace(4, 4, 4),
+				Remove(1, 1),
+				Remove(3, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 1),
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 2),
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(1, 2, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 1),
+				Replace(4, 4, 4),
+				Remove(0, 0),
+				Remove(3, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(0, 0, 0),
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 2),
+				Remove(1, 1),
+				Remove(4, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace((0, 0), (0, 1), 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {(0, 1), (1, 1)}, 0)
+			);
+	}
+
+
+	[TestMethod]
+	public void When_Update_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(1, (1, 1), 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {(1, 1), (2, 1)}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(3, (3, 1), 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {(2, 1), (3, 1)}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_Add_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSomeAndMove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Move_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_Remove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+
+	[TestMethod]
+	public void When_Update_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Add_ValueType()
+	{
+		FromInt(0, 2)
+			.To(0, 1, 2)
+			.With()
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirst_ValueType()
+	{
+		FromInt(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirstSome_ValueType()
+	{
+		FromInt(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLast_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSome_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSomeAndMove_ValueType()
+	{
+		FromInt(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Move_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLast_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedSome_ValueType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromInt(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Remove_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLast_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Add_ReferenceType()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2}, new[] {0, 2}, 0),
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirst_ReferenceType()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 0),
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirstSome_ReferenceType()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 0),
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLast_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSome_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSomeAndMove_ReferenceType()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 4}, new[] {0, 1, 4}, 0),
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Move_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3 }, new[] { 0, 1, 2, 3 }, 0),
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] { 0, 1, 2, 3, 4 }, 0),
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] { 0, 1, 2, 3, 4 }, 0),
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3 }, new[] { 0, 1, 2, 3 }, 0),
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3, 4 }, new[] { 0, 1, 2, 3, 4 }, 0),
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedSome_ReferenceType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3, 1, 2, 3, 4 }, new[] { 0, 1, 2, 3, 1, 2, 3, 4 }, 0),
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 0, 1, 2, 3}, new[] {0, 1, 0, 1, 2, 3}, 0),
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 2, 3}, new[] {0, 1, 2, 3, 2, 3}, 0),
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Remove_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(2, 2, 2),
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 1, 2 }, new[] { 1, 2 }, 1),
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 2, 3 }, new[] { 2, 3 }, 2),
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace((0, 0), (0, 1), 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {(0, 1), (1, 1)}, 0)
+			);
+	}
+
+
+	[TestMethod]
+	public void When_WithVisitor_Update_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(1, (1, 1), 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {(1, 1), (2, 1)}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Replace(3, (3, 1), 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {(2, 1), (3, 1)}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Add_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSomeAndMove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Move_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Remove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+
+	[TestMethod]
+	public void When_WithVisitor_Update_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void Scenario_1()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2)
+			.With(ItemComparer, null)
+			.ShouldBe(
+				Remove(1, 1),
+				RemoveSome(new[] {3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_2()
+	{
+		FromObj(0, 1, 2, 3, 4, 5, 6, 7)
+			.To(10, 11, 2, 13, 14, 0, 1, 3, 4, 5)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				AddSome(new[] {10, 11}, 0),
+				Move(2, 4, 2),
+				AddSome(new[] {13, 14}, 3),
+				RemoveSome(new[] {6, 7}, 10)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_2_WithUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4, 5, 6, 7)
+			.To(10, 11, (2, 1), 13, 14, (0, 1), (1, 1), (3, 1), (4, 1), (5, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3, 4, 5 }, new[] { (0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1) }, 0),
+				AddSome(new[] {10, 11}, 0),
+				Move((2, 1), 4, 2),
+				AddSome(new[] {13, 14}, 3),
+				RemoveSome(new[] {6, 7}, 10)
+			);
+	}
+
+
+	[TestMethod]
+	public void Scenario_3_MoveMultipleWithUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4, 5)
+			.To(6, (1, 1), (2, 1), (3, 1), (5, 1), (0, 1), (4, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4, 5}, new[] {(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)}, 0),
+				Add(6, 0),
+				MoveSome(new[] {(1, 1), (2, 1), (3, 1)}, 2, 1),
+				Move((5, 1), 6, 4)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_4_ReOrder()
+	{
+		FromObj(0, 1, 2, 3, 4, 5)
+			.To(5, 4, 3, 2, 1, 0)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Move(5, 5, 0),
+				Move(4, 5, 1),
+				Move(3, 5, 2),
+				Move(2, 5, 3),
+				Move(1, 5, 4)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_4_ReOrderWithMixedMoves()
+	{
+		FromObj(0, 1, 2, 3, 4, 5, 42)
+			.To(42, 0, 1, 5, 4, 3, 2)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Move(42, 6, 0),
+				Move(5, 6, 3),
+				Move(4, 6, 4),
+				Move(3, 6, 5)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_4_ReOrderWithMixedMoves2()
+	{
+		/*
+		*	 0   1   2   3   4   5   6
+		*
+		*	 0   1  (42) 2   3   4   5
+		*  [42] 0   1   2   3   4  (5)
+		*   42 [5]  0   1   2   3  (4)
+		*   42  5  [4]  0   1   2  (3)
+		*   42  5   4  [3]  0   1  (2)
+		*   42  5   4   3  [2]  0  (1)
+		*   42  5   4   3   2  [1]  0
+		*/
+
+
+		FromObj(0, 1, 42, 2, 3, 4, 5)
+			.To(42, 5, 4, 3, 2, 1, 0)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default)
+			.ShouldBe(
+				Move(42, 2, 0),
+				Move(5, 6, 1),
+				Move(4, 6, 2),
+				Move(3, 6, 3),
+				Move(2, 6, 4),
+				Move(1, 6, 5)
+			);
+	}
+
+	private static ImmutableListCollectionTrackerTester<MyClass> FromObj(params MyClass[] items)
+		=> new(new(ImmutableList.Create(items)), null);
+
+	private static ImmutableListCollectionTrackerTester<int> FromInt(params int[] items)
+		=> new(new(ImmutableList.Create(items)), null);
+
+	private class ImmutableListCollectionTrackerTester<T> : CollectionTrackerTester<ImmutableListWhichIsNotIList<T>, T>
+	{
+		/// <inheritdoc />
+		public ImmutableListCollectionTrackerTester(ImmutableListWhichIsNotIList<T> previous, ImmutableListWhichIsNotIList<T>? updated)
+			: base(previous, updated)
+		{
+		}
+
+		/// <inheritdoc />
+		protected override ImmutableListWhichIsNotIList<T> Create(T[] items)
+			=> new(items);
+
+		/// <inheritdoc />
+		protected override IEnumerable<T> AsEnumerable(ImmutableListWhichIsNotIList<T> collection)
+			=> collection;
+
+		/// <inheritdoc />
+		protected override CollectionUpdater GetUpdater(CollectionAnalyzer<T> analyzer, ImmutableListWhichIsNotIList<T> previous, ImmutableListWhichIsNotIList<T> updated, ICollectionUpdaterVisitor visitor)
+			=> analyzer.GetUpdater(previous, updated, visitor);
+	}
+
+	private class ImmutableListWhichIsNotIList<T> : IImmutableList<T>
+	{
+		private readonly IImmutableList<T> _inner;
+
+		public ImmutableListWhichIsNotIList(IEnumerable<T> inner)
+		{
+			_inner = inner.ToImmutableList();
+		}
+
+		/// <inheritdoc />
+		public IEnumerator<T> GetEnumerator()
+			=> _inner.GetEnumerator();
+
+		/// <inheritdoc />
+		IEnumerator IEnumerable.GetEnumerator()
+			=> ((IEnumerable)_inner).GetEnumerator();
+
+		/// <inheritdoc />
+		public int Count => _inner.Count;
+
+		/// <inheritdoc />
+		public T this[int index] => _inner[index];
+
+		/// <inheritdoc />
+		public IImmutableList<T> Add(T value)
+			=> _inner.Add(value);
+
+		/// <inheritdoc />
+		public IImmutableList<T> AddRange(IEnumerable<T> items)
+			=> _inner.AddRange(items);
+
+		/// <inheritdoc />
+		public IImmutableList<T> Clear()
+			=> _inner.Clear();
+
+		/// <inheritdoc />
+		public int IndexOf(T item, int index, int count, IEqualityComparer<T>? equalityComparer)
+			=> _inner.IndexOf(item, index, count, equalityComparer);
+
+		/// <inheritdoc />
+		public IImmutableList<T> Insert(int index, T element)
+			=> _inner.Insert(index, element);
+
+		/// <inheritdoc />
+		public IImmutableList<T> InsertRange(int index, IEnumerable<T> items)
+			=> _inner.InsertRange(index, items);
+
+		/// <inheritdoc />
+		public int LastIndexOf(T item, int index, int count, IEqualityComparer<T>? equalityComparer)
+			=> _inner.LastIndexOf(item, index, count, equalityComparer);
+
+		/// <inheritdoc />
+		public IImmutableList<T> Remove(T value, IEqualityComparer<T>? equalityComparer)
+			=> _inner.Remove(value, equalityComparer);
+
+		/// <inheritdoc />
+		public IImmutableList<T> RemoveAll(Predicate<T> match)
+			=> _inner.RemoveAll(match);
+
+		/// <inheritdoc />
+		public IImmutableList<T> RemoveAt(int index)
+			=> _inner.RemoveAt(index);
+
+		/// <inheritdoc />
+		public IImmutableList<T> RemoveRange(IEnumerable<T> items, IEqualityComparer<T>? equalityComparer)
+			=> _inner.RemoveRange(items, equalityComparer);
+
+		/// <inheritdoc />
+		public IImmutableList<T> RemoveRange(int index, int count)
+			=> _inner.RemoveRange(index, count);
+
+		/// <inheritdoc />
+		public IImmutableList<T> Replace(T oldValue, T newValue, IEqualityComparer<T>? equalityComparer)
+			=> _inner.Replace(oldValue, newValue, equalityComparer);
+
+		/// <inheritdoc />
+		public IImmutableList<T> SetItem(int index, T value)
+			=> _inner.SetItem(index, value);
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.List.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.List.cs
@@ -1,0 +1,2229 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Collections.Tracking;
+using Uno.Extensions.Reactive.Tests._Utils;
+using Uno.Extensions.Reactive.Utils;
+using static Uno.Extensions.Collections.CollectionChanged;
+
+namespace Uno.Extensions.Reactive.Tests.Collections.Tracking;
+
+[TestClass]
+public partial class Given_CollectionAnalyzer_List
+{
+	private IEqualityComparer<object?> ItemComparer { get; } = FuncEqualityComparer<MyClass>.Create(c => c.Value).ToEqualityComparer().ToEqualityComparer<object?>();
+
+	[TestMethod]
+	public void When_Add_ValueType()
+	{
+		FromInt(0, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirst_ValueType()
+	{
+		FromInt(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstSome_ValueType()
+	{
+		FromInt(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLast_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSome_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSomeAndMove_ValueType()
+	{
+		FromInt(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Move_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLast_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedSome_ValueType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromInt(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_Remove_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLast_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Add_ReferenceType()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2}, new[] {0, 2}, 0),
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddSome_ReferenceType()
+	{
+		FromObj(0, 3)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 3}, new[] {0, 3}, 0),
+				AddSome(new[] {1, 2}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 2, 4)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2, 4}, new[] {0, 2, 4}, 0),
+				Add(1, 1),
+				Add(3, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirst_ReferenceType()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 0),
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstSome_ReferenceType()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 0),
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(1, 2, 4)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2, 4}, new[] {1, 2, 4}, 0),
+				Add(0, 0),
+				Add(3, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLast_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSome_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 2, 3)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2, 3}, new[] {0, 2, 3}, 0),
+				Add(1, 1),
+				Add(4, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSomeAndMove_ReferenceType()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 4}, new[] {0, 1, 4}, 0),
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Move_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedSome_ReferenceType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 1, 2, 3, 4}, 0),
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 0, 1, 2, 3}, new[] {0, 1, 0, 1, 2, 3}, 0),
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 2, 3}, new[] {0, 1, 2, 3, 2, 3}, 0),
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_Remove_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(2, 2, 2),
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(3, 3, 3),
+				RemoveSome(new[] {1, 2}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(2, 2, 2),
+				Replace(4, 4, 4),
+				Remove(1, 1),
+				Remove(3, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 1),
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 2),
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(1, 2, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 1),
+				Replace(4, 4, 4),
+				Remove(0, 0),
+				Remove(3, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastNonConsecutiveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				Replace(0, 0, 0),
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 2),
+				Remove(1, 1),
+				Remove(4, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				Replace((0, 0), (0, 1), 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {(0, 1), (1, 1)}, 0)
+			);
+	}
+
+
+	[TestMethod]
+	public void When_Update_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				Replace(1, (1, 1), 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {(1, 1), (2, 1)}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				Replace(3, (3, 1), 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {(2, 1), (3, 1)}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_Add_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddLastSomeAndMove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_AddDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_Move_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_MoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_Remove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_RemoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_UpdateFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+
+	[TestMethod]
+	public void When_Update_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_UpdateLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBeEmpty();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Add_ValueType()
+	{
+		FromInt(0, 2)
+			.To(0, 1, 2)
+			.With()
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirst_ValueType()
+	{
+		FromInt(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirstSome_ValueType()
+	{
+		FromInt(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLast_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSome_ValueType()
+	{
+		FromInt(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSomeAndMove_ValueType()
+	{
+		FromInt(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Move_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLast_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedSome_ValueType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromInt(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedFirstSome_ValueType()
+	{
+		FromInt(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Remove_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirst_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirstSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLast_ValueType()
+	{
+		FromInt(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveDuplicatedLastSome_ValueType()
+	{
+		FromInt(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Add_ReferenceType()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 2}, new[] {0, 2}, 0),
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirst_ReferenceType()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {1, 2}, 0),
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirstSome_ReferenceType()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {2, 3}, 0),
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLast_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSome_ReferenceType()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSomeAndMove_ReferenceType()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 4}, new[] {0, 1, 4}, 0),
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] {0, 1, 2, 3, 4}, 0),
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Move_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3 }, new[] { 0, 1, 2, 3 }, 0),
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] { 0, 1, 2, 3, 4 }, 0),
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4}, new[] { 0, 1, 2, 3, 4 }, 0),
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3 }, new[] { 0, 1, 2, 3 }, 0),
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3, 4 }, new[] { 0, 1, 2, 3, 4 }, 0),
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedSome_ReferenceType()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3, 1, 2, 3, 4 }, new[] { 0, 1, 2, 3, 1, 2, 3, 4 }, 0),
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 0, 1, 2, 3}, new[] {0, 1, 0, 1, 2, 3}, 0),
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 2, 3}, new[] {0, 1, 2, 3, 2, 3}, 0),
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Remove_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				Replace(0, 0, 0),
+				Replace(2, 2, 2),
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] { 1, 2 }, new[] { 1, 2 }, 1),
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] { 2, 3 }, new[] { 2, 3 }, 2),
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLast_ReferenceType()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {0, 1}, 0),
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveDuplicatedLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, ReferenceEqualityComparer<MyClass>.Default.ToEqualityComparer().ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3}, new[] {0, 1, 2, 3}, 0),
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirst_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				Replace((0, 0), (0, 1), 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirstSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1}, new[] {(0, 1), (1, 1)}, 0)
+			);
+	}
+
+
+	[TestMethod]
+	public void When_WithVisitor_Update_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				Replace(1, (1, 1), 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {1, 2}, new[] {(1, 1), (2, 1)}, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLast_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				Replace(3, (3, 1), 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLastSome_ReferenceType()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {2, 3}, new[] {(2, 1), (3, 1)}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Add_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(1, 2)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(2, 3)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Add(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1)
+			.To(0, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddLastSomeAndMove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 4)
+			.To(0, 1, 2, 3, 4, 5, 6)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {2, 3}, 2),
+				AddSome(new[] {5, 6}, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 2, 3, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1),
+				AddSome(new[] {2, 3}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0),
+				AddSome(new[] {1, 2}, 3)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_AddDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.With(null, null)
+			.ShouldBe(
+				AddSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Move_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 2, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2, 3, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(1, 2, 0, 3)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {1, 2}, 1, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(2, 3, 0, 1, 4)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3}, 2, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {3, 4}, 3, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		/* ix:	0  1  2  3  4  5  6  7
+		*
+		* src: 0  1  2 (3) 1  2  3  4
+		*		0 [3] 1  2  1  2  3 (4)
+		*		0  3 [4] 1  2  1  2 (3)
+		*		0  3  4  1  2 [3] 1  2
+		*/
+
+		FromObj(0, 1, 2, 3, 1, 2, 3, 4)
+			.To(0, 3, 4, 1, 2, 3, 1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Move(3, 3, 1),
+				Move(4, 7, 2),
+				Move(3, 7, 5)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 0, 1, 2, 3)
+			.To(2, 0, 1, 0, 1, 3)
+			.With(null, null)
+			.ShouldBe(
+				Move(2, 4, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_MoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 2, 3)
+			.To(0, 2, 3, 2, 3, 1)
+			.With(null, null)
+			.ShouldBe(
+				MoveSome(new[] {2, 3, 2, 3}, 2, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_Remove_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(1, 1)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(1, 2)
+			.With(null, null)
+			.ShouldBe(
+				Remove(0, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1}, 0)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				Remove(2, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {2, 3}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_RemoveDuplicatedLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3, 0, 1, 2, 3, 2)
+			.To(0, 1, 2, 3)
+			.With(null, null)
+			.ShouldBe(
+				RemoveSome(new[] {0, 1, 2, 3, 2}, 4)
+			);
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirst_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), 1, 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateFirstSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To((0, 1), (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+
+	[TestMethod]
+	public void When_WithVisitor_Update_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), 2, 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, (1, 1), (2, 1), 3)
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLast_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, 2, (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void When_WithVisitor_UpdateLastSome_ReferenceType_WithoutRefrencesUpdates()
+	{
+		FromObj(0, 1, 2, 3)
+			.To(0, 1, (2, 1), (3, 1))
+			.With(ItemComparer, null)
+			.ShouldBe();
+	}
+
+	[TestMethod]
+	public void Scenario_1()
+	{
+		FromObj(0, 1, 2, 3, 4)
+			.To(0, 2)
+			.With(ItemComparer, null)
+			.ShouldBe(
+				Remove(1, 1),
+				RemoveSome(new[] {3, 4}, 2)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_2()
+	{
+		FromObj(0, 1, 2, 3, 4, 5, 6, 7)
+			.To(10, 11, 2, 13, 14, 0, 1, 3, 4, 5)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				AddSome(new[] {10, 11}, 0),
+				Move(2, 4, 2),
+				AddSome(new[] {13, 14}, 3),
+				RemoveSome(new[] {6, 7}, 10)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_2_WithUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4, 5, 6, 7)
+			.To(10, 11, (2, 1), 13, 14, (0, 1), (1, 1), (3, 1), (4, 1), (5, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] { 0, 1, 2, 3, 4, 5 }, new[] { (0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1) }, 0),
+				AddSome(new[] {10, 11}, 0),
+				Move((2, 1), 4, 2),
+				AddSome(new[] {13, 14}, 3),
+				RemoveSome(new[] {6, 7}, 10)
+			);
+	}
+
+
+	[TestMethod]
+	public void Scenario_3_MoveMultipleWithUpdates()
+	{
+		FromObj(0, 1, 2, 3, 4, 5)
+			.To(6, (1, 1), (2, 1), (3, 1), (5, 1), (0, 1), (4, 1))
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				ReplaceSome(new[] {0, 1, 2, 3, 4, 5}, new[] {(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1)}, 0),
+				Add(6, 0),
+				MoveSome(new[] {(1, 1), (2, 1), (3, 1)}, 2, 1),
+				Move((5, 1), 6, 4)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_4_ReOrder()
+	{
+		FromObj(0, 1, 2, 3, 4, 5)
+			.To(5, 4, 3, 2, 1, 0)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				Move(5, 5, 0),
+				Move(4, 5, 1),
+				Move(3, 5, 2),
+				Move(2, 5, 3),
+				Move(1, 5, 4)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_4_ReOrderWithMixedMoves()
+	{
+		FromObj(0, 1, 2, 3, 4, 5, 42)
+			.To(42, 0, 1, 5, 4, 3, 2)
+			.With(ItemComparer, EqualityComparer<MyClass>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				Move(42, 6, 0),
+				Move(5, 6, 3),
+				Move(4, 6, 4),
+				Move(3, 6, 5)
+			);
+	}
+
+	[TestMethod]
+	public void Scenario_4_ReOrderWithMixedMoves2()
+	{
+		/*
+		*	 0   1   2   3   4   5   6
+		*
+		*	 0   1  (42) 2   3   4   5
+		*  [42] 0   1   2   3   4  (5)
+		*   42 [5]  0   1   2   3  (4)
+		*   42  5  [4]  0   1   2  (3)
+		*   42  5   4  [3]  0   1  (2)
+		*   42  5   4   3  [2]  0  (1)
+		*   42  5   4   3   2  [1]  0
+		*/
+
+
+		FromObj(0, 1, 42, 2, 3, 4, 5)
+			.To(42, 5, 4, 3, 2, 1, 0)
+			.With(ItemComparer, EqualityComparer<MyClass?>.Default.ToEqualityComparer<object?>())
+			.ShouldBe(
+				Move(42, 2, 0),
+				Move(5, 6, 1),
+				Move(4, 6, 2),
+				Move(3, 6, 3),
+				Move(2, 6, 4),
+				Move(1, 6, 5)
+			);
+	}
+
+	private static ListCollectionTrackerTester<MyClass> FromObj(params MyClass[] items)
+		=> new(new ArrayList(items), null, o => o switch
+		{
+			int i => (MyClass)i,
+			ValueTuple<int, int> v => (MyClass)v,
+			_ => throw new InvalidCastException()
+		});
+
+	private static ListCollectionTrackerTester<int> FromInt(params int[] items)
+		=> new(new ArrayList(items), null, i => (int)i!);
+
+	private class ListCollectionTrackerTester<T> : CollectionTrackerTester<IList, object?>
+	{
+		private readonly Func<object?, T> _cast;
+
+		/// <inheritdoc />
+		public ListCollectionTrackerTester(IList previous, IList? updated, Func<object?, T> cast)
+			: base(previous, updated)
+		{
+			_cast = cast;
+		}
+
+		/// <inheritdoc />
+		protected override IList Create(object?[] items)
+			=> new ArrayList(items.Select(_cast).ToArray()); // Make sure to lost the IList<object?>
+
+		/// <inheritdoc />
+		protected override CollectionUpdater GetUpdater(CollectionAnalyzer<object?> analyzer, IList previous, IList updated, ICollectionUpdaterVisitor visitor)
+			=> analyzer.GetUpdater(previous, updated, visitor);
+
+		/// <inheritdoc />
+		protected override IEnumerable<object?> AsEnumerable(IList collection)
+			=> collection.Cast<object?>();
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.ListOfT.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.ListOfT.cs
@@ -2,13 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Collections.Tracking;
 using Uno.Extensions.Reactive.Tests._Utils;
 using static Uno.Extensions.Collections.CollectionChanged;
 
 namespace Uno.Extensions.Reactive.Tests.Collections.Tracking;
 
 [TestClass]
-public partial class Given_CollectionAnalyzer
+public partial class Given_CollectionAnalyzer_ListOfT
 {
 	private IEqualityComparer<MyClass> ItemComparer { get; } = FuncEqualityComparer<MyClass>.Create(c => c.Value);
 
@@ -2187,5 +2188,32 @@ public partial class Given_CollectionAnalyzer
 				Move(2, 6, 4),
 				Move(1, 6, 5)
 			);
+	}
+
+	private static ListOfTCollectionTrackerTester<MyClass> FromObj(params MyClass[] items)
+		=> new(new List<MyClass>(items), null);
+
+	private static ListOfTCollectionTrackerTester<int> FromInt(params int[] items)
+		=> new(new List<int>(items), null);
+
+	private class ListOfTCollectionTrackerTester<T> : CollectionTrackerTester<IList<T>, T>
+	{
+		/// <inheritdoc />
+		public ListOfTCollectionTrackerTester(IList<T> previous, IList<T>? updated)
+			: base(previous, updated)
+		{
+		}
+
+		/// <inheritdoc />
+		protected override IList<T> Create(T[] items)
+			=> items;
+
+		/// <inheritdoc />
+		protected override CollectionUpdater GetUpdater(CollectionAnalyzer<T> analyzer, IList<T> previous, IList<T> updated, ICollectionUpdaterVisitor visitor)
+			=> analyzer.GetUpdater(previous, updated, visitor);
+
+		/// <inheritdoc />
+		protected override IEnumerable<T> AsEnumerable(IList<T> collection)
+			=> collection;
 	}
 }

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Change.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Change.cs
@@ -67,8 +67,8 @@ partial class CollectionAnalyzer
 	private abstract class EntityChange : Change
 	{
 		protected readonly int _indexOffset;
-		protected readonly List<object> _oldItems = new();
-		protected readonly List<object> _newItems = new();
+		protected readonly List<object?> _oldItems = new();
+		protected readonly List<object?> _newItems = new();
 
 		public new EntityChange? Next
 		{
@@ -83,7 +83,7 @@ partial class CollectionAnalyzer
 			Ends = at;
 		}
 
-		public void Append(object oldItem, object newItem)
+		public void Append(object? oldItem, object? newItem)
 		{
 			_oldItems.Add(oldItem);
 			_newItems.Add(newItem);

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.ChangesBuffer.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.ChangesBuffer.cs
@@ -7,7 +7,7 @@ namespace Uno.Extensions.Collections.Tracking;
 
 partial class CollectionAnalyzer
 {
-	private class ChangesBuffer
+	private class ChangesBuffer<T>
 	{
 		/*
 		* We generate 4 kinds of changes:
@@ -95,7 +95,7 @@ partial class CollectionAnalyzer
 			}
 		}
 
-		public void Update(object oldItem, object newItem, int index)
+		public void Update(T oldItem, T newItem, int index)
 		{
 			// As they don't impact the 'result' index, replace-instance are buffered separately and will be inserted at the top of the changes collection.
 			// Note: We use a single '_Same' node for all updates
@@ -103,14 +103,14 @@ partial class CollectionAnalyzer
 			UpdateOrReplace(ref _sameHead, oldItem, newItem, index, (i, o) => new _Same(i, o)); ;
 		}
 
-		public void Replace(object oldItem, object newItem, int index)
+		public void Replace(T oldItem, T newItem, int index)
 		{
 			// As they don't impact the 'result' index, replaces are buffered separately and will be inserted at the top of the changes collection.
 
 			UpdateOrReplace(ref _replaceHead, oldItem, newItem, index, (i, o) => new _Replace(i, o));
 		}
 
-		public void Add(object item, int at, int max)
+		public void Add(T item, int at, int max)
 		{
 			if (!(Tail is _Add add) || add.Ends != at)
 			{
@@ -119,7 +119,7 @@ partial class CollectionAnalyzer
 			add.Append(item);
 		}
 
-		public void Move(object item, int from, int fromOffset, int to, int max)
+		public void Move(T item, int from, int fromOffset, int to, int max)
 		{
 			if (!(Tail is _Move move) || move.Ends != from)
 			{
@@ -128,7 +128,7 @@ partial class CollectionAnalyzer
 			move.Append(item);
 		}
 
-		public void Remove(object item, int at)
+		public void Remove(T item, int at)
 		{
 			if (!(Tail is _Remove remove) || remove.Ends != at)
 			{
@@ -137,8 +137,8 @@ partial class CollectionAnalyzer
 			remove.Append(item);
 		}
 
-		private void UpdateOrReplace<T>(ref T? head, object oldItem, object newItem, int index, Func<int, int, T> factory)
-			where T : EntityChange
+		private void UpdateOrReplace<TNode>(ref TNode? head, T oldItem, T newItem, int index, Func<int, int, TNode> factory)
+			where TNode : EntityChange
 		{
 			if (head is null)
 			{
@@ -152,7 +152,7 @@ partial class CollectionAnalyzer
 			var node = head;
 			while (node.Next is not null && node.Next.Starts < index)
 			{
-				node = (T)node.Next;
+				node = (TNode)node.Next;
 			}
 
 			// Then append the item to the selected nodes

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.ListRef.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.ListRef.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Uno.Extensions.Collections.Tracking;
+
+internal partial class CollectionAnalyzer
+{
+	internal delegate T ElementAtHandler<out T>(int index);
+
+	internal delegate int IndexOfHandler<in T>(T item, int startIndex, int count);
+
+	/// <summary>
+	/// An helper that abstract the fact that <see cref="IEqualityComparer"/> is **not** a <see cref="IEqualityComparer{T}"/>
+	/// (nor the opposite)
+	/// </summary>
+	internal delegate bool ComparerRef<T>(T oldItem, T newItem);
+
+	/// <summary>
+	/// An helper struct that abstract contract miss-matches between different types of list
+	/// (noticeably <see cref="IList"/> and <see cref="IImmutableList{T}"/>).
+	/// </summary>
+	protected struct ListRef<T>
+	{
+		public ListRef(int count, ElementAtHandler<T> elementAt, IndexOfHandler<T> indexOf)
+		{
+			Count = count;
+			ElementAt = elementAt;
+			IndexOf = indexOf;
+		}
+
+		public int Count { get; }
+
+		public ElementAtHandler<T> ElementAt { get; }
+
+		public IndexOfHandler<T> IndexOf { get; }
+	}
+}

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.SourceEnumerator.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.SourceEnumerator.cs
@@ -8,23 +8,19 @@ namespace Uno.Extensions.Collections.Tracking;
 
 partial class CollectionAnalyzer
 {
-	private class SourceEnumerator
+	private class SourceEnumerator<T>
 	{
-		private readonly IList _snapshot;
-		private readonly IndexOf _indexOf;
+		private readonly ListRef<T> _source;
 		private readonly IgnoredIndexCollection _ignored = new();
 
-		public SourceEnumerator(
-			IList snapshot,
-			IndexOf indexOf)
+		public SourceEnumerator(ListRef<T> source)
 		{
-			_snapshot = snapshot;
-			_indexOf = indexOf;
+			_source = source;
 		}
 
 		public int CurrentIndex { get; private set; } = -1;
 
-		public object? Current { get; private set; }
+		public T Current { get; private set; }
 
 		/// <summary>
 		/// Count of items that have been ignored by the enumerator
@@ -39,17 +35,17 @@ partial class CollectionAnalyzer
 				Ignored++;
 			}
 
-			if (index >= _snapshot.Count)
+			if (index >= _source.Count)
 			{
 				CurrentIndex = -1;
-				Current = default(object);
+				Current = default!;
 
 				return false;
 			}
 			else
 			{
 				CurrentIndex = index;
-				Current = _snapshot[index];
+				Current = _source.ElementAt(index);
 
 				return true;
 			}
@@ -64,13 +60,13 @@ partial class CollectionAnalyzer
 			_ignored.Add(index);
 		}
 
-		public (int index, int ignoredItemsAfter) NextIndexOf(object item)
+		public (int index, int ignoredItemsAfter) NextIndexOf(T item)
 		{
 			using var ignored = _ignored.GetEnumerator();
 			var index = CurrentIndex;
 			do
 			{
-				index = _indexOf(item, index + 1, _snapshot.Count - index - 1);
+				index = _source.IndexOf(item, index + 1, _source.Count - index - 1);
 
 				// Item is missing, break
 				if (index < 0)

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
@@ -16,16 +16,25 @@ internal class CollectionAnalyzer<T> : CollectionAnalyzer
 {
 	public static CollectionAnalyzer<T> Default { get; } = new(default);
 
+	private readonly IEqualityComparer<T>? _comparer;
+	private readonly ComparerRef<T>? _versionComparer;
+
 	/// <summary>
 	/// Creates a new instance using the given set of comparer.
 	/// </summary>
 	/// <param name="comparer">The set of comparer to use to track items.</param>
 	public CollectionAnalyzer(ItemComparer<T> comparer)
-		: base(
-			list => list.GetIndexOf(comparer.Entity),
-			comparer.Version is null ? null : (VersionEqual)((l, r) => comparer.Version.Equals((T)l, (T)r)))
+		: base(new(comparer.Entity?.ToEqualityComparer(), comparer.Version?.ToEqualityComparer()))
 	{
+		_comparer = comparer.Entity;
+		_versionComparer = GetRef(comparer.Version);
 	}
+
+	private ListRef<T> GetRef(IList<T> list)
+		=> new(list.Count, i => list[i], list.GetIndexOf(_comparer));
+
+	private ListRef<T> GetRef(IImmutableList<T> list)
+		=> new(list.Count, i => list[i], list.GetIndexOf(_comparer));
 
 	/// <summary>
 	/// Determines the set of changes between two snapshot of an <see cref="IList{T}"/>
@@ -35,7 +44,10 @@ internal class CollectionAnalyzer<T> : CollectionAnalyzer
 	/// <param name="visitor">A visitor that can be used to track changes while detecting them.</param>
 	/// <returns>A list of changes that have to be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
 	public CollectionUpdater GetUpdater(IList<T> oldItems, IList<T> newItems, ICollectionUpdaterVisitor visitor)
-		=> base.GetUpdater((IList)oldItems, (IList)newItems, visitor);
+		=> base.CreateUpdaterCore(GetRef(oldItems), GetRef(newItems), _versionComparer, visitor);
+
+	internal CollectionUpdater GetUpdater(IImmutableList<T> oldItems, IImmutableList<T> newItems, ICollectionUpdaterVisitor visitor)
+		=> base.CreateUpdaterCore(GetRef(oldItems), GetRef(newItems), _versionComparer, visitor);
 
 	/// <summary>
 	/// Determines the set of changes between two snapshot of an <see cref="IList{T}"/>
@@ -44,11 +56,11 @@ internal class CollectionAnalyzer<T> : CollectionAnalyzer
 	/// <param name="newItems">The target snapshot</param>
 	/// <returns>A list of changes that have to be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
 	public CollectionChangeSet GetChanges(IList<T> oldItems, IList<T> newItems)
-		=> base.GetChanges((IList)oldItems, (IList)newItems);
+		=> new(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer));
 
 	internal CollectionChangeSet GetChanges(IImmutableList<T> oldItems, IImmutableList<T> newItems)
-		=> base.GetChanges((IList)oldItems, (IList)newItems);
+		=> new(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer));
 
-	internal CollectionChangeSet GetReset(IImmutableList<T> oldItems, IImmutableList<T> newItems)
-		=> base.GetResetChange((IList)oldItems, (IList)newItems);
+	internal CollectionChangeSet GetResetChange(IImmutableList<T> oldItems, IImmutableList<T> newItems)
+		=> base.GetResetChange(oldItems.AsUntypedList(), newItems.AsUntypedList());
 }

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Add.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Add.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Uno.Extensions.Collections.Facades.Differential;
 
 namespace Uno.Extensions.Collections.Tracking;
 
@@ -10,7 +11,7 @@ partial class CollectionAnalyzer
 	private sealed class _Add : Change
 	{
 		private readonly int _indexOffset;
-		private readonly List<object> _items;
+		private readonly List<object?> _items;
 
 		public _Add(int at, int capacity)
 			: this(at, 0, capacity)
@@ -21,10 +22,10 @@ partial class CollectionAnalyzer
 			: base(at)
 		{
 			_indexOffset = indexOffset;
-			_items = new List<object>(capacity);
+			_items = new List<object?>(capacity);
 		}
 
-		public void Append(object item)
+		public void Append(object? item)
 		{
 			_items.Add(item);
 			Ends++;

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Move.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Move.cs
@@ -12,7 +12,7 @@ partial class CollectionAnalyzer
 	{
 		private readonly int _to;
 		private readonly int _indexOffset;
-		private readonly List<object> _items;
+		private readonly List<object?> _items;
 
 		public _Move(int from, int to, int capacity)
 			: this(from, to, 0, capacity)
@@ -27,7 +27,7 @@ partial class CollectionAnalyzer
 			_items = new(capacity);
 		}
 
-		public void Append(object item)
+		public void Append(object? item)
 		{
 			_items.Add(item);
 			Ends++;

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Remove.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Remove.cs
@@ -9,7 +9,7 @@ partial class CollectionAnalyzer
 	private sealed class _Remove : Change
 	{
 		private readonly int _indexOffset;
-		private readonly List<object> _items;
+		private readonly List<object?> _items;
 
 		public _Remove(int at, int capacity)
 			: this(at, 0, capacity)
@@ -20,10 +20,10 @@ partial class CollectionAnalyzer
 			: base(at)
 		{
 			_indexOffset = indexOffset;
-			_items = new List<object>(capacity);
+			_items = new List<object?>(capacity);
 		}
 
-		public void Append(object item)
+		public void Append(object? item)
 		{
 			_items.Add(item);
 		}

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
+using Uno.Extensions.Collections.Facades.Differential;
 using Uno.Extensions.Reactive.Collections;
 using Uno.Extensions.Reactive.Utils;
 
@@ -14,32 +15,28 @@ namespace Uno.Extensions.Collections.Tracking;
 /// </summary>
 internal partial class CollectionAnalyzer
 {
-	internal delegate int IndexOf(object item, int startIndex, int count);
-	internal delegate int IndexOf<in TCollection>(object item, TCollection snapshot, int startIndex);
-	internal delegate bool VersionEqual(object oldItem, object newItem);
 
-	private readonly Func<IList, IndexOf> _indexOfFactory;
-	private readonly VersionEqual? _versionEqual;
+	private readonly IEqualityComparer? _entityComparer;
+	private readonly ComparerRef<object?>? _versionComparer;
 
 	/// <summary>
 	/// Creates a new instance using the given set of comparer.
 	/// </summary>
 	/// <param name="comparer">The set of comparer to use to track items.</param>
 	public CollectionAnalyzer(ItemComparer comparer)
-		: this(
-			list => list.GetIndexOf(comparer.Entity),
-			comparer.Version == null ? null : (VersionEqual)(comparer.Version.Equals))
 	{
+		_entityComparer = comparer.Entity;
+		_versionComparer = GetRef(comparer.Version);
 	}
 
-	protected CollectionAnalyzer(
-		Func<IList, IndexOf> indexOfFactory,
-		VersionEqual? versionEqual)
-	{
-		_indexOfFactory = indexOfFactory;
-		_versionEqual = versionEqual;
-	}
+	private ListRef<object?> GetRef(IList list)
+		=> new(list.Count, i => list[i], list.GetIndexOf(_entityComparer));
 
+	private ComparerRef<object?>? GetRef(IEqualityComparer? comparer)
+		=> comparer is null ? null : comparer.Equals;
+
+	protected ComparerRef<T>? GetRef<T>(IEqualityComparer<T>? comparer)
+		=> comparer is null ? null : comparer.Equals;
 
 	/// <summary>
 	/// Creates a set of changes that contains only a reset event.
@@ -57,7 +54,7 @@ internal partial class CollectionAnalyzer
 	/// <param name="newItems">The target snapshot</param>
 	/// <returns>A list of changes that have to be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
 	public CollectionChangeSet GetChanges(IList oldItems, IList newItems)
-		=> new(GetChangesCore(oldItems, newItems));
+		=> new(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer));
 
 	/// <summary>
 	/// Determines the set of effective changes produced by a <see cref="NotifyCollectionChangedEventArgs"/>.
@@ -85,7 +82,7 @@ internal partial class CollectionAnalyzer
 	/// <param name="visitor">A visitor that can be used to track changes while detecting them.</param>
 	/// <returns>A list of changes that have to be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
 	public CollectionUpdater GetUpdater(IList oldItems, IList newItems, ICollectionUpdaterVisitor visitor)
-		=> CreateUpdaterCore(oldItems, newItems, visitor);
+		=> CreateUpdaterCore(GetRef(oldItems), GetRef(newItems), _versionComparer, visitor);
 
 	/// <summary>
 	/// Determines the set of effective changes produced by a <see cref="NotifyCollectionChangedEventArgs"/>.
@@ -103,14 +100,14 @@ internal partial class CollectionAnalyzer
 			: new(updaterHead);
 	}
 
-	private CollectionUpdater CreateUpdaterCore<TSnapshot>(
-		TSnapshot oldItems,
-		TSnapshot newItems,
+	private protected CollectionUpdater CreateUpdaterCore<T>(
+		ListRef<T> oldItems,
+		ListRef<T> newItems,
+		ComparerRef<T>? itemVersionComparer,
 		ICollectionUpdaterVisitor visitor,
 		int eventArgsOffset = 0)
-		where TSnapshot : IList
 	{
-		var changesHead = GetChangesCore(oldItems, newItems, eventArgsOffset);
+		var changesHead = GetChangesCore(oldItems, newItems, itemVersionComparer, eventArgsOffset);
 		var updaterHead = changesHead?.ToUpdater(visitor);
 
 		return updaterHead is null
@@ -118,7 +115,7 @@ internal partial class CollectionAnalyzer
 			: new(updaterHead);
 	}
 
-	private Change? GetChangesCore(RichNotifyCollectionChangedEventArgs arg)
+	private protected Change? GetChangesCore(RichNotifyCollectionChangedEventArgs arg)
 	{
 		switch (arg.Action)
 		{
@@ -129,23 +126,17 @@ internal partial class CollectionAnalyzer
 				return new _Event(arg);
 
 			case NotifyCollectionChangedAction.Replace:
-				return GetChangesCore(arg.OldItems, arg.NewItems, arg.OldStartingIndex);
+				return GetChangesCore(GetRef(arg.OldItems), GetRef(arg.NewItems), _versionComparer, arg.OldStartingIndex);
 
 			default:
 				throw new ArgumentOutOfRangeException(nameof(arg), arg.Action, $"Action '{arg.Action}' not supported.");
 		}
 	}
 
-	private Change? GetChangesCore(
-		IList oldItems,
-		IList newItems,
-		int eventArgsOffset = 0)
-		=> GetChangesCore((oldItems, _indexOfFactory(oldItems)), (newItems, _indexOfFactory(newItems)), _versionEqual, eventArgsOffset);
-
-	private static Change? GetChangesCore(
-		(IList items, IndexOf indexOf) old,
-		(IList items, IndexOf indexOf) @new,
-		VersionEqual? itemVersionComparer,
+	private protected static Change? GetChangesCore<T>(
+		ListRef<T> oldItems,
+		ListRef<T> newItems,
+		ComparerRef<T>? versionComparer,
 		int eventArgsOffset = 0)
 	{
 		/*
@@ -162,15 +153,15 @@ internal partial class CollectionAnalyzer
 		*/
 
 		int added = 0, moved = 0, removed = 0;
-		var buffer = new ChangesBuffer(old.items.Count, @new.items.Count, eventArgsOffset);
+		var buffer = new ChangesBuffer<T>(oldItems.Count, newItems.Count, eventArgsOffset);
 
-		var oldEnumerator = new SourceEnumerator(old.items, old.indexOf);
+		var oldEnumerator = new SourceEnumerator<T>(oldItems);
 		while (oldEnumerator.MoveNext())
 		{
 			var oldIndex = oldEnumerator.CurrentIndex;
 			var oldItem = oldEnumerator.Current!;
 			var resultIndex = oldIndex - removed + added + moved - oldEnumerator.Ignored; // The current index in the (virtual) result collection (i.e. oldIndex ignoring the removed/added items)
-			var newIndex = @new.indexOf(oldItem, resultIndex, @new.items.Count - resultIndex);
+			var newIndex = newItems.IndexOf(oldItem, resultIndex, newItems.Count - resultIndex);
 
 			if (newIndex < 0)
 			{
@@ -197,7 +188,7 @@ internal partial class CollectionAnalyzer
 				var movedBeforeItemLocal = 0;
 				for (var missingItemNewIndex = resultIndex; missingItemNewIndex < newIndex; missingItemNewIndex++)
 				{
-					var missingItem = @new.items[missingItemNewIndex]; // The item that is missing in the old collection
+					var missingItem = newItems.ElementAt(missingItemNewIndex); // The item that is missing in the old collection
 					var (missingItemOldIndex, missingItemOldIndexOffset) = oldEnumerator.NextIndexOf(missingItem);
 					if (missingItemOldIndex >= 0)
 					{
@@ -234,14 +225,14 @@ internal partial class CollectionAnalyzer
 		Debug.Assert(moved - oldEnumerator.Ignored == 0);
 
 		// Finally add items that remains at the end of the newItems (i.e. was missing in the previous)
-		var resultItemsCount = old.items.Count - removed + added;
-		var toAddCount = @new.items.Count - resultItemsCount;
+		var resultItemsCount = oldItems.Count - removed + added;
+		var toAddCount = newItems.Count - resultItemsCount;
 		if (toAddCount > 0)
 		{
 			var add = new _Add(at: resultItemsCount, indexOffset: eventArgsOffset, capacity: toAddCount);
 			for (var i = 0; i < toAddCount; i++)
 			{
-				var item = @new.items[i + resultItemsCount];
+				var item = newItems.ElementAt(i + resultItemsCount);
 				add.Append(item);
 			}
 
@@ -272,17 +263,17 @@ internal partial class CollectionAnalyzer
 		*  So we have to raise a 'Replace' event.
 		*/
 
-		void UpdateInstanceFromOld(object oldItem, int oldIndex, int newIndex)
+		void UpdateInstanceFromOld(T oldItem, int oldIndex, int newIndex)
 		{
-			if (itemVersionComparer is null || oldItem is ValueType)
+			if (versionComparer is null || oldItem is ValueType)
 			{
 				buffer.Update(oldItem, oldItem, oldIndex);
 
 				return;
 			}
 
-			var newItem = @new.items[newIndex];
-			if (itemVersionComparer(oldItem, newItem))
+			var newItem = newItems.ElementAt(newIndex);
+			if (versionComparer(oldItem, newItem))
 			{
 				buffer.Update(oldItem, newItem, oldIndex);
 			}
@@ -292,17 +283,17 @@ internal partial class CollectionAnalyzer
 			}
 		}
 
-		void UpdateInstanceFromNew(object newItem, int oldIndex)
+		void UpdateInstanceFromNew(T newItem, int oldIndex)
 		{
-			if (itemVersionComparer is null || newItem is ValueType)
+			if (versionComparer is null || newItem is ValueType)
 			{
 				buffer.Update(newItem, newItem, oldIndex);
 
 				return;
 			}
 
-			var oldItem = old.items[oldIndex];
-			if (itemVersionComparer(oldItem, newItem))
+			var oldItem = oldItems.ElementAt(oldIndex);
+			if (versionComparer(oldItem, newItem))
 			{
 				buffer.Update(oldItem, newItem, oldIndex);
 			}

--- a/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
+++ b/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
@@ -81,11 +81,11 @@ internal record FeedToListFeedAdapter<TCollection, TItem>(
 		var hadItems = previousData.IsSome(out var previousItems);
 		var hasItems = updatedData.IsSome(out var updatedItems);
 
-		return ((hadItems, hasItems)) switch
+		return (hadItems, hasItems) switch
 		{
 			(true, true) => collectionAnalyzer.GetChanges(previousItems, updatedItems),
-			(true, false) => collectionAnalyzer.GetReset(previousItems, ImmutableList<TItem>.Empty),
-			(false, true) => collectionAnalyzer.GetReset(ImmutableList<TItem>.Empty, updatedItems),
+			(true, false) => collectionAnalyzer.GetResetChange(previousItems, ImmutableList<TItem>.Empty),
+			(false, true) => collectionAnalyzer.GetResetChange(ImmutableList<TItem>.Empty, updatedItems),
 			(false, false) => CollectionChangeSet.Empty,
 		};
 	}

--- a/src/Uno.Extensions.Reactive/Operators/WhereListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/WhereListFeed.cs
@@ -51,13 +51,13 @@ internal class WhereListFeed<T> : IListFeed<T>
 			{
 				case OptionType.Undefined:
 					updated
-						.Data(Option.Undefined<IImmutableList<T>>(), _analyzer.GetReset(previousFilteredItems, ImmutableList<T>.Empty))
+						.Data(Option.Undefined<IImmutableList<T>>(), _analyzer.GetResetChange(previousFilteredItems, ImmutableList<T>.Empty))
 						.Error(null);
 					break;
 
 				case OptionType.None:
 					updated
-						.Data(Option.None<IImmutableList<T>>(), _analyzer.GetReset(previousFilteredItems, ImmutableList<T>.Empty))
+						.Data(Option.None<IImmutableList<T>>(), _analyzer.GetResetChange(previousFilteredItems, ImmutableList<T>.Empty))
 						.Error(null);
 					break;
 
@@ -79,7 +79,7 @@ internal class WhereListFeed<T> : IListFeed<T>
 						if (updatedFilteredItems is { Count: 0 })
 						{
 							updated
-								.Data(Option.None<IImmutableList<T>>(), _analyzer.GetReset(previousFilteredItems, ImmutableList<T>.Empty))
+								.Data(Option.None<IImmutableList<T>>(), _analyzer.GetResetChange(previousFilteredItems, ImmutableList<T>.Empty))
 								.Error(null);
 						}
 						else


### PR DESCRIPTION
related to https://github.com/unoplatform/uno.extensions/issues/372

## Bugfix
Make the CollectionAnalyzer trully generic and fix support of ImmutableList<T> which are not IList

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
