### PR TITLE
Fix ChangeSet (collection changes) might not being forwarded properly by some operators

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Core/Given_MessageManager.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Given_MessageManager.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Core;
+
+[TestClass]
+public class Given_MessageManager : FeedTests
+{
+	[TestMethod]
+	public void When_LocalSetAxisWithChanges_Then_ChangesForwarded()
+	{
+		(object value, TestChangeSet changes) local = (new(), new());
+
+		var axis = new MessageAxis<object>("testAxis", _ => throw new InvalidOperationException("Should not be used"));
+		var sut = new MessageManager<object, object>();
+
+		sut.Update(current => current.With().Set(axis, axis.ToMessageValue(local.value), local.changes), CT);
+
+		sut.Current.Current.Get(axis).Should().Be(local.value);
+		sut.Current.Changes.Contains(axis, out var actual).Should().BeTrue();
+		(actual as object).Should().Be(local.changes);
+	}
+
+	[TestMethod]
+	public void When_ParentSetAxisWithChanges_Then_ChangesForwarded()
+	{
+		(object value, TestChangeSet changes) parent = (new(), new());
+
+		var axis = new MessageAxis<object>("testAxis", _ => throw new InvalidOperationException("Should not be used"));
+		var parentMessage = Message<object>.Initial.With().Set(axis, axis.ToMessageValue(parent.value), parent.changes);
+		var sut = new MessageManager<object, object>();
+
+		sut.Update(current => current.With(parentMessage), CT);
+
+		sut.Current.Current.Get(axis).Should().Be(parent.value);
+		sut.Current.Changes.Contains(axis, out var actual).Should().BeTrue();
+		(actual as object).Should().Be(parent.changes);
+	}
+
+	[TestMethod]
+	public void When_ParentAndLocalSetAxisWithChanges_Then_ChangesAreNotForwarded()
+	{
+		// Remarks: We don't have yet a way to merge ChangeSet, so this test is only safety guard to make sure that we don't forward invalid an invalid ChangeSet
+		// (which contains either only the changes of the parent or the local changes, ignoring the fact that we did merged the value)
+
+		(object value, TestChangeSet changes) parent = (new(), new());
+		(object value, TestChangeSet changes) local = (new(), new());
+
+		var axis = new MessageAxis<object>("testAxis", _ => 42);
+		var parentMessage = Message<object>.Initial.With().Set(axis, axis.ToMessageValue(parent.value), parent.changes);
+		var sut = new MessageManager<object, object>();
+
+		sut.Update(current => current.With(parentMessage).Set(axis, axis.ToMessageValue(local.value), local.changes), CT);
+
+		sut.Current.Current.Get(axis).Should().Be(42);
+		sut.Current.Changes.Contains(axis, out var actual).Should().BeTrue();
+		(actual as object).Should().BeNull();
+	}
+
+	[TestMethod]
+	public void When_ParentAndThenLocalSetAxisWithChanges_Then_ChangesAreNotForwarded()
+	{
+		// Remarks: We don't have yet a way to merge ChangeSet, so this test is only safety guard to make sure that we don't forward invalid an invalid ChangeSet
+		// (which contains either only the changes of the parent or the local changes, ignoring the fact that we did merged the value)
+
+		(object value, TestChangeSet changes) parent = (new(), new());
+		(object value, TestChangeSet changes) local = (new(), new());
+
+		var axis = new MessageAxis<object>("testAxis", _ => 42);
+		var parentMessage = Message<object>.Initial.With().Set(axis, axis.ToMessageValue(parent.value), parent.changes);
+		var sut = new MessageManager<object, object>();
+
+		sut.Update(current => current.With(parentMessage), CT);
+		sut.Update(current => current.With().Set(axis, axis.ToMessageValue(local.value), local.changes), CT);
+
+		sut.Current.Current.Get(axis).Should().Be(42);
+		sut.Current.Changes.Contains(axis, out var actual).Should().BeTrue();
+		(actual as object).Should().BeNull();
+	}
+
+	[TestMethod]
+	public void When_LocalTheParentSetAxisWithChanges_Then_ChangesAreNotForwarded()
+	{
+		// Remarks: We don't have yet a way to merge ChangeSet, so this test is only safety guard to make sure that we don't forward invalid an invalid ChangeSet
+		// (which contains either only the changes of the parent or the local changes, ignoring the fact that we did merged the value)
+
+		(object value, TestChangeSet changes) parent = (new(), new());
+		(object value, TestChangeSet changes) local = (new(), new());
+
+		var axis = new MessageAxis<object>("testAxis", _ => 42);
+		var parentMessage = Message<object>.Initial.With().Set(axis, axis.ToMessageValue(parent.value), parent.changes);
+		var sut = new MessageManager<object, object>();
+
+		sut.Update(current => current.With().Set(axis, axis.ToMessageValue(local.value), local.changes), CT);
+		sut.Update(current => current.With(parentMessage), CT);
+
+		sut.Current.Current.Get(axis).Should().Be(42);
+		sut.Current.Changes.Contains(axis, out var actual).Should().BeTrue();
+		(actual as object).Should().BeNull();
+	}
+
+	private record TestChangeSet(params IChange[] Changes) : IChangeSet
+	{
+		/// <inheritdoc />
+		public IEnumerator<IChange> GetEnumerator()
+			=> Changes.AsEnumerable().GetEnumerator();
+
+		/// <inheritdoc />
+		IEnumerator IEnumerable.GetEnumerator()
+			=> GetEnumerator();
+	}
+}

--- a/src/Uno.Extensions.Reactive/Core/Axes/DataAxis.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/DataAxis.cs
@@ -65,8 +65,8 @@ public sealed class DataAxis : MessageAxis
 
 	/// <inheritdoc />
 	[Pure]
-	internal override MessageAxisValue GetLocalValue(MessageAxisValue parent, MessageAxisValue local)
-		=> local;
+	internal override (MessageAxisValue values, IChangeSet? changes) GetLocalValue(MessageAxisValue parent, MessageAxisValue currentLocal, (MessageAxisValue value, IChangeSet? changes) updatedLocal)
+		=> updatedLocal;
 
 	/// <inheritdoc />
 	[Pure]

--- a/src/Uno.Extensions.Reactive/Core/Axes/MessageAxis.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/MessageAxis.cs
@@ -54,19 +54,19 @@ public abstract class MessageAxis : IEquatable<MessageAxis>
 	public string Identifier { get; }
 
 	[Pure]
-	internal virtual MessageAxisValue GetLocalValue(MessageAxisValue parent, MessageAxisValue local)
+	internal virtual (MessageAxisValue values, IChangeSet? changes) GetLocalValue(MessageAxisValue parent, MessageAxisValue currentLocal, (MessageAxisValue value, IChangeSet? changes) updatedLocal)
 	{
 		if (!parent.IsSet)
 		{
-			return local;
+			return updatedLocal;
 		}
-		else if (!local.IsSet)
+		else if (!updatedLocal.value.IsSet)
 		{
-			return parent;
+			return (parent, null);
 		}
 		else
 		{
-			return Aggregate(new[] { parent, local });
+			return (Aggregate(new[] { parent, updatedLocal.value }), null);
 		}
 	}
 

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageAxisUpdate.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageAxisUpdate.cs
@@ -5,8 +5,6 @@ namespace Uno.Extensions.Reactive.Core;
 
 internal class MessageAxisUpdate
 {
-	public bool IsOverride { get; set; }
-
 	public MessageAxis Axis { get; }
 
 	public MessageAxisValue Value { get; set; }
@@ -20,6 +18,6 @@ internal class MessageAxisUpdate
 		Changes = changes;
 	}
 
-	public MessageAxisValue GetValue(MessageAxisValue parent, MessageAxisValue current)
-		=> IsOverride ? Value : Axis.GetLocalValue(parent, Value);
+	public (MessageAxisValue value, IChangeSet? changes) GetValue(MessageAxisValue parent, MessageAxisValue current)
+		=> Axis.GetLocalValue(parent, current, (Value, Changes));
 }

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.Message.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.Message.cs
@@ -59,18 +59,21 @@ internal partial class MessageManager<TParent, TResult>
 			/// This gives access to raw <see cref="MessageAxisValue"/> for extensibility but it should not be used directly.
 			/// Prefer to use dedicated extensions methods to access to values.
 			/// </remarks>
-			public void SetTransient(MessageAxis axis, MessageAxisValue value)
-				=> _transientUpdates[axis] = new MessageAxisUpdate(axis, value);
+			public MessageBuilder SetTransient(MessageAxis axis, MessageAxisValue value)
+			{
+				_transientUpdates[axis] = new MessageAxisUpdate(axis, value);
+				return this;
+			}
 
 			/// <inheritdoc />
 			(MessageAxisValue value, IChangeSet? changes) IMessageBuilder.Get(MessageAxis axis)
-				=> (Get(axis), default);
+				=> Get(axis);
 
 			/// <inheritdoc />
 			public void Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes = null)
 				=> Inner.Set(axis, value, changes);
 
-			private MessageAxisValue Get(MessageAxis axis)
+			private (MessageAxisValue value, IChangeSet? changes) Get(MessageAxis axis)
 			{
 				var parentValue = Inner.Parent?.Current[axis] ?? MessageAxisValue.Unset;
 				var localValue = Inner.Local.Current[axis];
@@ -81,7 +84,7 @@ internal partial class MessageManager<TParent, TResult>
 				}
 				else
 				{
-					return parentValue;
+					return (parentValue, null);
 				}
 			}
 

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.cs
@@ -43,6 +43,9 @@ internal partial class MessageManager<TParent, TResult>
 			_ctSubscription = ct.Register(Dispose);
 		}
 
+		public void Update(Func<CurrentMessage, MessageBuilder> updater)
+			=> Update((cm, u) => u(cm), updater);
+
 		public void Update<TState>(Func<CurrentMessage, TState, MessageBuilder> updater, TState state)
 		{
 			if (_state != State.Active)
@@ -57,6 +60,9 @@ internal partial class MessageManager<TParent, TResult>
 				(that: this, updater, state),
 				_ct);
 		}
+
+		public void Commit(Updater resultUpdater)
+			=> Commit(_stateLessUpdater, resultUpdater);
 
 		public void Commit<TState>(Updater<TState> resultUpdater, TState state)
 		{

--- a/src/Uno.Extensions.Reactive/Core/Internal/StateImpl.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/StateImpl.cs
@@ -60,7 +60,7 @@ internal sealed class StateImpl<T> : IState<T>, IFeed<T>, IAsyncDisposable, ISta
 		}
 
 		IAsyncEnumerable<Message<T>> GetSource()
-			=> feed.GetSource(context);
+			=> feed.GetSource(Context);
 
 		ValueTask UpdateState(Message<T> newSrcMsg, CancellationToken ct)
 			=> UpdateCore(currentStateMsg => currentStateMsg.OverrideBy(newSrcMsg), ct);

--- a/src/Uno.Extensions.Reactive/Core/MessageBuilder.TParent.cs
+++ b/src/Uno.Extensions.Reactive/Core/MessageBuilder.TParent.cs
@@ -52,7 +52,7 @@ public readonly struct MessageBuilder<TParent, TResult> : IMessageEntry, IMessag
 	internal MessageAxisValue this[MessageAxis axis]
 	{
 		get => Get(axis).value;
-		set => Set(axis, value);
+		set => Set(axis, value, changes: null);
 	}
 
 	/// <inheritdoc />
@@ -64,7 +64,7 @@ public readonly struct MessageBuilder<TParent, TResult> : IMessageEntry, IMessag
 		var localValue = Local.Current[axis];
 		if (_updates.TryGetValue(axis, out var updater))
 		{
-			return (updater.GetValue(parentValue, localValue), default);
+			return updater.GetValue(parentValue, localValue);
 		}
 		else
 		{
@@ -75,12 +75,11 @@ public readonly struct MessageBuilder<TParent, TResult> : IMessageEntry, IMessag
 	/// <inheritdoc />
 	void IMessageBuilder.Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes)
 		=> Set(axis, value, changes);
-	internal void Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes)
-		=> Set(axis, value);
-	private void Set(MessageAxis axis, MessageAxisValue value, bool overridesParent = false)
+
+	internal MessageBuilder<TParent, TResult> Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes)
 	{
 		// Note: We are not validating the axis.AreEquals as changes are detected by the MessageManager itself.
-
-		_updates[axis] = new MessageAxisUpdate(axis, value){IsOverride = overridesParent};
+		_updates[axis] = new MessageAxisUpdate(axis, value, changes);
+		return this;
 	}
 }

--- a/src/Uno.Extensions.Reactive/Core/MessageBuilder.cs
+++ b/src/Uno.Extensions.Reactive/Core/MessageBuilder.cs
@@ -43,11 +43,11 @@ public readonly struct MessageBuilder<T> : IMessageEntry, IMessageBuilder, IMess
 
 	void IMessageBuilder.Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes)
 		=> Set(axis, value, changes);
-	internal void Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes)
+	internal MessageBuilder<T> Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes)
 	{
 		if (axis.AreEquals(this[axis], value))
 		{
-			return;
+			return this;
 		}
 
 		if (value.IsSet)
@@ -59,6 +59,8 @@ public readonly struct MessageBuilder<T> : IMessageEntry, IMessageBuilder, IMess
 		{
 			_changes.Add(axis, changes);
 		}
+
+		return this;
 	}
 
 	/// <summary>


### PR DESCRIPTION
related to https://github.com/unoplatform/uno.extensions/issues/372

## Bugfix
Fix ChangeSet (collection changes) might not being forwarded properly by some operators

## What is the current behavior?
The ChangeSet is dismissed by all operator that are using the MessageManager

## What is the new behavior?
ChnageSet is forwarded properly

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
