### PR TITLE
Add PaginatedListFeed

### DIFF
--- a/src/Uno.Extensions.Reactive.Testing/ConstraintParts/Changed.cs
+++ b/src/Uno.Extensions.Reactive.Testing/ConstraintParts/Changed.cs
@@ -18,6 +18,8 @@ public class Changed : ChangesConstraint
 
 	public static Changed Refreshed { get; } = new(MessageAxis.Refresh);
 
+	public static Changed Pagination { get; } = new(MessageAxis.Pagination);
+
 	public static Changed Axes(params MessageAxis[] axes) 
 		=> new(axes);
 

--- a/src/Uno.Extensions.Reactive.Testing/ConstraintParts/Items.cs
+++ b/src/Uno.Extensions.Reactive.Testing/ConstraintParts/Items.cs
@@ -8,6 +8,11 @@ namespace Uno.Extensions.Reactive.Testing;
 
 public static class Items
 {
+	public static ItemsConstraint<int> Range(uint count)
+		=> new(count is 0
+			? Option.None<IImmutableList<int>>()
+			: Option.Some(Enumerable.Range(0, (int)count).ToImmutableList() as IImmutableList<int>));
+
 	public static ItemsConstraint<T> Some<T>(IEnumerable<T> items)
 		=> new(items.ToImmutableList() is { Count: > 0 } list
 			? Option.Some(list as IImmutableList<T>)
@@ -18,30 +23,32 @@ public static class Items
 			? Option.Some(list as IImmutableList<T>)
 			: throw new InvalidOperationException("An empty list is expected to be treated as None."));
 
-	public static ItemsChanged<T> Add<T>(int at, params T[] items)
-		=> ItemsChanged<T>.Add(at, items);
+	public static ItemsChanged Add<T>(int at, params T[] items)
+		=> ItemsChanged.Add(at, items);
 
-	public static ItemsChanged<T> Add<T>(int at, IEnumerable<T> items)
-		=> ItemsChanged<T>.Add(at, items);
+	public static ItemsChanged Add<T>(int at, IEnumerable<T> items)
+		=> ItemsChanged.Add(at, items);
 
-	public static ItemsChanged<T> Remove<T>(int at, params T[] items)
-		=> ItemsChanged<T>.Remove(at, items);
+	public static ItemsChanged Remove<T>(int at, params T[] items)
+		=> ItemsChanged.Remove(at, items);
 
-	public static ItemsChanged<T> Remove<T>(int at, IEnumerable<T> items)
-		=> ItemsChanged<T>.Remove(at, items);
+	public static ItemsChanged Remove<T>(int at, IEnumerable<T> items)
+		=> ItemsChanged.Remove(at, items);
 
-	public static ItemsChanged<T> Replace<T>(int at, IEnumerable<T> oldItems, IEnumerable<T> newItems)
-		=> ItemsChanged<T>.Replace(at, oldItems, newItems);
+	public static ItemsChanged Replace<T>(int at, IEnumerable<T> oldItems, IEnumerable<T> newItems)
+		=> ItemsChanged.Replace(at, oldItems, newItems);
 
-	public static ItemsChanged<T> Move<T>(int from, int to, params T[] items)
-		=> ItemsChanged<T>.Move(from, to, items);
+	public static ItemsChanged Move<T>(int from, int to, params T[] items)
+		=> ItemsChanged.Move(from, to, items);
 
-	public static ItemsChanged<T> Move<T>(int from, int to, IEnumerable<T> items)
-		=> ItemsChanged<T>.Move(from, to, items);
+	public static ItemsChanged Move<T>(int from, int to, IEnumerable<T> items)
+		=> ItemsChanged.Move(from, to, items);
 
-	public static ItemsChanged<T> Reset<T>(IEnumerable<T> oldItems, IEnumerable<T> newItems)
-		=> ItemsChanged<T>.Reset(oldItems, newItems);
+	public static ItemsChanged Reset<T>(IEnumerable<T> oldItems, IEnumerable<T> newItems)
+		=> ItemsChanged.Reset(oldItems, newItems);
 
-	public static ItemsChanged<T> Reset<T>(IEnumerable<T> newItems)
-		=> ItemsChanged<T>.Reset(newItems);
+	public static ItemsChanged Reset<T>(IEnumerable<T> newItems)
+		=> ItemsChanged.Reset(newItems);
+
+	public static ItemsChanged NotChanged { get; } = ItemsChanged.Empty;
 }

--- a/src/Uno.Extensions.Reactive.Testing/ConstraintParts/Pagination.cs
+++ b/src/Uno.Extensions.Reactive.Testing/ConstraintParts/Pagination.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace Uno.Extensions.Reactive.Testing;
+
+public class Pagination : AxisConstraint
+{
+	private readonly bool _isLoading;
+	private readonly bool _hasMoreItems;
+
+	public static Pagination HasMore { get; } = new(isLoading: false, hasMoreItems: true);
+
+	public static Pagination Loading { get; } = new(isLoading: true, hasMoreItems: true); // We cannot be loading if does not have more items!
+
+	public static Pagination Completed { get; } = new(isLoading: false, hasMoreItems: false);
+
+	/// <inheritdoc />
+	public override MessageAxis Axis => MessageAxis.Pagination;
+
+	public Pagination(bool isLoading, bool hasMoreItems)
+	{
+		_isLoading = isLoading;
+		_hasMoreItems = hasMoreItems;
+	}
+
+	/// <inheritdoc />m
+	public override void Assert(IMessageEntry actual)
+	{
+		var pageInfo = actual.GetPaginationInfo();
+
+		pageInfo.Should().NotBeNull();
+
+		using (AssertionScope.Current.ForContext("IsLoadingMoreItems"))
+		{
+			pageInfo?.IsLoadingMoreItems.Should().Be(_isLoading);
+		}
+
+		using (AssertionScope.Current.ForContext("HasMoreItems"))
+		{
+			pageInfo?.HasMoreItems.Should().Be(_hasMoreItems);
+		}
+	}
+
+}

--- a/src/Uno.Extensions.Reactive.Testing/Fluent/FluentAssertionExtensions.cs
+++ b/src/Uno.Extensions.Reactive.Testing/Fluent/FluentAssertionExtensions.cs
@@ -8,4 +8,7 @@ internal static class FluentAssertionExtensions
 {
 	public static AssertionScope ForContext(this AssertionScope scope, string additionalContext) 
 		=> new($"{scope.Context.Value} {additionalContext.Trim()}");
+
+	public static void Fail(this AssertionScope scope, string reason)
+		=> scope.FailWith($"{scope.Context.Value} {reason.Trim()}");
 }

--- a/src/Uno.Extensions.Reactive.Tests/Sources/Given_PaginatedListFeed.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Sources/Given_PaginatedListFeed.cs
@@ -1,0 +1,405 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Sources;
+using Uno.Extensions.Reactive.Testing;
+using static System.Linq.Enumerable;
+
+namespace Uno.Extensions.Reactive.Tests.Sources;
+
+[TestClass]
+public class Given_PaginatedListFeed : FeedTests
+{
+	[TestMethod]
+	public async Task When_RequestPage_Then_ItemsAdded()
+	{
+		var sut = ListFeed.Paginated<int>(async (page, ct) => Range((int)page.PageIndex * 20, (int)(page.DesiredPageSize ?? 20)).ToImmutableList());
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+
+		var result = sut.Record(ctx);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Reset(Range(0, 20)))
+				.Current(Items.Range(20), Error.No, Progress.Final, Pagination.HasMore))
+		);
+
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(2, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Reset(Range(0, 20)))
+				.Current(Items.Range(20), Error.No, Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Add(20, Range(20, 42)))
+				.Current(Items.Range(62), Error.No, Progress.Final, Pagination.HasMore))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_ByIndexAndPageIsEmpty_Then_ReportPaginationCompleted()
+	{
+		async ValueTask<IImmutableList<int>> GetPage(PageInfo page, CancellationToken ct)
+			=> page.PageIndex switch
+			{
+				0 => Range(0, 10).ToImmutableList(),
+				1 => Range(10, 10).ToImmutableList(),
+				2 => ImmutableList<int>.Empty,
+				_ => throw new InvalidOperationException("Should not happen"),
+			};
+
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+		var result = ListFeed.Paginated(GetPage).Record(ctx);
+
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(2, CT);
+
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(3, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Reset(Range(0, 10)))
+				.Current(Items.Range(10), Error.No, Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Add(10, Range(10, 10)))
+				.Current(Items.Range(20), Error.No, Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Pagination)
+				.Current(Items.Range(20), Error.No, Progress.Final, Pagination.Completed))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_ByIndexAndFirstPageIsEmpty_Then_ReportPaginationCompleted()
+	{
+		async ValueTask<IImmutableList<int>> GetPage(PageInfo page, CancellationToken ct)
+			=> page.PageIndex switch
+			{
+				0 => ImmutableList<int>.Empty,
+				_ => throw new InvalidOperationException("Should not happen"),
+			};
+
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+		var result = ListFeed.Paginated(GetPage).Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.NotChanged)
+				.Current(Data.None, Error.No, Progress.Final, Pagination.Completed))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_ByCursorAndGetPageHasNoNext_Then_ReportPaginationCompleted()
+	{
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+		var result = ListFeed<int>.PaginatedByCursor(new TestCursor(2), TestCursor.GetPage).Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(2, CT);
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(3, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Reset(Range(0, 10)))
+				.Current(Items.Range(10), Error.No, Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Add(10, Range(10, 10)))
+				.Current(Items.Range(20), Error.No, Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Add(20, Range(20, 10)))
+				.Current(Items.Range(30), Error.No, Progress.Final, Pagination.Completed))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_ByCursorAndPageHasNoNext_Then_ReportPaginationCompleted()
+	{
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+		var result = ListFeed<int>.PaginatedByCursor(new TestCursor(0), TestCursor.GetPage).Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Reset(Range(0, 10)))
+				.Current(Items.Range(10), Error.No, Progress.Final, Pagination.Completed))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_ByCursorAndFirstHasNoNext_Then_ReportPaginationCompleted()
+	{
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+		var result = ListFeed<int>.PaginatedByCursor(new TestCursor(0), TestCursor.GetPage).Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Reset(Range(0, 10)))
+				.Current(Items.Range(10), Error.No, Progress.Final, Pagination.Completed))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_ByCursorAndFirstIsEmptyAndHasNoNext_Then_ReportPaginationCompleted()
+	{
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+		var result = ListFeed<int>.PaginatedByCursor(new TestCursor(0, PageSize: 0), TestCursor.GetPage).Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.NotChanged)
+				.Current(Data.None, Error.No, Progress.Final, Pagination.Completed))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_ByCursorAndPagesAreEmptyButHasNext_Then_ContinuePagination()
+	{
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+		var result = ListFeed<int>.PaginatedByCursor(new TestCursor(1, PageSize: 0), TestCursor.GetPage).Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(2, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.NotChanged)
+				.Current(Data.None, Error.No, Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Pagination)
+				.Current(Data.None, Error.No, Progress.Final, Pagination.Completed))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_FirstPageThrow_Then_GoInErrorAndIgnorePageRequest()
+	{
+		async ValueTask<IImmutableList<int>> GetPage(PageInfo page, CancellationToken ct)
+			=> page.PageIndex switch
+			{
+				0 => throw new TestException(),
+				_ => Range(0,10).ToImmutableList()
+			};
+
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+		var result = ListFeed.Paginated(GetPage).Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+		try
+		{
+			requests.RequestMoreItems(42);
+			await result.WaitForMessages(2, CT, 100);
+		}
+		catch (OperationCanceledException)
+		{
+		}
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Error & Changed.Pagination)
+				.Current(Data.Undefined, typeof(TestException), Progress.Final, Pagination.Completed))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_SubsequentPagesThrow_Then_GoInErrorAndKeepDataAndKeepListeningPageRequest()
+	{
+		async ValueTask<IImmutableList<int>> GetPage(PageInfo page, CancellationToken ct)
+			=> page.PageIndex switch
+			{
+				0 => Range(0, 10).ToImmutableList(),
+				_ => throw new TestException(),
+			};
+
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+		var result = ListFeed.Paginated(GetPage).Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(2, CT);
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(3, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Reset(Range(0, 10)))
+				.Current(Items.Range(10), Error.No, Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Error & Changed.Pagination)
+				.Current(Items.Range(10), typeof(TestException), Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Error & Changed.Pagination)
+				.Current(Items.Range(10), typeof(TestException), Progress.Final, Pagination.HasMore))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_Refresh()
+	{
+		async ValueTask<IImmutableList<int>> GetPage(PageInfo page, CancellationToken ct)
+			=> page.PageIndex switch
+			{
+				0 => Range(0, 10).ToImmutableList(),
+				1 => Range(10, 10).ToImmutableList(),
+				_ => throw new TestException()
+			};
+
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+		var result = ListFeed.Paginated(GetPage).Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(2, CT);
+		requests.RequestRefresh();
+		await result.WaitForMessages(3, CT);
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(4, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Reset(Range(0, 10)))
+				.Current(Items.Range(10), Error.No, Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Add(at: 10, Range(10, 10)))
+				.Current(Items.Range(20), Error.No, Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination & Changed.Refreshed, Items.Reset(Range(0, 20), Range(0, 10)))
+				.Current(Items.Range(10), Error.No, Progress.Final, Pagination.HasMore, Refreshed.Is(1)))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Add(at: 10, Range(10, 10)))
+				.Current(Items.Range(20), Error.No, Progress.Final, Pagination.HasMore, Refreshed.Is(1)))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_Async_Then_FlagIsLoading()
+	{
+		var delay = new TaskCompletionSource<Unit>();
+
+		void GetNext()
+			=> Interlocked.Exchange(ref delay, new TaskCompletionSource<Unit>())!.SetResult(default);
+
+		async ValueTask<IImmutableList<int>> GetPage(PageInfo page, CancellationToken ct)
+		{
+			await delay.Task;
+			return page.PageIndex switch
+			{
+				0 => Range(0, 10).ToImmutableList(),
+				1 => Range(10, 10).ToImmutableList(),
+				_ => throw new TestException()
+			};
+		}
+
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+		var result = ListFeed.Paginated(GetPage).Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+		GetNext();
+		await result.WaitForMessages(2, CT);
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(3, CT);
+		GetNext();
+		await result.WaitForMessages(4, CT);
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(5, CT);
+		GetNext();
+		await result.WaitForMessages(6, CT);
+		requests.RequestRefresh();
+		await result.WaitForMessages(7, CT);
+		GetNext();
+		await result.WaitForMessages(8, CT);
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(9, CT);
+		GetNext();
+		await result.WaitForMessages(10, CT);
+		requests.RequestMoreItems(42);
+		await result.WaitForMessages(11, CT);
+		GetNext();
+		await result.WaitForMessages(12, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Pagination & Changed.Progress)
+				.Current(Data.Undefined, Error.No, Progress.Transient, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Progress, Items.Reset(Range(0, 10)))
+				.Current(Items.Range(10), Error.No, Progress.Final, Pagination.HasMore))
+			// Page 1 => Get Items
+			.Message(m => m
+				.Changed(Changed.Pagination)
+				.Current(Items.Range(10), Error.No, Progress.Final, Pagination.Loading))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Add(at: 10, Range(10, 10)))
+				.Current(Items.Range(20), Error.No, Progress.Final, Pagination.HasMore))
+			// Page 2 => Throws
+			.Message(m => m
+				.Changed(Changed.Pagination)
+				.Current(Items.Range(20), Error.No, Progress.Final, Pagination.Loading))
+			.Message(m => m
+				.Changed(Changed.Error & Changed.Pagination)
+				.Current(Items.Range(20), typeof(TestException), Progress.Final, Pagination.HasMore))
+			// Refresh request
+			.Message(m => m
+				.Changed(Changed.Refreshed & Changed.Pagination & Changed.Progress)
+				.Current(Items.Range(20), typeof(TestException), Progress.Transient, Pagination.HasMore, Refreshed.Is(1)))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Error & Changed.Progress, Items.Reset(Range(0, 20), Range(0, 10)))
+				.Current(Items.Range(10), Error.No, Progress.Final, Pagination.HasMore, Refreshed.Is(1)))
+			// Page 1 => Get Items
+			.Message(m => m
+				.Changed(Changed.Pagination)
+				.Current(Items.Range(10), Error.No, Progress.Final, Pagination.Loading, Refreshed.Is(1)))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Add(at: 10, Range(10, 10)))
+				.Current(Items.Range(20), Error.No, Progress.Final, Pagination.HasMore, Refreshed.Is(1)))
+			// Page 2 => Throws
+			.Message(m => m
+				.Changed(Changed.Pagination)
+				.Current(Items.Range(20), Error.No, Progress.Final, Pagination.Loading, Refreshed.Is(1)))
+			.Message(m => m
+				.Changed(Changed.Error & Changed.Pagination)
+				.Current(Items.Range(20), typeof(TestException), Progress.Final, Pagination.HasMore, Refreshed.Is(1)))
+		);
+	}
+
+	private record TestCursor(int RemainingPages, int PageIndex = 0, int PageSize = 10)
+	{
+		public TestCursor? Next => RemainingPages > 0 ? this with { RemainingPages = RemainingPages - 1, PageIndex = PageIndex + 1 } : default;
+
+		public IImmutableList<int> Items => Range(PageIndex * PageSize, PageSize).ToImmutableList();
+
+		public static async ValueTask<Page<TestCursor, int>> GetPage(TestCursor cursor, uint? desiredPageSize, CancellationToken ct)
+			=> new(cursor.Items, cursor.Next);
+	}
+}

--- a/src/Uno.Extensions.Reactive/Core/Axes/MessageAxes.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/MessageAxes.cs
@@ -31,6 +31,11 @@ public static class MessageAxes
 	internal const string Refresh = nameof(Refresh);
 
 	/// <summary>
+	/// Name of the pagination axis.
+	/// </summary>
+	internal const string Pagination = nameof(Pagination);
+
+	/// <summary>
 	/// Name of the axe used to de-bounce data bound values
 	/// </summary>
 	internal const string BindingSource = nameof(BindingSource);

--- a/src/Uno.Extensions.Reactive/Core/Axes/MessageAxis.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/MessageAxis.cs
@@ -41,6 +41,15 @@ public abstract class MessageAxis : IEquatable<MessageAxis>
 	/// </remarks>
 	internal static MessageAxis<TokenSet<RefreshToken>> Refresh => RefreshAxis.Instance;
 
+	/// <summary>
+	/// For a refreshable source, this axis contains information about the version of this source.
+	/// </summary>
+	/// <remarks>
+	/// This is expected to be full-filled only by "source" feed that are refreshable,
+	/// not the sources feed built from a stream of data nor operators.
+	/// </remarks>
+	internal static MessageAxis<PaginationInfo> Pagination => new(MessageAxes.Pagination, PaginationInfo.Aggregate);
+
 	internal MessageAxis(string identifier)
 	{
 		Identifier = identifier;

--- a/src/Uno.Extensions.Reactive/Core/Axes/MessageAxisExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/MessageAxisExtensions.cs
@@ -168,6 +168,26 @@ public static class MessageAxisExtensions
 		=> builder.Set(MessageAxis.Refresh, tokens);
 
 	/// <summary>
+	/// Gets the pagination info of an <see cref="MessageEntry{T}"/>
+	/// </summary>
+	/// <param name="entry">The entry.</param>
+	/// <returns>The progress.</returns>
+	/// <remarks>Use <see cref="MessageEntry{T}.IsTransient"/> instead.</remarks>
+	[Pure]
+	internal static PaginationInfo? GetPaginationInfo(this IMessageEntry entry)
+		=> entry.Get(MessageAxis.Pagination);
+
+	/// <summary>
+	/// Sets the pagination info of an <see cref="MessageBuilder{T}"/>
+	/// </summary>
+	/// <param name="builder">The builder.</param>
+	/// <param name="page">The pagination info.</param>
+	/// <returns>The <paramref name="builder"/> for fluent building.</returns>
+	internal static TBuilder Paginated<TBuilder>(this TBuilder builder, PaginationInfo? page)
+		where TBuilder : IMessageBuilder
+		=> builder.Set(MessageAxis.Pagination, page);
+
+	/// <summary>
 	/// Gets the progress of an <see cref="MessageEntry{T}"/>
 	/// </summary>
 	/// <param name="entry">The entry.</param>

--- a/src/Uno.Extensions.Reactive/Core/Axes/PaginationInfo.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/PaginationInfo.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Sources;
+
+namespace Uno.Extensions.Reactive;
+
+/// <summary>
+/// Info about the pagination of a ListFeed
+/// </summary>
+internal record PaginationInfo
+{
+	/// <summary>
+	/// Indicates that the source does has more items to load or not.
+	/// </summary>
+	public bool HasMoreItems { get; init; }
+
+	/// <summary>
+	/// Indicates that the source is currently loading a subsequent page.
+	/// </summary>
+	/// <remarks>
+	/// This is equivalent to the <see cref="MessageAxis.Progress"/> but specialized to the subsequent pages,
+	/// as a ListFeed is expected to go in transient state only while loading the first page.
+	/// </remarks>
+	public bool IsLoadingMoreItems { get; init; }
+
+	/// <summary>
+	/// A set of tokens that allows a subscriber to track the progress of a <see cref="PageRequest"/>.
+	/// </summary>
+	public TokenSet<PageToken> Tokens { get; init; } = TokenSet<PageToken>.Empty;
+
+	internal static PaginationInfo Aggregate(IReadOnlyCollection<PaginationInfo> values)
+	{
+		bool hasMoreItems = false, isLoadingMoreItems = false;
+		foreach (var value in values)
+		{
+			hasMoreItems |= value.HasMoreItems;
+			isLoadingMoreItems |= value.IsLoadingMoreItems;
+		}
+
+		var tokens = TokenSet<PageToken>.Aggregate(values.Select(value => value.Tokens));
+
+		return new PaginationInfo
+		{
+			HasMoreItems = hasMoreItems,
+			IsLoadingMoreItems = isLoadingMoreItems,
+			Tokens = tokens
+		};
+	}
+}

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/IPaginatedSource.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/IPaginatedSource.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Linq;
+using Uno.Extensions.Reactive.Core;
+
+namespace Uno.Extensions.Reactive.Sources;
+
+/// <summary>
+/// Tag interface for a feed that can be refreshed (cf. <see cref="PageToken"/>).
+/// </summary>
+internal interface IPaginatedSource
+{
+}

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/PageRequest.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/PageRequest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Uno.Extensions.Reactive.Sources;
+
+namespace Uno.Extensions.Reactive.Core;
+
+/// <summary>
+/// A request for a source ListFeed to load more items
+/// </summary>
+/// <param name="DesiredPageSize">The desired number of items.</param>
+internal record PageRequest(uint DesiredPageSize) : IContextRequest, IContextRequest<PageToken>
+{
+	private ImmutableList<PageToken> _result = ImmutableList<PageToken>.Empty;
+
+	/// <inheritdoc />
+	public void Register(PageToken token)
+		=> ImmutableInterlocked.Update(ref _result, (list, t) => list.Add(t), token);
+
+	/// <summary>
+	/// Get a set containing all token that has been issued in response of this request.
+	/// </summary>
+	public TokenSet<PageToken> GetResult()
+		=> new(_result);
+}

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/PageToken.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/PageToken.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Threading;
+using Uno.Extensions.Reactive.Sources;
+
+namespace Uno.Extensions.Reactive.Core;
+
+/// <summary>
+/// A token issue by a <see cref="IPaginatedSource"/> in response to a <see cref="PageRequest"/>.
+/// </summary>
+/// <param name="Source">The source that is able to react to the page request.</param>
+/// <param name="RootContextId"><inheritdoc cref="IToken.RootContextId"/></param>
+/// <param name="SequenceId"><inheritdoc cref="IToken.SequenceId"/></param>
+internal record PageToken(IPaginatedSource Source, uint RootContextId, uint SequenceId) : IToken, IToken<PageToken>
+{
+	/// <inheritdoc />
+	object IToken.Source => Source;
+
+	/// <summary>
+	/// Creates the initial token for a refreshable feed.
+	/// </summary>
+	/// <param name="source">The refreshable source feed.</param>
+	/// <param name="context">The context used to <see cref="ISignal{T}.GetSource"/> on the <paramref name="source"/>.</param>
+	/// <returns>The initial refresh token where <see cref="SequenceId"/> is set to 0.</returns>
+	/// <remarks>This token represents the initial load of the <paramref name="source"/> and should not be propagated.</remarks>
+	public static PageToken Initial(IPaginatedSource source, SourceContext context) => new(source, context.RootId, 0);
+
+	/// <inheritdoc />
+	[Pure]
+	public PageToken Next()
+		=> this with { SequenceId = SequenceId + 1 };
+}

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSourceExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSourceExtensions.cs
@@ -28,4 +28,26 @@ internal static class RequestSourceExtensions
 
 		return request.GetResult();
 	}
+
+	/// <summary>
+	/// Send a pagination request to (list) feed that has been subscribed using this subscriber context.
+	/// WARNING Read threading consideration in remarks.
+	/// </summary>
+	/// <remarks>
+	/// This is expected to be invoked from a background thread.
+	/// Using this from the UI thread will result into an empty TokenCollection.
+	/// This is due to the fact that the UI thread does not allow attached child tasks,
+	/// driving the request to be re-scheduled on a background thread before flowing into the requests <see cref="IAsyncEnumerable{T}"/>.
+	/// </remarks>
+	/// <returns>
+	/// A collection of <see cref="RefreshToken"/> which indicates the minimum version reflecting the load of the requested page,
+	/// for all source feeds that have been impacted by this request.
+	/// </returns>
+	public static TokenSet<PageToken> RequestMoreItems(this IRequestSource requests, uint count)
+	{
+		var request = new PageRequest(count);
+		requests.Send(request);
+
+		return request.GetResult();
+	}
 }

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/SequentialRequestManager.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/SequentialRequestManager.cs
@@ -79,9 +79,9 @@ internal class SequentialRequestManager<TRequest, TToken> : IAsyncEnumerable<Tok
 			if (Interlocked.CompareExchange(ref _current, next, current) == current)
 			{
 				LastRequest = request;
+				request.Register(next);
 
 				_tokens.TrySetNext(next);
-				request.Register(next);
 
 				return;
 			}

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.cs
@@ -40,6 +40,15 @@ public static partial class ListFeed
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IListFeed<T> AsyncEnumerable<T>(Func<IAsyncEnumerable<IImmutableList<T>>> enumerableProvider)
 		=> Feed.AsyncEnumerable(enumerableProvider).AsListFeed();
+
+	/// <summary>
+	/// Creates a list feed for a paginated collection.
+	/// </summary>
+	/// <typeparam name="T">The type of the data of the resulting feed.</typeparam>
+	/// <param name="getPage">The async method to load a page of items.</param>
+	/// <returns>A paginated list feed.</returns>
+	public static IListFeed<T> Paginated<T>(AsyncFunc<PageInfo, IImmutableList<T>> getPage)
+		=> ListFeed<T>.Paginated(getPage);
 	#endregion
 
 	#region Operators

--- a/src/Uno.Extensions.Reactive/Sources/Page.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Page.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Uno.Extensions.Reactive.Sources;
+
+/// <summary>
+/// Load a page of items of a paginated list.
+/// </summary>
+/// <typeparam name="TCursor">Type of the cursor used by the pagination</typeparam>
+/// <typeparam name="TItem">Type of the items of the list.</typeparam>
+/// <param name="cursor">The cursor of teh page to load.</param>
+/// <param name="desiredPageSize">The desired page size if any.</param>
+/// <param name="ct">A cancellation to cancel the async operation.</param>
+public delegate ValueTask<Page<TCursor, TItem>> GetPage<TCursor, TItem>(TCursor cursor, uint? desiredPageSize, CancellationToken ct);
+
+/// <summary>
+/// A page of items for a paginated list of items.
+/// </summary>
+/// <typeparam name="TCursor">The cursor used to track the pagination.</typeparam>
+/// <typeparam name="TItem">The type of items of the collection.</typeparam>
+/// <param name="Items">The items</param>
+/// <param name="NextPage">The cursor to use to get the next page, if any.</param>
+public record struct Page<TCursor, TItem>(IImmutableList<TItem> Items, TCursor? NextPage)
+{
+	/// <summary>
+	/// An empty page indicating the end of the list.
+	/// </summary>
+	public static Page<TCursor, TItem> Empty => new(ImmutableList<TItem>.Empty, NextPage: default);
+}

--- a/src/Uno.Extensions.Reactive/Sources/PageInfo.cs
+++ b/src/Uno.Extensions.Reactive/Sources/PageInfo.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive;
+
+/// <summary>
+/// Information about a page
+/// </summary>
+public struct PageInfo
+{
+	/// <summary>
+	/// The index of the page.
+	/// </summary>
+	public uint PageIndex { get; init; }
+
+	/// <summary>
+	/// The desired number of items, if any.
+	/// </summary>
+	/// <remarks>
+	/// This is the desired number of items that the view requested to load.
+	/// It's expected to be null only for the first page.
+	/// </remarks>
+	public uint? DesiredPageSize { get; init; }
+}

--- a/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions.Collections;
+using Uno.Extensions.Collections.Facades.Differential;
+using Uno.Extensions.Collections.Tracking;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Utils;
+
+namespace Uno.Extensions.Reactive.Sources;
+
+internal class PaginatedListFeed<TCursor, TItem> : IListFeed<TItem>, IRefreshableSource, IPaginatedSource
+{
+	private readonly TCursor _firstPage;
+	private readonly GetPage<TCursor, TItem> _getPage;
+	private readonly CollectionAnalyzer<TItem> _diffAnalyzer;
+
+	public PaginatedListFeed(TCursor firstPage, GetPage<TCursor, TItem> getPage)
+	{
+		_firstPage = firstPage;
+		_getPage = getPage;
+		_diffAnalyzer = new CollectionAnalyzer<TItem>(default);
+	}
+
+	/// <inheritdoc />
+	public IAsyncEnumerable<Message<IImmutableList<TItem>>> GetSource(SourceContext context, CancellationToken ct)
+	{
+		var refreshRequests = new CoercingRequestManager<RefreshRequest, RefreshToken>(context, RefreshToken.Initial(this, context), ct);
+		var pageRequests = new CoercingRequestManager<PageRequest, PageToken>(context, PageToken.Initial(this, context), ct);
+		var subject = new AsyncEnumerableSubject<Message<IImmutableList<TItem>>>(ReplayMode.EnabledForFirstEnumeratorOnly);
+		var messages = new MessageManager<IImmutableList<TItem>>(subject.SetNext);
+
+		_ = refreshRequests.ForEachAwaitWithCancellationAsync(Load, ConcurrencyMode.AbortPrevious, continueOnError: true, ct);
+
+		return subject;
+
+		async ValueTask Load(TokenSet<RefreshToken>? refresh, CancellationToken ct)
+		{
+			var cursor = _firstPage;
+			var pageInfo = new PaginationInfo { HasMoreItems = true };
+			var isFirstPage = true;
+
+			await foreach (var pageToken in pageRequests.WithCancellation(ct).ConfigureAwait(false))
+			{
+				// The Progress is set to indeterminate only for the first page as we don't want the
+				// FeedView to go in loading state when we are loading more items.
+				using var message = isFirstPage
+					? messages.BeginUpdate(ct, preservePendingAxes: MessageAxis.Progress)
+					: messages.BeginUpdate(ct, preservePendingAxes: MessageAxis.Pagination);
+				using var _ = context.AsCurrent();
+
+				(cursor, pageInfo) = await LoadPage(
+					message,
+					cursor!,
+					refresh,
+					pageInfo with { Tokens = pageToken },
+					pageRequests.LastRequest?.DesiredPageSize,
+					isFirstPage,
+					ct);
+
+				// If we reached the end of the list, then exit
+				if (!pageInfo.HasMoreItems)
+				{
+					return;
+				}
+
+				// Prepare the next token we will process
+				pageRequests.MoveNext();
+				isFirstPage = false;
+			}
+		}
+	}
+
+	private async Task<(TCursor? nextPage, PaginationInfo paginationState)> LoadPage(
+		MessageManager<Unit, IImmutableList<TItem>>.UpdateTransaction message,
+		TCursor cursor,
+		TokenSet<RefreshToken>? refreshInfo,
+		PaginationInfo pageInfo,
+		uint? desiredPageSize,
+		bool isFirstPage,
+		CancellationToken ct)
+	{
+		ValueTask<Page<TCursor, TItem>> pageTask = default;
+		Exception? error = default;
+		try
+		{
+			pageTask = _getPage(cursor, desiredPageSize, ct);
+		}
+		catch (OperationCanceledException) when (ct.IsCancellationRequested)
+		{
+			return (cursor, pageInfo);
+		}
+		catch (Exception e)
+		{
+			error = e;
+			if (isFirstPage)
+			{
+				pageInfo = pageInfo with { HasMoreItems = false };
+			}
+		}
+
+		if (error is not null)
+		{
+			message.Commit(msg => msg
+				.With()
+				.Error(error)
+				.Refreshed(refreshInfo)
+				.Paginated(pageInfo));
+
+			return (cursor, pageInfo);
+		}
+
+		// If we are not yet and the 'dataTask' is really async, we need to send a new message flagged as transient
+		// Note: This check is not "atomic", but it's valid as it only enables a fast path.
+		if (!message.Local.Current.IsTransient)
+		{
+			// As lot of async methods are actually not really async but only re-scheduled,
+			// we try to avoid the transient state by delaying a bit the message.
+			for (var i = 0; !pageTask.IsCompleted && !ct.IsCancellationRequested && i < 5; i++)
+			{
+				await Task.Yield();
+			}
+
+			if (ct.IsCancellationRequested)
+			{
+				return (cursor, pageInfo);
+			}
+
+			// The 'valueProvider' is not completed yet, so we need to flag the current value as transient.
+			// Note: We also provide the parentMsg which will be applied
+			if (!pageTask.IsCompleted)
+			{
+				message.Update(msg =>
+				{
+					var result = msg
+						.With()
+						.Refreshed(refreshInfo)
+						.Paginated(pageInfo);
+
+					if (isFirstPage)
+					{
+						result.SetTransient(MessageAxis.Progress, MessageAxis.Progress.ToMessageValue(true));
+					}
+					else
+					{
+						result.SetTransient(MessageAxis.Pagination, MessageAxis.Pagination.ToMessageValue(pageInfo with { IsLoadingMoreItems = true }));
+					}
+
+					return result;
+				});
+			}
+		}
+
+		var items = (DifferentialImmutableList<TItem>)message.Local.Current.Data.SomeOrDefault(DifferentialImmutableList<TItem>.Empty);
+		var changes = default(CollectionChangeSet?);
+		var nextPage = default(TCursor?);
+		try
+		{
+			var page = await pageTask;
+			var hadItems = items is { Count: > 0 };
+			var hasItems = page.Items is { Count: > 0 };
+
+			(items, changes) = (hadItems, hasItems, isFirstPage) switch
+			{
+				(false, false, _) => (DifferentialImmutableList<TItem>.Empty, CollectionChangeSet.Empty),
+				(false, true, _) => Reset(items, page.Items),
+				(true, false, true) => Clear(items),
+				(true, false, false) => (items, CollectionChangeSet.Empty),
+				(true, true, true) => Reset(items, page.Items),
+				(true, true, false) => Add(items, page.Items),
+			};
+
+			nextPage = page.NextPage;
+			if (nextPage is null)
+			{
+				pageInfo = pageInfo with { HasMoreItems = false };
+			}
+		}
+		catch (OperationCanceledException) when (ct.IsCancellationRequested)
+		{
+			return (cursor, pageInfo);
+		}
+		catch (Exception e)
+		{
+			error = e;
+			if (isFirstPage)
+			{
+				pageInfo = pageInfo with { HasMoreItems = false };
+			}
+		}
+
+		message.Commit(
+			msg =>
+			{
+				var builder = msg
+					.With()
+					.Refreshed(refreshInfo)
+					.Paginated(pageInfo);
+
+				if (error is not null)
+				{
+					builder.Error(error);
+				}
+				else if(items.Count == 0)
+				{
+					builder.Data(Option<IImmutableList<TItem>>.None(), changes).Error(null);
+				}
+				else
+				{
+					builder.Data(items, changes).Error(null);
+				}
+
+				return builder;
+			});
+
+		return (nextPage, pageInfo);
+	}
+
+	private (DifferentialImmutableList<TItem> items, CollectionChangeSet changes) Reset(DifferentialImmutableList<TItem> current, IImmutableList<TItem> page)
+	{
+		var updated = new DifferentialImmutableList<TItem>(page);
+
+		return (updated, ((CollectionAnalyzer)_diffAnalyzer).GetResetChange(current, updated));
+	}
+
+	private (DifferentialImmutableList<TItem> items, CollectionChangeSet changes) Clear(DifferentialImmutableList<TItem> current)
+	{
+		return (DifferentialImmutableList<TItem>.Empty, ((CollectionAnalyzer)_diffAnalyzer).GetResetChange(current, Array.Empty<TItem>()));
+	}
+
+	private (DifferentialImmutableList<TItem> items, CollectionChangeSet changes) Add(DifferentialImmutableList<TItem> current, IImmutableList<TItem> page)
+	{
+		var updated = current.AddRange(page);
+		var changes = _diffAnalyzer.GetChanges(RichNotifyCollectionChangedEventArgs.AddSome(page.AsUntypedList(), current.Count));
+
+		return (updated, changes);
+	}
+}

--- a/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
@@ -69,6 +69,7 @@ internal class PaginatedListFeed<TCursor, TItem> : IListFeed<TItem>, IRefreshabl
 
 				// Prepare the next token we will process
 				pageRequests.MoveNext();
+				refreshRequests.MoveNext();
 				isFirstPage = false;
 			}
 		}
@@ -156,7 +157,7 @@ internal class PaginatedListFeed<TCursor, TItem> : IListFeed<TItem>, IRefreshabl
 
 		var items = (DifferentialImmutableList<TItem>)message.Local.Current.Data.SomeOrDefault(DifferentialImmutableList<TItem>.Empty);
 		var changes = default(CollectionChangeSet?);
-		var nextPage = default(TCursor?);
+		var nextPage = cursor;
 		try
 		{
 			var page = await pageTask;


### PR DESCRIPTION
related to https://github.com/unoplatform/uno.extensions/issues/372

## Feature
Add PaginatedListFeed

## What is the current behavior?
Pagination has to be handle at app level

## What is the new behavior?
We now have ability to declare de paginated ListFeed using `ListFeed.Paginated(GetPage)`

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
