### PR TITLE
refactor(feeds): Rename Page to PageRequest to avoid name clash

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Sources/Given_PaginatedListFeed.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Sources/Given_PaginatedListFeed.cs
@@ -48,7 +48,7 @@ public class Given_PaginatedListFeed : FeedTests
 	[TestMethod]
 	public async Task When_ByIndexAndPageIsEmpty_Then_ReportPaginationCompleted()
 	{
-		async ValueTask<IImmutableList<int>> GetPage(Page page, CancellationToken ct)
+		async ValueTask<IImmutableList<int>> GetPage(PageRequest page, CancellationToken ct)
 			=> page.Index switch
 			{
 				0 => Range(0, 10).ToImmutableList(),
@@ -83,7 +83,7 @@ public class Given_PaginatedListFeed : FeedTests
 	[TestMethod]
 	public async Task When_ByIndexAndFirstPageIsEmpty_Then_ReportPaginationCompleted()
 	{
-		async ValueTask<IImmutableList<int>> GetPage(Page page, CancellationToken ct)
+		async ValueTask<IImmutableList<int>> GetPage(PageRequest page, CancellationToken ct)
 			=> page.Index switch
 			{
 				0 => ImmutableList<int>.Empty,
@@ -201,7 +201,7 @@ public class Given_PaginatedListFeed : FeedTests
 	[TestMethod]
 	public async Task When_FirstPageThrow_Then_GoInErrorAndIgnorePageRequest()
 	{
-		async ValueTask<IImmutableList<int>> GetPage(Page page, CancellationToken ct)
+		async ValueTask<IImmutableList<int>> GetPage(PageRequest page, CancellationToken ct)
 			=> page.Index switch
 			{
 				0 => throw new TestException(),
@@ -232,7 +232,7 @@ public class Given_PaginatedListFeed : FeedTests
 	[TestMethod]
 	public async Task When_SubsequentPagesThrow_Then_GoInErrorAndKeepDataAndKeepListeningPageRequest()
 	{
-		async ValueTask<IImmutableList<int>> GetPage(Page page, CancellationToken ct)
+		async ValueTask<IImmutableList<int>> GetPage(PageRequest page, CancellationToken ct)
 			=> page.Index switch
 			{
 				0 => Range(0, 10).ToImmutableList(),
@@ -265,7 +265,7 @@ public class Given_PaginatedListFeed : FeedTests
 	[TestMethod]
 	public async Task When_Refresh()
 	{
-		async ValueTask<IImmutableList<int>> GetPage(Page page, CancellationToken ct)
+		async ValueTask<IImmutableList<int>> GetPage(PageRequest page, CancellationToken ct)
 			=> page.Index switch
 			{
 				0 => Range(0, 10).ToImmutableList(),
@@ -309,7 +309,7 @@ public class Given_PaginatedListFeed : FeedTests
 		void GetNext()
 			=> Interlocked.Exchange(ref delay, new TaskCompletionSource<Unit>())!.SetResult(default);
 
-		async ValueTask<IImmutableList<int>> GetPage(Page page, CancellationToken ct)
+		async ValueTask<IImmutableList<int>> GetPage(PageRequest page, CancellationToken ct)
 		{
 			await delay.Task;
 			return page.Index switch

--- a/src/Uno.Extensions.Reactive/Core/Axes/PaginationInfo.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/PaginationInfo.cs
@@ -27,7 +27,7 @@ internal record PaginationInfo
 	public bool IsLoadingMoreItems { get; init; }
 
 	/// <summary>
-	/// A set of tokens that allows a subscriber to track the progress of a <see cref="PageRequest"/>.
+	/// A set of tokens that allows a subscriber to track the progress of a <see cref="Core.PageRequest"/>.
 	/// </summary>
 	public TokenSet<PageToken> Tokens { get; init; } = TokenSet<PageToken>.Empty;
 

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.T.cs
@@ -80,15 +80,15 @@ public static class ListFeed<T>
 	/// </summary>
 	/// <param name="getPage">The async method to load a page of items.</param>
 	/// <returns>A paginated list feed.</returns>
-	public static IListFeed<T> AsyncPaginated(AsyncFunc<Page, IImmutableList<T>> getPage)
+	public static IListFeed<T> AsyncPaginated(AsyncFunc<PageRequest, IImmutableList<T>> getPage)
 		=> AttachedProperty.GetOrCreate(getPage, gp => new PaginatedListFeed<ByIndexCursor, T>(ByIndexCursor.First, PaginatedByIndex(gp)));
 
-	private static GetPage<ByIndexCursor, T> PaginatedByIndex(AsyncFunc<Page, IImmutableList<T>> getPage) => async (cursor, desiredCount, ct) =>
+	private static GetPage<ByIndexCursor, T> PaginatedByIndex(AsyncFunc<PageRequest, IImmutableList<T>> getPage) => async (cursor, desiredCount, ct) =>
 	{
-		var request = new Page
+		var request = new PageRequest
 		{
 			Index = cursor.Index,
-			TotalCount = cursor.TotalCount,
+			CurrentCount = cursor.TotalCount,
 			DesiredSize = desiredCount
 		};
 

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.cs
@@ -47,7 +47,7 @@ public static partial class ListFeed
 	/// <typeparam name="T">The type of the data of the resulting feed.</typeparam>
 	/// <param name="getPage">The async method to load a page of items.</param>
 	/// <returns>A paginated list feed.</returns>
-	public static IListFeed<T> AsyncPaginated<T>(AsyncFunc<Page, IImmutableList<T>> getPage)
+	public static IListFeed<T> AsyncPaginated<T>(AsyncFunc<PageRequest, IImmutableList<T>> getPage)
 		=> ListFeed<T>.AsyncPaginated(getPage);
 	#endregion
 

--- a/src/Uno.Extensions.Reactive/Sources/PageRequest.cs
+++ b/src/Uno.Extensions.Reactive/Sources/PageRequest.cs
@@ -6,7 +6,7 @@ namespace Uno.Extensions.Reactive;
 /// <summary>
 /// Information about a page
 /// </summary>
-public struct Page
+public struct PageRequest
 {
 	/// <summary>
 	/// The index of the page.
@@ -16,7 +16,7 @@ public struct Page
 	/// <summary>
 	/// This is the total number of items currently in the list.
 	/// </summary>
-	public uint TotalCount { get; init; }
+	public uint CurrentCount { get; init; }
 
 	/// <summary>
 	/// The desired number of items for the current page, if any.
@@ -26,7 +26,7 @@ public struct Page
 	/// It's expected to be null only for the first page.
 	/// Be aware that this might change between pages (especially is user resize the window),
 	/// DO NOT use like `source.Skip(page.Index * page.DesiredSize).Take(page.DesiredSize)`.
-	/// Prefer to use the <see cref="TotalCount"/>.
+	/// Prefer to use the <see cref="CurrentCount"/> like `source.Skip(page.CurrentCount).Take(page.DesiredSize)`.
 	/// </remarks>
 	public uint? DesiredSize { get; init; }
 }

--- a/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
@@ -29,7 +29,7 @@ internal class PaginatedListFeed<TCursor, TItem> : IListFeed<TItem>, IRefreshabl
 	public IAsyncEnumerable<Message<IImmutableList<TItem>>> GetSource(SourceContext context, CancellationToken ct)
 	{
 		var refreshRequests = new CoercingRequestManager<RefreshRequest, RefreshToken>(context, RefreshToken.Initial(this, context), ct);
-		var pageRequests = new CoercingRequestManager<PageRequest, PageToken>(context, PageToken.Initial(this, context), ct);
+		var pageRequests = new CoercingRequestManager<Core.PageRequest, PageToken>(context, PageToken.Initial(this, context), ct);
 		var subject = new AsyncEnumerableSubject<Message<IImmutableList<TItem>>>(ReplayMode.EnabledForFirstEnumeratorOnly);
 		var messages = new MessageManager<IImmutableList<TItem>>(subject.SetNext);
 


### PR DESCRIPTION
related to #372 

## Refactoring
Rename Page to PageRequest to avoid name clash with Xaml.Page + Rename TotalCount to CurrentCount

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

