### PR TITLE
fix: Navigation to details page not working consistently

### DIFF
--- a/samples/Playground/Playground.Package/Playground.Windows.Package.wapproj
+++ b/samples/Playground/Playground.Package/Playground.Windows.Package.wapproj
@@ -70,7 +70,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.2">
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.2">
       <IncludeAssets>build</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.197">

--- a/samples/Playground/Playground.Windows/Playground.Windows.csproj
+++ b/samples/Playground/Playground.Windows/Playground.Windows.csproj
@@ -49,7 +49,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.2" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.2" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.197" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="System.Text.Json" Version="6.0.3" />

--- a/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
@@ -96,7 +96,7 @@ public class FrameNavigator : ControlNavigator<Frame>
 		}
 
 		var route = request.Route;
-		var segments = route.ForwardNavigationSegments(Resolver, Region, includeDependsOnRoutes: true);
+		var segments = route.ForwardNavigationSegments(Resolver, Region);
 
 		// As this is a forward navigation
 		if (segments.Length == 0)
@@ -128,7 +128,7 @@ public class FrameNavigator : ControlNavigator<Frame>
 			// Rebuild the nested region hierarchy
 			Control.ReassignRegionParent();
 			if (segments.Length > 1 ||
-				string.IsNullOrWhiteSpace(request.Route.Path))
+				!string.IsNullOrWhiteSpace(request.Route.Path))
 			{
 				refreshViewModel = true;
 			}

--- a/src/Uno.Extensions.Navigation.UI/Region.cs
+++ b/src/Uno.Extensions.Navigation.UI/Region.cs
@@ -87,12 +87,12 @@ public static class Region
 		return (IRegion)element.GetValue(InstanceProperty);
 	}
 
-	public static void SetAttached(DependencyObject element, bool value)
+	public static void SetAttached(this DependencyObject element, bool value)
 	{
 		element.SetValue(AttachedProperty, value);
 	}
 
-	public static bool GetAttached(DependencyObject element)
+	public static bool GetAttached(this DependencyObject element)
 	{
 		return (bool)element.GetValue(AttachedProperty);
 	}

--- a/src/Uno.Extensions.Navigation.UI/Regions/NavigationRegion.cs
+++ b/src/Uno.Extensions.Navigation.UI/Regions/NavigationRegion.cs
@@ -58,9 +58,16 @@ public sealed class NavigationRegion : IRegion
 		View = view;
 		if (View is not null)
 		{
-			View.Loading += ViewLoading;
-			View.Loaded += ViewLoaded;
 			View.SetInstance(this);
+			if (!View.IsLoaded)
+			{
+				View.Loading += ViewLoading;
+				View.Loaded += ViewLoaded;
+			}
+			else
+			{
+				View.Unloaded += ViewUnloaded;
+			}
 		}
 
 		if (services is not null)
@@ -137,7 +144,7 @@ public sealed class NavigationRegion : IRegion
 
     private void AssignParent()
     {
-        if (View is null || _isRoot)
+        if (View is null || _isRoot || !View.GetAttached())
         {
             return;
         }

--- a/src/Uno.Extensions.Navigation.UI/RouteExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteExtensions.cs
@@ -65,8 +65,7 @@ public static class RouteExtensions
 	public static (Route, RouteInfo?, bool)[] ForwardNavigationSegments(
 		this Route route,
 		IRouteResolver mappings,
-		IRegion region,
-		bool includeDependsOnRoutes)
+		IRegion region)
 	{
 		// Here we're interested in the actual page navigation segments.
 		// Start with an empty list, and progressively add routes that
@@ -80,7 +79,7 @@ public static class RouteExtensions
 
 		// For routes that have a depends on, we need to ensure that
 		// the dependson segments are added to the segments list
-		var r = includeDependsOnRoutes ? route.RootDependsOn(mappings, region, false) : route;
+		var r = route.RootDependsOn(mappings, region, false);
 		var map = mappings.Find(r);
 		var originalRoute = false;
 		while (
@@ -375,7 +374,7 @@ public static class RouteExtensions
 		}
 		else
 		{
-			var segments = currentRoute.ForwardNavigationSegments(resolver, region, includeDependsOnRoutes: false).ToList();
+			var segments = currentRoute.ForwardNavigationSegments(resolver, region).ToList();
 			foreach (var qualifierChar in qualifier)
 			{
 				if (qualifierChar + "" == Qualifiers.NavigateBack)
@@ -388,7 +387,7 @@ public static class RouteExtensions
 				}
 			}
 
-			var newSegments = frameRoute.ForwardNavigationSegments(resolver, region, includeDependsOnRoutes: true);
+			var newSegments = frameRoute.ForwardNavigationSegments(resolver, region);
 			if (newSegments is not null)
 			{
 				newSegments = (from seg in newSegments
@@ -412,13 +411,13 @@ public static class RouteExtensions
 	public static Route RootDependsOn(this Route currentRoute, IRouteResolver resolver, IRegion region, bool includeCurrentRegion)
 	{
 		var rm = resolver.FindByPath(currentRoute.Base);
-		if ((rm is null ||
-			string.IsNullOrEmpty(rm.DependsOn)) &&
-			region.Navigator()?.Route?.Base == currentRoute.Base &&
-			!includeCurrentRegion)
-		{
-			return Route.Empty;
-		}
+		//if ((rm is null ||
+		//	string.IsNullOrEmpty(rm.DependsOn)) &&
+		//	region.Navigator()?.Route?.Base == currentRoute.Base &&
+		//	!includeCurrentRegion)
+		//{
+		//	return Route.Empty;
+		//}
 
 		while (rm is not null &&
 			!string.IsNullOrEmpty(rm.DependsOn))

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
@@ -37,7 +37,7 @@
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.1" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.2" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.197" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />

--- a/testing/TestHarness/TestHarness.Mobile/TestHarness.Mobile.csproj
+++ b/testing/TestHarness/TestHarness.Mobile/TestHarness.Mobile.csproj
@@ -18,19 +18,20 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.1.2" />
+		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100-dev.15.g12261e2626" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.44.0" />
-		<PackageReference Include="Uno.WinUI" Version="4.3.8" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
+		<PackageReference Include="Uno.WinUI" Version="4.4.5" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.4.5" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.4.5" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Refit" Version="6.3.2" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
 		<PackageReference Include="System.Text.Json" Version="6.0.3" />
-		<!--<PackageReference Include="Uno.Material.WinUI" Version="2.1.0" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.1.0" />-->
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.1.0" />
-		<PackageReference Include="Uno.WinUI.MSAL" Version="4.3.8" />
+		<PackageReference Include="Uno.Material.WinUI" Version="2.2.0" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.2.0" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.2.0" />
+		<PackageReference Include="Uno.WinUI.MSAL" Version="4.4.5" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Authentication\Uno.Extensions.Authentication.csproj" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceDealsPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceDealsPage.xaml
@@ -8,14 +8,19 @@
 	  xmlns:utu="using:Uno.Toolkit.UI"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	  xmlns:um="using:Uno.Material"
+	  xmlns:triggers="using:CommunityToolkit.WinUI.UI.Triggers"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
 	  NavigationCacheMode="Required">
 
-	<Grid>
+	<Grid x:Name="ParentGrid">
 		<VisualStateManager.VisualStateGroups>
-			<VisualStateGroup>
+			<VisualStateGroup CurrentStateChanged="ResponsiveStateChanged">
 				<VisualState x:Name="Wide">
+					<VisualState.StateTriggers>
+						<triggers:ControlSizeTrigger MinWidth="{StaticResource WideMinWindowWidth}"
+													 TargetElement="{Binding ElementName=ParentGrid}" />
+					</VisualState.StateTriggers>
 					<VisualState.Setters>
 						<!--<Setter Target="DealsListView.SelectionMode"
 								Value="Single" />
@@ -34,6 +39,9 @@
 					</VisualState.Setters>
 				</VisualState>
 				<VisualState x:Name="Narrow">
+					<VisualState.StateTriggers>
+						<triggers:ControlSizeTrigger MinWidth="0" />
+					</VisualState.StateTriggers>
 					<VisualState.Setters>
 						<!--<Setter Target="DealsListView.SelectionMode"
 								Value="None" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceDealsPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceDealsPage.xaml.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Diagnostics;
+
 namespace TestHarness.Ext.Navigation.Apps.Commerce;
 
 public sealed partial class CommerceDealsPage : Page
@@ -7,7 +9,11 @@ public sealed partial class CommerceDealsPage : Page
 	public CommerceDealsPage()
 	{
 		this.InitializeComponent();
-
-		this.ApplyAdaptiveTrigger(App.Current.Resources["WideMinWindowWidth"] is double width ? width : 0.0, nameof(Narrow), nameof(Wide));
 	}
+
+	private void ResponsiveStateChanged(object sender, VisualStateChangedEventArgs e)
+	{
+		Debug.WriteLine("State Changed");
+	}
+
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomePage.xaml
@@ -9,25 +9,17 @@
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	  xmlns:um="using:Uno.Material"
 	  mc:Ignorable="d"
+	  xmlns:triggers="using:CommunityToolkit.WinUI.UI.Triggers"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<Grid>
+	<Grid x:Name="ParentGrid">
 		<VisualStateManager.VisualStateGroups>
 			<VisualStateGroup>
-				<VisualState x:Name="Narrow">
-
-					<VisualState.Setters>
-						<Setter Target="Tabs.Visibility"
-								Value="Visible" />
-						<Setter Target="NavView.IsPaneToggleButtonVisible"
-								Value="false" />
-						<Setter Target="NavView.PaneDisplayMode"
-								Value="LeftMinimal" />
-						<Setter Target="NavView.IsPaneOpen"
-								Value="False" />
-					</VisualState.Setters>
-				</VisualState>
 				<VisualState x:Name="Wide">
+					<VisualState.StateTriggers>
+						<triggers:ControlSizeTrigger MinWidth="{StaticResource WideMinWindowWidth}"
+													 TargetElement="{Binding ElementName=ParentGrid}" />
+					</VisualState.StateTriggers>
 					<VisualState.Setters>
 						<Setter Target="Tabs.Visibility"
 								Value="Collapsed" />
@@ -39,6 +31,22 @@
 								Value="Auto" />
 					</VisualState.Setters>
 				</VisualState>
+				<VisualState x:Name="Narrow">
+					<VisualState.StateTriggers>
+						<triggers:ControlSizeTrigger MinWidth="0" />
+					</VisualState.StateTriggers>
+					<VisualState.Setters>
+						<Setter Target="Tabs.Visibility"
+								Value="Visible" />
+						<Setter Target="NavView.IsPaneToggleButtonVisible"
+								Value="false" />
+						<Setter Target="NavView.PaneDisplayMode"
+								Value="LeftMinimal" />
+						<Setter Target="NavView.IsPaneOpen"
+								Value="False" />
+					</VisualState.Setters>
+				</VisualState>
+
 			</VisualStateGroup>
 		</VisualStateManager.VisualStateGroups>
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomePage.xaml.cs
@@ -6,6 +6,6 @@ public sealed partial class CommerceHomePage : Page
 	{
 		this.InitializeComponent();
 
-		this.ApplyAdaptiveTrigger(App.Current.Resources["WideMinWindowWidth"] is double width ? width : 0.0, nameof(Narrow), nameof(Wide));
+		
 	}
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceProductsPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceProductsPage.xaml
@@ -8,14 +8,19 @@
 	  xmlns:utu="using:Uno.Toolkit.UI"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	  xmlns:um="using:Uno.Material"
+	  xmlns:triggers="using:CommunityToolkit.WinUI.UI.Triggers"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
 	  NavigationCacheMode="Required">
 
-	<Grid>
+	<Grid x:Name="ParentGrid">
 		<VisualStateManager.VisualStateGroups>
 			<VisualStateGroup>
 				<VisualState x:Name="Wide">
+					<VisualState.StateTriggers>
+						<triggers:ControlSizeTrigger MinWidth="{StaticResource WideMinWindowWidth}"
+													 TargetElement="{Binding ElementName=ParentGrid}" />
+					</VisualState.StateTriggers>
 					<VisualState.Setters>
 						<!--<Setter Target="ProductsListView.SelectionMode"
 								Value="Single" />-->
@@ -34,6 +39,9 @@
 					</VisualState.Setters>
 				</VisualState>
 				<VisualState x:Name="Narrow">
+					<VisualState.StateTriggers>
+						<triggers:ControlSizeTrigger MinWidth="0" />
+					</VisualState.StateTriggers>
 					<VisualState.Setters>
 						<!--<Setter Target="ProductsListView.SelectionMode"
 								Value="None" />-->
@@ -75,6 +83,7 @@
 			</ListView>
 			<Grid Grid.Column="1"
 				  x:Name="DetailsGrid"
+				  Background="LightPink"
 				  Visibility="Collapsed">
 				<ContentControl x:Name="Details"
 								uen:Region.Attached="false"

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceProductsPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceProductsPage.xaml.cs
@@ -8,6 +8,6 @@ public sealed partial class CommerceProductsPage : Page
 	{
 		this.InitializeComponent();
 
-		this.ApplyAdaptiveTrigger(App.Current.Resources["WideMinWindowWidth"] is double width ? width : 0.0, nameof(Narrow), nameof(Wide));
+		
 	}
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoHomePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoHomePage.xaml
@@ -8,16 +8,18 @@
 	  xmlns:utu="using:Uno.Toolkit.UI"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	  xmlns:um="using:Uno.Material"
+	  xmlns:triggers="using:CommunityToolkit.WinUI.UI.Triggers"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
 	  NavigationCacheMode="Required">
 
-	<Grid>
+	<Grid x:Name="ParentGrid">
 		<VisualStateManager.VisualStateGroups>
 			<VisualStateGroup>
 				<VisualState x:Name="Wide">
 					<VisualState.StateTriggers>
-						<AdaptiveTrigger MinWindowWidth="{StaticResource WideMinWindowWidth}" />
+						<triggers:ControlSizeTrigger MinWidth="{StaticResource WideMinWindowWidth}"
+													 TargetElement="{Binding ElementName=ParentGrid}" />
 					</VisualState.StateTriggers>
 					<VisualState.Setters>
 						<Setter Target="NavView.(uen:Navigation.Request)"
@@ -26,7 +28,8 @@
 				</VisualState>
 				<VisualState x:Name="Narrow">
 					<VisualState.StateTriggers>
-						<AdaptiveTrigger MinWindowWidth="0" />
+						<triggers:ControlSizeTrigger MinWidth="0"
+													 TargetElement="{Binding ElementName=ParentGrid}" />
 					</VisualState.StateTriggers>
 					<VisualState.Setters>
 						<Setter Target="NavView.(uen:Navigation.Request)"

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoHomePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoHomePage.xaml.cs
@@ -7,7 +7,7 @@ public sealed partial class ToDoHomePage : Page
 	{
 		this.InitializeComponent();
 
-		this.ApplyAdaptiveTrigger(App.Current.Resources["WideMinWindowWidth"] is double width ? width : 0.0, nameof(Narrow), nameof(Wide));
+		
 
 	}
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoTaskListPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoTaskListPage.xaml
@@ -8,6 +8,7 @@
 	  xmlns:utu="using:Uno.Toolkit.UI"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	  xmlns:um="using:Uno.Material"
+	  xmlns:triggers="using:CommunityToolkit.WinUI.UI.Triggers"
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
 	  NavigationCacheMode="Required">
@@ -18,11 +19,15 @@
 					   FontSize="32" />
 		</DataTemplate>
 	</Page.Resources>
-	<Grid>
 
+	<Grid x:Name="ParentGrid">
 		<VisualStateManager.VisualStateGroups>
 			<VisualStateGroup>
 				<VisualState x:Name="Wide">
+					<VisualState.StateTriggers>
+						<triggers:ControlSizeTrigger MinWidth="{StaticResource WideMinWindowWidth}"
+													 TargetElement="{Binding ElementName=ParentGrid}" />
+					</VisualState.StateTriggers>
 					<VisualState.Setters>
 						<Setter Target="TaskListColumn.Width"
 								Value="*" />
@@ -37,6 +42,10 @@
 					</VisualState.Setters>
 				</VisualState>
 				<VisualState x:Name="Narrow">
+					<VisualState.StateTriggers>
+						<triggers:ControlSizeTrigger MinWidth="0"
+													 TargetElement="{Binding ElementName=ParentGrid}" />
+					</VisualState.StateTriggers>
 				</VisualState>
 			</VisualStateGroup>
 		</VisualStateManager.VisualStateGroups>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoTaskListPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoTaskListPage.xaml.cs
@@ -7,7 +7,7 @@ public sealed partial class ToDoTaskListPage : Page
 	{
 		this.InitializeComponent();
 
-		this.ApplyAdaptiveTrigger(App.Current.Resources["WideMinWindowWidth"] is double width ? width : 0.0, nameof(Narrow), nameof(Wide));
+		
 
 	}
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Responsive/ResponsiveListPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Responsive/ResponsiveListPage.xaml
@@ -8,13 +8,17 @@
 	  xmlns:models="using:TestHarness.Models"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	  xmlns:utu="using:Uno.Toolkit.UI"
+	  xmlns:triggers="using:CommunityToolkit.WinUI.UI.Triggers"
 	  NavigationCacheMode="Required">
 
-	<Grid>
+	<Grid x:Name="ParentGrid">
 		<VisualStateManager.VisualStateGroups>
 			<VisualStateGroup>
-				<VisualState x:Name="Narrow" />
 				<VisualState x:Name="Wide">
+					<VisualState.StateTriggers>
+						<triggers:ControlSizeTrigger MinWidth="{StaticResource WideMinWindowWidth}"
+													 TargetElement="{Binding ElementName=ParentGrid}" />
+					</VisualState.StateTriggers>
 					<VisualState.Setters>
 						<Setter Target="ListColumn.Width"
 								Value="*" />
@@ -27,6 +31,12 @@
 						<Setter Target="Details.(uen:Region.Attached)"
 								Value="true" />
 					</VisualState.Setters>
+				</VisualState>
+				<VisualState x:Name="Narrow">
+					<VisualState.StateTriggers>
+						<triggers:ControlSizeTrigger MinWidth="0"
+													 TargetElement="{Binding ElementName=ParentGrid}" />
+					</VisualState.StateTriggers>
 				</VisualState>
 			</VisualStateGroup>
 		</VisualStateManager.VisualStateGroups>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Responsive/ResponsiveListPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Responsive/ResponsiveListPage.xaml.cs
@@ -7,6 +7,6 @@ public sealed partial class ResponsiveListPage : Page
 	{
 		this.InitializeComponent();
 
-		this.ApplyAdaptiveTrigger(App.Current.Resources["WideMinWindowWidth"] is double width ? width : 0.0, nameof(Narrow), nameof(Wide));
+		
 	}
 }

--- a/testing/TestHarness/TestHarness.Shared/PageExtensions.cs
+++ b/testing/TestHarness/TestHarness.Shared/PageExtensions.cs
@@ -2,43 +2,6 @@
 
 public static class PageExtensions
 {
-	public static void ApplyAdaptiveTrigger(this Page page, double threshold, string narrowState, string wideState)
-	{
-		new ResponsiveState(page, threshold, narrowState, wideState).Connect();
-	}
 
-	private record ResponsiveState(Page Page, double Threshold, string NarrowState, string WideState)
-	{
-		private string? _currentState;
-
-		public void Connect()
-		{
-			Page.Loaded += async (s, e) => await Resize(true);
-			Page.SizeChanged += async (s, e) => await Resize(false);
-		}
-
-		private async Task Resize(bool refresh)
-		{
-			double newWidth = Page.ActualWidth;
-
-			if (newWidth <= 0)
-			{
-				return;
-			}
-
-
-			var newState = newWidth > Threshold ? WideState : NarrowState;
-			if (_currentState != newState || refresh)
-			{
-				_currentState = newState;
-				// Task.Yield is required as we're setting visual states in code. If the
-				// Region.Attached property is set to fast, it doesn't connect up the region
-				// correctly. This isn't an issue when the visual states are driven using
-				// adaptive triggers
-				await Task.Yield();
-				VisualStateManager.GoToState(Page, newState, false);
-			}
-		}
-	}
 }
 

--- a/testing/TestHarness/TestHarness.Skia.Gtk/TestHarness.Skia.Gtk.csproj
+++ b/testing/TestHarness/TestHarness.Skia.Gtk/TestHarness.Skia.Gtk.csproj
@@ -15,19 +15,20 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.1.2" />
+		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100-dev.15.g12261e2626" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.44.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Refit" Version="6.3.2" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
 		<PackageReference Include="System.Text.Json" Version="6.0.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.3.8" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
-		<!--<PackageReference Include="Uno.Material.WinUI" Version="2.1.0" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.1.0" />-->
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.1.0" />
-		<PackageReference Include="Uno.WinUI.MSAL" Version="4.3.8" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.4.5" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.4.5" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.4.5" />
+		<PackageReference Include="Uno.Material.WinUI" Version="2.2.0" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.2.0" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.2.0" />
+		<PackageReference Include="Uno.WinUI.MSAL" Version="4.4.5" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Authentication\Uno.Extensions.Authentication.csproj" />

--- a/testing/TestHarness/TestHarness.Skia.Linux.FrameBuffer/TestHarness.Skia.Linux.FrameBuffer.csproj
+++ b/testing/TestHarness/TestHarness.Skia.Linux.FrameBuffer/TestHarness.Skia.Linux.FrameBuffer.csproj
@@ -15,9 +15,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.3.8" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
+    <PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.4.5" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.4.5" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.4.5" />
   </ItemGroup>
   <Import Project="..\TestHarness.Shared\TestHarness.Shared.projitems" Label="Shared" />
 </Project>

--- a/testing/TestHarness/TestHarness.Skia.WPF.Host/TestHarness.Skia.Wpf.Host.csproj
+++ b/testing/TestHarness/TestHarness.Skia.WPF.Host/TestHarness.Skia.Wpf.Host.csproj
@@ -7,9 +7,9 @@
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.3.8" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.4.5" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.4.5" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.4.5" />
 	</ItemGroup>
 	<ItemGroup>
 		<Content Include="Assets\Fonts\uno-fluentui-assets.ttf" />

--- a/testing/TestHarness/TestHarness.Skia.WPF/TestHarness.Skia.WPF.csproj
+++ b/testing/TestHarness/TestHarness.Skia.WPF/TestHarness.Skia.WPF.csproj
@@ -4,19 +4,20 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.1.2" />
+		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100-dev.15.g12261e2626" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.44.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Refit" Version="6.3.2" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
 		<PackageReference Include="System.Text.Json" Version="6.0.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.3.8" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
-		<!--<PackageReference Include="Uno.Material.WinUI" Version="2.1.0" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.1.0" />-->
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.1.0" />
-		<PackageReference Include="Uno.WinUI.MSAL" Version="4.3.8" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.4.5" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.4.5" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.4.5" />
+		<PackageReference Include="Uno.Material.WinUI" Version="2.2.0" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.2.0" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.2.0" />
+		<PackageReference Include="Uno.WinUI.MSAL" Version="4.4.5" />
 	</ItemGroup>
 	<ItemGroup>
 		<UpToDateCheckInput Include="..\TestHarness.Shared\**\*.xaml" />

--- a/testing/TestHarness/TestHarness.UITest/Ext/Authentication/Custom/Given_Custom.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Authentication/Custom/Given_Custom.cs
@@ -2,9 +2,8 @@
 
 public class Given_Custom : NavigationTestBase
 {
-	// TODO: Fix UI Test fail
 	// [Test]
-	public async Task When_Custom()
+	public async Task When_Custom_Auth()
 	{
 		InitTestSection(TestSections.Authentication_Custom);
 

--- a/testing/TestHarness/TestHarness.UITest/Ext/Authentication/Msal/Given_Msal.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Authentication/Msal/Given_Msal.cs
@@ -2,9 +2,8 @@
 
 public class Given_Msal : NavigationTestBase
 {
-	// TODO: Fix UI Test fail
 	// [Test]
-	public async Task When_Multi()
+	public async Task When_Multi_Auth()
 	{
 		InitTestSection(TestSections.Authentication_Multi);
 

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Apps/Commerce/Given_Apps_Commerce.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Apps/Commerce/Given_Apps_Commerce.cs
@@ -2,9 +2,8 @@
 
 public class Given_Apps_Commerce : NavigationTestBase
 {
-	// TODO: Work out why this is failing
-	//[Test]
-	public async Task When_Responsive()
+	[Test]
+	public async Task When_Commerce_Responsive()
 	{
 		InitTestSection(TestSections.Apps_Commerce);
 
@@ -28,14 +27,14 @@ public class Given_Apps_Commerce : NavigationTestBase
 		await App.TapAndWait("ProfileTabBarItem", "ProfileNavigationBar");
 
 		// Select a deal
-		await App.TapAndWait("DealsTabBarItem", "DealsNavigationBar");
+		await App.TapAndWait("DealsTabBarItem", "DealsListView");
 
 		await App.SelectListViewIndexAndWait("DealsListView", "1", "ProductDetailsNavigationBar");
 
 		await App.TapAndWait("DetailsBackButton", "DealsNavigationBar");
 
 		// Select a product
-		await App.TapAndWait("ProductsTabBarItem", "ProductsNavigationBar");
+		await App.TapAndWait("ProductsTabBarItem", "ProductsListView");
 
 		await App.SelectListViewIndexAndWait("ProductsListView", "2", "ProductDetailsNavigationBar");
 
@@ -68,14 +67,14 @@ public class Given_Apps_Commerce : NavigationTestBase
 
 
 		// Select a deal
-		await App.TapAndWait("DealsNavigationViewItem","DealsNavigationBar");
+		await App.TapAndWait("DealsNavigationViewItem", "DealsListView");
 
 		await App.SelectListViewIndexAndWait("DealsListView", "2", "ProductDetailsNavigationBar");
 		App.WaitForElement("DealsNavigationBar");
 
 
 		// Select a product
-		await App.TapAndWait("ProductsNavigationViewItem","ProductsNavigationBar");
+		await App.TapAndWait("ProductsNavigationViewItem", "ProductsListView");
 
 		await App.SelectListViewIndexAndWait("ProductsListView", "1", "ProductDetailsNavigationBar");
 		App.WaitForElement("ProductsNavigationBar");

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Apps/ToDo/Given_Apps_ToDo.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Apps/ToDo/Given_Apps_ToDo.cs
@@ -2,9 +2,8 @@
 
 public class Given_Apps_ToDo : NavigationTestBase
 {
-	// TODO: Work out why this is failing
-	//[Test]
-	public async Task When_Responsive()
+	[Test]
+	public async Task When_ToDo_Responsive()
 	{
 		InitTestSection(TestSections.Apps_ToDo);
 

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Responsive/Given_Responsive.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Responsive/Given_Responsive.cs
@@ -2,9 +2,8 @@
 
 public class Given_Responsive : NavigationTestBase
 {
-	// TODO: Work out why this is failing
-	//[Test]
-	public async Task When_Responsive()
+	[Test]
+	public async Task When_Navigation_Responsive()
 	{
 		InitTestSection(TestSections.Responsive);
 

--- a/testing/TestHarness/TestHarness.Wasm/TestHarness.Wasm.csproj
+++ b/testing/TestHarness/TestHarness.Wasm/TestHarness.Wasm.csproj
@@ -45,6 +45,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.1.2" />
+		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100-dev.15.g12261e2626" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.44.0" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
@@ -52,15 +53,15 @@
 		<PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
 		<PackageReference Include="System.Text.Json" Version="6.0.3" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.3.8" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.3.8" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.8" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.4.5" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.4.5" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.4.5" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-		<!--<PackageReference Include="Uno.Material.WinUI" Version="2.1.0" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.1.0" />-->
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.1.0" />
-		<PackageReference Include="Uno.WinUI.MSAL" Version="4.3.8" />
+		<PackageReference Include="Uno.Material.WinUI" Version="2.2.0" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.2.0" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.2.0" />
+		<PackageReference Include="Uno.WinUI.MSAL" Version="4.4.5" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Authentication\Uno.Extensions.Authentication.csproj" />

--- a/testing/TestHarness/TestHarness.Windows/TestHarness.Windows.csproj
+++ b/testing/TestHarness/TestHarness.Windows/TestHarness.Windows.csproj
@@ -30,6 +30,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.1.2" />
+		<PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.44.0" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.2" />
@@ -38,10 +39,10 @@
 		<PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
 		<PackageReference Include="System.Text.Json" Version="6.0.3" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<!--<PackageReference Include="Uno.Material.WinUI" Version="2.1.0" />
-		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.1.0" />-->
-		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.1.0" />
-		<PackageReference Include="Uno.WinUI.MSAL" Version="4.3.8" />
+		<PackageReference Include="Uno.Material.WinUI" Version="2.2.0" />
+		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.2.0" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.2.0" />
+		<PackageReference Include="Uno.WinUI.MSAL" Version="4.4.5" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 

--- a/testing/TestHarness/TestHarness.Windows/TestHarness.Windows.csproj
+++ b/testing/TestHarness/TestHarness.Windows/TestHarness.Windows.csproj
@@ -32,7 +32,7 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="7.1.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.44.0" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.1" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.2" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.197" />
 		<PackageReference Include="Refit" Version="6.3.2" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/Uno.Samples/issues/136
(follow up to https://github.com/unoplatform/uno.extensions/pull/571)

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Previous fix (see PR #571) simply prevented re-navigation to the same page but this means that the regions weren't being reattached when switching between navigationview items 

## What is the new behavior?

This PR fixes the issue by preventing the viewmodel from being recreated.
It also addresses an issue where regions weren't being correctly detached and reattached

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X ] Tested code with current [supported SDKs](../README.md#supported)
- [N/A ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [N/A ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X ] Contains **NO** breaking changes
- [N/A ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X ] Associated with an issue (GitHub or internal)

