### PR TITLE
fix: Navigation thread issue due to accessing control properties from background thread

### DIFF
--- a/src/Uno.Extensions.Navigation.Toolkit/Navigators/DrawerControlNavigator.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/Navigators/DrawerControlNavigator.cs
@@ -32,9 +32,14 @@ public class DrawerControlNavigator : ControlNavigator<DrawerControl>
 		Region.Navigator()?.NavigateRouteAsync((sender ?? Control) ?? this, "hide");
 	}
 
-	protected override bool RegionCanNavigate(Route route, RouteInfo? routeMap) =>
-			route.IsBackOrCloseNavigation() ||
-			base.RegionCanNavigate(route, routeMap);
+	protected override Task<bool> RegionCanNavigate(Route route, RouteInfo? routeMap)
+	{
+		if (route.IsBackOrCloseNavigation())
+		{
+			return Task.FromResult(true);
+		}
+		return base.RegionCanNavigate(route, routeMap);
+	}
 
 	protected override async Task<string?> Show(string? path, Type? viewType, object? data)
 	{

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ContentControlNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ContentControlNavigator.cs
@@ -16,9 +16,9 @@ public class ContentControlNavigator : ControlNavigator<ContentControl>
 
 	protected override bool CanNavigateToDependentRoutes => true;
 
-	protected override bool RegionCanNavigate(Route route, RouteInfo? routeMap)
+	protected override async Task<bool> RegionCanNavigate(Route route, RouteInfo? routeMap)
 	{
-		if (!base.RegionCanNavigate(route, routeMap))
+		if (!await base.RegionCanNavigate(route, routeMap))
 		{
 			return false;
 		}

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ContentDialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ContentDialogNavigator.cs
@@ -13,9 +13,14 @@ public class ContentDialogNavigator : DialogNavigator
 	{
 	}
 
-	protected override bool RegionCanNavigate(Route route, RouteInfo? routeMap) =>
-			base.RegionCanNavigate(route, routeMap) &&
-			(routeMap?.RenderView?.IsSubclassOf(typeof(ContentDialog)) ?? false);
+	protected override Task<bool> RegionCanNavigate(Route route, RouteInfo? routeMap)
+	{
+		if(!(routeMap?.RenderView?.IsSubclassOf(typeof(ContentDialog)) ?? false))
+		{
+			return Task.FromResult(false);
+		}
+		return base.RegionCanNavigate(route, routeMap);
+	}
 
 	protected override async Task<IAsyncInfo?> DisplayDialog(NavigationRequest request, Type? viewType, object? viewModel)
 	{

--- a/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
@@ -19,10 +19,18 @@ public class FlyoutNavigator : ControlNavigator
 		_window = window;
 	}
 
-	protected override bool RegionCanNavigate(Route route, RouteInfo? routeMap) =>
-		route.IsBackOrCloseNavigation() || 
-		(base.RegionCanNavigate(route, routeMap) &&
-		routeMap?.RenderView is not null);
+	protected override Task<bool> RegionCanNavigate(Route route, RouteInfo? routeMap)
+	{
+		if (route.IsBackOrCloseNavigation())
+		{
+			return Task.FromResult(true);
+		}
+		if (routeMap?.RenderView is null)
+		{
+			return Task.FromResult(false);
+		}
+		return base.RegionCanNavigate(route, routeMap);
+	}
 
 	protected override async Task<Route?> ExecuteRequestAsync(NavigationRequest request)
 	{
@@ -47,7 +55,7 @@ public class FlyoutNavigator : ControlNavigator
 			}
 
 			var mapping = Resolver.Find(route);
-			injectedFlyout = !(mapping?.RenderView?.IsSubclassOf(typeof(Flyout))??false);
+			injectedFlyout = !(mapping?.RenderView?.IsSubclassOf(typeof(Flyout)) ?? false);
 			var viewModel = await CreateViewModel(Region.Services, request, route, mapping);
 			Flyout = await DisplayFlyout(request, mapping?.RenderView, viewModel, injectedFlyout);
 		}
@@ -94,7 +102,7 @@ public class FlyoutNavigator : ControlNavigator
 			flyout = resource as Flyout;
 		}
 
-		if(flyout is null)
+		if (flyout is null)
 		{
 			return default;
 		}
@@ -152,7 +160,7 @@ public class FlyoutNavigator : ControlNavigator
 		Flyout.Closed -= Flyout_Closed;
 
 		var navigation = Region.Navigator();
-		if(navigation is null)
+		if (navigation is null)
 		{
 			return;
 		}

--- a/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
@@ -33,7 +33,7 @@ public class FrameNavigator : ControlNavigator<Frame>
 	// TODO: IsUnnamed and  composite region
 	protected override bool CanNavigateToDependentRoutes => !Region.Children.Any(x=>x.IsUnnamed(this.Route) && !(x.Navigator()?.IsComposite()??false));
 
-	protected override bool RegionCanNavigate(Route route, RouteInfo? routeMap)
+	protected override async Task<bool> RegionCanNavigate(Route route, RouteInfo? routeMap)
 	{
 		if (route.IsBackOrCloseNavigation())
 		{
@@ -45,7 +45,7 @@ public class FrameNavigator : ControlNavigator<Frame>
 			return !string.IsNullOrWhiteSpace(route.Base) || !(FullRoute?.Next()?.IsEmpty() ?? true);
 		}
 
-		if (!base.RegionCanNavigate(route, routeMap))
+		if (!await base.RegionCanNavigate(route, routeMap))
 		{
 			return false;
 		}
@@ -128,7 +128,8 @@ public class FrameNavigator : ControlNavigator<Frame>
 			// Rebuild the nested region hierarchy
 			Control.ReassignRegionParent();
 			if (segments.Length > 1 ||
-				!string.IsNullOrWhiteSpace(request.Route.Path))
+				!string.IsNullOrWhiteSpace(request.Route.Path)||
+				request.Route.Data?.Count>0)
 			{
 				refreshViewModel = true;
 			}

--- a/src/Uno.Extensions.Navigation.UI/Navigators/MessageDialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/MessageDialogNavigator.cs
@@ -15,9 +15,15 @@ public class MessageDialogNavigator : DialogNavigator
 		_localizer = localizer;
 	}
 
-	protected override bool RegionCanNavigate(Route route, RouteInfo? routeMap) =>
-		base.RegionCanNavigate(route, routeMap) &&
-		(routeMap?.RenderView == typeof(MessageDialog));
+	protected override Task<bool> RegionCanNavigate(Route route, RouteInfo? routeMap)
+	{
+		if (!(routeMap?.RenderView == typeof(MessageDialog)))
+		{
+			return Task.FromResult(false);
+		}
+
+		return base.RegionCanNavigate(route, routeMap);
+	}
 
 	protected override async Task<IAsyncInfo?> DisplayDialog(NavigationRequest request, Type? viewType, object? viewModel)
 	{

--- a/src/Uno.Extensions.Navigation.UI/Navigators/PanelVisiblityNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/PanelVisiblityNavigator.cs
@@ -16,17 +16,22 @@ public class PanelVisiblityNavigator : ControlNavigator<Panel>
 	{
 	}
 
-	protected override bool RegionCanNavigate(Route route, RouteInfo? routeMap)
+	protected override async Task<bool> RegionCanNavigate(Route route, RouteInfo? routeMap)
 	{
-		if (!base.RegionCanNavigate(route, routeMap))
+		if (!await base.RegionCanNavigate(route, routeMap))
 		{
 			return false;
 		}
 
-		return (
-			(FindByPath(routeMap?.Path ?? route.Base) is not null) ||
-			(routeMap?.RenderView?.IsSubclassOf(typeof(FrameworkElement)) ?? false)
-		);
+		if(routeMap?.RenderView?.IsSubclassOf(typeof(FrameworkElement)) ?? false)
+		{
+			return true;
+		}
+
+		return await Dispatcher.ExecuteAsync(async () =>
+		{
+			return FindByPath(routeMap?.Path ?? route.Base) is not null;
+		});
 	}
 
 	private FrameworkElement? CurrentlyVisibleControl { get; set; }

--- a/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
@@ -21,9 +21,18 @@ public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
 
 	protected override FrameworkElement? CurrentView => SelectedItem;
 
-	protected override bool RegionCanNavigate(Route route, RouteInfo? routeMap) =>
-		base.RegionCanNavigate(route, routeMap) &&
-		(FindByPath(routeMap?.Path??route.Base) is not null);
+	protected override async Task<bool> RegionCanNavigate(Route route, RouteInfo? routeMap)
+	{
+		if(!await base.RegionCanNavigate(route, routeMap))
+		{
+			return false;
+		}
+
+		return await Dispatcher.ExecuteAsync(async () =>
+		{
+			return FindByPath(routeMap?.Path ?? route.Base) is not null;
+		});
+	}
 
 	protected SelectorNavigator(
 		ILogger logger,

--- a/src/Uno.Extensions.Navigation.UI/Regions/RegionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/Regions/RegionExtensions.cs
@@ -4,6 +4,12 @@ public static class RegionExtensions
 {
 	public static INavigator? Navigator(this IRegion region) => region.Services?.GetRequiredService<INavigator>();
 
+	public static Task<bool> CanNavigate(this IRegion region, Route route)
+	{
+		var navigator = region.Navigator();
+		return navigator is not null ? navigator.CanNavigate(route) : Task.FromResult(false);
+	}
+
 	public static Task<NavigationResponse?> NavigateAsync(this IRegion region, NavigationRequest request) => (region.Navigator()?.NavigateAsync(request)) ?? Task.FromResult<NavigationResponse?>(default);
 
 	public static bool IsUnnamed(this IRegion region, Route? parentRoute=null) =>

--- a/src/Uno.Extensions.Navigation.UI/ResponseNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/ResponseNavigator.cs
@@ -91,5 +91,5 @@ public class ResponseNavigator<TResult> : IResponseNavigator, IInstance<IService
 		return new NavigationResultResponse<TResult>(response?.Route ?? Route.Empty, ResultCompletion.Task, response?.Success ?? false);
 	}
 
-	public bool CanNavigate(Route route) => Navigation.CanNavigate(route);
+	public Task<bool> CanNavigate(Route route) => Navigation.CanNavigate(route);
 }

--- a/src/Uno.Extensions.Navigation/INavigator.cs
+++ b/src/Uno.Extensions.Navigation/INavigator.cs
@@ -4,7 +4,7 @@ public interface INavigator
 {
     Route? Route { get; }
 
-	bool CanNavigate(Route route);
+	Task<bool> CanNavigate(Route route);
 
 	Task<NavigationResponse?> NavigateAsync(NavigationRequest request);
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomePage.xaml
@@ -99,13 +99,18 @@
 				</muxc:NavigationView.MenuItems>
 				<Grid>
 					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
 						<RowDefinition />
 						<RowDefinition Height="Auto" />
 					</Grid.RowDefinitions>
+					<StackPanel Orientation="Horizontal">
+						<Button Content="Products (threading test)"
+								Click="{x:Bind ViewModel.GoToProducts}" />
+					</StackPanel>
 					<Grid uen:Region.Attached="True"
-						  uen:Region.Navigator="Visibility" />
+						  uen:Region.Navigator="Visibility" Grid.Row="1"/>
 					<utu:TabBar x:Name="Tabs"
-								Grid.Row="1"
+								Grid.Row="2"
 								uen:Region.Attached="True">
 						<utu:TabBarItem AutomationProperties.AutomationId="DealsTabBarItem"
 										IsSelectable="True"

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomePage.xaml.cs
@@ -2,10 +2,9 @@
 
 public sealed partial class CommerceHomePage : Page
 {
+	public CommerceHomeViewModel? ViewModel => DataContext as CommerceHomeViewModel;
 	public CommerceHomePage()
 	{
 		this.InitializeComponent();
-
-		
 	}
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomeViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomeViewModel.cs
@@ -1,0 +1,12 @@
+﻿namespace TestHarness.Ext.Navigation.Apps.Commerce;
+
+public record CommerceHomeViewModel(INavigator Navigator)
+{
+	public async Task GoToProducts()
+	{
+		await Task.Run(async () =>
+		await Navigator.NavigateViewModelAsync<CommerceProductsViewModel>(this, qualifier: Qualifiers.Nested)
+		);
+	}
+
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHostInit.cs
@@ -35,12 +35,11 @@ public class CommerceHostInit : IHostInitialization
 		views.Register(
 				new ViewMap(ViewModel: typeof(CommerceShellViewModel)),
 				new ViewMap<CommerceLoginPage, CommerceLoginViewModel>(ResultData: typeof(CommerceCredentials)),
-				new ViewMap<CommerceHomePage>(Data: new DataMap<CommerceCredentials>()),
+				new DataViewMap<CommerceHomePage,CommerceHomeViewModel, CommerceCredentials>(),
 				new ViewMap<CommerceProductsPage, CommerceProductsViewModel>(),
-				new ViewMap<CommerceProductDetailsPage, CommerceProductDetailsViewModel>(),
+				new DataViewMap<CommerceProductDetailsPage, CommerceProductDetailsViewModel, CommerceProduct>(),
 				new ViewMap<CommerceDealsPage, CommerceDealsViewModel>(),
-				new ViewMap<CommerceProfilePage, CommerceProfileViewModel>(),
-				new DataViewMap<CommerceProductDetailsPage, CommerceProductDetailsViewModel, CommerceProduct>()
+				new ViewMap<CommerceProfilePage, CommerceProfileViewModel>()
 				);
 
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceProductsPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceProductsPage.xaml
@@ -51,7 +51,7 @@
 				</VisualState>
 			</VisualStateGroup>
 		</VisualStateManager.VisualStateGroups>
-		
+
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition />
@@ -68,19 +68,34 @@
 				<ColumnDefinition Width="0"
 								  x:Name="DetailsColumn" />
 			</Grid.ColumnDefinitions>
-			<ListView AutomationProperties.AutomationId="ProductsListView"
-					  x:Name="ProductsListView"
-					  ItemsSource="{Binding Products}"
-					  uen:Navigation.Request="Product">
-				<!--SelectionMode="None"
+			<Grid>
+				<Grid.RowDefinitions>
+					<RowDefinition Height="Auto" />
+					<RowDefinition />
+				</Grid.RowDefinitions>
+				<StackPanel Orientation="Horizontal">
+					<Button AutomationProperties.AutomationId="FirstProductButton"
+							Content="First Product - UI Thread"
+							Click="{x:Bind ViewModel.ShowFirstProductUIThread}" />
+					<Button AutomationProperties.AutomationId="FirstProductBackgroundButton"
+							Content="First Product - Background Thread"
+							Click="{x:Bind ViewModel.ShowFirstProductBackgroundThread}" />
+				</StackPanel>
+				<ListView AutomationProperties.AutomationId="ProductsListView"
+						  Grid.Row="1"
+						  x:Name="ProductsListView"
+						  ItemsSource="{Binding Products}"
+						  uen:Navigation.Request="Product">
+					<!--SelectionMode="None"
 					  IsItemClickEnabled="True"-->
-				<ListView.ItemTemplate>
-					<DataTemplate x:DataType="local:CommerceProduct">
-						<TextBlock Text="{x:Bind Name}"
-								   FontSize="30" />
-					</DataTemplate>
-				</ListView.ItemTemplate>
-			</ListView>
+					<ListView.ItemTemplate>
+						<DataTemplate x:DataType="local:CommerceProduct">
+							<TextBlock Text="{x:Bind Name}"
+									   FontSize="30" />
+						</DataTemplate>
+					</ListView.ItemTemplate>
+				</ListView>
+			</Grid>
 			<Grid Grid.Column="1"
 				  x:Name="DetailsGrid"
 				  Background="LightPink"

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceProductsViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceProductsViewModel.cs
@@ -9,5 +9,15 @@ public record CommerceProductsViewModel(INavigator Navigator) : BaseCommerceView
 					new CommerceProduct("Sun glasses"),
 					new CommerceProduct("Watch")
 				};
-
+	public async Task ShowFirstProductUIThread()
+	{
+		await Navigator.NavigateDataAsync(this, Products.First());
+	}
+	public async Task ShowFirstProductBackgroundThread()
+	{
+		await Task.Run(async () =>
+		{
+			await Navigator.NavigateDataAsync(this, Products.First());
+		});
+	}
 }

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -63,6 +63,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Apps\Commerce\CommerceLoginPage.xaml.cs">
       <DependentUpon>CommerceLoginPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Apps\Commerce\CommerceHomeViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Apps\Commerce\CommerceMainPage.xaml.cs">
       <DependentUpon>CommerceMainPage.xaml</DependentUpon>
     </Compile>

--- a/testing/TestHarness/TestHarness.UITest/Constants.cs
+++ b/testing/TestHarness/TestHarness.UITest/Constants.cs
@@ -4,7 +4,7 @@ namespace TestHarness.UITest;
 
 public class Constants
 {
-	public readonly static string WebAssemblyDefaultUri = "https://localhost:53299";
+	public readonly static string WebAssemblyDefaultUri = "https://localhost:64806";
 	public readonly static string iOSAppName = "uno.platform.extensions.demo";
 	public readonly static string AndroidAppName = "uno.platform.extensions.demo";
 	public readonly static string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Apps/Commerce/Given_Apps_Commerce.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Apps/Commerce/Given_Apps_Commerce.cs
@@ -139,4 +139,37 @@ public class Given_Apps_Commerce : NavigationTestBase
 
 	}
 
+
+	[Test]
+	public async Task When_BackgroundThread()
+	{
+		InitTestSection(TestSections.Apps_Commerce);
+
+		App.WaitThenTap("ShowAppButton");
+
+		// Select the narrow layout
+		App.WaitThenTap("WideButton");
+
+		// Make sure the app has loaded
+		App.WaitForElement("LoginNavigationBar");
+
+		// Login
+		App.WaitThenTap("LoginButton");
+
+
+		/// Tap through each navigation view item
+		await App.TapAndWait("DealsNavigationViewItem", "DealsNavigationBar");
+
+		await App.TapAndWait("ProductsNavigationViewItem", "ProductsNavigationBar");
+
+		await App.TapAndWait("FirstProductButton", "ProductDetailsNavigationBar"); // Navigation by product data type finds the dealsproducts route first!
+
+		await App.TapAndWait("DetailsBackButton", "DealsNavigationBar");
+
+		await App.TapAndWait("ProductsNavigationViewItem", "ProductsNavigationBar");
+
+		await App.TapAndWait("FirstProductBackgroundButton", "ProductDetailsNavigationBar"); // Navigation by product data type finds the dealsproducts route first!
+
+		await App.TapAndWait("DetailsBackButton", "DealsNavigationBar");
+	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #590 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

CanNavigate check doesn't switch to UI thread - can cause issues if navigation is triggered from background thread

## What is the new behavior?

CanNavigate is now async, which means that where appropriate Navigators can use IDispatcher to switch to the UI thread.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X ] Tested code with current [supported SDKs](../README.md#supported)
- [N/A ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ N/A] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X ] Contains **NO** breaking changes
- [N/A ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
