### PR TITLE
fix: Fixing build error when UWP app references Navigation.Toolkit

### DIFF
--- a/src/Uno.Extensions-uwp.slnf
+++ b/src/Uno.Extensions-uwp.slnf
@@ -1,0 +1,40 @@
+{
+  "solution": {
+    "path": "Uno.Extensions.sln",
+    "projects": [
+      "Uno.Extensions.Authentication.MSAL\\Uno.Extensions.Authentication.MSAL.UI.Wasm.csproj",
+      "Uno.Extensions.Authentication.MSAL\\Uno.Extensions.Authentication.MSAL.UI.csproj",
+      "Uno.Extensions.Authentication.UI\\Uno.Extensions.Authentication.UI.csproj",
+      "Uno.Extensions.Authentication\\Uno.Extensions.Authentication.csproj",
+      "Uno.Extensions.Configuration\\Uno.Extensions.Configuration.csproj",
+      "Uno.Extensions.Core\\Uno.Extensions.Core.csproj",
+      "Uno.Extensions.Hosting.UI\\Uno.Extensions.Hosting.UWP.Skia.csproj",
+      "Uno.Extensions.Hosting.UI\\Uno.Extensions.Hosting.UWP.Wasm.csproj",
+      "Uno.Extensions.Hosting.UI\\Uno.Extensions.Hosting.UWP.csproj",
+      "Uno.Extensions.Hosting\\Uno.Extensions.Hosting.csproj",
+      "Uno.Extensions.Http.Refit\\Uno.Extensions.Http.Refit.csproj",
+      "Uno.Extensions.Http.Tests\\Uno.Extensions.Http.Tests.csproj",
+      "Uno.Extensions.Http\\Uno.Extensions.Http.csproj",
+      "Uno.Extensions.Localization\\Uno.Extensions.Localization.csproj",
+      "Uno.Extensions.Logging.Serilog\\Uno.Extensions.Logging.Serilog.csproj",
+      "Uno.Extensions.Logging\\Uno.Extensions.Logging.UWP.Skia.csproj",
+      "Uno.Extensions.Logging\\Uno.Extensions.Logging.UWP.Wasm.csproj",
+      "Uno.Extensions.Logging\\Uno.Extensions.Logging.UWP.csproj",
+      "Uno.Extensions.Navigation.Toolkit\\Uno.Extensions.Navigation.Toolkit.UI.csproj",
+      "Uno.Extensions.Navigation.UI\\Uno.Extensions.Navigation.UI.csproj",
+      "Uno.Extensions.Navigation\\Uno.Extensions.Navigation.csproj",
+      "Uno.Extensions.Reactive.Generator\\Uno.Extensions.Reactive.Generator.csproj",
+      "Uno.Extensions.Reactive.Messaging\\Uno.Extensions.Reactive.Messaging.csproj",
+      "Uno.Extensions.Reactive.Testing\\Uno.Extensions.Reactive.Testing.csproj",
+      "Uno.Extensions.Reactive.Tests\\Uno.Extensions.Reactive.Tests.csproj",
+      "Uno.Extensions.Reactive.UI\\Uno.Extensions.Reactive.UI.csproj",
+      "Uno.Extensions.Reactive\\Uno.Extensions.Reactive.csproj",
+      "Uno.Extensions.Serialization.Http\\Uno.Extensions.Serialization.Http.csproj",
+      "Uno.Extensions.Serialization.Refit\\Uno.Extensions.Serialization.Refit.csproj",
+      "Uno.Extensions.Serialization.Tests\\Uno.Extensions.Serialization.Tests.csproj",
+      "Uno.Extensions.Serialization\\Uno.Extensions.Serialization.csproj",
+      "Uno.Extensions.Templates\\Uno.Extensions.Templates.csproj",
+      "Uno.Extensions\\Uno.Extensions.csproj"
+    ]
+  }
+}

--- a/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.UI.csproj
+++ b/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.UI.csproj
@@ -30,7 +30,7 @@
 	<Target Name="FixXrXml"
 						AfterTargets="_SdkIncludeWindowsLibraryLayoutItems"
 						Condition="'$(GenerateLibraryLayout)' == 'true' AND '$(SDKIdentifier)' == 'Windows'">
-		<Message Importance="high" Text="Fix for missing .xr.xml files" />
+		<Message Importance="high" Text="Applying fix for missing .xr.xml files" />
 		<ItemGroup>
 			<TfmSpecificPackageFile Include="@(_LayoutFile)"
                               Condition="'$(ProjectName)' != '%(_LayoutFile.ProjectName)'"

--- a/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.UI.csproj
+++ b/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.UI.csproj
@@ -24,7 +24,7 @@
 
 	<!--
 	Fix for: https://github.com/unoplatform/uno.extensions/issues/563 
-	MSBuild Extras excludes .xf.xml layout files from referenced libraries at
+	MSBuild Extras excludes .xr.xml layout files from referenced libraries at
 	https://github.com/novotnyllc/MSBuildSdkExtras/blob/252ba9af3300db98fde54644316567f0c6426e1e/Source/MSBuild.Sdk.Extras/Build/Workarounds.targets#L94
 	-->
 	<Target Name="FixXrXml"

--- a/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.UI.csproj
+++ b/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.UI.csproj
@@ -19,7 +19,22 @@
 		<PackageReference Include="Uno.UI" Version="4.3.6" />
 		<PackageReference Include="Uno.Toolkit.UI" Version="2.0.0" />
 	</ItemGroup>
-	
+
 	<Import Project="common.props" />
 
+	<!--
+	Fix for: https://github.com/unoplatform/uno.extensions/issues/563 
+	MSBuild Extras excludes .xf.xml layout files from referenced libraries at
+	https://github.com/novotnyllc/MSBuildSdkExtras/blob/252ba9af3300db98fde54644316567f0c6426e1e/Source/MSBuild.Sdk.Extras/Build/Workarounds.targets#L94
+	-->
+	<Target Name="FixXrXml"
+						AfterTargets="_SdkIncludeWindowsLibraryLayoutItems"
+						Condition="'$(GenerateLibraryLayout)' == 'true' AND '$(SDKIdentifier)' == 'Windows'">
+		<Message Importance="high" Text="Fix for missing .xr.xml files" />
+		<ItemGroup>
+			<TfmSpecificPackageFile Include="@(_LayoutFile)"
+                              Condition="'$(ProjectName)' != '%(_LayoutFile.ProjectName)'"
+                              PackagePath="lib\$(TargetFramework)\%(_LayoutFile.TargetPath)"/>
+		</ItemGroup>
+	</Target>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): #563

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Build error in UWP app after adding a reference to Uno.Extensions.Navigation.Toolkit.UI

## What is the new behavior?

No build error when adding a reference to Uno.Extensions.Navigation.Toolkit.UI 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
