### PR TITLE
feat: Adding helpers for serializing entities into tokencache

### DIFF
--- a/src/Uno.Extensions.Authentication/Custom/CustomAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication/Custom/CustomAuthenticationProvider.cs
@@ -51,7 +51,7 @@ internal record CustomAuthenticationProvider<TService>
 		{
 			return default;
 		}
-		return await Settings.LoginCallback(Services.GetRequiredService<TService>(), dispatcher, Tokens, credentials!, cancellationToken);
+		return await Settings.LoginCallback(Services.GetRequiredService<TService>(), Services, dispatcher, Tokens, credentials!, cancellationToken);
 	}
 
 	public async override ValueTask<bool> LogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
@@ -60,7 +60,7 @@ internal record CustomAuthenticationProvider<TService>
 		{
 			return true;
 		}
-		return await Settings.LogoutCallback(Services.GetRequiredService<TService>(), dispatcher, Tokens, await Tokens.GetAsync(cancellationToken), cancellationToken);
+		return await Settings.LogoutCallback(Services.GetRequiredService<TService>(), Services, dispatcher, Tokens, await Tokens.GetAsync(cancellationToken), cancellationToken);
 	}
 
 	public async override ValueTask<IDictionary<string, string>?> RefreshAsync(CancellationToken cancellationToken)
@@ -69,6 +69,6 @@ internal record CustomAuthenticationProvider<TService>
 		{
 			return default;
 		}
-		return await Settings.RefreshCallback(Services.GetRequiredService<TService>(), Tokens, await Tokens.GetAsync(cancellationToken), cancellationToken);
+		return await Settings.RefreshCallback(Services.GetRequiredService<TService>(), Services, Tokens, await Tokens.GetAsync(cancellationToken), cancellationToken);
 	}
 }

--- a/src/Uno.Extensions.Authentication/Custom/CustomAuthenticationSettings.cs
+++ b/src/Uno.Extensions.Authentication/Custom/CustomAuthenticationSettings.cs
@@ -10,7 +10,7 @@ internal record CustomAuthenticationSettings
 
 internal record CustomAuthenticationSettings<TService>
 {
-	public AsyncFunc<TService, IDispatcher?, ITokenCache, IDictionary<string, string>, IDictionary<string, string>?>? LoginCallback { get; init; }
-	public AsyncFunc<TService, ITokenCache, IDictionary<string, string>, IDictionary<string, string>?>? RefreshCallback { get; init; }
-	public AsyncFunc<TService, IDispatcher?, ITokenCache, IDictionary<string, string>, bool>? LogoutCallback { get; init; }
+	public AsyncFunc<TService, IServiceProvider, IDispatcher?, ITokenCache, IDictionary<string, string>, IDictionary<string, string>?>? LoginCallback { get; init; }
+	public AsyncFunc<TService, IServiceProvider, ITokenCache, IDictionary<string, string>, IDictionary<string, string>?>? RefreshCallback { get; init; }
+	public AsyncFunc<TService, IServiceProvider, IDispatcher?, ITokenCache, IDictionary<string, string>, bool>? LogoutCallback { get; init; }
 }

--- a/src/Uno.Extensions.Authentication/CustomAuthenticationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication/CustomAuthenticationBuilderExtensions.cs
@@ -38,19 +38,26 @@ public static class CustomAuthenticationBuilderExtensions
 	this ICustomAuthenticationBuilder<TService> builder,
 		AsyncFunc<TService, IDictionary<string, string>, IDictionary<string, string>?> loginCallback)
 	{
-		return builder.Login((sp, dispatcher, cache, tokens, ct) => loginCallback(sp, tokens, ct));
+		return builder.Login((service, sp, dispatcher, cache, tokens, ct) => loginCallback(service, tokens, ct));
 	}
 
 	public static ICustomAuthenticationBuilder<TService> Login<TService>(
 		this ICustomAuthenticationBuilder<TService> builder,
 			AsyncFunc<TService, IDispatcher?, IDictionary<string, string>, IDictionary<string, string>?> loginCallback)
 	{
-		return builder.Login((sp, dispatcher, cache, tokens, ct) => loginCallback(sp, dispatcher, tokens, ct));
+		return builder.Login((service, sp, dispatcher, cache, tokens, ct) => loginCallback(service, dispatcher, tokens, ct));
 	}
 
 	public static ICustomAuthenticationBuilder<TService> Login<TService>(
 		this ICustomAuthenticationBuilder<TService> builder,
 		AsyncFunc<TService, IDispatcher?, ITokenCache, IDictionary<string, string>, IDictionary<string, string>?> loginCallback)
+	{
+		return builder.Login((service, sp, dispatcher, cache, tokens, ct) => loginCallback(service, dispatcher, cache, tokens, ct));
+	}
+
+	public static ICustomAuthenticationBuilder<TService> Login<TService>(
+		this ICustomAuthenticationBuilder<TService> builder,
+		AsyncFunc<TService, IServiceProvider, IDispatcher?, ITokenCache, IDictionary<string, string>, IDictionary<string, string>?> loginCallback)
 	{
 		if (builder is IBuilder<CustomAuthenticationSettings<TService>> authBuilder)
 		{
@@ -89,12 +96,19 @@ public static class CustomAuthenticationBuilderExtensions
 		this ICustomAuthenticationBuilder<TService> builder,
 		AsyncFunc<TService, IDictionary<string, string>, IDictionary<string, string>?> refreshCallback)
 	{
-		return builder.Refresh((sp, cache, tokens, ct) => refreshCallback(sp, tokens, ct));
+		return builder.Refresh((service, sp, cache, tokens, ct) => refreshCallback(service, tokens, ct));
 	}
 
 	public static ICustomAuthenticationBuilder<TService> Refresh<TService>(
 		this ICustomAuthenticationBuilder<TService> builder,
 		AsyncFunc<TService, ITokenCache, IDictionary<string, string>, IDictionary<string, string>?> refreshCallback)
+	{
+		return builder.Refresh((service, sp, cache, tokens, ct) => refreshCallback(service, cache, tokens, ct));
+	}
+
+	public static ICustomAuthenticationBuilder<TService> Refresh<TService>(
+		this ICustomAuthenticationBuilder<TService> builder,
+		AsyncFunc<TService, IServiceProvider, ITokenCache, IDictionary<string, string>, IDictionary<string, string>?> refreshCallback)
 	{
 		if (builder is IBuilder<CustomAuthenticationSettings<TService>> authBuilder)
 		{
@@ -148,19 +162,26 @@ public static class CustomAuthenticationBuilderExtensions
 		this ICustomAuthenticationBuilder<TService> builder,
 		AsyncFunc<TService, IDictionary<string, string>, bool> logoutCallback)
 	{
-		return builder.Logout((sp, dispatcher, cache, tokens, ct) => logoutCallback(sp, tokens, ct));
+		return builder.Logout((service, sp, dispatcher, cache, tokens, ct) => logoutCallback(service, tokens, ct));
 	}
 
 	public static ICustomAuthenticationBuilder<TService> Logout<TService>(
 		this ICustomAuthenticationBuilder<TService> builder,
 		AsyncFunc<TService, IDispatcher?, IDictionary<string, string>, bool> logoutCallback)
 	{
-		return builder.Logout((sp, dispatcher, cache, tokens, ct) => logoutCallback(sp, dispatcher, tokens, ct));
+		return builder.Logout((service, sp, dispatcher, cache, tokens, ct) => logoutCallback(service, dispatcher, tokens, ct));
 	}
 
 	public static ICustomAuthenticationBuilder<TService> Logout<TService>(
 		this ICustomAuthenticationBuilder<TService> builder,
 		AsyncFunc<TService, IDispatcher?, ITokenCache, IDictionary<string, string>, bool> logoutCallback)
+	{
+		return builder.Logout((service, sp, dispatcher, cache, tokens, ct) => logoutCallback(service, dispatcher, cache, tokens, ct));
+	}
+
+	public static ICustomAuthenticationBuilder<TService> Logout<TService>(
+		this ICustomAuthenticationBuilder<TService> builder,
+		AsyncFunc<TService, IServiceProvider, IDispatcher?, ITokenCache, IDictionary<string, string>, bool> logoutCallback)
 	{
 		if (builder is IBuilder<CustomAuthenticationSettings<TService>> authBuilder)
 		{

--- a/src/Uno.Extensions.Authentication/TokenCacheExtensions.cs
+++ b/src/Uno.Extensions.Authentication/TokenCacheExtensions.cs
@@ -1,5 +1,7 @@
 ﻿
 
+using Uno.Extensions.Serialization;
+
 namespace Uno.Extensions.Authentication;
 
 public static class TokenCacheExtensions
@@ -34,5 +36,19 @@ public static class TokenCacheExtensions
 			dict[AccessTokenKey] = refreshToken!;
 		}
 		return await cache.SaveAsync(provider, dict, cancellation);
+	}
+
+	public static TEntity? Get<TEntity>(this IDictionary<string,string> tokens, ISerializer<TEntity> serializer, string key)
+	{
+		if(tokens.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value))
+		{
+			return serializer.FromString(value);
+		}
+		return default;
+	}
+
+	public static void Set<TEntity>(this IDictionary<string,string> tokens, ISerializer<TEntity> serializer, string key, TEntity entity)
+	{
+		tokens[key] = serializer.ToString(entity);
 	}
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationServiceHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationServiceHostInit.cs
@@ -39,7 +39,7 @@ public class CustomAuthenticationServiceHostInit : IHostInitialization
 				.UseAuthentication(auth =>
 					auth.AddCustom<ICustomAuthenticationDummyJsonEndpoint>(custom =>
 						custom
-							.Login(async (authService, dispatcher, credentials, cancellationToken) =>
+							.Login(async (authService, services, dispatcher, cache, credentials, cancellationToken) =>
 							{
 								if (credentials is null)
 								{
@@ -53,12 +53,24 @@ public class CustomAuthenticationServiceHostInit : IHostInitialization
 								if (authResponse?.Token is not null)
 								{
 									credentials[TokenCacheExtensions.AccessTokenKey] = authResponse.Token;
+
+									var w = new Widget { Name = "Bob" };
+									var serializer = services.GetRequiredService<ISerializer<Widget>>();
+									credentials.Set(serializer, nameof(Widget), w);
+
 									return credentials;
 								}
 								return default;
 							})
-							.Refresh(async (authService, tokenDictionary, cancellationToken) =>
+							.Refresh(async (authService, services, cache, tokenDictionary, cancellationToken) =>
 							{
+								var serializer = services.GetRequiredService<ISerializer<Widget>>();
+								var widget = tokenDictionary.Get(serializer, nameof(Widget));
+								if(widget is null)
+								{
+									return default;
+								}
+
 								var creds = new CustomAuthenticationCredentials
 								{
 									Username = tokenDictionary.TryGetValue(nameof(CustomAuthenticationCredentials.Username), out var name) ? name : string.Empty,
@@ -71,6 +83,7 @@ public class CustomAuthenticationServiceHostInit : IHostInitialization
 									if (authResponse?.Token is not null)
 									{
 										tokenDictionary[TokenCacheExtensions.AccessTokenKey] = authResponse.Token;
+										tokenDictionary.Set<Widget>(serializer, nameof(Widget), widget);
 										return tokenDictionary;
 									}
 								}
@@ -97,6 +110,8 @@ public class CustomAuthenticationServiceHostInit : IHostInitialization
 
 							.AddRefitClient<ICustomAuthenticationDummyJsonEndpoint>(context);
 				})
+
+				.UseSerialization()
 				.Build(enableUnoLogging: true);
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): (internal)


## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Hard to serialize an entity into tokencache as no access to service provider

## What is the new behavior?

There is an overload that provides access to the service provider, making it possible to request an ISerializer
Also helper methods for Get/Set entity into the IDictionary

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
