### PR TITLE
fix(reactive): Fix threading issue in pagination

### DIFF
--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/PaginationFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/PaginationFacet.cs
@@ -39,16 +39,16 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 				return EmptyResult;
 			}
 
-			return Task
-				.Run(
-					async () =>
-					{
-						var loadedCount = await _service!.LoadMoreItems(requestedCount, _ct.Token);
+			return LoadMoreItemsCore(requestedCount).AsAsyncOperation();
+		}
 
-						return new LoadMoreItemsResult { Count = loadedCount };
-					},
-					_ct.Token)
-				.AsAsyncOperation();
+		private async Task<LoadMoreItemsResult> LoadMoreItemsCore(uint requestedCount)
+		{
+			var loadedCount = await Task
+				.Run(() => _service!.LoadMoreItems(requestedCount, _ct.Token), _ct.Token)
+				.ConfigureAwait(true); // The task must complete on the UI thread!
+
+			return new LoadMoreItemsResult { Count = loadedCount };
 		}
 
 		private void OnServiceStateChanged(object? sender, EventArgs _)


### PR DESCRIPTION
## Bugfix
On WinUI only the two first pages are loaded

## What is the current behavior?
The ListView invokes the `LoadMoreItemsAsync` only once.

## What is the new behavior?
🙃

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
