### PR TITLE
fix: UITests to not run in headless mode in debug

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -80,15 +80,18 @@
   <PropertyGroup Condition="$(_IsIOS)">
     <DefineConstants>$(DefineConstants);IOS1_0;XAMARIN;XAMARIN_IOS;XAMARIN_IOS_UNIFIED</DefineConstants>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+	 <TargetPlatformMinVersion>10.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(_IsMacOS)">
     <DefineConstants>$(DefineConstants);XAMARIN</DefineConstants>
     <SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
+	<TargetPlatformMinVersion>10.14</TargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(_IsCatalyst)">
     <SupportedOSPlatformVersion>13.1</SupportedOSPlatformVersion>
+	<TargetPlatformMinVersion>13.1</TargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(_IsAndroid)">
@@ -96,6 +99,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <DefineConstants>$(DefineConstants);__ANDROID__;XAMARIN;MONOANDROID5_0;XAMARIN_ANDROID</DefineConstants>
 	<SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+	<TargetPlatformMinVersion>21.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
 	<PropertyGroup Condition="$(_IsUWP)">

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.UITests/Constants.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.UITests/Constants.cs
@@ -4,7 +4,7 @@ namespace MyExtensionsApp.UITests;
 
 public class Constants
 {
-	public readonly static string WebAssemblyDefaultUri = "https://localhost:64469/";
+	public readonly static string WebAssemblyDefaultUri = "https://localhost:58524/";
 	public readonly static string iOSAppName = "com.example.app";
 	public readonly static string AndroidAppName = "com.example.app";
 	public readonly static string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (3rd generation)";

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.UITests/TestBase.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.UITests/TestBase.cs
@@ -15,6 +15,9 @@ public class TestBase
 		AppInitializer.TestEnvironment.iOSDeviceNameOrId = Constants.iOSDeviceNameOrId;
 		AppInitializer.TestEnvironment.CurrentPlatform = Constants.CurrentPlatform;
 
+#if DEBUG
+		AppInitializer.TestEnvironment.WebAssemblyHeadless = false;
+#endif
 
 		// Start the app only once, so the tests runs don't restart it
 		// and gain some time for the tests.


### PR DESCRIPTION
GitHub Issue (If applicable): #640 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Can't run UITests from Test Explorer in VS because it tries to run them headless

## What is the new behavior?

UITests run when selected in Test Explorer
This update also adds min platform version for the net6 targets which is now required with latest VS preview

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
