### PR TITLE
fix: Address build error when compiling net6 mobile target for testharness

### DIFF
--- a/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
+++ b/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 
-		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
 		<RootNamespace>Uno.Extensions</RootNamespace>
 
 		<!--Temporary disable missing XML doc until fixed in the whole package-->

--- a/src/Uno.Extensions.Reactive/Uno.Extensions.Reactive.csproj
+++ b/src/Uno.Extensions.Reactive/Uno.Extensions.Reactive.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
 		<Description>Reactive Extensions for the Uno Platform, UWP and WinUI</Description>
 	</PropertyGroup>
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

TestHarness.Mobile won't compile, complaining about missing folder for android-x64

## What is the new behavior?

All TestHarness projects compile

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
