### PR TITLE
feat: Adding reactive feed support to navigation

### DIFF
--- a/src/Uno.Extensions.Navigation/DataMap.cs
+++ b/src/Uno.Extensions.Navigation/DataMap.cs
@@ -8,7 +8,7 @@ public record DataMap(
 	Func<IServiceProvider, IDictionary<string, object>, Task<object?>>? UntypedFromQuery = null
 )
 {
-	internal virtual void RegisterTypes(IServiceCollection services)
+	public virtual void RegisterTypes(IServiceCollection services)
 	{
 	}
 }
@@ -22,7 +22,7 @@ public record DataMap<TData>(
 	async (IServiceProvider sp, IDictionary<string, object> query) => await ((FromQuery is not null && query is not null) ? FromQuery(sp, query) : Task.FromResult<TData?>(default)))
 	where TData : class
 {
-	internal override void RegisterTypes(IServiceCollection services)
+	public override void RegisterTypes(IServiceCollection services)
 	{
 		services.AddViewModelData<TData>();
 	}

--- a/testing/TestHarness/TestHarness.Shared/App.xaml
+++ b/testing/TestHarness/TestHarness.Shared/App.xaml
@@ -17,7 +17,7 @@
 				<MaterialResources xmlns="using:Uno.Material" />
 
 				<MaterialToolkitResources xmlns="using:Uno.Toolkit.UI.Material" />-->
-
+				<ResourceDictionary Source="ms-appx:///Uno.Extensions.Reactive.UI/View/FeedView.xaml" />
 			</ResourceDictionary.MergedDictionaries>
 			
             <!-- Add resources here -->

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml
@@ -1,17 +1,24 @@
-﻿<Page
-    x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveFivePage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+﻿<Page x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveFivePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  mc:Ignorable="d"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<utu:NavigationBar Content="Reactive - Five"
+						   AutomationProperties.AutomationId="ReactiveFiveNavigationBar" />
 		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center">
+					VerticalAlignment="Center"
+					Grid.Row="1">
 			<Button AutomationProperties.AutomationId="FivePageBackButton"
 					Content="Back"
 					uen:Navigation.Request="-" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFourPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFourPage.xaml
@@ -1,17 +1,24 @@
-﻿<Page
-    x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveFourPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+﻿<Page x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveFourPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  mc:Ignorable="d"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<utu:NavigationBar Content="Reactive - Four"
+						   AutomationProperties.AutomationId="ReactiveFourNavigationBar" />
 		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center">
+					VerticalAlignment="Center"
+					Grid.Row="1">
 			<Button AutomationProperties.AutomationId="FourPageToFivePageButton"
 					Content="Five"
 					uen:Navigation.Request="Five" />
@@ -20,10 +27,10 @@
 					uen:Navigation.Request="-" />
 			<Button AutomationProperties.AutomationId="FourPageToFivePageCodebehindButton"
 					Content="Five (Codebehind)"
-					Click="FourPageToFivePageCodebehindClick"/>
+					Click="FourPageToFivePageCodebehindClick" />
 			<Button AutomationProperties.AutomationId="FourPageBackCodebehindButton"
 					Content="Back (Codebehind)"
-					Click="FourPageBackCodebehindClick"/>
+					Click="FourPageBackCodebehindClick" />
 			<Button AutomationProperties.AutomationId="FourPageToFivePageViewModelButton"
 					Content="Five (ViewModel)"
 					Command="{Binding GoToFive}" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOnePage.xaml
@@ -6,11 +6,18 @@
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  mc:Ignorable="d"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<utu:NavigationBar Content="Reactive - One"
+						   AutomationProperties.AutomationId="ReactiveOneNavigationBar" />
 		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center">
+					VerticalAlignment="Center" Grid.Row="1">
 			<Button AutomationProperties.AutomationId="OnePageToTwoPageButton"
 					Content="Two"
 					uen:Navigation.Request="Two" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreePage.xaml
@@ -1,17 +1,26 @@
-﻿<Page
-    x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveThreePage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+﻿<Page x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveThreePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  mc:Ignorable="d"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  xmlns:reactive="using:Uno.Extensions.Reactive.UI"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<utu:NavigationBar Content="Reactive - Three"
+						   AutomationProperties.AutomationId="ReactiveThreeNavigationBar" />
 		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center">
+					VerticalAlignment="Center"
+					Grid.Row="1">
 			<Button AutomationProperties.AutomationId="ThreePageToFourPageButton"
 					Content="Four"
 					uen:Navigation.Request="Four" />
@@ -35,5 +44,14 @@
 					Command="{Binding GoToFourData}" />
 
 		</StackPanel>
+		<reactive:FeedView Grid.Row="2"
+						   Source="{Binding DataModel}"
+						   Style="{StaticResource CompositeFeedViewStyle}">
+			<DataTemplate>
+				<Grid>
+					<TextBlock Text="{Binding Data.Widget.Name}" />
+				</Grid>
+			</DataTemplate>
+		</reactive:FeedView>
 	</Grid>
 </Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreeViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreeViewModel.cs
@@ -2,12 +2,12 @@
 
 public partial class ReactiveThreeViewModel : BaseViewModel
 {
-	public ReactiveThreeViewModel(INavigator navigator, ThreeModel? model) : base(navigator)
+	public ReactiveThreeViewModel(INavigator navigator, IFeed<ThreeModel>? model) : base(navigator)
 	{
-		DataModel = State.Value(this, () => model);
+		DataModel = model ?? Feed.Async( async ct => new ThreeModel(new ReactiveWidget("Empty",0.0)));
 	}
 
-	public IState<ThreeModel?> DataModel { get; }
+	public IFeed<ThreeModel> DataModel { get; }
 
 	public async Task GoToFour()
 	{
@@ -16,7 +16,7 @@ public partial class ReactiveThreeViewModel : BaseViewModel
 
 	public async Task GoToFourData()
 	{
-		await Navigator.NavigateDataAsync(this, data: new FourModel(new ReactiveWidget("From Three",67)));
+		await Navigator.NavigateDataAsync(this, data: new FourModel(new ReactiveWidget("From Three", 67)));
 	}
 
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveTwoPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveTwoPage.xaml
@@ -1,16 +1,24 @@
-﻿<Page
-    x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveTwoPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
+﻿<Page x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveTwoPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  xmlns:utu="using:Uno.Toolkit.UI"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
 	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<utu:NavigationBar Content="Reactive - Two"
+						   AutomationProperties.AutomationId="ReactiveTwoNavigationBar" />
 		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center">
+					VerticalAlignment="Center"
+					Grid.Row="1">
 			<TextBlock Text="{Binding DataModel.Widget.Name}" />
 			<Button AutomationProperties.AutomationId="TwoPageToThreePageButton"
 					Content="Three"
@@ -20,23 +28,26 @@
 					uen:Navigation.Request="-" />
 			<Button AutomationProperties.AutomationId="TwoPageToThreePageCodebehindButton"
 					Content="Three (Codebehind)"
-					Click="TwoPageToThreePageCodebehindClick"/>
+					Click="TwoPageToThreePageCodebehindClick" />
 			<Button AutomationProperties.AutomationId="TwoPageBackCodebehindButton"
 					Content="Back (Codebehind)"
-					Click="TwoPageBackCodebehindClick"/>
+					Click="TwoPageBackCodebehindClick" />
 			<Button AutomationProperties.AutomationId="TwoPageToThreePageViewModelButton"
 					Content="Three (ViewModel)"
 					Command="{Binding GoToThree}" />
 			<Button AutomationProperties.AutomationId="TwoPageBackViewModelButton"
 					Content="Back (ViewModel)"
-					Command="{Binding GoBack}"/>
+					Command="{Binding GoBack}" />
 			<Button AutomationProperties.AutomationId="TwoPageToThreePageDataButton"
 					Content="Three (Data)"
 					Command="{Binding GoToThreeData}" />
+			<Button AutomationProperties.AutomationId="TwoPageToThreePageDataByNameButton"
+					Content="Three (Data By Name)"
+					Command="{Binding GoToThreeDataByName}" />
 			<Button AutomationProperties.AutomationId="TwoPageToThreePageDataButton"
 					Content="Three (XAML Data)"
 					uen:Navigation.Request="Three"
-					uen:Navigation.Data="{Binding NextModel.Value}"/>
+					uen:Navigation.Data="{Binding NextModel.Value}" />
 
 		</StackPanel>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveTwoViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveTwoViewModel.cs
@@ -21,6 +21,10 @@ public partial class ReactiveTwoViewModel: BaseViewModel
 		await Navigator.NavigateDataAsync(this, data: new ThreeModel(new ReactiveWidget("From Two",34)));
 	}
 
+	public async Task GoToThreeDataByName()
+	{
+		await Navigator.NavigateViewModelAsync<ReactiveThreeViewModel>(this, data: "From Two - Name");
+	}
 
 	public async Task GoBack()
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #595 

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

No support for converting from an id or model to a Feed for async loading

## What is the new behavior?

Can define a ReactiveDataMap that supports converting id or model to a Feed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
