### PR TITLE
fix(feeds): State cannot be updated by VM once a value has been published by the View

### DIFF
--- a/build/ci/.azure-pipelines.Android.yml
+++ b/build/ci/.azure-pipelines.Android.yml
@@ -2,7 +2,7 @@ jobs:
 - job: Android
 
   pool:
-    vmImage: macOS-11
+    vmImage: macOS-10.15
 
   variables:
     - name: NUGET_PACKAGES

--- a/build/ci/.azure-pipelines.Android.yml
+++ b/build/ci/.azure-pipelines.Android.yml
@@ -2,7 +2,7 @@ jobs:
 - job: Android
 
   pool:
-    vmImage: macOS-10.15
+    vmImage: macOS-11
 
   variables:
     - name: NUGET_PACKAGES

--- a/src/Uno.Extensions.Reactive.Testing/FeedRecorderExtensions.cs
+++ b/src/Uno.Extensions.Reactive.Testing/FeedRecorderExtensions.cs
@@ -26,6 +26,15 @@ public static class FeedRecorderExtensions
 		[CallerMemberName] string? memberName = null,
 		[CallerLineNumber] int line = -1)
 		=> new(_ => feed.AsFeed(), context ?? SourceContext.Current, autoEnable, feedExpression ?? $"{memberName}@{line}");
+
+	public static FeedRecorder<IState<T>, T> Record<T>(
+		this IState<T> state,
+		SourceContext? context = null,
+		bool autoEnable = true,
+		[CallerArgumentExpression("state")] string? feedExpression = null,
+		[CallerMemberName] string? memberName = null,
+		[CallerLineNumber] int line = -1)
+		=> new(_ => state, context ?? SourceContext.Current, autoEnable, feedExpression ?? $"{memberName}@{line}");
 }
 
 public static class F<T>

--- a/src/Uno.Extensions.Reactive.Tests/Core/Given_MessageBuilder.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Given_MessageBuilder.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Core;
+
+[TestClass]
+public class Given_MessageBuilder : FeedTests
+{
+	[TestMethod]
+	public void When_TransientAxis_Then_Dismissed()
+	{
+		var myAxis = new MessageAxis<object>("my test axis", _ => new object()) { IsTransient = true };
+		var original = Message<string>.Initial.With().Set(myAxis, new object()).Build();
+
+		var builder = original.With();
+		var updated = builder.Build();
+
+		original.Current[myAxis].IsSet.Should().BeTrue();
+		builder.Get(myAxis).value.IsSet.Should().BeFalse("transient axis should have been cleared at beginning to reflect resulting state");
+		updated.Current[myAxis].IsSet.Should().BeFalse("transient axis should have been cleared on update");
+	}
+
+	[TestMethod]
+	public async Task When_TransientAxis_Then_Dismissed_OfT()
+	{
+		var myAxis = new MessageAxis<object>("my test axis", _ => new object()) { IsTransient = true };
+		var manager = new MessageManager<object, object>();
+		manager.Update(current => current.With().Set(myAxis, new object()), CT);
+		var original = manager.Current;
+
+		// Note: Even if we don't set any axis in Update, the Current message should be updated only by the fact that the transient axis has been automatically removed
+		MessageBuilder<object, object> builder = default;
+		manager.Update(current => builder = current.With(), CT);
+		var updated = manager.Current;
+
+		original.Current[myAxis].IsSet.Should().BeTrue();
+		builder.Get(myAxis).value.IsSet.Should().BeFalse("transient axis should have been cleared at beginning to reflect resulting state");
+		updated.Current[myAxis].IsSet.Should().BeFalse("transient axis should have been cleared on update");
+	}
+
+	[TestMethod]
+	public async Task When_TransientAxis_Then_Dismissed_TransactionOfT()
+	{
+		var myAxis = new MessageAxis<object>("my test axis", _ => new object()) { IsTransient = true };
+		var manager = new MessageManager<object, object>();
+		manager.Update(current => current.With().Set(myAxis, new object()), CT);
+		var original = manager.Current;
+
+		// Note: Even if we don't set any axis in Update, the Current message should be updated only by the fact that the transient axis has been automatically removed
+		// Note 2: No needs to Commit the transaction, manager.Current should already reflect changes
+		MessageManager<object, object>.UpdateTransaction.MessageBuilder builder = default;
+		using var transaction = manager.BeginUpdate(CT);
+		transaction.Update(current => builder = current.With());
+		var updated = manager.Current;
+
+		original.Current[myAxis].IsSet.Should().BeTrue();
+		builder.Get(myAxis).value.IsSet.Should().BeFalse("transient axis should have been cleared at beginning to reflect resulting state");
+		updated.Current[myAxis].IsSet.Should().BeFalse("transient axis should have been cleared on update");
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Core/Given_MessageBuilder.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Given_MessageBuilder.cs
@@ -44,6 +44,44 @@ public class Given_MessageBuilder : FeedTests
 	}
 
 	[TestMethod]
+	public async Task When_TransientAxisByParent_Then_NotDismissed_OfT()
+	{
+		var myAxis = new MessageAxis<object>("my test axis", _ => new object()) { IsTransient = true };
+		var parentMsg = Message<object>.Initial.With().Set(myAxis, new object()).Build();
+		var manager = new MessageManager<object, object>();
+		manager.Update(current => current.With(parentMsg), CT);
+		var original = manager.Current;
+
+		// Note: Even if we don't set any axis in Update, the Current message should be updated only by the fact that the transient axis has been automatically removed
+		MessageBuilder<object, object> builder = default;
+		manager.Update(current => builder = current.With(), CT);
+		var updated = manager.Current;
+
+		original.Current[myAxis].IsSet.Should().BeTrue();
+		builder.Get(myAxis).value.IsSet.Should().BeTrue("transient axis should have been kept as it was defined on parent");
+		updated.Current[myAxis].IsSet.Should().BeTrue("transient axis should have been kept as it was defined on parent");
+	}
+
+	[TestMethod]
+	public async Task When_TransientAxisByParentAndLocally_Then_NotDismissed_OfT()
+	{
+		var myAxis = new MessageAxis<object>("my test axis", _ => new object()) { IsTransient = true };
+		var parentMsg = Message<object>.Initial.With().Set(myAxis, new object()).Build();
+		var manager = new MessageManager<object, object>();
+		manager.Update(current => current.With(parentMsg).Set(myAxis, new object()), CT);
+		var original = manager.Current;
+
+		// Note: Even if we don't set any axis in Update, the Current message should be updated only by the fact that the transient axis has been automatically removed
+		MessageBuilder<object, object> builder = default;
+		manager.Update(current => builder = current.With(), CT);
+		var updated = manager.Current;
+
+		original.Current[myAxis].IsSet.Should().BeTrue();
+		builder.Get(myAxis).value.IsSet.Should().BeTrue("transient axis should have been kept as it was also defined on parent");
+		updated.Current[myAxis].IsSet.Should().BeTrue("transient axis should have been kept as it was also defined on parent");
+	}
+
+	[TestMethod]
 	public async Task When_TransientAxis_Then_Dismissed_TransactionOfT()
 	{
 		var myAxis = new MessageAxis<object>("my test axis", _ => new object()) { IsTransient = true };
@@ -61,5 +99,47 @@ public class Given_MessageBuilder : FeedTests
 		original.Current[myAxis].IsSet.Should().BeTrue();
 		builder.Get(myAxis).value.IsSet.Should().BeFalse("transient axis should have been cleared at beginning to reflect resulting state");
 		updated.Current[myAxis].IsSet.Should().BeFalse("transient axis should have been cleared on update");
+	}
+
+	[TestMethod]
+	public async Task When_TransientAxisByParent_Then_NotDismissed_TransactionOfT()
+	{
+		var myAxis = new MessageAxis<object>("my test axis", _ => new object()) { IsTransient = true };
+		var parentMsg = Message<object>.Initial.With().Set(myAxis, new object()).Build();
+		var manager = new MessageManager<object, object>();
+		manager.Update(current => current.With(parentMsg).Set(myAxis, new object()), CT);
+		var original = manager.Current;
+
+		// Note: Even if we don't set any axis in Update, the Current message should be updated only by the fact that the transient axis has been automatically removed
+		// Note 2: No needs to Commit the transaction, manager.Current should already reflect changes
+		MessageManager<object, object>.UpdateTransaction.MessageBuilder builder = default;
+		using var transaction = manager.BeginUpdate(CT);
+		transaction.Update(current => builder = current.With());
+		var updated = manager.Current;
+
+		original.Current[myAxis].IsSet.Should().BeTrue();
+		builder.Get(myAxis).value.IsSet.Should().BeTrue("transient axis should have been kept as it was defined on parent");
+		updated.Current[myAxis].IsSet.Should().BeTrue("transient axis should have been kept as it was defined on parent");
+	}
+
+	[TestMethod]
+	public async Task When_TransientAxisByParentAndLocally_Then_NotDismissed_TransactionOfT()
+	{
+		var myAxis = new MessageAxis<object>("my test axis", _ => new object()) { IsTransient = true };
+		var parentMsg = Message<object>.Initial.With().Set(myAxis, new object()).Build();
+		var manager = new MessageManager<object, object>();
+		manager.Update(current => current.With(parentMsg).Set(myAxis, new object()), CT);
+		var original = manager.Current;
+
+		// Note: Even if we don't set any axis in Update, the Current message should be updated only by the fact that the transient axis has been automatically removed
+		// Note 2: No needs to Commit the transaction, manager.Current should already reflect changes
+		MessageManager<object, object>.UpdateTransaction.MessageBuilder builder = default;
+		using var transaction = manager.BeginUpdate(CT);
+		transaction.Update(current => builder = current.With());
+		var updated = manager.Current;
+
+		original.Current[myAxis].IsSet.Should().BeTrue();
+		builder.Get(myAxis).value.IsSet.Should().BeTrue("transient axis should have been kept as it was also defined on parent");
+		updated.Current[myAxis].IsSet.Should().BeTrue("transient axis should have been kept as it was also defined on parent");
 	}
 }

--- a/src/Uno.Extensions.Reactive.Tests/Core/Given_StateImpl.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Given_StateImpl.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Core;
+
+[TestClass]
+public class Given_StateImpl : FeedTests
+{
+	[TestMethod]
+	public async Task When_Empty_Then_CanBeUpdatedByMessage()
+	{
+		var (result, sut) = new StateImpl<string>(Context, Option<string>.None()).Record();
+
+		await sut.UpdateMessage(msg => msg.With().Data("42"), CT);
+
+		result.Should().Be(r => r
+			.Message(Data.None, Progress.Final, Error.No)
+			.Message("42", Progress.Final, Error.No, Changed.Data));
+	}
+
+	[TestMethod]
+	public async Task When_Empty_Then_CanBeUpdatedByValue()
+	{
+		var (result, sut) = new StateImpl<string>(Context, Option<string>.None()).Record();
+
+		await sut.UpdateValue(_ => "42", CT);
+
+		result.Should().Be(r => r
+			.Message(Data.None, Progress.Final, Error.No)
+			.Message("42", Progress.Final, Error.No, Changed.Data));
+	}
+
+	[TestMethod]
+	public async Task When_Empty_Then_CanBeUpdated()
+	{
+		var (result, sut) = new StateImpl<string>(Context, Option<string>.None()).Record();
+
+		await sut.Update(_ => "42", CT);
+
+		result.Should().Be(r => r
+			.Message(Data.None, Progress.Final, Error.No)
+			.Message("42", Progress.Final, Error.No, Changed.Data));
+	}
+
+	[TestMethod]
+	public async Task When_Value_Then_CanBeUpdatedByMessage()
+	{
+		var (result, sut) = new StateImpl<string>(Context, Option<string>.Some("0")).Record();
+
+		await sut.UpdateMessage(msg => msg.With().Data("42"), CT);
+
+		result.Should().Be(r => r
+			.Message("0", Progress.Final, Error.No)
+			.Message("42", Progress.Final, Error.No, Changed.Data));
+	}
+
+	[TestMethod]
+	public async Task When_Value_Then_CanBeUpdatedByValue()
+	{
+		var (result, sut) = new StateImpl<string>(Context, Option<string>.Some("0")).Record();
+
+		await sut.UpdateValue(_ => "42", CT);
+
+		result.Should().Be(r => r
+			.Message("0", Progress.Final, Error.No)
+			.Message("42", Progress.Final, Error.No, Changed.Data));
+	}
+
+	[TestMethod]
+	public async Task When_Value_Then_CanBeUpdated()
+	{
+		var (result, sut) = new StateImpl<string>(Context, Option<string>.Some("0")).Record();
+
+		await sut.Update(_ => "42", CT);
+
+		result.Should().Be(r => r
+			.Message("0", Progress.Final, Error.No)
+			.Message("42", Progress.Final, Error.No, Changed.Data));
+	}
+}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableViewModelBase.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableViewModelBase.cs
@@ -18,7 +18,7 @@ namespace Uno.Extensions.Reactive.Bindings;
 [EditorBrowsable(EditorBrowsableState.Advanced)]
 public abstract partial class BindableViewModelBase : IBindable, INotifyPropertyChanged, IAsyncDisposable
 {
-	internal static MessageAxis<object?> BindingSource { get; } = new(MessageAxes.BindingSource, _ => null);
+	internal static MessageAxis<object?> BindingSource { get; } = new(MessageAxes.BindingSource, _ => null) { IsTransient = true };
 
 	private readonly CompositeAsyncDisposable _disposables = new();
 	private readonly AsyncLazyDispatcherProvider _dispatcher = new();

--- a/src/Uno.Extensions.Reactive/Core/Axes/MessageAxis.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/MessageAxis.cs
@@ -62,6 +62,8 @@ public abstract class MessageAxis : IEquatable<MessageAxis>
 	/// </summary>
 	public string Identifier { get; }
 
+	internal bool IsTransient { get; init; }
+
 	[Pure]
 	internal virtual (MessageAxisValue values, IChangeSet? changes) GetLocalValue(MessageAxisValue parent, MessageAxisValue currentLocal, (MessageAxisValue value, IChangeSet? changes) updatedLocal)
 	{

--- a/src/Uno.Extensions.Reactive/Core/ChangeCollection.cs
+++ b/src/Uno.Extensions.Reactive/Core/ChangeCollection.cs
@@ -45,6 +45,6 @@ public record ChangeCollection : IReadOnlyCollection<MessageAxis>
 	public bool Contains(MessageAxis axis, out IChangeSet? changeSet)
 		=> _values.TryGetValue(axis, out changeSet);
 
-	internal void Add(MessageAxis axis, IChangeSet? changeSet = null)
-		=> _values.Add(axis, changeSet);
+	internal void Set(MessageAxis axis, IChangeSet? changeSet = null)
+		=> _values[axis] = changeSet;
 }

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.Message.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.Message.cs
@@ -73,7 +73,7 @@ internal partial class MessageManager<TParent, TResult>
 			public void Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes = null)
 				=> Inner.Set(axis, value, changes);
 
-			private (MessageAxisValue value, IChangeSet? changes) Get(MessageAxis axis)
+			internal (MessageAxisValue value, IChangeSet? changes) Get(MessageAxis axis)
 			{
 				var parentValue = Inner.Parent?.Current[axis] ?? MessageAxisValue.Unset;
 				var localValue = Inner.Local.Current[axis];

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.cs
@@ -61,9 +61,46 @@ internal partial class MessageManager<TParent, TResult>
 				_ct);
 		}
 
+		/// <summary>
+		/// Commits the transaction, cf. remarks for perf considerations.
+		/// </summary>
+		/// <remarks>
+		/// For performance consideration,
+		/// especially if you are using transient values (which is the purpose of this UpdateTransaction!),
+		/// avoid to do something like:
+		///		```csharp
+		///		transaction.Update(msg => msg.With().Data(new object()));
+		///		transaction.Commit();
+		///		```
+		/// but prefer to use the overloads of `Commit` that accepts an updater, e.g.:
+		///		```csharp
+		///		transaction.Commit(msg => msg.With().Data(new object()));
+		///		```
+		/// This will ensure to push only one message that removes transient axis values among the final update you are doing.
+		/// </remarks>
+		public void Commit()
+		{
+			if (Interlocked.CompareExchange(ref _state, State.Committed, State.Active) == State.Active)
+			{
+				_owner.EndUpdate(this);
+			}
+
+			Dispose();
+		}
+
+		/// <summary>
+		/// Apply the final update of the message and commits the transaction.
+		/// </summary>
+		/// <param name="resultUpdater">The updater to build the final message produced by the operation wrapped by this transaction.</param>
 		public void Commit(Updater resultUpdater)
 			=> Commit(_stateLessUpdater, resultUpdater);
 
+		/// <summary>
+		/// Apply the final update of the message and commits the transaction.
+		/// </summary>
+		/// <typeparam name="TState">Type of the state used by the <paramref name="resultUpdater"/>.</typeparam>
+		/// <param name="resultUpdater">The updater to build the final message produced by the operation wrapped by this transaction.</param>
+		/// <param name="state">The argument to provide to the <paramref name="resultUpdater"/>.</param>
 		public void Commit<TState>(Updater<TState> resultUpdater, TState state)
 		{
 			if (Interlocked.CompareExchange(ref _state, State.Committed, State.Active) == State.Active)

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.UpdateTransaction.cs
@@ -62,21 +62,21 @@ internal partial class MessageManager<TParent, TResult>
 		}
 
 		/// <summary>
-		/// Commits the transaction, cf. remarks for perf considerations.
+		/// Commits the transaction, cf. remarks for performance considerations.
 		/// </summary>
 		/// <remarks>
-		/// For performance consideration,
-		/// especially if you are using transient values (which is the purpose of this UpdateTransaction!),
-		/// avoid to do something like:
+		/// For performance considerations,
+		/// particularly when using transient values (which is the purpose of this UpdateTransaction!),
+		/// avoid doing something like:
 		///		```csharp
 		///		transaction.Update(msg => msg.With().Data(new object()));
 		///		transaction.Commit();
 		///		```
-		/// but prefer to use the overloads of `Commit` that accepts an updater, e.g.:
+		/// and prefer the use of `Commit` overloads which accept an updater, e.g.:
 		///		```csharp
 		///		transaction.Commit(msg => msg.With().Data(new object()));
 		///		```
-		/// This will ensure to push only one message that removes transient axis values among the final update you are doing.
+		/// This will ensure to push only one message that removes transient axis values among the final update being done.
 		/// </remarks>
 		public void Commit()
 		{

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.cs
@@ -118,7 +118,7 @@ internal partial class MessageManager<TParent, TResult>
 
 				if (!axis.AreEquals(currentValue, updated.value))
 				{
-					changes.Add(axis, updated.changes);
+					changes.Set(axis, updated.changes);
 				}
 			}
 

--- a/src/Uno.Extensions.Reactive/Core/Message.cs
+++ b/src/Uno.Extensions.Reactive/Core/Message.cs
@@ -71,17 +71,17 @@ public sealed class Message<T> : IMessage
 				&& axis.AreEquals(currentValue, newMessage.Previous[axis]))
 			{
 				// If we have a changeSet and it applies tu update from the currentValue, we propagate it
-				changes.Add(axis, changeSet);
+				changes.Set(axis, changeSet);
 			}
 			else
 			{
-				changes.Add(axis);
+				changes.Set(axis);
 			}
 		}
 
 		foreach (var removedAxis in oldValues.Keys.Except(newValues.Keys))
 		{
-			changes.Add(removedAxis);
+			changes.Set(removedAxis);
 		}
 
 		return new Message<T>(Current, newMessage.Current, changes);

--- a/src/Uno.Extensions.Reactive/Core/MessageBuilder.TParent.cs
+++ b/src/Uno.Extensions.Reactive/Core/MessageBuilder.TParent.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Uno.Extensions.Reactive.Core;
 using Uno.Extensions.Reactive.Utils;
+using static Uno.Extensions.Collections.Tracking.CollectionAnalyzer;
 
 namespace Uno.Extensions.Reactive;
 
@@ -23,6 +24,16 @@ public readonly struct MessageBuilder<TParent, TResult> : IMessageEntry, IMessag
 		Local = local.value;
 
 		_updates = local.updates.ToDictionary();
+
+		// We make sure to clear all transient axes when we update a message
+		// Note: We remove only "local" values, parent values are still propagated, it's there responsibility to remove them.
+		foreach (var value in local.updates)
+		{
+			if (value.Key.IsTransient)
+			{
+				_updates.Remove(value.Key);
+			}
+		}
 	}
 
 	/// <summary>

--- a/src/Uno.Extensions.Reactive/Core/MessageBuilder.TParent.cs
+++ b/src/Uno.Extensions.Reactive/Core/MessageBuilder.TParent.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Uno.Extensions.Reactive.Core;
 using Uno.Extensions.Reactive.Utils;
-using static Uno.Extensions.Collections.Tracking.CollectionAnalyzer;
 
 namespace Uno.Extensions.Reactive;
 

--- a/src/Uno.Extensions.Reactive/Core/MessageBuilder.TParent.cs
+++ b/src/Uno.Extensions.Reactive/Core/MessageBuilder.TParent.cs
@@ -22,17 +22,9 @@ public readonly struct MessageBuilder<TParent, TResult> : IMessageEntry, IMessag
 		Parent = parent;
 		Local = local.value;
 
-		_updates = local.updates.ToDictionary();
-
 		// We make sure to clear all transient axes when we update a message
 		// Note: We remove only "local" values, parent values are still propagated, it's there responsibility to remove them.
-		foreach (var value in local.updates)
-		{
-			if (value.Key.IsTransient)
-			{
-				_updates.Remove(value.Key);
-			}
-		}
+		_updates = local.updates.ToDictionaryWhereKey(k => !k.IsTransient);
 	}
 
 	/// <summary>

--- a/src/Uno.Extensions.Reactive/Core/MessageBuilder.cs
+++ b/src/Uno.Extensions.Reactive/Core/MessageBuilder.cs
@@ -20,6 +20,16 @@ public readonly struct MessageBuilder<T> : IMessageEntry, IMessageBuilder, IMess
 		_previous = current;
 		_changes = new();
 		_values = current.Values.ToDictionary();
+
+		// We make sure to clear all transient axes when we update a message
+		foreach (var value in current.Values)
+		{
+			if (value.Key.IsTransient)
+			{
+				_changes.Set(value.Key);
+				_values.Remove(value.Key);
+			}
+		}
 	}
 
 	Option<object> IMessageEntry.Data => CurrentData;
@@ -53,11 +63,11 @@ public readonly struct MessageBuilder<T> : IMessageEntry, IMessageBuilder, IMess
 		if (value.IsSet)
 		{
 			_values[axis] = value;
-			_changes.Add(axis, changes);
+			_changes.Set(axis, changes);
 		}
 		else if (_values.Remove(axis))
 		{
-			_changes.Add(axis, changes);
+			_changes.Set(axis, changes);
 		}
 
 		return this;

--- a/src/Uno.Extensions.Reactive/Core/MessageBuilder.cs
+++ b/src/Uno.Extensions.Reactive/Core/MessageBuilder.cs
@@ -19,17 +19,9 @@ public readonly struct MessageBuilder<T> : IMessageEntry, IMessageBuilder, IMess
 	{
 		_previous = current;
 		_changes = new();
-		_values = current.Values.ToDictionary();
 
 		// We make sure to clear all transient axes when we update a message
-		foreach (var value in current.Values)
-		{
-			if (value.Key.IsTransient)
-			{
-				_changes.Set(value.Key);
-				_values.Remove(value.Key);
-			}
-		}
+		_values = current.Values.ToDictionaryWhereKey(k => !k.IsTransient);
 	}
 
 	Option<object> IMessageEntry.Data => CurrentData;

--- a/src/Uno.Extensions.Reactive/Utils/DictionaryExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/DictionaryExtensions.cs
@@ -6,6 +6,20 @@ namespace Uno.Extensions.Reactive.Utils;
 
 internal static class DictionaryExtensions
 {
+	public static Dictionary<TKey, TValue> ToDictionaryWhereKey<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> readOnly, Predicate<TKey> predicate)
+	{
+		var result = new Dictionary<TKey, TValue>(readOnly.Count);
+		foreach (var kvp in readOnly)
+		{
+			if (predicate(kvp.Key))
+			{
+				result.Add(kvp.Key, kvp.Value);
+			}
+		}
+
+		return result;
+	}
+
 	public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> readOnly)
 	{
 		if (readOnly is IDictionary<TKey, TValue> dic)


### PR DESCRIPTION

## Bugfix
State cannot be updated by VM once a value has been published by the View

## What is the current behavior?
When the View pushes a value to a Feed/State, it flags that value so we are able to avoid to raise back a NPC on the "subscriber" side.

The issue is that since we removed the `Input`, the VM is no longer flagging itself as source of the values it is publishing, so the previous value is kept.

So if the View pushes a value, and then the VM updates it, the source flagged remains the View, so the NPC is not raised.

## What is the new behavior?
The "source" axis is now flagged as "transient", and values of transient axes are automatically flushed by MessageBuilders.

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
