### PR TITLE
feat: Added logging for all Authentication Providers

### DIFF
--- a/src/Uno.Extensions.Authentication.Msal/MsalAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.Msal/MsalAuthenticationProvider.cs
@@ -8,11 +8,11 @@ using MsalCacheHelper = Microsoft.Identity.Client.Extensions.Msal.MsalCacheHelpe
 namespace Uno.Extensions.Authentication.MSAL;
 
 internal record MsalAuthenticationProvider(
-		ILogger<MsalAuthenticationProvider> Logger,
+		ILogger<MsalAuthenticationProvider> ProviderLogger,
 		IOptions<MsalConfiguration> Configuration,
 		ITokenCache Tokens,
 		IStorage Storage,
-		MsalAuthenticationSettings? Settings = null) : BaseAuthenticationProvider(DefaultName, Tokens)
+		MsalAuthenticationSettings? Settings = null) : BaseAuthenticationProvider(ProviderLogger, DefaultName, Tokens)
 {
 	public const string DefaultName = "Msal";
 	private const string CacheFileName = "msal.cache";
@@ -44,7 +44,8 @@ internal record MsalAuthenticationProvider(
 		await SetupStorage();
 		return (await _pca!.GetAccountsAsync()).Count() > 0;
 	}
-	public async override ValueTask<IDictionary<string, string>?> LoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
+
+	protected async override ValueTask<IDictionary<string, string>?> InternalLoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
 	{
 		try
 		{
@@ -74,7 +75,7 @@ internal record MsalAuthenticationProvider(
 
 	}
 
-	public async override ValueTask<bool> LogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
+	protected async override ValueTask<bool> InternalLogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
 	{
 		if (dispatcher is null)
 		{
@@ -98,7 +99,8 @@ internal record MsalAuthenticationProvider(
 
 		return true;
 	}
-	public async override ValueTask<IDictionary<string, string>?> RefreshAsync(CancellationToken cancellationToken)
+
+	protected async override ValueTask<IDictionary<string, string>?> InternalRefreshAsync(CancellationToken cancellationToken)
 	{
 		await SetupStorage();
 		var result = await AcquireSilentTokenAsync();

--- a/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationProvider.cs
@@ -5,10 +5,10 @@ using System.Diagnostics;
 namespace Uno.Extensions.Authentication.Oidc;
 
 internal record OidcAuthenticationProvider(
-		ILogger<OidcAuthenticationProvider> Logger,
+		ILogger<OidcAuthenticationProvider> ProviderLogger,
 		IOptions<OidcClientOptions> Configuration,
 		ITokenCache Tokens,
-		OidcAuthenticationSettings? Settings = null) : BaseAuthenticationProvider(DefaultName, Tokens)
+		OidcAuthenticationSettings? Settings = null) : BaseAuthenticationProvider(ProviderLogger, DefaultName, Tokens)
 {
 	public const string DefaultName = "Oidc";
 
@@ -37,7 +37,7 @@ internal record OidcAuthenticationProvider(
 		return true;
 	}
 
-	public async override ValueTask<IDictionary<string, string>?> LoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
+	protected async override ValueTask<IDictionary<string, string>?> InternalLoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
 	{
 		if (_client is null)
 		{
@@ -62,7 +62,7 @@ internal record OidcAuthenticationProvider(
 		return default;
 	}
 
-	public async override ValueTask<bool> LogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
+	protected async override ValueTask<bool> InternalLogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
 	{
 		if (_client is null)
 		{
@@ -72,7 +72,8 @@ internal record OidcAuthenticationProvider(
 		var authenticationResult = await _client.LoginAsync();
 		return true;
 	}
-	public async override ValueTask<IDictionary<string, string>?> RefreshAsync(CancellationToken cancellationToken)
+
+	protected async override ValueTask<IDictionary<string, string>?> InternalRefreshAsync(CancellationToken cancellationToken)
 	{
 		var token = await Tokens.RefreshTokenAsync(cancellationToken);
 		if (_client is null || string.IsNullOrWhiteSpace(token))

--- a/src/Uno.Extensions.Authentication.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Authentication.UI/GlobalUsings.cs
@@ -5,11 +5,12 @@ global using System.IO;
 global using System.Linq;
 global using System.Threading;
 global using System.Threading.Tasks;
+global using System.Web;
 global using System.Xml;
 global using System.Xml.Linq;
 global using System.Xml.XPath;
 global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Hosting;
+global using Microsoft.Extensions.Logging;
 global using Uno.Extensions;
 global using Uno.Extensions.Authentication;
 global using Uno.Extensions.Authentication.Web;
@@ -17,9 +18,8 @@ global using Uno.Extensions.Hosting;
 global using Uno.Extensions.Navigation;
 global using Windows.Security.Authentication.Web;
 
-
 #if WINUI
-global using Microsoft.UI.Dispatching;
+	global using Microsoft.UI.Dispatching;
 	global using Microsoft.UI.Xaml;
 	global using Microsoft.UI.Xaml.Controls;
 	global using Microsoft.UI.Xaml.Controls.Primitives;
@@ -39,3 +39,4 @@ global using Windows.System;
 	global using Windows.UI.Xaml.Data;
 	global using Windows.UI.Xaml.Media;
 #endif
+

--- a/src/Uno.Extensions.Authentication/BaseAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication/BaseAuthenticationProvider.cs
@@ -1,22 +1,65 @@
-﻿namespace Uno.Extensions.Authentication;
+﻿
+namespace Uno.Extensions.Authentication;
 
-public abstract record BaseAuthenticationProvider(string Name, ITokenCache Tokens) : IAuthenticationProvider
+public abstract record BaseAuthenticationProvider(ILogger Logger, string Name, ITokenCache Tokens) : IAuthenticationProvider
 {
 	public async virtual ValueTask<bool> CanRefresh(CancellationToken cancellationToken) => true;
 
-	public virtual ValueTask<IDictionary<string, string>?> LoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
+	public ValueTask<IDictionary<string, string>?> LoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
+	{
+		try
+		{
+			return InternalLoginAsync(dispatcher, credentials, cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Error attempting to login [Error - {ex.Message}]");
+			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Login credentials {credentials?.ToString()}");
+			return default;
+		}
+	}
+
+	protected virtual ValueTask<IDictionary<string, string>?> InternalLoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
 	{
 		// Default behavior is to return null, which indicates unsuccessful login 
 		return default;
 	}
 
-	public virtual async ValueTask<bool> LogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
+	public ValueTask<bool> LogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
+	{
+		try
+		{
+			return InternalLogoutAsync(dispatcher, cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Error attempting to logout [Error - {ex.Message}]");
+			return new ValueTask<bool>(false);
+		}
+	}
+
+	protected virtual async ValueTask<bool> InternalLogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
 	{
 		// Default implementation is to return true, which will cause the token cache to be flushed
 		return true;
 	}
 
-	public virtual async ValueTask<IDictionary<string, string>?> RefreshAsync(CancellationToken cancellationToken)
+	public async ValueTask<IDictionary<string, string>?> RefreshAsync(CancellationToken cancellationToken)
+	{
+		var tokens = await Tokens.GetAsync(cancellationToken);
+		try
+		{
+			return await InternalRefreshAsync(cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Error attempting to refresh [Error - {ex.Message}]");
+			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Current tokens {tokens}");
+			return default;
+		}
+	}
+
+	protected virtual async ValueTask<IDictionary<string, string>?> InternalRefreshAsync(CancellationToken cancellationToken)
 	{
 		// Default implementation is to just return the existing tokens (ie success!)
 		return await Tokens.GetAsync();

--- a/src/Uno.Extensions.Authentication/GlobalUsings.cs
+++ b/src/Uno.Extensions.Authentication/GlobalUsings.cs
@@ -15,6 +15,7 @@ global using Uno.Extensions.Authentication.Handlers;
 global using Uno.Extensions.Configuration;
 global using Uno.Extensions.Hosting;
 global using Uno.Extensions.Navigation;
+global using Uno.Extensions.Logging;
 
 
 

--- a/src/Uno.Extensions.Http/CookieManager.cs
+++ b/src/Uno.Extensions.Http/CookieManager.cs
@@ -44,6 +44,21 @@ public record CookieManager(ILogger<CookieManager> Logger) : ICookieManager
 			try
 			{
 				native.CookieContainer = new CookieContainer();
+
+#if __IOS__
+				native.UseCookies = true;
+#elif __ANDROID__
+#if NET6_0_OR_GREATER
+				native.UseCookies = true;
+#else
+				native.UseCookies = true;
+#endif
+#elif WINDOWS || WINDOWS_UWP
+				native.CookieUsePolicy = CookieUsePolicy.UseSpecifiedCookieContainer;
+#else
+				native.UseCookies = true;
+#endif
+
 			}
 			catch
 			{


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

No logging around the authentication provider methods: login, refresh and logout

## What is the new behavior?

All providers have access to a Logger and the back provider logs information about requests for login, refresh and logout

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
