### PR TITLE
feat(feeds): Add ability to create a paginated ListState

### DIFF
--- a/src/Uno.Extensions.Reactive.Testing/FeedRecorder.cs
+++ b/src/Uno.Extensions.Reactive.Testing/FeedRecorder.cs
@@ -12,7 +12,7 @@ using Uno.Extensions.Reactive.Core;
 namespace Uno.Extensions.Reactive.Testing;
 
 public class FeedRecorder<TFeed, TValue> : IFeedRecorder<TValue>, ICollection<Message<TValue>>, IDisposable
-	where TFeed : IFeed<TValue>
+	where TFeed : ISignal<Message<TValue>>
 {
 	private event EventHandler? _messageAdded;
 

--- a/src/Uno.Extensions.Reactive.Testing/FeedRecorderExtensions.cs
+++ b/src/Uno.Extensions.Reactive.Testing/FeedRecorderExtensions.cs
@@ -18,17 +18,26 @@ public static class FeedRecorderExtensions
 		[CallerLineNumber] int line = -1)
 		=> new(_ => feed, context ?? SourceContext.Current, autoEnable, feedExpression ?? $"{memberName}@{line}");
 
-	public static FeedRecorder<IFeed<IImmutableList<T>>, IImmutableList<T>> Record<T>(
+	public static FeedRecorder<IListFeed<T>, IImmutableList<T>> Record<T>(
 		this IListFeed<T> feed,
 		SourceContext? context = null,
 		bool autoEnable = true,
 		[CallerArgumentExpression("feed")] string? feedExpression = null,
 		[CallerMemberName] string? memberName = null,
 		[CallerLineNumber] int line = -1)
-		=> new(_ => feed.AsFeed(), context ?? SourceContext.Current, autoEnable, feedExpression ?? $"{memberName}@{line}");
+		=> new(_ => feed, context ?? SourceContext.Current, autoEnable, feedExpression ?? $"{memberName}@{line}");
 
 	public static FeedRecorder<IState<T>, T> Record<T>(
 		this IState<T> state,
+		SourceContext? context = null,
+		bool autoEnable = true,
+		[CallerArgumentExpression("state")] string? feedExpression = null,
+		[CallerMemberName] string? memberName = null,
+		[CallerLineNumber] int line = -1)
+		=> new(_ => state, context ?? SourceContext.Current, autoEnable, feedExpression ?? $"{memberName}@{line}");
+
+	public static FeedRecorder<IListState<T>, IImmutableList<T>> Record<T>(
+		this IListState<T> state,
 		SourceContext? context = null,
 		bool autoEnable = true,
 		[CallerArgumentExpression("state")] string? feedExpression = null,

--- a/src/Uno.Extensions.Reactive.Tests/Core/Given_StateImpl.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Given_StateImpl.cs
@@ -18,7 +18,7 @@ public class Given_StateImpl : FeedTests
 	{
 		var (result, sut) = new StateImpl<string>(Context, Option<string>.None()).Record();
 
-		await sut.UpdateMessage(msg => msg.With().Data("42"), CT);
+		await sut.UpdateMessage(msg => msg.Data("42"), CT);
 
 		result.Should().Be(r => r
 			.Message(Data.None, Progress.Final, Error.No)
@@ -30,7 +30,7 @@ public class Given_StateImpl : FeedTests
 	{
 		var (result, sut) = new StateImpl<string>(Context, Option<string>.None()).Record();
 
-		await sut.UpdateValue(_ => "42", CT);
+		await sut.UpdateData(_ => "42", CT);
 
 		result.Should().Be(r => r
 			.Message(Data.None, Progress.Final, Error.No)
@@ -54,7 +54,7 @@ public class Given_StateImpl : FeedTests
 	{
 		var (result, sut) = new StateImpl<string>(Context, Option<string>.Some("0")).Record();
 
-		await sut.UpdateMessage(msg => msg.With().Data("42"), CT);
+		await sut.UpdateMessage(msg => msg.Data("42"), CT);
 
 		result.Should().Be(r => r
 			.Message("0", Progress.Final, Error.No)
@@ -66,7 +66,7 @@ public class Given_StateImpl : FeedTests
 	{
 		var (result, sut) = new StateImpl<string>(Context, Option<string>.Some("0")).Record();
 
-		await sut.UpdateValue(_ => "42", CT);
+		await sut.UpdateData(_ => "42", CT);
 
 		result.Should().Be(r => r
 			.Message("0", Progress.Final, Error.No)

--- a/src/Uno.Extensions.Reactive.Tests/Factories/Given_ListFeedFactories.Caching.Sources.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Factories/Given_ListFeedFactories.Caching.Sources.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Sources;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Factories;
+
+[TestClass]
+public partial class Given_ListFeedFactories : FeedTests
+{
+	[TestMethod]
+	public void When_Create_Then_Cached()
+	{
+		Func<CancellationToken, IAsyncEnumerable<Message<IImmutableList<object>>>> sourceProvider1 = ct => default!;
+		Func<CancellationToken, IAsyncEnumerable<Message<IImmutableList<object>>>> sourceProvider2 = ct => default!;
+
+		var inst1 = ListFeed<object>.Create(sourceProvider1);
+		var inst2 = ListFeed<object>.Create(sourceProvider2);
+		var inst1_prime = ListFeed<object>.Create(sourceProvider1);
+		var inst2_prime = ListFeed<object>.Create(sourceProvider2);
+
+		inst1_prime.Should().BeSameAs(inst1, "instance should have been cached using sourceProvider");
+		inst1_prime.Should().NotBeSameAs(inst2, "instance should have been cached as not the exact same sourceProvider");
+
+		inst2_prime.Should().NotBeSameAs(inst1, "instance should have been cached as not the exact same sourceProvider");
+		inst2_prime.Should().BeSameAs(inst2, "instance should have been cached using sourceProvider");
+	}
+
+	[TestMethod]
+	public void When_CreateWithoutCT_Then_Cached()
+	{
+		Func<IAsyncEnumerable<Message<IImmutableList<object>>>> sourceProvider1 = () => default!;
+		Func<IAsyncEnumerable<Message<IImmutableList<object>>>> sourceProvider2 = () => default!;
+
+		var inst1 = ListFeed<object>.Create(sourceProvider1);
+		var inst2 = ListFeed<object>.Create(sourceProvider2);
+		var inst1_prime = ListFeed<object>.Create(sourceProvider1);
+		var inst2_prime = ListFeed<object>.Create(sourceProvider2);
+
+		inst1_prime.Should().BeSameAs(inst1, "instance should have been cached using sourceProvider");
+		inst1_prime.Should().NotBeSameAs(inst2, "instance should have been cached as not the exact same sourceProvider");
+
+		inst2_prime.Should().NotBeSameAs(inst1, "instance should have been cached as not the exact same sourceProvider");
+		inst2_prime.Should().BeSameAs(inst2, "instance should have been cached using sourceProvider");
+	}
+
+	[TestMethod]
+	public void When_AsyncOption_Then_Cached()
+	{
+		AsyncFunc<Option<IImmutableList<object>>> valueProvider1 = async ct => default!;
+		AsyncFunc<Option<IImmutableList<object>>> valueProvider2 = async ct => default!;
+
+		var inst1 = ListFeed<object>.Async(valueProvider1);
+		var inst2 = ListFeed<object>.Async(valueProvider2);
+		var inst1_prime = ListFeed<object>.Async(valueProvider1);
+		var inst2_prime = ListFeed<object>.Async(valueProvider2);
+
+		inst1_prime.Should().BeSameAs(inst1, "instance should have been cached using valueProvider");
+		inst1_prime.Should().NotBeSameAs(inst2, "instance should have been cached as not the exact same valueProvider");
+
+		inst2_prime.Should().NotBeSameAs(inst1, "instance should have been cached as not the exact same valueProvider");
+		inst2_prime.Should().BeSameAs(inst2, "instance should have been cached using valueProvider");
+	}
+
+	[TestMethod]
+	public void When_Async_Then_Cached()
+	{
+		AsyncFunc<IImmutableList<object>> valueProvider1 = async ct => ImmutableList<object>.Empty;
+		AsyncFunc<IImmutableList<object>> valueProvider2 = async ct => ImmutableList<object>.Empty;
+
+		var inst1 = ListFeed<object>.Async(valueProvider1);
+		var inst2 = ListFeed<object>.Async(valueProvider2);
+		var inst1_prime = ListFeed<object>.Async(valueProvider1);
+		var inst2_prime = ListFeed<object>.Async(valueProvider2);
+
+		inst1_prime.Should().BeSameAs(inst1, "instance should have been cached using valueProvider");
+		inst1_prime.Should().NotBeSameAs(inst2, "instance should have been cached as not the exact same valueProvider");
+
+		inst2_prime.Should().NotBeSameAs(inst1, "instance should have been cached as not the exact same valueProvider");
+		inst2_prime.Should().BeSameAs(inst2, "instance should have been cached using valueProvider");
+	}
+
+	[TestMethod]
+	public void When_AsyncOptionWithSignal_Then_Cached()
+	{
+		AsyncFunc<Option<IImmutableList<object>>> valueProvider1 = async ct => default!;
+		AsyncFunc<Option<IImmutableList<object>>> valueProvider2 = async ct => default!;
+		var signal1 = new Signal();
+		var signal2 = new Signal();
+
+		var inst1_1 = ListFeed<object>.Async(valueProvider1, signal1);
+		var inst1_2 = ListFeed<object>.Async(valueProvider1, signal2);
+		var inst2_1 = ListFeed<object>.Async(valueProvider2, signal1);
+		var inst2_2 = ListFeed<object>.Async(valueProvider2, signal2);
+		var inst1_1_prime = ListFeed<object>.Async(valueProvider1, signal1);
+		var inst1_2_prime = ListFeed<object>.Async(valueProvider1, signal2);
+		var inst2_1_prime = ListFeed<object>.Async(valueProvider2, signal1);
+		var inst2_2_prime = ListFeed<object>.Async(valueProvider2, signal2);
+
+		inst1_1_prime.Should().BeSameAs(inst1_1, "instance should have been cached using valueProvider and signal");
+		inst1_1_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst1_1_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst1_1_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+
+		inst1_2_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst1_2_prime.Should().BeSameAs(inst1_2, "instance should have been cached using valueProvider and signal");
+		inst1_2_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst1_2_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+
+		inst2_1_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst2_1_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst2_1_prime.Should().BeSameAs(inst2_1, "instance should have been cached using valueProvider and signal");
+		inst2_1_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+
+		inst2_2_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst2_2_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst2_2_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst2_2_prime.Should().BeSameAs(inst2_2, "instance should have been cached using valueProvider and signal");
+	}
+
+	[TestMethod]
+	public void When_AsyncWithSignal_Then_Cached()
+	{
+		AsyncFunc<IImmutableList<object>> valueProvider1 = async ct => default!;
+		AsyncFunc<IImmutableList<object>> valueProvider2 = async ct => default!;
+		var signal1 = new Signal();
+		var signal2 = new Signal();
+
+		var inst1_1 = ListFeed<object>.Async(valueProvider1, signal1);
+		var inst1_2 = ListFeed<object>.Async(valueProvider1, signal2);
+		var inst2_1 = ListFeed<object>.Async(valueProvider2, signal1);
+		var inst2_2 = ListFeed<object>.Async(valueProvider2, signal2);
+		var inst1_1_prime = ListFeed<object>.Async(valueProvider1, signal1);
+		var inst1_2_prime = ListFeed<object>.Async(valueProvider1, signal2);
+		var inst2_1_prime = ListFeed<object>.Async(valueProvider2, signal1);
+		var inst2_2_prime = ListFeed<object>.Async(valueProvider2, signal2);
+
+		inst1_1_prime.Should().BeSameAs(inst1_1, "instance should have been cached using valueProvider and signal");
+		inst1_1_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst1_1_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst1_1_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+
+		inst1_2_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst1_2_prime.Should().BeSameAs(inst1_2, "instance should have been cached using valueProvider and signal");
+		inst1_2_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst1_2_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+
+		inst2_1_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst2_1_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst2_1_prime.Should().BeSameAs(inst2_1, "instance should have been cached using valueProvider and signal");
+		inst2_1_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+
+		inst2_2_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst2_2_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst2_2_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of valueProvider and signal");
+		inst2_2_prime.Should().BeSameAs(inst2_2, "instance should have been cached using valueProvider and signal");
+	}
+
+	[TestMethod]
+	public void When_AsyncEnumerableOptions_Then_Cached()
+	{
+		Func<IAsyncEnumerable<Option<IImmutableList<object>>>> enumerableProvider1 = () => default!;
+		Func<IAsyncEnumerable<Option<IImmutableList<object>>>> enumerableProvider2 = () => default!;
+
+		var inst1 = ListFeed<object>.AsyncEnumerable(enumerableProvider1);
+		var inst2 = ListFeed<object>.AsyncEnumerable(enumerableProvider2);
+		var inst1_prime = ListFeed<object>.AsyncEnumerable(enumerableProvider1);
+		var inst2_prime = ListFeed<object>.AsyncEnumerable(enumerableProvider2);
+
+		inst1_prime.Should().BeSameAs(inst1, "instance should have been cached using enumerableProvider");
+		inst1_prime.Should().NotBeSameAs(inst2, "instance should have been cached as not the exact same enumerableProvider");
+
+		inst2_prime.Should().NotBeSameAs(inst1, "instance should have been cached as not the exact same enumerableProvider");
+		inst2_prime.Should().BeSameAs(inst2, "instance should have been cached using enumerableProvider");
+	}
+
+	[TestMethod]
+	public void When_AsyncEnumerable_Then_Cached()
+	{
+		Func<IAsyncEnumerable<IImmutableList<object>>> enumerableProvider1 = () => default!;
+		Func<IAsyncEnumerable<IImmutableList<object>>> enumerableProvider2 = () => default!;
+
+		var inst1 = ListFeed<object>.AsyncEnumerable(enumerableProvider1);
+		var inst2 = ListFeed<object>.AsyncEnumerable(enumerableProvider2);
+		var inst1_prime = ListFeed<object>.AsyncEnumerable(enumerableProvider1);
+		var inst2_prime = ListFeed<object>.AsyncEnumerable(enumerableProvider2);
+
+		inst1_prime.Should().BeSameAs(inst1, "instance should have been cached using enumerableProvider");
+		inst1_prime.Should().NotBeSameAs(inst2, "instance should have been cached as not the exact same enumerableProvider");
+
+		inst2_prime.Should().NotBeSameAs(inst1, "instance should have been cached as not the exact same enumerableProvider");
+		inst2_prime.Should().BeSameAs(inst2, "instance should have been cached using enumerableProvider");
+	}
+
+	[TestMethod]
+	public void When_AsyncPaginatedByCursor_Then_Cached()
+	{
+		object firstPage1 = new();
+		object firstPage2 = new();
+		GetPage<object, object> getPage1 = async (_, __, ct) => default!;
+		GetPage<object, object> getPage2 = async (_, __, ct) => default!;
+
+		var inst1_1 = ListFeed<object>.AsyncPaginatedByCursor(firstPage1, getPage1);
+		var inst1_2 = ListFeed<object>.AsyncPaginatedByCursor(firstPage1, getPage2);
+		var inst2_1 = ListFeed<object>.AsyncPaginatedByCursor(firstPage2, getPage1);
+		var inst2_2 = ListFeed<object>.AsyncPaginatedByCursor(firstPage2, getPage2);
+		var inst1_1_prime = ListFeed<object>.AsyncPaginatedByCursor(firstPage1, getPage1);
+		var inst1_2_prime = ListFeed<object>.AsyncPaginatedByCursor(firstPage1, getPage2);
+		var inst2_1_prime = ListFeed<object>.AsyncPaginatedByCursor(firstPage2, getPage1);
+		var inst2_2_prime = ListFeed<object>.AsyncPaginatedByCursor(firstPage2, getPage2);
+
+		inst1_1_prime.Should().BeSameAs(inst1_1, "instance should have been cached using firstPage and getPage");
+		inst1_1_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+		inst1_1_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+		inst1_1_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+
+		inst1_2_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+		inst1_2_prime.Should().BeSameAs(inst1_2, "instance should have been cached using firstPage and getPage");
+		inst1_2_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+		inst1_2_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+
+		inst2_1_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+		inst2_1_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+		inst2_1_prime.Should().BeSameAs(inst2_1, "instance should have been cached using firstPage and getPage");
+		inst2_1_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+
+		inst2_2_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+		inst2_2_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+		inst2_2_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+		inst2_2_prime.Should().BeSameAs(inst2_2, "instance should have been cached using firstPage and getPage");
+	}
+
+	[TestMethod]
+	public void When_AsyncPaginated_Then_Cached()
+	{
+		AsyncFunc<PageRequest, IImmutableList<object>> getPage1 = async (_, ct) => default!;
+		AsyncFunc<PageRequest, IImmutableList<object>> getPage2 = async (_, ct) => default!;
+
+		var inst1 = ListFeed<object>.AsyncPaginated(getPage1);
+		var inst2 = ListFeed<object>.AsyncPaginated(getPage2);
+		var inst1_prime = ListFeed<object>.AsyncPaginated(getPage1);
+		var inst2_prime = ListFeed<object>.AsyncPaginated(getPage2);
+
+		inst1_prime.Should().BeSameAs(inst1, "instance should have been cached using getPage");
+		inst1_prime.Should().NotBeSameAs(inst2, "instance should have been cached as not the exact same getPage");
+
+		inst2_prime.Should().NotBeSameAs(inst1, "instance should have been cached as not the exact same getPage");
+		inst2_prime.Should().BeSameAs(inst2, "instance should have been cached using getPage");
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Factories/Given_StateFeedFactories.Caching.Sources.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Factories/Given_StateFeedFactories.Caching.Sources.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Sources;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Factories;
+
+[TestClass]
+public partial class Given_ListStateFactories : FeedTests
+{
+	[TestMethod]
+	public void When_Create_Then_Cached()
+	{
+		object owner1 = new();
+		object owner2 = new();
+		Func<CancellationToken, IAsyncEnumerable<Message<IImmutableList<object>>>> sourceProvider1 = ct => default!;
+		Func<CancellationToken, IAsyncEnumerable<Message<IImmutableList<object>>>> sourceProvider2 = ct => default!;
+
+		var sut = ListState<object>.Create(owner1, sourceProvider1);
+
+		var inst1_1 = ListState<object>.Create(owner1, sourceProvider1);
+		var inst1_2 = ListState<object>.Create(owner1, sourceProvider2);
+		var inst2_1 = ListState<object>.Create(owner2, sourceProvider1);
+
+		inst1_1.Should().BeSameAs(sut, "instance should have been cached on owner using sourceProvider");
+		inst1_2.Should().NotBeSameAs(sut, "instance should not have been cached as not the same sourceProvider");
+		inst2_1.Should().NotBeSameAs(sut, "instance should not have been cached as not the same owner");
+	}
+
+	[TestMethod]
+	public void When_CreateWithoutCT_Then_Cached()
+	{
+		object owner1 = new();
+		object owner2 = new();
+		Func<IAsyncEnumerable<Message<IImmutableList<object>>>> sourceProvider1 = () => default!;
+		Func<IAsyncEnumerable<Message<IImmutableList<object>>>> sourceProvider2 = () => default!;
+
+		var sut = ListState<object>.Create(owner1, sourceProvider1);
+
+		var inst1_1 = ListState<object>.Create(owner1, sourceProvider1);
+		var inst1_2 = ListState<object>.Create(owner1, sourceProvider2);
+		var inst2_1 = ListState<object>.Create(owner2, sourceProvider1);
+
+		inst1_1.Should().BeSameAs(sut, "instance should have been cached on owner using sourceProvider");
+		inst1_2.Should().NotBeSameAs(sut, "instance should not have been cached as not the same sourceProvider");
+		inst2_1.Should().NotBeSameAs(sut, "instance should not have been cached as not the same owner");
+	}
+
+	[TestMethod]
+	public void When_AsyncOption_Then_Cached()
+	{
+		object owner1 = new();
+		object owner2 = new();
+		AsyncFunc<Option<IImmutableList<object>>> valueProvider1 = async ct => default!;
+		AsyncFunc<Option<IImmutableList<object>>> valueProvider2 = async ct => default!;
+
+		var sut = ListState<object>.Async(owner1, valueProvider1);
+
+		var inst1_1 = ListState<object>.Async(owner1, valueProvider1);
+		var inst1_2 = ListState<object>.Async(owner1, valueProvider2);
+		var inst2_1 = ListState<object>.Async(owner2, valueProvider1);
+
+		inst1_1.Should().BeSameAs(sut, "instance should have been cached on owner using valueProvider");
+		inst1_2.Should().NotBeSameAs(sut, "instance should not have been cached as not the same valueProvider");
+		inst2_1.Should().NotBeSameAs(sut, "instance should not have been cached as not the same owner");
+	}
+
+	[TestMethod]
+	public void When_Async_Then_Cached()
+	{
+		object owner1 = new();
+		object owner2 = new();
+		AsyncFunc<IImmutableList<object>> valueProvider1 = async ct => ImmutableList<object>.Empty;
+		AsyncFunc<IImmutableList<object>> valueProvider2 = async ct => ImmutableList<object>.Empty;
+
+		var sut = ListState<object>.Async(owner1, valueProvider1);
+
+		var inst1_1 = ListState<object>.Async(owner1, valueProvider1);
+		var inst1_2 = ListState<object>.Async(owner1, valueProvider2);
+		var inst2_1 = ListState<object>.Async(owner2, valueProvider1);
+
+		inst1_1.Should().BeSameAs(sut, "instance should have been cached on owner using valueProvider");
+		inst1_2.Should().NotBeSameAs(sut, "instance should not have been cached as not the same valueProvider");
+		inst2_1.Should().NotBeSameAs(sut, "instance should not have been cached as not the same owner");
+	}
+
+	[TestMethod]
+	public void When_AsyncOptionWithSignal_Then_Cached()
+	{
+		object owner1 = new();
+		object owner2 = new();
+		AsyncFunc<Option<IImmutableList<object>>> valueProvider1 = async ct => default!;
+		AsyncFunc<Option<IImmutableList<object>>> valueProvider2 = async ct => default!;
+		var signal1 = new Signal();
+		var signal2 = new Signal();
+
+		var sut = ListState<object>.Async(owner1, valueProvider1, signal1);
+
+		var inst1_1_1 = ListState<object>.Async(owner1, valueProvider1, signal1);
+		var inst1_1_2 = ListState<object>.Async(owner1, valueProvider1, signal2);
+		var inst1_2_1 = ListState<object>.Async(owner1, valueProvider2, signal1);
+		var inst2_1_1 = ListState<object>.Async(owner2, valueProvider1, signal1);
+
+		inst1_1_1.Should().BeSameAs(sut, "instance should have been cached on owner using valueProvider and signal");
+		inst1_1_2.Should().NotBeSameAs(sut, "instance should not have been cached as not the same signal");
+		inst1_2_1.Should().NotBeSameAs(sut, "instance should not have been cached as not the same valueProvider");
+		inst2_1_1.Should().NotBeSameAs(sut, "instance should not have been cached as not the same owner");
+	}
+
+	[TestMethod]
+	public void When_AsyncWithSignal_Then_Cached()
+	{
+		object owner1 = new();
+		object owner2 = new();
+		AsyncFunc<IImmutableList<object>> valueProvider1 = async ct => default!;
+		AsyncFunc<IImmutableList<object>> valueProvider2 = async ct => default!;
+		var signal1 = new Signal();
+		var signal2 = new Signal();
+
+		var sut = ListState<object>.Async(owner1, valueProvider1, signal1);
+
+		var inst1_1_1 = ListState<object>.Async(owner1, valueProvider1, signal1);
+		var inst1_1_2 = ListState<object>.Async(owner1, valueProvider1, signal2);
+		var inst1_2_1 = ListState<object>.Async(owner1, valueProvider2, signal1);
+		var inst2_1_1 = ListState<object>.Async(owner2, valueProvider1, signal1);
+
+		inst1_1_1.Should().BeSameAs(sut, "instance should have been cached on owner using valueProvider and signal");
+		inst1_1_2.Should().NotBeSameAs(sut, "instance should not have been cached as not the same signal");
+		inst1_2_1.Should().NotBeSameAs(sut, "instance should not have been cached as not the same valueProvider");
+		inst2_1_1.Should().NotBeSameAs(sut, "instance should not have been cached as not the same owner");
+	}
+
+	[TestMethod]
+	public void When_AsyncEnumerableOptions_Then_Cached()
+	{
+		object owner1 = new();
+		object owner2 = new();
+		Func<IAsyncEnumerable<Option<IImmutableList<object>>>> enumerableProvider1 = () => default!;
+		Func<IAsyncEnumerable<Option<IImmutableList<object>>>> enumerableProvider2 = () => default!;
+
+		var sut = ListState<object>.AsyncEnumerable(owner1, enumerableProvider1);
+
+		var inst1_1 = ListState<object>.AsyncEnumerable(owner1, enumerableProvider1);
+		var inst1_2 = ListState<object>.AsyncEnumerable(owner1, enumerableProvider2);
+		var inst2_1 = ListState<object>.AsyncEnumerable(owner2, enumerableProvider1);
+
+		inst1_1.Should().BeSameAs(sut, "instance should have been cached on owner using enumerableProvider");
+		inst1_2.Should().NotBeSameAs(sut, "instance should not have been cached as not the same enumerableProvider");
+		inst2_1.Should().NotBeSameAs(sut, "instance should not have been cached as not the same owner");
+	}
+
+	[TestMethod]
+	public void When_AsyncEnumerable_Then_Cached()
+	{
+		object owner1 = new();
+		object owner2 = new();
+		Func<IAsyncEnumerable<IImmutableList<object>>> enumerableProvider1 = () => default!;
+		Func<IAsyncEnumerable<IImmutableList<object>>> enumerableProvider2 = () => default!;
+
+		var sut = ListState<object>.AsyncEnumerable(owner1, enumerableProvider1);
+
+		var inst1_1 = ListState<object>.AsyncEnumerable(owner1, enumerableProvider1);
+		var inst1_2 = ListState<object>.AsyncEnumerable(owner1, enumerableProvider2);
+		var inst2_1 = ListState<object>.AsyncEnumerable(owner2, enumerableProvider1);
+
+		inst1_1.Should().BeSameAs(sut, "instance should have been cached on owner using enumerableProvider");
+		inst1_2.Should().NotBeSameAs(sut, "instance should not have been cached as not the same enumerableProvider");
+		inst2_1.Should().NotBeSameAs(sut, "instance should not have been cached as not the same owner");
+	}
+
+	//[TestMethod]
+	//public void When_AsyncPaginatedByCursor_Then_Cached()
+	//{
+	//	object owner1 = new();
+	//	object owner2 = new();
+	//	object firstPage1 = new();
+	//	object firstPage2 = new();
+	//	GetPage<object, object> getPage1 = async (_, __, ct) => default!;
+	//	GetPage<object, object> getPage2 = async (_, __, ct) => default!;
+
+	//	var inst1_1 = ListState<object>.AsyncPaginatedByCursor(owner1, firstPage1, getPage1);
+	//	var inst1_2 = ListState<object>.AsyncPaginatedByCursor(owner1, firstPage1, getPage2);
+	//	var inst2_1 = ListState<object>.AsyncPaginatedByCursor(owner1, firstPage2, getPage1);
+	//	var inst2_2 = ListState<object>.AsyncPaginatedByCursor(owner1, firstPage2, getPage2);
+	//	var inst1_1_prime = ListState<object>.AsyncPaginatedByCursor(owner1, firstPage1, getPage1);
+	//	var inst1_2_prime = ListState<object>.AsyncPaginatedByCursor(owner1, firstPage1, getPage2);
+	//	var inst2_1_prime = ListState<object>.AsyncPaginatedByCursor(owner1, firstPage2, getPage1);
+	//	var inst2_2_prime = ListState<object>.AsyncPaginatedByCursor(owner1, firstPage2, getPage2);
+
+	//	inst1_1_prime.Should().BeSameAs(inst1_1, "instance should have been cached using firstPage and getPage");
+	//	inst1_1_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+	//	inst1_1_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+	//	inst1_1_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+
+	//	inst1_2_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+	//	inst1_2_prime.Should().BeSameAs(inst1_2, "instance should have been cached using firstPage and getPage");
+	//	inst1_2_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+	//	inst1_2_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+
+	//	inst2_1_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+	//	inst2_1_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+	//	inst2_1_prime.Should().BeSameAs(inst2_1, "instance should have been cached using firstPage and getPage");
+	//	inst2_1_prime.Should().NotBeSameAs(inst2_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+
+	//	inst2_2_prime.Should().NotBeSameAs(inst1_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+	//	inst2_2_prime.Should().NotBeSameAs(inst1_2, "instance should have been cached as not the exact same combination of firstPage and getPage");
+	//	inst2_2_prime.Should().NotBeSameAs(inst2_1, "instance should have been cached as not the exact same combination of firstPage and getPage");
+	//	inst2_2_prime.Should().BeSameAs(inst2_2, "instance should have been cached using firstPage and getPage");
+	//}
+
+	[TestMethod]
+	public void When_AsyncPaginated_Then_Cached()
+	{
+		object owner1 = new();
+		object owner2 = new();
+		AsyncFunc<PageRequest, IImmutableList<object>> getPage1 = async (_, ct) => default!;
+		AsyncFunc<PageRequest, IImmutableList<object>> getPage2 = async (_, ct) => default!;
+
+		var sut = ListState<object>.AsyncPaginated(owner1, getPage1);
+
+		var inst1_1 = ListState<object>.AsyncPaginated(owner1, getPage1);
+		var inst1_2 = ListState<object>.AsyncPaginated(owner1, getPage2);
+		var inst2_1 = ListState<object>.AsyncPaginated(owner2, getPage1);
+
+		inst1_1.Should().BeSameAs(sut, "instance should have been cached on owner using getPage");
+		inst1_2.Should().NotBeSameAs(sut, "instance should not have been cached as not the same getPage");
+		inst2_1.Should().NotBeSameAs(sut, "instance should not have been cached as not the same owner");
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Factories/Given_StateFeedFactories.Integration.Sources.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Factories/Given_StateFeedFactories.Integration.Sources.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Testing;
+using static System.Linq.Enumerable;
+
+namespace Uno.Extensions.Reactive.Tests.Factories;
+
+public partial class Given_ListStateFactories
+{
+	[TestMethod]
+	public async Task When_UpdateToEmptyList_Then_GoesToNone()
+	{
+		var (result, sut) = ListState<int>.Async(this, async ct => Range(0, 20).ToImmutableList() as IImmutableList<int>).Record();
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data, Items.Reset(Range(0, 20)))
+				.Current(Items.Range(20), Error.No, Progress.Final))
+		);
+
+		await sut.Update(_ => ImmutableList<int>.Empty, CT);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data, Items.Reset(Range(0, 20)))
+				.Current(Items.Range(20), Error.No, Progress.Final))
+			.Message(m => m
+				.Changed(Changed.Data, Items.Reset(Range(0, 20), Empty<int>()))
+				.Current(Data.None, Error.No, Progress.Final))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_AsyncPaginated_Then_CurrentCountReflectsUpdates()
+	{
+		var sut = ListState<int>.AsyncPaginated(this, async (req, ct) => Range((int)req.CurrentCount, (int)(req.DesiredSize ?? 2)).ToImmutableList());
+		var requests = new RequestSource();
+		var ctx = Context.SourceContext.CreateChild(requests);
+
+		var result = sut.Record(ctx);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Reset(Range(0, 2)))
+				.Current(Items.Range(2), Error.No, Progress.Final, Pagination.HasMore))
+		);
+
+		await sut.InsertAsync(42, CT);
+		requests.RequestMoreItems(3);
+
+		result.Should().Be(b => b
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Reset(Range(0, 2)))
+				.Current(Items.Range(2), Error.No, Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Data, Items.Add(at: 0, items: 42))
+				.Current(Items.Some(42, 0, 1), Error.No, Progress.Final, Pagination.HasMore))
+			.Message(m => m
+				.Changed(Changed.Data & Changed.Pagination, Items.Add(at: 3, items: Range(3, 3)))
+				.Current(Items.Some(42, 0, 1, 3, 4, 5), Error.No, Progress.Final, Pagination.HasMore))
+		);
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_CombineFeed.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_CombineFeed.cs
@@ -19,8 +19,8 @@ namespace Uno.Extensions.Reactive.Tests.Operators
 
 			var sut = Feed.Combine(feed1, feed2).Record();
 
-			await feed1.UpdateMessage(msg => msg.With().Data(42), CT);
-			await feed2.UpdateMessage(msg => msg.With().Data(43), CT);
+			await feed1.UpdateMessage(msg => msg.Data(42), CT);
+			await feed2.UpdateMessage(msg => msg.Data(43), CT);
 
 			sut.Should().Be(r => r
 				.Message(Changed.None, Data.Undefined, Error.No, Progress.Final)

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
@@ -70,11 +70,11 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 	}
 
 	/// <inheritdoc />
-	ValueTask IListState<T>.UpdateMessage(Func<Message<IImmutableList<T>>, MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
+	ValueTask IListState<T>.UpdateMessage(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
 		=> _state.UpdateMessage(updater, ct);
 
 	/// <inheritdoc />
-	ValueTask IState<IImmutableList<T>>.UpdateMessage(Func<Message<IImmutableList<T>>, MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
+	ValueTask IState<IImmutableList<T>>.UpdateMessage(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
 		=> _state.UpdateMessage(updater, ct);
 
 

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableViewModelBase.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableViewModelBase.cs
@@ -168,12 +168,12 @@ public abstract partial class BindableViewModelBase : IBindable, INotifyProperty
 				.Run(async () => await stateImpl.UpdateMessage(DoUpdate, ct).ConfigureAwait(false), ct)
 				.ConfigureAwait(false);
 
-			MessageBuilder<TProperty> DoUpdate(Message<TProperty> msg)
+			void DoUpdate(MessageBuilder<TProperty> msg)
 			{
-				var current = msg.Current.Data.SomeOrDefault(GetDefaultValueForBindings<TProperty>());
+				var current = msg.CurrentData.SomeOrDefault(GetDefaultValueForBindings<TProperty>());
 				var updated = updater(current);
 
-				return msg.With().Data(Option.Some(updated)).Set(BindingSource, (this, propertyName));
+				msg.Data(Option.Some(updated)).Set(BindingSource, (this, propertyName));
 			}
 		}
 	}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Input.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Input.cs
@@ -24,8 +24,14 @@ internal sealed class Input<T> : IInput<T>
 		=> _state.GetSource(context, ct);
 
 	/// <inheritdoc />
-	public ValueTask UpdateMessage(Func<Message<T>, MessageBuilder<T>> updater, CancellationToken ct)
-		=> _state.UpdateMessage(msg => updater(msg).Set(BindableViewModelBase.BindingSource, this), ct);
+	public ValueTask UpdateMessage(Action<MessageBuilder<T>> updater, CancellationToken ct)
+		=> _state.UpdateMessage(
+			msg =>
+			{
+				updater(msg);
+				msg.Set(BindableViewModelBase.BindingSource, this);
+			},
+			ct);
 
 	/// <inheritdoc />
 	public ValueTask DisposeAsync()

--- a/src/Uno.Extensions.Reactive/Core/IListState.cs
+++ b/src/Uno.Extensions.Reactive/Core/IListState.cs
@@ -21,5 +21,5 @@ public interface IListState<T> : IListFeed<T>, IAsyncDisposable
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
 	/// <remarks>This is the raw way to update a state, you should consider using the <see cref="ListState.Update{T}"/> method instead.</remarks>
-	ValueTask UpdateMessage(Func<Message<IImmutableList<T>>, MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct);
+	ValueTask UpdateMessage(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct);
 }

--- a/src/Uno.Extensions.Reactive/Core/IState.cs
+++ b/src/Uno.Extensions.Reactive/Core/IState.cs
@@ -21,5 +21,5 @@ public interface IState<T> : IFeed<T>, IAsyncDisposable
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
 	/// <remarks>This is the raw way to update a state, you should consider using the <see cref="State.Update{T}"/> method instead.</remarks>
-	ValueTask UpdateMessage(Func<Message<T>, MessageBuilder<T>> updater, CancellationToken ct);
+	ValueTask UpdateMessage(Action<MessageBuilder<T>> updater, CancellationToken ct);
 }

--- a/src/Uno.Extensions.Reactive/Core/Internal/ByIndexCursor.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/ByIndexCursor.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Uno.Extensions.Reactive.Sources;
+
+namespace Uno.Extensions.Reactive.Core;
+
+internal record ByIndexCursor<T>(uint Index, uint TotalCount)
+{
+	public static ByIndexCursor<T> First { get; } = new(0, 0);
+
+	public static GetPage<ByIndexCursor<T>, T> GetPage(AsyncFunc<Reactive.PageRequest, IImmutableList<T>> getPage) => async (cursor, desiredCount, ct) =>
+	{
+		var request = new Reactive.PageRequest
+		{
+			Index = cursor.Index,
+			CurrentCount = cursor.TotalCount,
+			DesiredSize = desiredCount
+		};
+
+		if (await getPage(request, ct) is { Count: > 0 } items)
+		{
+			var nextCursor = cursor with { Index = cursor.Index + 1, TotalCount = cursor.TotalCount + (uint)items.Count };
+
+			return new PageResult<ByIndexCursor<T>, T>(items, nextCursor);
+		}
+		else
+		{
+			return PageResult<ByIndexCursor<T>, T>.Empty;
+		}
+	};
+}

--- a/src/Uno.Extensions.Reactive/Core/Internal/IStateStore.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/IStateStore.cs
@@ -25,8 +25,11 @@ internal interface IStateStore : IAsyncDisposable
 	/// Create a <see cref="IState{T}"/> for a given value.
 	/// </summary>
 	/// <typeparam name="T">Type of the value of items.</typeparam>
-	/// <param name="initialValue">The initial value of the state</param>
-	/// <returns>The list state wrapping the given list feed</returns>
+	/// <typeparam name="TState">The requested type of state.</typeparam>
+	/// <param name="initialValue">The initial value of the state.</param>
+	/// <param name="factory">Factory to build the state.</param>
+	/// <returns>A new state initialized with given initial value</returns>
 	/// <exception cref="ObjectDisposedException">This store has been disposed.</exception>
-	IState<T> CreateState<T>(Option<T> initialValue);
+	TState CreateState<T, TState>(Option<T> initialValue, Func<SourceContext, Option<T>, TState> factory)
+		where TState : IStateImpl, IAsyncDisposable;
 }

--- a/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.CurrentMessage.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/MessageManager.CurrentMessage.cs
@@ -18,6 +18,9 @@ internal partial class MessageManager<TParent, TResult>
 
 		public Message<TResult> Local => _owner.Current;
 
+		internal MessageBuilder<TParent, TResult> WithParentOnly(Message<TParent>? updatedParent)
+			=> new(updatedParent ?? Parent, _owner._local.result);
+
 		public MessageBuilder<TParent, TResult> With() 
 			=> new(Parent, (_owner._local.defined, _owner._local.result));
 

--- a/src/Uno.Extensions.Reactive/Core/Internal/SourceContext.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/SourceContext.cs
@@ -297,7 +297,7 @@ public sealed class SourceContext : IAsyncDisposable
 	/// <exception cref="ObjectDisposedException">This context has been disposed.</exception>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
 	public IState<T> CreateState<T>(Option<T> initialValue)
-		=> States.CreateState(initialValue);
+		=> CreateStateCore(initialValue);
 
 	/// <summary>
 	/// Create a <see cref="IState{T}"/> for a given value.
@@ -308,7 +308,10 @@ public sealed class SourceContext : IAsyncDisposable
 	/// <exception cref="ObjectDisposedException">This context has been disposed.</exception>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
 	public IListState<T> CreateListState<T>(Option<IImmutableList<T>> initialValue)
-		=> new ListStateImpl<T>(CreateState(initialValue));
+		=> new ListStateImpl<T>(CreateStateCore(initialValue));
+
+	private StateImpl<T> CreateStateCore<T>(Option<T> initialValue)
+		=> States.CreateState(initialValue, (ctx, iv) => new StateImpl<T>(ctx, iv));
 	#endregion
 
 	#region Requests

--- a/src/Uno.Extensions.Reactive/Core/Internal/SourceContext.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/SourceContext.cs
@@ -288,6 +288,11 @@ public sealed class SourceContext : IAsyncDisposable
 	private StateImpl<T> GetOrCreateStateCore<T>(IFeed<T> feed)
 		=> States.GetOrCreateState(feed, (ctx, f) => new StateImpl<T>(ctx, f));
 
+	// WARNING: DO NOT USE, this breaks the cache by providing a custom config!
+	// We need to make those config "upgradable" in order to properly share the instances of State
+	internal ListStateImpl<T> DoNotUse_GetOrCreateListState<T>(IListFeed<T> feed, StateUpdateKind updatesKind)
+		=> new ListStateImpl<T>(States.GetOrCreateState(feed, (ctx, f) => new StateImpl<IImmutableList<T>>(ctx, f.AsFeed(), updatesKind: updatesKind)));
+
 	/// <summary>
 	/// Create a <see cref="IState{T}"/> for a given value.
 	/// </summary>

--- a/src/Uno.Extensions.Reactive/Core/Internal/StateStore.None.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/StateStore.None.cs
@@ -13,7 +13,8 @@ internal class NoneStateStore : IStateStore
 		=> throw new InvalidOperationException("Cannot create a state on SourceContext.None. " + SourceContext.NoneContextErrorDesc);
 
 	/// <inheritdoc />
-	public IState<T> CreateState<T>(Option<T> initialValue)
+	public TState CreateState<T, TState>(Option<T> initialValue, Func<SourceContext, Option<T>, TState> factory)
+		where TState : IStateImpl, IAsyncDisposable
 		=> throw new InvalidOperationException("Cannot create a state on SourceContext.None. " + SourceContext.NoneContextErrorDesc);
 
 	/// <inheritdoc />

--- a/src/Uno.Extensions.Reactive/Core/Internal/StateUpdateKind.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/StateUpdateKind.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive.Core;
+
+internal enum StateUpdateKind
+{
+	/// <summary>
+	/// The updates made on State are flushed as soon as the source feed produces a new value
+	/// </summary>
+	Volatile,
+
+	/// <summary>
+	/// The updates made on State are re-applied on each message produced by the source feed,
+	/// until update is being explicitly removed or reports as inactive.
+	/// </summary>
+	Persistent
+}

--- a/src/Uno.Extensions.Reactive/Core/ListState.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.T.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Uno.Extensions.Reactive.Core;
 using Uno.Extensions.Reactive.Sources;
 using Uno.Extensions.Reactive.Utils;
@@ -121,7 +122,7 @@ public static class ListState<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IListState<T> Async<TOwner>(TOwner owner, AsyncFunc<Option<IImmutableList<T>>> valueProvider, Signal? refresh = null)
 		where TOwner : class
-		=> AttachedProperty.GetOrCreate(owner, valueProvider, refresh, (o, vp, r) => S(o, new AsyncFeed<IImmutableList<T>>(vp, r)));
+		=> AttachedProperty.GetOrCreate(owner, (valueProvider, refresh), (o, args) => S(o, new AsyncFeed<IImmutableList<T>>(args.valueProvider, args.refresh)));
 
 	/// <summary>
 	/// Creates a custom feed from an async method.
@@ -145,7 +146,7 @@ public static class ListState<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IListState<T> Async<TOwner>(TOwner owner, AsyncFunc<IImmutableList<T>> valueProvider, Signal? refresh = null)
 		where TOwner : class
-		=> AttachedProperty.GetOrCreate(owner, valueProvider, refresh, (o, vp, r) => S(o, new AsyncFeed<IImmutableList<T>>(vp, r)));
+		=> AttachedProperty.GetOrCreate(owner, (valueProvider, refresh), (o, args) => S(o, new AsyncFeed<IImmutableList<T>>(args.valueProvider, args.refresh)));
 
 	/// <summary>
 	/// Creates a custom feed from an async method.
@@ -199,6 +200,58 @@ public static class ListState<T>
 	internal static IListState<T> AsyncEnumerable(Func<IAsyncEnumerable<IImmutableList<T>>> enumerableProvider)
 		=> AttachedProperty.GetOrCreate(Validate(enumerableProvider), ep => S(ep, new AsyncEnumerableFeed<IImmutableList<T>>(ep)));
 
+	// WARNING: This not implemented for restrictions described in the remarks section of the AsyncPaginated
+	//			While restrictions are acceptable for a paginated by index ListState, it would be invalid for custom cursors.
+	///// <summary>
+	///// Creates a list feed for a paginated collection.
+	///// </summary>
+	///// <typeparam name="TOwner">Type of the owner of the state.</typeparam>
+	///// <typeparam name="TCursor">Type of the cursor that is used to identify a page to load.</typeparam>
+	///// <param name="owner">The owner of the state.</param>
+	///// <param name="firstPage">The cursor of the first page.</param>
+	///// <param name="getPage">The async method to load a page of items.</param>
+	///// <returns>A paginated list feed.</returns>
+	//public static IListState<T> AsyncPaginatedByCursor<TOwner, TCursor>(TOwner owner, TCursor firstPage, GetPage<TCursor, T> getPage)
+	//	where TOwner : class
+	//	=> AttachedProperty.GetOrCreate(owner, (getPage, firstPage), (o, args) => S(o, new PaginatedListFeed<TCursor, T>(args.firstPage, args.getPage).AsFeed()));
+
+	/// <summary>
+	/// Creates a list state for a paginated collection.
+	/// WARNING, be aware of restriction described in remarks.
+	/// </summary>
+	/// <typeparam name="TOwner">Type of the owner of the state.</typeparam>
+	/// <param name="owner">The owner of the state.</param>
+	/// <param name="getPage">The async method to load a page of items.</param>
+	/// <returns>A paginated list feed.</returns>
+	/// <remarks>
+	/// This is only a weak implementation which provides the current count of items in the ListState when a new page is requested,
+	/// instead of the number of items that has been loaded so far by pagination.
+	/// ** It does not ensure any tracking of entities. **
+	/// This means that the only operations that this state (weakly) supports is Insert.
+	/// For instance if you load a first page of 20 items, then insert one **on top**, next page request will be with CurrentCount = 21,
+	/// so item which was at index 19 and now is at index 20 won't be loaded twice from the server.
+	/// </remarks>
+	public static IListState<T> AsyncPaginated<TOwner>(TOwner owner, AsyncFunc<PageRequest, IImmutableList<T>> getPage)
+		where TOwner : class
+		=> AttachedProperty.GetOrCreate(owner, getPage, (o, gp) =>
+		{
+			ListStateImpl<T>? state = default;
+			var paginatedFeed = new PaginatedListFeed<ByIndexCursor<T>, T>(ByIndexCursor<T>.First, ByIndexCursor<T>.GetPage(GetPage));
+			state = SourceContext.GetOrCreate(o).DoNotUse_GetOrCreateListState(paginatedFeed, StateUpdateKind.Persistent);
+
+			return state;
+
+			ValueTask<IImmutableList<T>> GetPage(PageRequest request, CancellationToken ct)
+			{
+				var actualCount = state?.Current.Current.Data.IsSome(out var currentItems) ?? false
+					? (uint)currentItems.Count
+					: request.CurrentCount;
+				var actualRequest = request with { CurrentCount = actualCount };
+
+				return gp(actualRequest, ct);
+			}
+		});
+
 	private static TKey Validate<TKey>(TKey key, [CallerMemberName] string? caller = null)
 		where TKey : Delegate
 	{
@@ -213,8 +266,13 @@ public static class ListState<T>
 		return key;
 	}
 
-	private static IListState<T> S<TOwner>(TOwner owner, IFeed<IImmutableList<T>> feed)
+	private static IListState<T> S<TOwner>(TOwner owner, IListFeed<T> feed)
 		where TOwner : class
 		// We make sure to use the SourceContext to create the State, so it will be disposed with the context.
+		=> SourceContext.GetOrCreate(owner).GetOrCreateListState(feed);
+
+	private static IListState<T> S<TOwner>(TOwner owner, IFeed<IImmutableList<T>> feed)
+		where TOwner : class
+	// We make sure to use the SourceContext to create the State, so it will be disposed with the context.
 		=> SourceContext.GetOrCreate(owner).GetOrCreateListState(feed);
 }

--- a/src/Uno.Extensions.Reactive/Core/MessageBuilder.cs
+++ b/src/Uno.Extensions.Reactive/Core/MessageBuilder.cs
@@ -11,57 +11,115 @@ namespace Uno.Extensions.Reactive;
 /// <typeparam name="T">The type of the value of the message to build.</typeparam>
 public readonly struct MessageBuilder<T> : IMessageEntry, IMessageBuilder, IMessageBuilder<T>
 {
-	private readonly MessageEntry<T> _previous;
-	private readonly ChangeCollection _changes;
-	private readonly Dictionary<MessageAxis, MessageAxisValue> _values;
+	// We prefer to use this class over the interface for public API in order to hide the Get and Set of the interface,
+	// as they should be used only for extensibility, but not in application code.
+	// Note: We should consider to make this an abstract base class, but it would cause breaking change
+	//		 and significant changes in the code that are not the purpose of the current work.
+
+	internal delegate (MessageAxisValue value, IChangeSet? changes) Getter(MessageAxis axis);
+	internal delegate void Setter(MessageAxis axis, MessageAxisValue value, IChangeSet? changes);
+
+	private readonly Getter _get;
+	private readonly Setter _set;
+	private readonly Func<Message<T>>? _build;
 
 	internal MessageBuilder(MessageEntry<T> current)
 	{
-		_previous = current;
-		_changes = new();
-
 		// We make sure to clear all transient axes when we update a message
-		_values = current.Values.ToDictionaryWhereKey(k => !k.IsTransient);
+		var values = current.Values.ToDictionaryWhereKey(k => !k.IsTransient);
+		var changeCollection = new ChangeCollection();
+
+		_get = DoGet;
+		_set = DoSet;
+		_build = DoBuild;
+
+		(MessageAxisValue value, IChangeSet? changes) DoGet(MessageAxis axis)
+			=> (values.TryGetValue(axis, out var value) ? value : default, default);
+
+		void DoSet(MessageAxis axis, MessageAxisValue value, IChangeSet? changes)
+		{
+			var current = DoGet(axis);
+			if (axis.AreEquals(current.value, value))
+			{
+				return;
+			}
+
+			if (value.IsSet)
+			{
+				values[axis] = value;
+				changeCollection.Set(axis, changes);
+			}
+			else if (values.Remove(axis))
+			{
+				changeCollection.Set(axis, changes);
+			}
+		}
+
+		Message<T> DoBuild()
+			=> new(current, new MessageEntry<T>(values), changeCollection);
 	}
 
+	/// <summary>
+	/// Creates builder that wraps another IMessageBuilder
+	/// </summary>
+	/// <param name="get">The get method.</param>
+	/// <param name="set">The set method.</param>
+	internal MessageBuilder(Getter get, Setter set)
+	{
+		_get = get;
+		_set = set;
+		_build = null;
+	}
+
+	#region IMessageEntry
 	Option<object> IMessageEntry.Data => CurrentData;
 	Exception? IMessageEntry.Error => CurrentError;
 	bool IMessageEntry.IsTransient => CurrentIsTransient;
 	MessageAxisValue IMessageEntry.this[MessageAxis axis] => Get(axis).value;
+	#endregion
 
-	internal Option<T> CurrentData => this.GetData<T>();
-	internal Exception? CurrentError => this.GetError();
-	internal bool CurrentIsTransient => this.GetProgress();
-	internal MessageAxisValue this[MessageAxis axis]
-	{
-		get => Get(axis).value;
-		set => Set(axis, value, default);
-	}
+	/// <summary>
+	/// Gets the current data of the message build by this builder.
+	/// </summary>
+	/// <remarks>
+	/// This represents the current value, if the data has already been modified on this builder,
+	/// the value returned will reflect that change.
+	/// This means that this value is only a syntax sugar but **MUST NOT be used as reference for change tracking**.
+	/// </remarks>
+	public Option<T> CurrentData => this.GetData<T>();
+
+	/// <summary>
+	/// Gets the current error of the message build by this builder.
+	/// </summary>
+	/// <remarks>
+	/// This represents the current value, if the error has already been modified on this builder,
+	/// the value returned will reflect that change.
+	/// This means that this value is only a syntax sugar but **MUST NOT be used as reference for change tracking**.
+	/// </remarks>
+	public Exception? CurrentError => this.GetError();
+
+
+	/// <summary>
+	/// Gets the current progress of the message build by this builder.
+	/// </summary>
+	/// <remarks>
+	/// This represents the current value, if the error has already been modified on this builder,
+	/// the value returned will reflect that change.
+	/// This means that this value is only a syntax sugar but **MUST NOT be used as reference for change tracking**.
+	/// </remarks>
+	public bool CurrentIsTransient => this.GetProgress();
 
 	(MessageAxisValue value, IChangeSet? changes) IMessageBuilder.Get(MessageAxis axis)
 		=> Get(axis);
 	internal (MessageAxisValue value, IChangeSet? changes) Get(MessageAxis axis)
-		=> (_values.TryGetValue(axis, out var value) ? value : default, default);
+		=> _get(axis);
 
 	void IMessageBuilder.Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes)
 		=> Set(axis, value, changes);
+
 	internal MessageBuilder<T> Set(MessageAxis axis, MessageAxisValue value, IChangeSet? changes)
 	{
-		if (axis.AreEquals(this[axis], value))
-		{
-			return this;
-		}
-
-		if (value.IsSet)
-		{
-			_values[axis] = value;
-			_changes.Set(axis, changes);
-		}
-		else if (_values.Remove(axis))
-		{
-			_changes.Set(axis, changes);
-		}
-
+		_set(axis, value, changes);
 		return this;
 	}
 
@@ -69,7 +127,9 @@ public readonly struct MessageBuilder<T> : IMessageEntry, IMessageBuilder, IMess
 	/// Builds the resulting message.
 	/// </summary>
 	public Message<T> Build()
-		=> new(_previous, new MessageEntry<T>(_values), _changes);
+		=> _build is null
+			? throw new InvalidOperationException("This builder does not support direct convert to Message<T>.")
+			: _build();
 
 	/// <summary>
 	/// Builds the resulting message.

--- a/src/Uno.Extensions.Reactive/Core/State.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/State.Extensions.cs
@@ -24,10 +24,10 @@ partial class State
 		=> state.UpdateMessage(
 			m =>
 			{
-				var updatedValue = updater(m.Current.Data.SomeOrDefault());
+				var updatedValue = updater(m.CurrentData.SomeOrDefault());
 				var updatedData = updatedValue is null ? Option<T>.None() : Option.Some(updatedValue);
 
-				return m.With().Data(updatedData);
+				m.Data(updatedData);
 			},
 			ct);
 
@@ -40,14 +40,17 @@ partial class State
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
 	public static ValueTask UpdateData<T>(this IState<T> state, Func<Option<T>, Option<T>> updater, CancellationToken ct)
-		=> state.UpdateMessage(m => m.With().Data(updater(m.Current.Data)), ct);
+		=> state.UpdateMessage(m => m.Data(updater(m.CurrentData)), ct);
 
 	/// <summary>
 	/// [DEPRECATED] Use UpdateData instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use UpdateData")]
+#endif
 	public static ValueTask UpdateValue<T>(this IState<T> state, Func<Option<T>, Option<T>> updater, CancellationToken ct)
-		=> state.UpdateMessage(m => m.With().Data(updater(m.Current.Data)), ct);
+		=> UpdateData(state, updater, ct);
 
 	/// <summary>
 	/// Sets the value of a state
@@ -59,7 +62,7 @@ partial class State
 	/// <returns>A ValueTask to track the async update.</returns>
 	public static ValueTask Set<T>(this IState<T> state, T? value, CancellationToken ct)
 		where T : struct
-		=> state.UpdateMessage(m => m.With().Data(value is null ? Option<T>.None() : Option.Some(value.Value)), ct);
+		=> state.UpdateMessage(m => m.Data(value is null ? Option<T>.None() : Option.Some(value.Value)), ct);
 
 	/// <summary>
 	/// Sets the value of a state
@@ -69,12 +72,15 @@ partial class State
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
 	public static ValueTask Set(this IState<string> state, string? value, CancellationToken ct)
-		=> state.UpdateMessage(m => m.With().Data(value is { Length: > 0 } ? value : Option<string>.None()), ct);
+		=> state.UpdateMessage(m => m.Data(value is { Length: > 0 } ? value : Option<string>.None()), ct);
 
 	/// <summary>
 	/// [DEPRECATED] Use .ForEachAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use ForEachAsync")]
+#endif
 	public static IDisposable Execute<T>(this IState<T> state, AsyncAction<T?> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
 		where T : notnull
 		=> ForEachAsync(state, action, caller, line);

--- a/src/Uno.Extensions.Reactive/Operators/CombineFeedHelper.cs
+++ b/src/Uno.Extensions.Reactive/Operators/CombineFeedHelper.cs
@@ -100,7 +100,10 @@ internal sealed class CombineFeedHelper<TResult>
 			}
 			else
 			{
-				builder[changedAxis] = changedAxis.Aggregate(_parents.Select(p => p is not null && p.TryGetValue(changedAxis, out var value) ? value : default));
+				var values = _parents.Select(p => p is not null && p.TryGetValue(changedAxis, out var value) ? value : default);
+				var resultValue = changedAxis.Aggregate(values);
+
+				builder.Set(changedAxis, resultValue, changes: null);
 			}
 		}
 

--- a/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
+++ b/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
@@ -72,7 +72,7 @@ internal class FeedToListFeedAdapter<TCollection, TItem> : IListFeed<TItem>
 			{
 				try // As we might invoke the app Equality implementation, we make sure to try / catch it
 				{
-					changeSet = GetChangeSet(_analyzer, parentMsg.Previous.Data.Map(_toImmutable), updatedData);
+					changeSet = GetChangeSet(parentMsg.Previous.Data.Map(_toImmutable), updatedData);
 				}
 				catch (Exception e)
 				{
@@ -90,10 +90,10 @@ internal class FeedToListFeedAdapter<TCollection, TItem> : IListFeed<TItem>
 		return updated;
 	}
 
-	private static CollectionChangeSet GetChangeSet(Option<IImmutableList<TItem>> previousData, Option<IImmutableList<TItem>> updatedData)
-		=> GetChangeSet(CollectionAnalyzer<TItem>.Default, previousData, updatedData);
+	private protected CollectionChangeSet GetChangeSet(Option<IImmutableList<TItem>> previousData, Option<IImmutableList<TItem>> updatedData)
+		=> GetChangeSet(_analyzer, previousData, updatedData);
 
-	private static CollectionChangeSet GetChangeSet(CollectionAnalyzer<TItem> collectionAnalyzer, Option<IImmutableList<TItem>> previousData, Option<IImmutableList<TItem>> updatedData)
+	private protected static CollectionChangeSet GetChangeSet(CollectionAnalyzer<TItem> collectionAnalyzer, Option<IImmutableList<TItem>> previousData, Option<IImmutableList<TItem>> updatedData)
 	{
 		var hadItems = previousData.IsSome(out var previousItems);
 		var hasItems = updatedData.IsSome(out var updatedItems);

--- a/src/Uno.Extensions.Reactive/Operators/UpdateFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/UpdateFeed.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Utils;
+
+namespace Uno.Extensions.Reactive.Operators;
+
+internal record FeedUpdate<T>(Predicate<MessageBuilder<T>> IsActive, Action<MessageBuilder<T>> Apply);
+
+internal class UpdateFeed<T> : IFeed<T>
+{
+	private readonly AsyncEnumerableSubject<(UpdateAction action, FeedUpdate<T> update)> _updates = new(ReplayMode.Disabled);
+	private readonly IFeed<T> _source;
+
+	private enum UpdateAction
+	{
+		Add,
+		Remove
+	}
+
+	public UpdateFeed(IFeed<T> source)
+	{
+		_source = source;
+	}
+
+	public async ValueTask Update(Predicate<MessageBuilder<T>> predicate, Action<MessageBuilder<T>> updater, CancellationToken ct)
+		=> _updates.SetNext((UpdateAction.Add, new FeedUpdate<T>(predicate, updater)));
+
+	/// <inheritdoc />
+	public IAsyncEnumerable<Message<T>> GetSource(SourceContext context, CancellationToken ct)
+		=> new UpdateFeedSource(this, context, ct);
+
+	private class UpdateFeedSource : IAsyncEnumerable<Message<T>>
+	{
+		private readonly CancellationToken _ct;
+		private readonly AsyncEnumerableSubject<Message<T>> _subject;
+		private readonly MessageManager<T, T> _message;
+
+		private ImmutableList<FeedUpdate<T>> _activeUpdates;
+		private bool _isInError;
+
+		public UpdateFeedSource(UpdateFeed<T> owner, SourceContext context, CancellationToken ct)
+		{
+			_ct = ct;
+			_subject = new AsyncEnumerableSubject<Message<T>>(ReplayMode.EnabledForFirstEnumeratorOnly);
+			_message = new MessageManager<T, T>(_subject.SetNext);
+			_activeUpdates = ImmutableList<FeedUpdate<T>>.Empty;
+
+			// mode=AbortPrevious => When we receive a new update, we can abort the update and start a new one
+			owner._updates.ForEachAsync(OnUpdateReceived, ct);
+			owner._source.GetSource(context, ct).ForEachAsync(OnParentUpdated, ct);
+		}
+
+		/// <inheritdoc />
+		public IAsyncEnumerator<Message<T>> GetAsyncEnumerator(CancellationToken ct = default)
+			=> _subject.GetAsyncEnumerator(ct);
+
+		private void OnUpdateReceived((UpdateAction action, FeedUpdate<T> update) args)
+		{
+			lock (this)
+			{
+				switch (args.action)
+				{
+					case UpdateAction.Add:
+						_activeUpdates = _activeUpdates.Add(args.update);
+						if (!_isInError)
+						{
+							IncrementalUpdate(args.update);
+							return;
+						}
+						break;
+
+					case UpdateAction.Remove:
+						_activeUpdates = _activeUpdates.Remove(args.update);
+						break;
+
+					default:
+						throw new ArgumentOutOfRangeException($"Unkown update action '{args.action}'");
+				}
+				
+				RebuildMessage(parentMsg: default);
+			}
+		}
+
+		private void OnParentUpdated(Message<T> parentMsg)
+		{
+			lock (this)
+			{
+				RebuildMessage(parentMsg);
+			}
+		}
+
+		private void IncrementalUpdate(FeedUpdate<T> update)
+			=> _message.Update(
+				(current, u) =>
+				{
+					try
+					{
+						var msg = current.With();
+						u.Apply(new (msg.Get, ((IMessageBuilder)msg).Set));
+						return msg;
+					}
+					catch (Exception error)
+					{
+						_isInError = true;
+						return current
+							.WithParentOnly(null)
+							.Data(Option<T>.Undefined())
+							.Error(error);
+					}
+				},
+				update,
+				_ct);
+
+		private void RebuildMessage(Message<T>? parentMsg)
+		{
+			_isInError = false;
+			_message.Update(
+				(current, parent) =>
+				{
+					try
+					{
+						var msg = current.WithParentOnly(parent);
+						foreach (var update in _activeUpdates)
+						{
+							var builder = new MessageBuilder<T>(msg.Get, ((IMessageBuilder)msg).Set);
+							if (update.IsActive(builder))
+							{
+								update.Apply(builder);
+							}
+							else
+							{
+								_activeUpdates = _activeUpdates.Remove(update);
+							}
+						}
+
+						return msg;
+					}
+					catch (Exception error)
+					{
+						_isInError = true;
+						return current
+							.WithParentOnly(parent)
+							.Data(Option<T>.Undefined())
+							.Error(error);
+					}
+				},
+				parentMsg,
+				_ct);
+		}
+	}
+}


### PR DESCRIPTION
## Feature
Add ability to create a paginated ListState

## What is the current behavior?
We can only create a Paginated feed

## What is the new behavior?
We can create a paginated (only by index) ListState

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
