### PR TITLE
feat: Preventing recursive refresh token

### DIFF
--- a/src/Uno.Extensions.Authentication/BaseAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication/BaseAuthenticationProvider.cs
@@ -1,22 +1,65 @@
-﻿namespace Uno.Extensions.Authentication;
+﻿
+namespace Uno.Extensions.Authentication;
 
-public abstract record BaseAuthenticationProvider(string Name, ITokenCache Tokens) : IAuthenticationProvider
+public abstract record BaseAuthenticationProvider(ILogger Logger, string Name, ITokenCache Tokens) : IAuthenticationProvider
 {
 	public async virtual ValueTask<bool> CanRefresh(CancellationToken cancellationToken) => true;
 
-	public virtual ValueTask<IDictionary<string, string>?> LoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
+	public ValueTask<IDictionary<string, string>?> LoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
+	{
+		try
+		{
+			return InternalLoginAsync(dispatcher, credentials, cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Error attempting to login [Error - {ex.Message}]");
+			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Login credentials {credentials?.ToString()}");
+			return default;
+		}
+	}
+
+	protected virtual ValueTask<IDictionary<string, string>?> InternalLoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
 	{
 		// Default behavior is to return null, which indicates unsuccessful login 
 		return default;
 	}
 
-	public virtual async ValueTask<bool> LogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
+	public ValueTask<bool> LogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
+	{
+		try
+		{
+			return InternalLogoutAsync(dispatcher, cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Error attempting to logout [Error - {ex.Message}]");
+			return new ValueTask<bool>(false);
+		}
+	}
+
+	protected virtual async ValueTask<bool> InternalLogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
 	{
 		// Default implementation is to return true, which will cause the token cache to be flushed
 		return true;
 	}
 
-	public virtual async ValueTask<IDictionary<string, string>?> RefreshAsync(CancellationToken cancellationToken)
+	public async ValueTask<IDictionary<string, string>?> RefreshAsync(CancellationToken cancellationToken)
+	{
+		var tokens = await Tokens.GetAsync(cancellationToken);
+		try
+		{
+			return await InternalRefreshAsync(cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Error attempting to refresh [Error - {ex.Message}]");
+			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Current tokens {tokens}");
+			return default;
+		}
+	}
+
+	protected virtual async ValueTask<IDictionary<string, string>?> InternalRefreshAsync(CancellationToken cancellationToken)
 	{
 		// Default implementation is to just return the existing tokens (ie success!)
 		return await Tokens.GetAsync();

--- a/src/Uno.Extensions.Authentication/GlobalUsings.cs
+++ b/src/Uno.Extensions.Authentication/GlobalUsings.cs
@@ -14,7 +14,6 @@ global using Uno.Extensions.Authentication.Custom;
 global using Uno.Extensions.Authentication.Handlers;
 global using Uno.Extensions.Configuration;
 global using Uno.Extensions.Hosting;
-global using Uno.Extensions.Navigation;
 global using Uno.Extensions.Logging;
 
 

--- a/src/Uno.Extensions.Authentication/GlobalUsings.cs
+++ b/src/Uno.Extensions.Authentication/GlobalUsings.cs
@@ -15,7 +15,3 @@ global using Uno.Extensions.Authentication.Handlers;
 global using Uno.Extensions.Configuration;
 global using Uno.Extensions.Hosting;
 global using Uno.Extensions.Logging;
-
-
-
-

--- a/src/Uno.Extensions.Authentication/GlobalUsings.cs
+++ b/src/Uno.Extensions.Authentication/GlobalUsings.cs
@@ -15,6 +15,7 @@ global using Uno.Extensions.Authentication.Handlers;
 global using Uno.Extensions.Configuration;
 global using Uno.Extensions.Hosting;
 global using Uno.Extensions.Navigation;
+global using Uno.Extensions.Logging;
 
 
 

--- a/src/Uno.Extensions.Authentication/Headers.cs
+++ b/src/Uno.Extensions.Authentication/Headers.cs
@@ -1,0 +1,7 @@
+﻿namespace Uno.Extensions.Authentication;
+
+public static class Headers
+{
+	internal const string NoRefreshKey = "No-Refresh";
+	public const string NoRefresh = $"{NoRefreshKey}:true";
+}

--- a/src/Uno.Extensions.Authentication/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication/HostBuilderExtensions.cs
@@ -99,7 +99,8 @@ public static class HostBuilderExtensions
 		hostBuilder
 			.ConfigureServices(services =>
 			{
-				services.AddSingleton(authBuilder.Settings);
+				services
+				.AddSingleton(authBuilder.Settings);
 			});
 
 		if (!authBuilder.Settings.NoHandlers)
@@ -119,6 +120,4 @@ public static class HostBuilderExtensions
 	}
 
 }
-
-
 

--- a/src/Uno.Extensions.Http/CookieManager.cs
+++ b/src/Uno.Extensions.Http/CookieManager.cs
@@ -44,6 +44,21 @@ public record CookieManager(ILogger<CookieManager> Logger) : ICookieManager
 			try
 			{
 				native.CookieContainer = new CookieContainer();
+
+#if __IOS__
+				native.UseCookies = true;
+#elif __ANDROID__
+#if NET6_0_OR_GREATER
+				native.UseCookies = true;
+#else
+				native.UseCookies = true;
+#endif
+#elif WINDOWS || WINDOWS_UWP
+				native.CookieUsePolicy = CookieUsePolicy.UseSpecifiedCookieContainer;
+#else
+				native.UseCookies = true;
+#endif
+
 			}
 			catch
 			{

--- a/testing/TestHarness/TestBackend/Controllers/CustomAuthController.cs
+++ b/testing/TestHarness/TestBackend/Controllers/CustomAuthController.cs
@@ -39,7 +39,7 @@ public class CustomAuthController : ControllerBase
 			HttpOnly = true,
 			SameSite = SameSiteMode.None
 		});
-		Response.Cookies.Append("RefreshToken", "Refresh-" + token, new CookieOptions
+		Response.Cookies.Append("RefreshToken", "Refresh|" + token, new CookieOptions
 		{
 			Secure = false, // For local non-https testing this needs to be false otherwise cookies can't be extracted from cookiecontainer
 			HttpOnly = true,
@@ -52,7 +52,8 @@ public class CustomAuthController : ControllerBase
 	{
 		try
 		{
-			var token = Request.Cookies.FirstOrDefault(x => x.Key == "AccessToken").Value;
+			var token = Request.Cookies.FirstOrDefault(x => x.Key == "RefreshToken").Value;
+			token = token.Split('|').Skip(1).FirstOrDefault()??string.Empty;
 			var bits = token.Base64Decode().Split(":");
 			if (bits.Length == 2)
 			{
@@ -62,7 +63,7 @@ public class CustomAuthController : ControllerBase
 					HttpOnly = true,
 					SameSite = SameSiteMode.None
 				});
-				Response.Cookies.Append("RefreshToken", $"Refresh-{DateTime.Now.ToString("HH:mm:sss")}" + token, new CookieOptions
+				Response.Cookies.Append("RefreshToken", $"Refresh-{DateTime.Now.ToString("HH:mm:sss")}|" + token, new CookieOptions
 				{
 					Secure = false, // For local non-https testing this needs to be false otherwise cookies can't be extracted from cookiecontainer
 					HttpOnly = true,
@@ -153,11 +154,19 @@ public static class AuthExtensions
 
 	public static string Base64Encode(this string plainText)
 	{
+		if (string.IsNullOrWhiteSpace(plainText))
+		{
+			return plainText;
+		}
 		var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(plainText);
 		return System.Convert.ToBase64String(plainTextBytes);
 	}
 	public static string Base64Decode(this string base64EncodedData)
 	{
+		if (string.IsNullOrWhiteSpace(base64EncodedData))
+		{
+			return base64EncodedData;
+		}
 		var base64EncodedBytes = System.Convert.FromBase64String(base64EncodedData);
 		return System.Text.Encoding.UTF8.GetString(base64EncodedBytes);
 	}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationHomePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationHomePage.xaml
@@ -22,13 +22,16 @@
 
 		<StackPanel Grid.Row="1">
 			<StackPanel HorizontalAlignment="Center"
-						Orientation="Horizontal">
+						Orientation="Vertical">
 				<Button AutomationProperties.AutomationId="RetrieveProductsButton"
 						Content="Products"
 						Click="{x:Bind ViewModel.RetrieveProducts}" />
 				<Button AutomationProperties.AutomationId="ClearAccessTokenButton"
-						Content="Clear Access Token"
+						Content="Clear Access Token (test refresh using RefreshToken)"
 						Click="{x:Bind ViewModel.ClearAccessToken}" />
+				<Button AutomationProperties.AutomationId="ClearAccessTokenButton"
+						Content="Clear All Tokens (refresh should fail!)"
+						Click="{x:Bind ViewModel.ClearAllTokens}" />
 				<Button AutomationProperties.AutomationId="LogoutButton"
 						Content="Logout"
 						Click="{x:Bind ViewModel.Logout}" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationHomeTestBackendPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationHomeTestBackendPage.xaml
@@ -22,7 +22,7 @@
 
 		<StackPanel Grid.Row="1">
 			<StackPanel HorizontalAlignment="Center"
-						Orientation="Horizontal">
+						Orientation="Vertical">
 				<Button AutomationProperties.AutomationId="RetrieveButton"
 						Content="Items (Authorization header)"
 						Click="{x:Bind ViewModel.Retrieve}" />
@@ -30,12 +30,19 @@
 						Content="Items (Cookie)"
 						Click="{x:Bind ViewModel.RetrieveCookie}" />
 				<Button AutomationProperties.AutomationId="ClearAccessTokenButton"
-						Content="Clear Access Token"
+						Content="Clear Access Token (test refresh using RefreshToken)"
 						Click="{x:Bind ViewModel.ClearAccessToken}" />
+				<Button AutomationProperties.AutomationId="InvalidateTokensButton"
+						Content="Invalidate (don't delete) all Tokens (refresh should fail)"
+						Click="{x:Bind ViewModel.InvalidateTokens}" />
+				<Button AutomationProperties.AutomationId="ClearAccessTokenButton"
+						Content="Clear All Tokens (can't refresh)"
+						Click="{x:Bind ViewModel.ClearAllTokens}" />
 				<Button AutomationProperties.AutomationId="LogoutButton"
 						Content="Logout"
 						Click="{x:Bind ViewModel.Logout}" />
 			</StackPanel>
+			
 			<TextBlock AutomationProperties.AutomationId="RetrieveProductsResultTextBlock"
 					   Text="{Binding RetrieveProductsResult}" />
 		</StackPanel>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationHomeTestBackendViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationHomeTestBackendViewModel.cs
@@ -42,6 +42,23 @@ public partial class CustomAuthenticationHomeTestBackendViewModel : ObservableOb
 		await Tokens.SaveAsync(Tokens.CurrentProvider ?? string.Empty, creds);
 	}
 
+	public async void ClearAllTokens()
+	{
+		var creds = await Tokens.GetAsync();
+		creds.Remove(TokenCacheExtensions.AccessTokenKey);
+		creds.Remove(TokenCacheExtensions.RefreshTokenKey);
+		await Tokens.SaveAsync(Tokens.CurrentProvider ?? string.Empty, creds);
+	}
+
+	public async void InvalidateTokens()
+	{
+		var creds = await Tokens.GetAsync();
+		creds[TokenCacheExtensions.AccessTokenKey]= $"Some invalid access token {DateTime.Now.Ticks}";
+		creds[TokenCacheExtensions.RefreshTokenKey] = $"Some invalid refresh token {DateTime.Now.Ticks}"; ;
+		await Tokens.SaveAsync(Tokens.CurrentProvider ?? string.Empty, creds);
+	}
+	
+
 	public async void Retrieve()
 	{
 		try

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationHomeViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationHomeViewModel.cs
@@ -42,6 +42,14 @@ public partial class CustomAuthenticationHomeViewModel : ObservableObject
 		await Tokens.SaveAsync(Tokens.CurrentProvider ?? string.Empty, creds);
 	}
 
+	public async void ClearAllTokens()
+	{
+		var creds = await Tokens.GetAsync();
+		creds.Remove(TokenCacheExtensions.AccessTokenKey);
+		creds.Remove(TokenCacheExtensions.RefreshTokenKey);
+		await Tokens.SaveAsync(Tokens.CurrentProvider ?? string.Empty, creds);
+	}
+
 	public async void RetrieveProducts()
 	{
 		try

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationTestBackendCookieHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationTestBackendCookieHostInit.cs
@@ -26,12 +26,14 @@ public class CustomAuthenticationTestBackendCookieHostInit : BaseHostInitializat
 							})
 							.Refresh(async (authService, cache, tokenDictionary, cancellationToken) =>
 							{
+								await Task.Delay(3000);
 								await authService.RefreshCookie(cancellationToken);
 								return await cache.GetAsync(cancellationToken);
 							})),
 							configureAuthorization: builder =>
 							{
-								builder.Cookies("AccessToken", "RefreshToken");
+								builder
+									.Cookies("AccessToken", "RefreshToken");
 							}
 				)
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/ICustomAuthenticationTestBackendEndpoint.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/ICustomAuthenticationTestBackendEndpoint.cs
@@ -6,12 +6,15 @@ namespace TestHarness.Ext.Authentication.Custom;
 public interface ICustomAuthenticationTestBackendEndpoint
 {
 	[Get("/customauth/login")]
+	[Headers(Uno.Extensions.Authentication.Headers.NoRefresh)]
 	Task<CustomAuthenticationCustomAuthResponse> Login([Query] string username, [Query] string password, CancellationToken ct);
 
 	[Post("/customauth/logincookie")]
+	[Headers(Uno.Extensions.Authentication.Headers.NoRefresh)]
 	Task LoginCookie([Query] string username, [Query] string password, CancellationToken ct);
 
 	[Post("/customauth/refreshcookie")]
+	[Headers(Uno.Extensions.Authentication.Headers.NoRefresh)]
 	Task RefreshCookie(CancellationToken ct);
 
 


### PR DESCRIPTION
GitHub Issue (If applicable): #694


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

See #694 - no way to prevent refresh token logic running for authentication endpoints

## What is the new behavior?

Authentication endpoints, login, refresh etc, should be attributed with Header(Headers.NoRefresh) to flag that the refresh logic shouldn't be executed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
