### PR TITLE
feat(feeds): Add ability to avoid loading state when refreshing

### DIFF
--- a/doc/Overview/Reactive/in-apps.md
+++ b/doc/Overview/Reactive/in-apps.md
@@ -85,7 +85,7 @@ Uno.Extensions also defines a `RefreshContainerExtensions.Command` attached prop
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:uer="using:Uno.Extensions.Reactive.UI">
 
-<uer:FeedView Source="{Binding Products}">
+<uer:FeedView Source="{Binding Products}" RefreshingState="None">
 	<DataTemplate>
 		<RefreshContainer uer:RefreshContainerExtensions.Command="{Binding Refresh}">
 			<ListView ItemsSource="{Binding Data}" />
@@ -93,6 +93,11 @@ Uno.Extensions also defines a `RefreshContainerExtensions.Command` attached prop
 	</DataTemplate>
 </uer:FeedView>
 ```
+
+> [!TIP]
+> When you use a `RefreshContainer` to trigger the refresh of your _feed_, as the `RefreshContainer` do have its own loading indicator,
+> you might have 2 loading indicators, one from the `RefreshContainer` itself, and a second one from the `FeedView`.
+> In order to avoid that, you should instruct your `FeedView` to not use the loading state in case of refresh by setting `RefreshingState="None"`.
 
 ## Pagination
 

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.Subscription.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.Subscription.cs
@@ -72,7 +72,7 @@ public partial class FeedView
 			{
 				_view.State.Update(message);
 
-				if (_view.VisualStateSelector?.GetVisualStates(message).ToList() is { Count: > 0 } visualStates)
+				if (_view.VisualStateSelector?.GetVisualStates(_view, message).ToList() is { Count: > 0 } visualStates)
 				{
 					foreach (var state in visualStates)
 					{

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.cs
@@ -180,13 +180,33 @@ public partial class FeedView : Control
 	{
 		get => (DataTemplate)GetValue(ErrorTemplateProperty);
 		set => SetValue(ErrorTemplateProperty, value);
+	}
+	#endregion
+
+	#region RefreshingState (DP)
+	/// <summary>
+	/// Backing dependency property for <see cref="RefreshingState"/>.
+	/// </summary>
+	public static readonly DependencyProperty RefreshingStateProperty = DependencyProperty.Register(
+		"RefreshingState", typeof(FeedViewRefreshState), typeof(FeedView), new PropertyMetadata(default(FeedViewRefreshState)));
+
+	/// <summary>
+	/// Defines the visual state that should be used for refresh.
+	/// </summary>
+	public FeedViewRefreshState RefreshingState
+	{
+		get => (FeedViewRefreshState)GetValue(RefreshingStateProperty);
+		set => SetValue(RefreshingStateProperty, value);
 	} 
 	#endregion
 
 	private bool _isReady;
 	private Subscription? _subscription;
 
-	internal RefreshCommand Refresh { get; }
+	/// <summary>
+	/// Gets a command which request to refresh the source when executed.
+	/// </summary>
+	public IAsyncCommand Refresh { get; }
 
 	/// <summary>
 	/// Creates a new instance.

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.cs
@@ -188,7 +188,7 @@ public partial class FeedView : Control
 	/// Backing dependency property for <see cref="RefreshingState"/>.
 	/// </summary>
 	public static readonly DependencyProperty RefreshingStateProperty = DependencyProperty.Register(
-		"RefreshingState", typeof(FeedViewRefreshState), typeof(FeedView), new PropertyMetadata(default(FeedViewRefreshState)));
+		"RefreshingState", typeof(FeedViewRefreshState), typeof(FeedView), new PropertyMetadata(FeedViewRefreshState.Default));
 
 	/// <summary>
 	/// Defines the visual state that should be used for refresh.

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.xaml
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.xaml
@@ -2,7 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:uer="using:Uno.Extensions.Reactive.UI">
 
-	<Style TargetType="uer:FeedView">
+	<Style TargetType="uer:FeedView" x:Key="DefaultFeedViewStyle">
 		<Setter Property="VerticalAlignment" Value="Stretch" />
 		<Setter Property="HorizontalAlignment" Value="Stretch" />
 		<Setter Property="VerticalContentAlignment" Value="Stretch" />
@@ -355,4 +355,6 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+
+	<!--<Style TargetType="uer:FeedView" BasedOn="{StaticResource DefaultFeedViewStyle}"/>-->
 </ResourceDictionary>

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.xaml
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.xaml
@@ -2,7 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:uer="using:Uno.Extensions.Reactive.UI">
 
-	<Style TargetType="uer:FeedView" x:Key="DefaultFeedViewStyle">
+	<Style TargetType="uer:FeedView">
 		<Setter Property="VerticalAlignment" Value="Stretch" />
 		<Setter Property="HorizontalAlignment" Value="Stretch" />
 		<Setter Property="VerticalContentAlignment" Value="Stretch" />
@@ -355,6 +355,4 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
-
-	<!--<Style TargetType="uer:FeedView" BasedOn="{StaticResource DefaultFeedViewStyle}"/>-->
 </ResourceDictionary>

--- a/src/Uno.Extensions.Reactive.UI/View/FeedViewRefreshState.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedViewRefreshState.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive.UI;
+
+/// <summary>
+/// Defines the visual state that should be used for refresh.
+/// </summary>
+public enum FeedViewRefreshState
+{
+	/// <summary>
+	/// Do not use any visual state, this is usually use-full when you have an external refreshing visual state,
+	/// like a RefreshContainer (cf. Remarks about limitations).
+	/// </summary>
+	/// <remarks>
+	///	This will disable the refreshing state for refresh sources, no matter who as triggered the refresh.
+	/// This means that if you use this flag because you are using a RefreshContainer,
+	/// but your source is being refreshed due to another on canvas refresh button or just because a dependency is being refreshed,
+	/// you won't have any refresh template neither.
+	/// </remarks>
+	None,
+
+	/// <summary>
+	/// Use the loading visual state while refreshing.
+	/// </summary>
+	Loading,
+
+	/// <summary>
+	/// The default is to use the <see cref="Loading"/> for now.
+	/// </summary>
+	Default = Loading,
+}

--- a/src/Uno.Extensions.Reactive.UI/View/FeedViewVisualStateSelector.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedViewVisualStateSelector.cs
@@ -12,21 +12,24 @@ public class FeedViewVisualStateSelector
 	/// <summary>
 	/// Gets all visual states to apply for a given message.
 	/// </summary>
+	/// <param name="feedView">The feed view for which the states should be selected.</param>
 	/// <param name="message">The message to render.</param>
-	/// <returns>Visual states to apply</returns>
-	protected internal virtual IEnumerable<(string stateName, bool shouldUseTransition)> GetVisualStates(IMessage message)
+	/// <returns>Visual states to apply.</returns>
+	protected internal virtual IEnumerable<(string stateName, bool shouldUseTransition)> GetVisualStates(FeedView feedView, IMessage message)
 		=> message
 			.Changes
-			.Select(axis => (name: GetVisualState(axis, message.Current[axis])!, true))
+			.Select(axis => (name: GetVisualState(feedView, message, axis, message.Current[axis])!, true))
 			.Where(state => !string.IsNullOrWhiteSpace(state.name));
 
 	/// <summary>
 	/// Gets the visual state to apply for a given axis regarding its current value.
 	/// </summary>
+	/// <param name="feedView">The feed view for which the state should be selected.</param>
+	/// <param name="message">The message to render.</param>
 	/// <param name="axis">The axis.</param>
 	/// <param name="value">The metadata raw value.</param>
 	/// <returns>The state to apply, or null if none.</returns>
-	protected virtual string? GetVisualState(MessageAxis axis, MessageAxisValue value)
+	protected virtual string? GetVisualState(FeedView feedView, IMessage message, MessageAxis axis, MessageAxisValue value)
 		=> axis.Identifier switch
 		{
 			MessageAxes.Data => MessageAxis.Data.FromMessageValue(value).Type.ToString(),
@@ -34,7 +37,7 @@ public class FeedViewVisualStateSelector
 			MessageAxes.Error when value.IsSet => "Error",
 			MessageAxes.Error => "NoError",
 
-			MessageAxes.Progress when MessageAxis.Progress.FromMessageValue(value) => "Indeterminate",
+			MessageAxes.Progress when MessageAxis.Progress.FromMessageValue(value) && (!message.Current[MessageAxis.Refresh].IsSet || feedView.RefreshingState is FeedViewRefreshState.Loading) => "Indeterminate",
 			MessageAxes.Progress => "NoProgress",
 
 			MessageAxes.BindingSource => null,


### PR DESCRIPTION
## Feature
feat(feeds): Add ability to avoid loading state when refreshing

## What is the current behavior?
The loading visual state is triggered when a feed is being refreshed

## What is the new behavior?
You can request to ignore it!

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
