### PR TITLE
fix: Preventing read/write lock on writable settings

### DIFF
--- a/src/Uno.Extensions.Configuration/Reloader.cs
+++ b/src/Uno.Extensions.Configuration/Reloader.cs
@@ -61,7 +61,7 @@ public class Reloader
 						}
 						if (!read)
 						{
-							await Task.Yield();
+							await Task.Delay(50);
 						}
 					}
 				}

--- a/src/Uno.Extensions.Configuration/WritableOptions.cs
+++ b/src/Uno.Extensions.Configuration/WritableOptions.cs
@@ -45,25 +45,24 @@ public class WritableOptions<T> : IWritableOptions<T>
 	public async Task UpdateAsync(Func<T, T> applyChanges)
 	{
 		if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogDebugMessage($@"Updating options, saving to file '{_file}'");
-
-		var physicalPath = _file;
-		var jObject = File.Exists(physicalPath) ? JsonSerializer.Deserialize<Dictionary<string, object>>(File.ReadAllText(physicalPath)) : new Dictionary<string, object>();
-		jObject = jObject ?? new Dictionary<string, object>();
 		var sectionObject = Value ?? new T();
-
 		sectionObject = applyChanges?.Invoke(sectionObject) ?? new T();
 
-		jObject[_section] = sectionObject;
-
-		var json = JsonSerializer.Serialize(jObject);
-		var dir = Path.GetDirectoryName(physicalPath);
-		if (dir is not null && !Directory.Exists(dir))
-		{
-			Directory.CreateDirectory(dir);
-		}
+		var physicalPath = _file;
 		await Reloader.ReadWriteLock.WaitAsync();
 		try
 		{
+			var jObject = File.Exists(physicalPath) ? JsonSerializer.Deserialize<Dictionary<string, object>>(File.ReadAllText(physicalPath)) : new Dictionary<string, object>();
+			jObject = jObject ?? new Dictionary<string, object>();
+
+			jObject[_section] = sectionObject;
+
+			var json = JsonSerializer.Serialize(jObject);
+			var dir = Path.GetDirectoryName(physicalPath);
+			if (dir is not null && !Directory.Exists(dir))
+			{
+				Directory.CreateDirectory(dir);
+			}
 			File.WriteAllText(physicalPath, json);
 		}
 		finally

--- a/src/Uno.Extensions.Configuration/WritableOptions.cs
+++ b/src/Uno.Extensions.Configuration/WritableOptions.cs
@@ -84,7 +84,7 @@ public class WritableOptions<T> : IWritableOptions<T>
 			}
 			if(!written)
 			{
-				await Task.Yield();
+				await Task.Delay(50);
 			}
 		}
 

--- a/src/Uno.Extensions.Configuration/WritableOptions.cs
+++ b/src/Uno.Extensions.Configuration/WritableOptions.cs
@@ -3,8 +3,6 @@
 public class WritableOptions<T> : IWritableOptions<T>
 	where T : class, new()
 {
-	private const int MaxWriteRetries = 100;
-
 	private readonly IOptionsMonitor<T> _options;
 
 	private readonly string _section;
@@ -63,31 +61,15 @@ public class WritableOptions<T> : IWritableOptions<T>
 		{
 			Directory.CreateDirectory(dir);
 		}
-		var written = false;
-		var attempt = 0;
-		while (!written && attempt++ < MaxWriteRetries)
+		await Reloader.ReadWriteLock.WaitAsync();
+		try
 		{
-			await Reloader.ReadWriteLock.WaitAsync();
-			try
-			{
-				written = true;
-				File.WriteAllText(physicalPath, json);
-			}
-			catch(IOException)
-			{
-				// Only retry on IOExceptions eg sharing violation
-				written = false;
-			}
-			finally
-			{
-				Reloader.ReadWriteLock.Release();
-			}
-			if(!written)
-			{
-				await Task.Delay(50);
-			}
+			File.WriteAllText(physicalPath, json);
 		}
-
+		finally
+		{
+			Reloader.ReadWriteLock.Release();
+		}
 
 		await _reloader.ReloadAllFileConfigurationProviders(physicalPath);
 	}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
@@ -28,6 +28,9 @@
 			<Button AutomationProperties.AutomationId="OnePageToTwoPageViewModelButton"
 					Content="Two (ViewModel)"
 					Click="{x:Bind ViewModel.GoToTwo}"/>
+			<Button AutomationProperties.AutomationId="RapidSettingsWriteTestButton"
+					Content="Settings Write Test"
+					Click="{x:Bind ViewModel.SettingsWriteTest}" />
 		</StackPanel>
 	</Grid>
 </Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOneViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using FluentAssertions;
 
 namespace TestHarness.Ext.Navigation.PageNavigation;
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOneViewModel.cs
@@ -1,11 +1,40 @@
-﻿namespace TestHarness.Ext.Navigation.PageNavigation;
+﻿using System.Collections.Immutable;
+using FluentAssertions;
 
-public record PageNavigationOneViewModel (INavigator Navigator, IWritableOptions<PageNavigationSettings> Settings)
+namespace TestHarness.Ext.Navigation.PageNavigation;
+
+public record PageNavigationOneViewModel(IServiceProvider Services, INavigator Navigator, IWritableOptions<PageNavigationSettings> Settings)
 {
 	public async void GoToTwo()
 	{
 		await Settings.UpdateAsync(s => s with { PagesVisited = s.PagesVisited.Add(this.GetType().Name) });
 		await Navigator.NavigateViewModelAsync<PageNavigationTwoViewModel>(this);
+	}
+
+	public async void SettingsWriteTest()
+	{
+		var tasks = new List<Task>();
+		for (int i = 0; i < 5; i++)
+		{
+			tasks.Add(Task.Run(()=>ReadWriteTest()));
+		}
+		await Task.WhenAll(tasks);
+	}
+
+	private async Task ReadWriteTest()
+	{
+		var rnd = new Random();
+		await Settings.UpdateAsync(s => s with { PagesVisited = ImmutableList<string>.Empty });
+		var settings = Settings.Value;
+		for (int i = 0; i < 50; i++)
+		{
+			await Settings.UpdateAsync(s => s with { PagesVisited = s.PagesVisited.Add($"Random {rnd.NextDouble() * 10000}") });
+			settings = Settings.Value;
+
+			var accessor = Services.GetRequiredService<IWritableOptions<PageNavigationSettings>>();
+			settings = accessor.Value;
+		}
+
 	}
 
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #695

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

There's no locking around file access for either read or write

## What is the new behavior?

Added semaphore around reading and writing to prevent concurrent access to same files

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
