### PR TITLE
fix: Preventing additional tokens from being cleaned out when refreshing cookies

### DIFF
--- a/src/Uno.Extensions.Authentication/TokenCacheExtensions.cs
+++ b/src/Uno.Extensions.Authentication/TokenCacheExtensions.cs
@@ -26,7 +26,7 @@ public static class TokenCacheExtensions
 	}
 	public static async ValueTask<bool> SaveTokensAsync(this ITokenCache cache, string provider, string? accessToken=null, string? refreshToken=null, CancellationToken? cancellation = default)
 	{
-		var dict = new Dictionary<string, string>();
+		var dict = await cache.GetAsync(cancellation);
 		if (!string.IsNullOrWhiteSpace(accessToken))
 		{
 			dict[AccessTokenKey] = accessToken!;

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationTestBackendCookieHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationTestBackendCookieHostInit.cs
@@ -22,10 +22,13 @@ public class CustomAuthenticationTestBackendCookieHostInit : BaseHostInitializat
 								var name = credentials.FirstOrDefault(x => x.Key == nameof(CustomAuthenticationCredentials.Username)).Value;
 								var password = credentials.FirstOrDefault(x => x.Key == nameof(CustomAuthenticationCredentials.Password)).Value;
 								await authService.LoginCookie(name, password, cancellationToken);
-								return await cache.GetAsync(cancellationToken);
+								var tokens = await cache.GetAsync(cancellationToken);
+								tokens["Expiry"] = DateTime.Now.AddMinutes(10).ToString();
+								return tokens;
 							})
 							.Refresh(async (authService, cache, tokenDictionary, cancellationToken) =>
 							{
+								var expiry = tokenDictionary["Expiry"];
 								await Task.Delay(3000);
 								await authService.RefreshCookie(cancellationToken);
 								return await cache.GetAsync(cancellationToken);


### PR DESCRIPTION
GitHub Issue (If applicable): #697


## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

CookieHandler saves tokens using the SaveTokenAsync extension which saves a new dictionary with the updated access and refresh tokens added to it. This will clear out any other tokens

## What is the new behavior?

CookieHandler gets the current dictionary of tokens from the cache and updates it with the new access and refresh tokens. This way the additional data isn't lost

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
