### PR TITLE
fix: Exception when attempting to navigate from XAML

### DIFF
--- a/src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs
@@ -121,7 +121,7 @@ public static class NavigationRequestExtensions
 								m.IsGenericMethodDefinition).ToArray();
 		var navMethod = navMethods.First();
 		var constructedNavMethod = navMethod.MakeGenericMethod(hint.Result);
-		var nav = (NavigationRequest)constructedNavMethod.Invoke(null, new object?[] { hint, resolver, sender, data, cancellation });
+		var nav = (NavigationRequest)constructedNavMethod.Invoke(null, new object?[] { hint, navigator, resolver, sender, data, cancellation });
 		return nav;
 
 	}


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

When navigating in XAML the incorrect number of parameters are passed when attempting to invoke the generic ToRequest method

## What is the new behavior?

The correct parameters are passed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
