### PR TITLE
fix: Capturing exceptions during login

### DIFF
--- a/src/Uno.Extensions.Authentication/BaseAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication/BaseAuthenticationProvider.cs
@@ -5,11 +5,11 @@ public abstract record BaseAuthenticationProvider(ILogger Logger, string Name, I
 {
 	public async virtual ValueTask<bool> CanRefresh(CancellationToken cancellationToken) => true;
 
-	public ValueTask<IDictionary<string, string>?> LoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
+	public async ValueTask<IDictionary<string, string>?> LoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
 	{
 		try
 		{
-			return InternalLoginAsync(dispatcher, credentials, cancellationToken);
+			return await InternalLoginAsync(dispatcher, credentials, cancellationToken);
 		}
 		catch (Exception ex)
 		{
@@ -25,16 +25,16 @@ public abstract record BaseAuthenticationProvider(ILogger Logger, string Name, I
 		return default;
 	}
 
-	public ValueTask<bool> LogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
+	public async ValueTask<bool> LogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken)
 	{
 		try
 		{
-			return InternalLogoutAsync(dispatcher, cancellationToken);
+			return await InternalLogoutAsync(dispatcher, cancellationToken);
 		}
 		catch (Exception ex)
 		{
 			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Error attempting to logout [Error - {ex.Message}]");
-			return new ValueTask<bool>(false);
+			return false;
 		}
 	}
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Exceptions during login callback aren't being captured and are bubbling up out of the LoginAsync method (it should just return false)

## What is the new behavior?

LoginAsync returns false

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
