### PR TITLE
chore(ci): Fix reactive test not running on CI

### DIFF
--- a/build/ci/.azure-pipelines.Packages.yml
+++ b/build/ci/.azure-pipelines.Packages.yml
@@ -65,6 +65,7 @@ jobs:
         !**/obj/**
       vsTestVersion: toolsInstaller
       testSelector: testAssemblies
+      runSettingsFile: build/tests.runsettings
 
   - task: PowerShell@2
     displayName: Authenticode Sign Packages

--- a/build/tests.runsettings
+++ b/build/tests.runsettings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+	<TargetPlatform>x86</TargetPlatform>
+	<TargetFrameworkVersion>net6.0</TargetFrameworkVersion>
+	<TestSessionTimeout>10000</TestSessionTimeout>
+	<TreatNoTestsAsError>true</TreatNoTestsAsError>
+</RunSettings>


### PR DESCRIPTION
## Build or CI related changes
Fix reactive test not running on CI

## What is the current behavior?
Reactive test assembly is ignored as it targets net6.0 (while test engine is looking only for .net 4.0 assemblies)

