### PR TITLE
feat: Adding configuration to web authentication

### DIFF
--- a/src/Uno.Extensions.Authentication.Msal/MsalAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.Msal/MsalAuthenticationProvider.cs
@@ -31,7 +31,12 @@ internal record MsalAuthenticationProvider(
 		if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Invoking settings Build callback");
 		Settings?.Build?.Invoke(builder);
 
-		_scopes = Settings?.Scopes ?? new string[] { };
+		_scopes = config.Scopes ?? new string[] { };
+		if(_scopes.Length == 0 &&
+			Settings?.Scopes is not null)
+		{
+			_scopes = Settings.Scopes;
+		}
 
 		if (PlatformHelper.IsWebAssembly)
 		{

--- a/src/Uno.Extensions.Authentication.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Authentication.UI/GlobalUsings.cs
@@ -14,6 +14,7 @@ global using Microsoft.Extensions.Logging;
 global using Uno.Extensions;
 global using Uno.Extensions.Authentication;
 global using Uno.Extensions.Authentication.Web;
+global using Uno.Extensions.Configuration;
 global using Uno.Extensions.Hosting;
 global using Uno.Extensions.Navigation;
 global using Windows.Security.Authentication.Web;

--- a/src/Uno.Extensions.Authentication.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication.UI/HostBuilderExtensions.cs
@@ -10,6 +10,18 @@ public static class HostBuilderExtensions
 #if WINDOWS
 		WinUIEx.WebAuthenticator.Init();
 #endif
+		var hostBuilder = (builder as IBuilder)?.HostBuilder;
+		if (hostBuilder is null)
+		{
+			return builder;
+		}
+
+		hostBuilder
+			.UseConfiguration(configure: configBuilder =>
+					configBuilder
+						.Section<WebConfiguration>(name)
+				);
+
 
 		var authBuilder = builder.AsBuilder<WebAuthenticationBuilder>();
 
@@ -32,7 +44,17 @@ public static class HostBuilderExtensions
 #if WINDOWS
 		WinUIEx.WebAuthenticator.Init();
 #endif
+		var hostBuilder = (builder as IBuilder)?.HostBuilder;
+		if (hostBuilder is null)
+		{
+			return builder;
+		}
 
+		hostBuilder
+			.UseConfiguration(configure: configBuilder =>
+					configBuilder
+						.Section<WebConfiguration>(name)
+				);
 		var authBuilder = builder.AsBuilder<WebAuthenticationBuilder<TService>>();
 
 		configure?.Invoke(authBuilder);

--- a/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationSettings.cs
+++ b/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationSettings.cs
@@ -2,6 +2,7 @@
 
 internal record WebAuthenticationSettings
 {
+	public bool PrefersEphemeralWebBrowserSession { get; init; }
 	public string? LoginStartUri { get; init; }
 
 	public AsyncFunc<IServiceProvider, ITokenCache, IDictionary<string, string>?, string?, string>? PrepareLoginStartUri { get; init; }

--- a/src/Uno.Extensions.Authentication.UI/Web/WebConfiguration.cs
+++ b/src/Uno.Extensions.Authentication.UI/Web/WebConfiguration.cs
@@ -1,0 +1,14 @@
+﻿namespace Uno.Extensions.Authentication.Web;
+
+internal record WebConfiguration
+{
+	public bool PrefersEphemeralWebBrowserSession { get; init; }
+	public string? LoginStartUri { get; init; }
+	public string? LoginCallbackUri { get; init; }
+	public string? AccessTokenKey { get; init; }
+	public string? RefreshTokenKey { get; init; }
+	public string? IdTokenKey { get; init; }
+	public IDictionary<string, string>? OtherTokenKeys { get; init; }
+	public string? LogoutStartUri { get; init; }
+	public string? LogoutCallbackUri { get; init; }
+}

--- a/src/Uno.Extensions.Authentication.UI/WebAuthenticationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication.UI/WebAuthenticationBuilderExtensions.cs
@@ -2,6 +2,14 @@
 
 public static class WebAuthenticationBuilderExtensions
 {
+	public static TWebAuthenticationBuilder PrefersEphemeralWebBrowserSession<TWebAuthenticationBuilder>(
+	this TWebAuthenticationBuilder builder,
+	bool preferEphemeral)
+	where TWebAuthenticationBuilder : IWebAuthenticationBuilder
+	=>
+		builder.Property((WebAuthenticationSettings s)
+			=> s with { PrefersEphemeralWebBrowserSession = preferEphemeral });
+
 	public static TWebAuthenticationBuilder LoginStartUri<TWebAuthenticationBuilder>(
 		this TWebAuthenticationBuilder builder,
 		string uri)

--- a/testing/TestHarness/TestHarness.Core/TestSections.cs
+++ b/testing/TestHarness/TestHarness.Core/TestSections.cs
@@ -22,5 +22,6 @@ public enum TestSections
 	Authentication_Multi,
 	Authentication_Oidc,
 	Authentication_Web,
+	Authentication_Web_Settings,
 	Core_Storage
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/WebAuthenticationMainPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/WebAuthenticationMainPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿namespace TestHarness.Ext.Authentication.Web;
 
 [TestSectionRoot("Authentication: Web",TestSections.Authentication_Web, typeof(WebAuthenticationHostInit))]
+[TestSectionRoot("Authentication: Web using appsettings", TestSections.Authentication_Web_Settings, typeof(WebAuthenticationSettingsHostInit))]
 public sealed partial class WebAuthenticationMainPage : BaseTestSectionPage
 {
 	public WebAuthenticationMainPage()

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/WebAuthenticationSettingsHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/WebAuthenticationSettingsHostInit.cs
@@ -1,0 +1,58 @@
+﻿namespace TestHarness.Ext.Authentication.Web;
+
+public class WebAuthenticationSettingsHostInit : BaseHostInitialization
+{
+	protected override string[] ConfigurationFiles => new string[] {
+		"TestHarness.Ext.Authentication.Web.appsettings.webauth.json",
+		"TestHarness.Ext.Authentication.Web.appsettings.webauthsettings.json"};
+
+	protected override IHostBuilder Custom(IHostBuilder builder)
+	{
+		return builder
+			.UseAuthentication(auth =>
+					auth
+					.AddWeb<IWebAuthenticationTestEndpoint>(name: "WebSettings")) // name defines not only the name of the provider but also the section in the appsettings file
+
+				.ConfigureServices(services =>
+					services
+							.AddSingleton<IAuthenticationRouteInfo>(
+									_ => new AuthenticationRouteInfo<
+											WebAuthenticationLoginViewModel,
+											WebAuthenticationHomeViewModel>())
+				)
+
+				.ConfigureServices((context, services) =>
+				{
+					services
+							.AddNativeHandler()
+							.AddContentSerializer()
+
+							.AddRefitClient<IWebAuthenticationTestEndpoint>(context);
+				});
+	}
+
+	protected override void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+	{
+
+		views.Register(
+				new ViewMap(ViewModel: typeof(AuthenticationShellViewModel)),
+				new ViewMap<WebAuthenticationLoginPage, WebAuthenticationLoginViewModel>(),
+				new ViewMap<WebAuthenticationHomePage, WebAuthenticationHomeViewModel>()
+				);
+
+
+		routes
+			.Register(
+				new RouteMap("", View: views.FindByViewModel<AuthenticationShellViewModel>(),
+						Nested: new RouteMap[]
+						{
+							new RouteMap("Login", View: views.FindByViewModel<WebAuthenticationLoginViewModel>()),
+							new RouteMap("Home", View: views.FindByViewModel<WebAuthenticationHomeViewModel>())
+						}));
+	}
+}
+
+
+
+
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/appsettings.webauthsettings.json
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/appsettings.webauthsettings.json
@@ -1,0 +1,6 @@
+﻿{
+  "WebSettings": {
+    "LoginStartUri": "https://localhost:7193/webauth/Login/Facebook?redirect_uri=oidc-auth://",
+    "LogoutStartUri": "https://localhost:7193/webauth/Logout/Facebook"
+  }
+}

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -79,6 +79,7 @@
       <DependentUpon>WebAuthenticationHomePage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\WebAuthenticationHomeViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\WebAuthenticationSettingsHostInit.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\WebAuthenticationHostInit.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\WebAuthenticationLoginPage.xaml.cs">
       <DependentUpon>WebAuthenticationLoginPage.xaml</DependentUpon>
@@ -576,6 +577,7 @@
 		 explicitly included in the projitem, so files can be added from vscode
 		 without manipulating the projitem file.
 	-->
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\appsettings.webauthsettings.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\appsettings.webauth.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Custom\appsettings.testbackend.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Custom\appsettings.dummyjson.json" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

WebAuth parameters such as loginstarturi have to be set in code. The static values should be able to be set in appsettings

## What is the new behavior?

- WebAuth parameters can be specified in appsettings.json. Default section name is Web and maps to the WebConfiguration record
```
internal record WebConfiguration
{
	public bool PrefersEphemeralWebBrowserSession { get; init; }
	public string? LoginStartUri { get; init; }
	public string? LoginCallbackUri { get; init; }
	public string? AccessTokenKey { get; init; }
	public string? RefreshTokenKey { get; init; }
	public string? IdTokenKey { get; init; }
	public IDictionary<string, string>? OtherTokenKeys { get; init; }
	public string? LogoutStartUri { get; init; }
	public string? LogoutCallbackUri { get; init; }
}
```
- Added support on ios for PrefersEphemeralWebBrowserSession attribute to be configured
- If no callback uri is provided and the redirect_uri parameter is set on the login(logout)starturi, the redirect_uri value will be automatically extracted as the callbackuri 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
