### PR TITLE
feat: Reworking logic around keyvaluestorage

### DIFF
--- a/src/Uno.Extensions.Authentication/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication/HostBuilderExtensions.cs
@@ -83,11 +83,10 @@ public static class HostBuilderExtensions
 			.ConfigureServices(services =>
 			{
 				services
-					.AddSingleton(
-							sp=>new TokenStorageProvider(
-										sp,
-										sp.GetRequiredService<SecureStorage>().Name))
-					.AddSingleton<ITokenCache, TokenCache>()
+					.AddSingleton<ITokenCache>(sp =>
+							new TokenCache(
+								sp.GetRequiredService<ILogger<TokenCache>>(),
+								sp.GetRequiredDefaultInstance<IKeyValueStorage>()))
 					.AddSingleton<IAuthenticationService, AuthenticationService>();
 			})
 			.Authorization(configureAuthorization);

--- a/src/Uno.Extensions.Authentication/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication/HostBuilderExtensions.cs
@@ -84,9 +84,9 @@ public static class HostBuilderExtensions
 			{
 				services
 					.AddSingleton(
-							sp=>new KeyValueStorageSelector<TokenCache>(
+							sp=>new TokenStorageProvider(
 										sp,
-										sp.GetRequiredService<KeyValueStorageIndex>().MostSecure))
+										sp.GetRequiredService<SecureStorage>().Name))
 					.AddSingleton<ITokenCache, TokenCache>()
 					.AddSingleton<IAuthenticationService, AuthenticationService>();
 			})

--- a/src/Uno.Extensions.Authentication/TokenCache.cs
+++ b/src/Uno.Extensions.Authentication/TokenCache.cs
@@ -1,6 +1,6 @@
 ﻿namespace Uno.Extensions.Authentication;
 
-public record TokenCache : ITokenCache
+internal record TokenCache : ITokenCache
 {
 	private readonly ILogger _logger;
 	private readonly SemaphoreSlim tokenLock = new SemaphoreSlim(1);
@@ -8,7 +8,7 @@ public record TokenCache : ITokenCache
 
 	public TokenCache(
 		ILogger<TokenCache> logger,
-		KeyValueStorageSelector<TokenCache> secureCacheSelector)
+		TokenStorageProvider secureCacheSelector)
 	{
 		_logger = logger;
 		_secureCache = secureCacheSelector.Storage;

--- a/src/Uno.Extensions.Authentication/TokenCache.cs
+++ b/src/Uno.Extensions.Authentication/TokenCache.cs
@@ -8,10 +8,10 @@ internal record TokenCache : ITokenCache
 
 	public TokenCache(
 		ILogger<TokenCache> logger,
-		TokenStorageProvider secureCacheSelector)
+		IKeyValueStorage secureCache)
 	{
 		_logger = logger;
-		_secureCache = secureCacheSelector.Storage;
+		_secureCache = secureCache;
 	}
 
 	public event EventHandler? Cleared;

--- a/src/Uno.Extensions.Authentication/TokenStorageProvider.cs
+++ b/src/Uno.Extensions.Authentication/TokenStorageProvider.cs
@@ -1,6 +1,6 @@
-﻿namespace Uno.Extensions.Storage.KeyValueStorage;
+﻿namespace Uno.Extensions.Authentication;
 
-public record KeyValueStorageSelector<TService>(IServiceProvider Services, string Name)
+internal record TokenStorageProvider(IServiceProvider Services, string Name)
 {
 	public IKeyValueStorage Storage => Services.GetNamedService<IKeyValueStorage>(Name)??throw new KeyNotFoundException($"No KeyValueStorage available for {Name}");
 }

--- a/src/Uno.Extensions.Authentication/TokenStorageProvider.cs
+++ b/src/Uno.Extensions.Authentication/TokenStorageProvider.cs
@@ -1,6 +1,0 @@
-﻿namespace Uno.Extensions.Authentication;
-
-internal record TokenStorageProvider(IServiceProvider Services, string Name)
-{
-	public IKeyValueStorage Storage => Services.GetNamedService<IKeyValueStorage>(Name)??throw new KeyNotFoundException($"No KeyValueStorage available for {Name}");
-}

--- a/src/Uno.Extensions.Core/DependencyInjection/NamedInstance.cs
+++ b/src/Uno.Extensions.Core/DependencyInjection/NamedInstance.cs
@@ -13,3 +13,4 @@ internal record NamedInstance<TService, TImplementation>(IServiceProvider Servic
 		return Services.GetRequiredService<TImplementation>();
 	}
 }
+

--- a/src/Uno.Extensions.Core/DependencyInjection/NamedInstanceReference.cs
+++ b/src/Uno.Extensions.Core/DependencyInjection/NamedInstanceReference.cs
@@ -1,0 +1,15 @@
+﻿namespace Uno.Extensions.DependencyInjection;
+
+internal record NamedInstanceReference<TService>(IServiceProvider Services, string OriginalName, string Name) : INamedInstance<TService>
+{
+	public TService? Get()
+	{
+		return Services.GetNamedService<TService>(OriginalName);
+	}
+
+	public TService GetRequired()
+	{
+		return Services.GetRequiredNamedService<TService>(OriginalName);
+	}
+}
+

--- a/src/Uno.Extensions.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.Extensions.DependencyInjection.Extensions;
-
-namespace Uno.Extensions;
+﻿namespace Uno.Extensions;
 
 public static class ServiceCollectionExtensions
 {
+	private const string DefaultInstanceKey = "Default";
+
 	public static IServiceCollection AddNamedSingleton<TService, TImplementation>(this IServiceCollection services, string Name)
 		where TService : class where TImplementation : class, TService
 	{
@@ -17,6 +17,35 @@ public static class ServiceCollectionExtensions
 				// Register the named resolve
 				.AddSingleton<INamedInstance<TService>>(sp=>new NamedInstance<TService,TImplementation>(sp,Name));
 	}
+
+	private static IServiceCollection AddNamedSingletonReference<TService>(this IServiceCollection services, string OriginalName, string Name)
+	{
+		return services
+				// Register the named resolve
+				.AddSingleton<INamedInstance<TService>>(sp => new NamedInstanceReference<TService>(sp, OriginalName, Name));
+	}
+
+	public static IServiceCollection SetDefaultInstance<TService, TImplementation>(this IServiceCollection services)
+		where TService : class where TImplementation : class, TService
+	{
+		return services.AddNamedSingleton<TService, TImplementation>(DefaultInstanceKey);
+	}
+
+	public static IServiceCollection SetDefaultInstance<TService> (this IServiceCollection services, string ExistingInstance)
+	{
+		return services.AddNamedSingletonReference<TService>(ExistingInstance, DefaultInstanceKey);
+	}
+
+	public static TService? GetDefaultInstance<TService>(this IServiceProvider sp)
+	{
+		return GetNamedService<TService>(sp, DefaultInstanceKey);
+	}
+
+	public static TService GetRequiredDefaultInstance<TService>(this IServiceProvider sp)
+	{
+		return GetRequiredNamedService<TService>(sp, DefaultInstanceKey);
+	}
+
 
 	private static INamedInstance<TService> FindNamedInstance<TService>(this IServiceProvider sp, string Name)
 	{

--- a/src/Uno.Extensions.Core/GlobalUsings.cs
+++ b/src/Uno.Extensions.Core/GlobalUsings.cs
@@ -5,8 +5,8 @@ global using System.Runtime.InteropServices;
 global using System.Threading;
 global using System.Threading.Tasks;
 global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.DependencyInjection.Extensions;
 global using Microsoft.Extensions.Logging;
 global using Uno.Extensions.DependencyInjection;
-global using Uno.Extensions.Logging;
-global using Uno.Extensions.Threading;
+
 

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/ApplicationDataKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/ApplicationDataKeyValueStorage.cs
@@ -10,6 +10,9 @@ internal record ApplicationDataKeyValueStorage(ILogger<ApplicationDataKeyValueSt
 	private readonly ApplicationDataContainer _dataContainer = ApplicationData.Current.LocalSettings;
 
 	/// <inheritdoc />
+	public virtual  bool IsEncrypted => false;
+
+	/// <inheritdoc />
 	public async ValueTask ClearAsync(string? name, CancellationToken ct)
 	{
 		if (Logger.IsEnabled(LogLevel.Debug))

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/EncryptedApplicationDataKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/EncryptedApplicationDataKeyValueStorage.cs
@@ -14,6 +14,11 @@ internal record EncryptedApplicationDataKeyValueStorage(ILogger<ApplicationDataK
 	private readonly DataProtectionProvider _provider = new DataProtectionProvider(DataProtectionProviderDescriptor);
 
 	private const string DataProtectionProviderDescriptor = "LOCAL=user";
+
+	/// <inheritdoc />
+	public override bool IsEncrypted => false;
+
+
 #nullable disable
 	protected override async Task<T> GetTypedValue<T>(object encryptedData, CancellationToken ct) 
 	{

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyChainKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyChainKeyValueStorage.cs
@@ -26,6 +26,8 @@ public record KeyChainSettingsStorage(ILogger<KeyChainSettingsStorage> Logger, I
 
 	private readonly FastAsyncLock _clearKeychain = new FastAsyncLock();
 
+	/// <inheritdoc />
+	public bool IsEncrypted => true;
 
 	/// <inheritdoc/>
 	public async ValueTask ClearAsync(string? name, CancellationToken ct)

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyStoreKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyStoreKeyValueStorage.cs
@@ -52,6 +52,9 @@ internal record KeyStoreSettingsStorage : IKeyValueStorage
 	}
 
 	/// <inheritdoc />
+	public bool IsEncrypted => true;
+
+	/// <inheritdoc />
 	public async ValueTask ClearAsync(string? name, CancellationToken ct)
 	{
 		if (_logger.IsEnabled(LogLevel.Debug))

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/PasswordVaultKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/PasswordVaultKeyValueStorage.cs
@@ -17,6 +17,9 @@ internal record PasswordVaultKeyValueStorage(
 
 	private readonly PasswordVault _passwordVault = new PasswordVault();
 
+	/// <inheritdoc />
+	public bool IsEncrypted => false;
+
 	/// <inheritdoc/>
 	public async ValueTask ClearAsync(string? name, CancellationToken ct)
 	{

--- a/src/Uno.Extensions.Storage.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Storage.UI/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System.Reflection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Uno.Extensions.DependencyInjection;
 
 namespace Uno.Extensions;
 
@@ -29,36 +31,37 @@ public static class ServiceCollectionExtensions
 #if WINDOWS
 				.AddNamedSingleton<IKeyValueStorage, EncryptedApplicationDataKeyValueStorage>(EncryptedApplicationDataKeyValueStorage.Name)
 #endif
-				.AddSingleton<SecureStorage>(
+				.SetDefaultInstance<IKeyValueStorage>(
 #if WINUI
 #if __ANDROID__
-					new SecureStorage(KeyStoreSettingsStorage.Name)
+					KeyStoreSettingsStorage.Name
 #elif __IOS__
-					new SecureStorage(KeyChainSettingsStorage.Name)
+					KeyChainSettingsStorage.Name
 #elif WINDOWS
-					new SecureStorage(EncryptedApplicationDataKeyValueStorage.Name)
+					EncryptedApplicationDataKeyValueStorage.Name
 #else
 					// For WASM and other platforms where we don't currently have
 					// a secure storage option, we default to InMemory to avoid
 					// security concerns with saving plain text
-					new SecureStorage(InMemoryKeyValueStorage.Name)
+					InMemoryKeyValueStorage.Name
 #endif
 
 #else
 #if __ANDROID__
-					new SecureStorage(PasswordVaultKeyValueStorage.Name)
+					PasswordVaultKeyValueStorage.Name
 #elif __IOS__
-					new SecureStorage(PasswordVaultKeyValueStorage.Name)
+					PasswordVaultKeyValueStorage.Name
 #elif WINDOWS_UWP
-					new SecureStorage(PasswordVaultKeyValueStorage.Name)
+					PasswordVaultKeyValueStorage.Name
 #else
 					// For WASM and other platforms where we don't currently have
 					// a secure storage option, we default to InMemory to avoid
 					// security concerns with saving plain text
-					new SecureStorage(InMemoryKeyValueStorage.Name)
+					InMemoryKeyValueStorage.Name
 #endif
 #endif
-
 					);
 	}
+
+
 }

--- a/src/Uno.Extensions.Storage.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Storage.UI/ServiceCollectionExtensions.cs
@@ -29,66 +29,33 @@ public static class ServiceCollectionExtensions
 #if WINDOWS
 				.AddNamedSingleton<IKeyValueStorage, EncryptedApplicationDataKeyValueStorage>(EncryptedApplicationDataKeyValueStorage.Name)
 #endif
-				.AddSingleton<KeyValueStorageIndex>(
+				.AddSingleton<SecureStorage>(
 #if WINUI
 #if __ANDROID__
-					new KeyValueStorageIndex(
-						MostSecure: KeyStoreSettingsStorage.Name,
-						(InMemoryKeyValueStorage.Name, false),
-						(ApplicationDataKeyValueStorage.Name, false),
-						(KeyStoreSettingsStorage.Name, true))
+					new SecureStorage(KeyStoreSettingsStorage.Name)
 #elif __IOS__
-					new KeyValueStorageIndex(
-						MostSecure: KeyChainSettingsStorage.Name,
-						(InMemoryKeyValueStorage.Name, false),
-						(ApplicationDataKeyValueStorage.Name, false),
-						(KeyChainSettingsStorage.Name, true))
+					new SecureStorage(KeyChainSettingsStorage.Name)
 #elif WINDOWS
-					new KeyValueStorageIndex(
-						MostSecure: EncryptedApplicationDataKeyValueStorage.Name,
-						(InMemoryKeyValueStorage.Name, false),
-						(ApplicationDataKeyValueStorage.Name, false),
-						(EncryptedApplicationDataKeyValueStorage.Name, true))
+					new SecureStorage(EncryptedApplicationDataKeyValueStorage.Name)
 #else
-					new KeyValueStorageIndex(
-						// For WASM and other platforms where we don't currently have
-						// a secure storage option, we default to InMemory to avoid
-						// security concerns with saving plain text
-						MostSecure: InMemoryKeyValueStorage.Name,
-						(InMemoryKeyValueStorage.Name, false),
-						(ApplicationDataKeyValueStorage.Name, false))
+					// For WASM and other platforms where we don't currently have
+					// a secure storage option, we default to InMemory to avoid
+					// security concerns with saving plain text
+					new SecureStorage(InMemoryKeyValueStorage.Name)
 #endif
 
 #else
 #if __ANDROID__
-					new KeyValueStorageIndex(
-						MostSecure: PasswordVaultKeyValueStorage.Name,
-						(InMemoryKeyValueStorage.Name, false),
-						(ApplicationDataKeyValueStorage.Name, false),
-						(KeyStoreSettingsStorage.Name, true),
-						(PasswordVaultKeyValueStorage.Name, true))
+					new SecureStorage(PasswordVaultKeyValueStorage.Name)
 #elif __IOS__
-					new KeyValueStorageIndex(
-						MostSecure: PasswordVaultKeyValueStorage.Name,
-						(InMemoryKeyValueStorage.Name, false),
-						(ApplicationDataKeyValueStorage.Name, false),
-						(KeyChainSettingsStorage.Name, true),
-						(PasswordVaultKeyValueStorage.Name, true))
+					new SecureStorage(PasswordVaultKeyValueStorage.Name)
 #elif WINDOWS_UWP
-					new KeyValueStorageIndex(
-						MostSecure: PasswordVaultKeyValueStorage.Name,
-						(InMemoryKeyValueStorage.Name, false),
-						(ApplicationDataKeyValueStorage.Name, false),
-						(EncryptedApplicationDataKeyValueStorage.Name, true),
-						(PasswordVaultKeyValueStorage.Name, true))
+					new SecureStorage(PasswordVaultKeyValueStorage.Name)
 #else
-					new KeyValueStorageIndex(
-						// For WASM and other platforms where we don't currently have
-						// a secure storage option, we default to InMemory to avoid
-						// security concerns with saving plain text
-						MostSecure: InMemoryKeyValueStorage.Name,
-						(InMemoryKeyValueStorage.Name, false),
-						(ApplicationDataKeyValueStorage.Name, false))
+					// For WASM and other platforms where we don't currently have
+					// a secure storage option, we default to InMemory to avoid
+					// security concerns with saving plain text
+					new SecureStorage(InMemoryKeyValueStorage.Name)
 #endif
 #endif
 

--- a/src/Uno.Extensions.Storage/GlobalUsings.cs
+++ b/src/Uno.Extensions.Storage/GlobalUsings.cs
@@ -1,10 +1,10 @@
 ﻿global using System;
 global using System.Collections.Generic;
+global using System.IO;
 global using System.Linq;
 global using System.Threading;
 global using System.Threading.Tasks;
 global using Microsoft.Extensions.Logging;
 global using Uno.Extensions.Logging;
 global using Uno.Extensions.Serialization;
-global using Uno.Extensions.Storage.KeyValueStorage;
 global using Uno.Extensions.Threading;

--- a/src/Uno.Extensions.Storage/IStorage.cs
+++ b/src/Uno.Extensions.Storage/IStorage.cs
@@ -1,7 +1,4 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-
-namespace Uno.Extensions.Storage;
+﻿namespace Uno.Extensions.Storage;
 
 public interface IStorage
 {

--- a/src/Uno.Extensions.Storage/KeyValueStorage/IKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage/KeyValueStorage/IKeyValueStorage.cs
@@ -8,6 +8,11 @@ namespace Uno.Extensions.Storage.KeyValueStorage;
 public interface IKeyValueStorage
 {
 	/// <summary>
+	/// Gets a value indicating whether data is encrypted
+	/// </summary>
+	bool IsEncrypted { get; }
+
+	/// <summary>
 	/// Removes any value stored under the provided key.
 	/// </summary>
 	/// <param name="key">The key to clear</param>

--- a/src/Uno.Extensions.Storage/KeyValueStorage/InMemoryKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage/KeyValueStorage/InMemoryKeyValueStorage.cs
@@ -13,6 +13,9 @@ internal record InMemoryKeyValueStorage(ILogger<InMemoryKeyValueStorage> Logger)
 	private readonly Dictionary<string, object> _values = new Dictionary<string, object>();
 
 	/// <inheritdoc />
+	public bool IsEncrypted => false;
+
+	/// <inheritdoc />
 	public async ValueTask ClearAsync(string? name, CancellationToken ct)
 	{
 		if (Logger.IsEnabled(LogLevel.Debug))

--- a/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageIndex.cs
+++ b/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageIndex.cs
@@ -1,5 +1,5 @@
 ﻿namespace Uno.Extensions.Storage.KeyValueStorage;
 
-internal record KeyValueStorageIndex(string MostSecure, params (string Name, bool IsEncrypted)[] AvailableStorage)
+internal record SecureStorage(string Name)
 {
 }

--- a/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageIndex.cs
+++ b/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageIndex.cs
@@ -1,5 +1,0 @@
-﻿namespace Uno.Extensions.Storage.KeyValueStorage;
-
-internal record SecureStorage(string Name)
-{
-}


### PR DESCRIPTION
# PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Extra code around registration of IKeyValueStorage implementations that's not necessary

## What is the new behavior?

- Multiple IKeyValueStorage implementations are registered for each platform
- IKeyValueStorage now includes an IsEncrypted property indicating whether data is encrypted (ie safe to use for credentials etc)
- For each platform a Default instance is registered with the DI container. 
- The Default instance is used when registering the instance of the TokenCache


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
