### PR TITLE
feat: Removing try-catch around login/logout/refresh logic

### DIFF
--- a/src/Uno.Extensions.Authentication/BaseAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication/BaseAuthenticationProvider.cs
@@ -14,7 +14,9 @@ public abstract record BaseAuthenticationProvider(ILogger Logger, string Name, I
 		{
 			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Error attempting to login [Error - {ex.Message}]");
 			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Login credentials {credentials?.ToString()}");
-			return default;
+
+			// Exception is bubbled so that the caller of IAuthenticationService.LoginAsync can handle it
+			throw;
 		}
 		finally
 		{
@@ -38,7 +40,9 @@ public abstract record BaseAuthenticationProvider(ILogger Logger, string Name, I
 		catch (Exception ex)
 		{
 			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Error attempting to logout [Error - {ex.Message}]");
-			return false;
+
+			// Exception is bubbled so that the caller of IAuthenticationService.LogoutAsync can handle it
+			throw;
 		}
 		finally
 		{
@@ -64,7 +68,9 @@ public abstract record BaseAuthenticationProvider(ILogger Logger, string Name, I
 		{
 			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Error attempting to refresh [Error - {ex.Message}]");
 			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Current tokens {tokens}");
-			return default;
+
+			// Exception is bubbled so that the caller of IAuthenticationService.RefreshAsync can handle it
+			throw;
 		}
 		finally
 		{

--- a/src/Uno.Extensions.Authentication/Handlers/BaseAuthorizationHandler.cs
+++ b/src/Uno.Extensions.Authentication/Handlers/BaseAuthorizationHandler.cs
@@ -155,8 +155,15 @@ internal abstract class BaseAuthorizationHandler : DelegatingHandler
 	protected virtual async Task<bool> RefreshAuthenticationToken(CancellationToken ct)
 	{
 		if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogDebugMessage($"Requesting refresh for token.");
-
-		return await _authenticationService.RefreshAsync(ct);
+		try
+		{
+			return await _authenticationService.RefreshAsync(ct);
+		}
+		catch(Exception ex)
+		{
+			if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogDebugMessage($"Error refreshing token - {ex.Message}");
+			return false;
+		}
 	}
 
 	/// <summary>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationLoginViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationLoginViewModel.cs
@@ -6,14 +6,21 @@ internal record class CustomAuthenticationLoginViewModel(INavigator Navigator, I
 	public string? Password { get; set; } = DummyJsonEndpointConstants.ValidPassword;
 	public async void Login()
 	{
-		var authenticated = await Authentication.LoginAsync(new Dictionary<string, string>()
+		try
+		{
+			var authenticated = await Authentication.LoginAsync(new Dictionary<string, string>()
 		{
 			{nameof(CustomAuthenticationCredentials.Username),Name??string.Empty },
 			{nameof(CustomAuthenticationCredentials.Password),Password??string.Empty}
 		});
-		if (authenticated)
+			if (authenticated)
+			{
+				await Navigator.NavigateViewModelAsync(this, RouteInfo.HomeViewModel, qualifier: Qualifiers.ClearBackStack);
+			}
+		}
+		catch(Exception ex)
 		{
-			await Navigator.NavigateViewModelAsync(this, RouteInfo.HomeViewModel, qualifier: Qualifiers.ClearBackStack);
+			await Navigator.ShowMessageDialogAsync(this, title: "Invalid Credentials", content: $"The username and password you have entered are incorrect. Please try {DummyJsonEndpointConstants.ValidUserName} and {DummyJsonEndpointConstants.ValidPassword}");
 		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

If there is an exception during login it is swallowed with a false being returned. This makes it impossible to do conditional logic based on the type of error eg network, credentials 

## What is the new behavior?

Exceptions in the login method are now bubbled up - the caller of LoginAsync/LogoutAsync is responsible for handling these exceptions if they occur

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
