### PR TITLE
fix: Correcting language override to use full culture name and added Localization page to TestHarness

### DIFF
--- a/src/Uno.Extensions.Hosting.UI/HostBuilder.cs
+++ b/src/Uno.Extensions.Hosting.UI/HostBuilder.cs
@@ -121,7 +121,24 @@ public class HostBuilder : IHostBuilder
 		CreateServiceProvider();
 
 		var host = _appServices?.GetRequiredService<IHost>();
+
+		InitializeBuildServices();
+
 		return host;
+	}
+
+	private void InitializeBuildServices()
+	{
+		var services = _appServices?.GetServices<IServiceInitialize>();
+		if(services is null)
+		{
+			return;
+		}
+
+		foreach (var service in services)
+		{
+			service.Initialize();
+		}
 	}
 
 	private void BuildHostConfiguration()

--- a/src/Uno.Extensions.Hosting/IServiceInitialize.cs
+++ b/src/Uno.Extensions.Hosting/IServiceInitialize.cs
@@ -1,0 +1,12 @@
+﻿namespace Uno.Extensions.Hosting;
+
+/// <summary>
+/// Defines services that require initialization immediately after the IHost is built
+/// </summary>
+public interface IServiceInitialize
+{
+	/// <summary>
+	/// Initializes service immediately after IHost is built
+	/// </summary>
+	void Initialize();
+}

--- a/src/Uno.Extensions.Localization/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Localization/HostBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Localization;
+﻿using Uno.Extensions.Hosting;
+
+namespace Uno.Extensions.Localization;
 
 public static class HostBuilderExtensions
 {
@@ -24,7 +26,8 @@ public static class HostBuilderExtensions
 			.ConfigureServices((ctx, services) =>
 		{
 			_ = services
-			.AddHostedService<LocalizationService>()
+			.AddSingleton<LocalizationService>()
+			.AddSingleton<IServiceInitialize>(sp => sp.GetRequiredService<LocalizationService>())
 			.AddSingleton<IStringLocalizer, ResourceLoaderStringLocalizer>();
 		});
 	}

--- a/src/Uno.Extensions.Localization/LocalizationService.cs
+++ b/src/Uno.Extensions.Localization/LocalizationService.cs
@@ -1,6 +1,8 @@
-﻿namespace Uno.Extensions.Localization;
+﻿using Uno.Extensions.Hosting;
 
-public class LocalizationService : IHostedService
+namespace Uno.Extensions.Localization;
+
+public class LocalizationService : IServiceInitialize
 {
 	private static string DefaultCulture = "en-US";
 
@@ -28,7 +30,7 @@ public class LocalizationService : IHostedService
 		SupportedCultures = configuration.Value?.Cultures?.AsCultures() ?? new[] { DefaultCulture.AsCulture()! };
 	}
 
-	public Task StartAsync(CancellationToken cancellationToken)
+	public void Initialize()
 	{
 		_uiThread = Thread.CurrentThread;
 		ApplyCurrentCulture();
@@ -36,13 +38,6 @@ public class LocalizationService : IHostedService
 		{
 			ApplyCurrentCulture(false);
 		});
-		return Task.CompletedTask;
-	}
-
-	public Task StopAsync(CancellationToken cancellationToken)
-	{
-		_settingsListener?.Dispose();
-		return Task.CompletedTask;
 	}
 
 	private void ApplyCurrentCulture(bool updateThreadCulture = true)
@@ -53,7 +48,10 @@ public class LocalizationService : IHostedService
 				((CurrentCulture is not null) ?
 				PickSupportedCulture(CurrentCulture) :
 				PickSupportedCulture(CultureInfo.CurrentCulture)) ?? new CultureInfo(DefaultCulture);
-			ApplicationLanguages.PrimaryLanguageOverride = culture.Name;
+			if (ApplicationLanguages.PrimaryLanguageOverride != culture.Name)
+			{
+				ApplicationLanguages.PrimaryLanguageOverride = culture.Name;
+			}
 			CultureInfo.DefaultThreadCurrentCulture = culture;
 			CultureInfo.DefaultThreadCurrentUICulture = culture;
 			if (updateThreadCulture &&

--- a/src/Uno.Extensions.Localization/LocalizationService.cs
+++ b/src/Uno.Extensions.Localization/LocalizationService.cs
@@ -53,7 +53,7 @@ public class LocalizationService : IHostedService
 				((CurrentCulture is not null) ?
 				PickSupportedCulture(CurrentCulture) :
 				PickSupportedCulture(CultureInfo.CurrentCulture)) ?? new CultureInfo(DefaultCulture);
-			ApplicationLanguages.PrimaryLanguageOverride = culture.TwoLetterISOLanguageName;
+			ApplicationLanguages.PrimaryLanguageOverride = culture.Name;
 			CultureInfo.DefaultThreadCurrentCulture = culture;
 			CultureInfo.DefaultThreadCurrentUICulture = culture;
 			if (updateThreadCulture &&

--- a/testing/TestHarness/TestHarness.Core/TestSections.cs
+++ b/testing/TestHarness/TestHarness.Core/TestSections.cs
@@ -23,5 +23,6 @@ public enum TestSections
 	Authentication_Oidc,
 	Authentication_Web,
 	Authentication_Web_Settings,
-	Core_Storage
+	Core_Storage,
+	Localization
 }

--- a/testing/TestHarness/TestHarness.Shared/BaseTestSectionPage.cs
+++ b/testing/TestHarness/TestHarness.Shared/BaseTestSectionPage.cs
@@ -2,7 +2,7 @@
 
 namespace TestHarness;
 
-public partial class BaseTestSectionPage : Page
+public partial class BaseTestSectionPage : Page, IDisposable
 {
 	protected IHost? Host { get; set; }
 
@@ -16,7 +16,7 @@ public partial class BaseTestSectionPage : Page
 	{
 		if (HostInit is not null)
 		{
-			InitializeHost();
+			_ = InitializeHost();
 		}
 	}
 	protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -28,13 +28,13 @@ public partial class BaseTestSectionPage : Page
 
 			if (this.IsLoaded)
 			{
-				InitializeHost();
+				_ = InitializeHost();
 			}
 		}
 	}
 
 	private bool init;
-	private void InitializeHost()
+	private async Task InitializeHost()
 	{
 		if (init)
 		{
@@ -63,6 +63,13 @@ public partial class BaseTestSectionPage : Page
 				};
 			}
 		}
+
+		await Task.Run(() => Host.StartAsync());
+	}
+
+	public void Dispose()
+	{
+		_ = Host!.StopAsync();
 	}
 }
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationHostInit.cs
@@ -1,0 +1,18 @@
+﻿namespace TestHarness;
+
+public class LocalizationHostInit : BaseHostInitialization
+{
+	protected override string[] ConfigurationFiles => new string[] { "TestHarness.Ext.Localization.appsettings.locale.json" };
+
+	protected override void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+	{
+		views.Register();
+
+
+		// RouteMap required for Shell if initialRoute or initialViewModel isn't specified when calling NavigationHost
+		routes.Register(
+			new RouteMap(""));
+	}
+}
+
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationMainPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationMainPage.xaml
@@ -1,0 +1,37 @@
+﻿<testharness:BaseTestSectionPage xmlns:testharness="using:TestHarness"
+								 x:Class="TestHarness.Ext.Navigation.Localization.LocalizationMainPage"
+								 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+								 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+								 xmlns:local="using:TestHarness.Ext.Navigation.Localization"
+								 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+								 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+								 mc:Ignorable="d"
+								 Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<TextBlock Text="Localization Tests"
+				   Margin="20"
+				   FontSize="30" />
+
+		<ContentControl AutomationProperties.AutomationId="NavigationRoot"
+						x:Name="NavigationRoot"
+						HorizontalAlignment="Stretch"
+						VerticalAlignment="Stretch"
+						HorizontalContentAlignment="Stretch"
+						VerticalContentAlignment="Stretch"
+						Grid.Row="1" />
+
+		<StackPanel Grid.Row="2"
+					Orientation="Horizontal"
+					HorizontalAlignment="Center">
+			<Button AutomationProperties.AutomationId="ShowOnePageButton"
+					Content="One"
+					Click="OnePageClick" />
+		</StackPanel>
+	</Grid>
+
+</testharness:BaseTestSectionPage>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationMainPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationMainPage.xaml.cs
@@ -1,0 +1,16 @@
+﻿namespace TestHarness.Ext.Navigation.Localization;
+
+[TestSectionRoot("Localization",TestSections.Localization, typeof(LocalizationHostInit))]
+public sealed partial class LocalizationMainPage : BaseTestSectionPage
+{
+	public LocalizationMainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public async void OnePageClick(object sender, RoutedEventArgs e)
+	{
+		await NavigationRoot.Navigator()!.NavigateViewModelAsync<LocalizationOneViewModel>(this);
+	}
+
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOnePage.xaml
@@ -1,0 +1,37 @@
+﻿<Page x:Class="TestHarness.Ext.Navigation.Localization.LocalizationOnePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.Localization"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<utu:NavigationBar Content="Localization"
+						   AutomationProperties.AutomationId="LocalizationOne" />
+
+		<StackPanel Grid.Row="1">
+			<TextBlock HorizontalAlignment="Center"
+					   FontSize="24"
+					   x:Uid="Localization_Greeting" />
+			<utu:ChipGroup x:Name="LanguageChipGroup"
+						   SelectionMode="Single"
+						   SelectedItem="{Binding SelectedCulture, Mode=TwoWay}"
+						   ItemsSource="{Binding SupportedCultures}">
+				<utu:ChipGroup.ItemTemplate>
+					<DataTemplate>
+						<TextBlock Text="{Binding}"
+								   Tag="{Binding}" />
+					</DataTemplate>
+				</utu:ChipGroup.ItemTemplate>
+			</utu:ChipGroup>
+		</StackPanel>
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOnePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOnePage.xaml.cs
@@ -1,0 +1,12 @@
+﻿
+namespace TestHarness.Ext.Navigation.Localization;
+
+public sealed partial class LocalizationOnePage : Page
+{
+	public LocalizationOneViewModel? ViewModel => DataContext as LocalizationOneViewModel;
+	public LocalizationOnePage()
+	{
+		this.InitializeComponent();
+	}
+
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOneViewModel.cs
@@ -1,0 +1,34 @@
+﻿using System.Globalization;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+
+namespace TestHarness.Ext.Navigation.Localization;
+
+[ReactiveBindable(false)]
+public partial class LocalizationOneViewModel : ObservableObject
+{
+	private readonly IWritableOptions<LocalizationSettings> _localization;
+	public LocalizationOneViewModel(
+		IOptions<LocalizationConfiguration> configuration,
+		IWritableOptions<LocalizationSettings> localization,
+		IStringLocalizer localizer)
+	{
+		_localization = localization;
+		SupportedCultures = configuration.Value?.Cultures?.AsCultures() ?? new[] { "en-US".AsCulture()! };
+
+		var language = localizer[_localization.Value?.CurrentCulture ?? "en"];
+	}
+
+	public CultureInfo[] SupportedCultures { get; }
+
+	public CultureInfo SelectedCulture
+	{
+		get => SupportedCultures.FirstOrDefault(x => x.Name == _localization.Value?.CurrentCulture) ?? SupportedCultures.First();
+		set
+		{
+			_ = _localization.UpdateAsync(settings => settings with { CurrentCulture = value.Name });
+		}
+	}
+
+}
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/appsettings.locale.json
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/appsettings.locale.json
@@ -1,0 +1,5 @@
+﻿{
+  "LocalizationConfiguration": {
+    "Cultures": [ "en", "en-AU", "fr" ]
+  }
+}

--- a/testing/TestHarness/TestHarness.Shared/Strings/en-AU/Resources.resw
+++ b/testing/TestHarness/TestHarness.Shared/Strings/en-AU/Resources.resw
@@ -121,6 +121,6 @@
     <value>$ext_safeprojectname$</value>
   </data>
   <data name="Localization_Greeting.Text" xml:space="preserve">
-    <value>Hello</value>
+    <value>G'Day Mate</value>
   </data>
 </root>

--- a/testing/TestHarness/TestHarness.Shared/Strings/fr/Resources.resw
+++ b/testing/TestHarness/TestHarness.Shared/Strings/fr/Resources.resw
@@ -121,6 +121,6 @@
     <value>$ext_safeprojectname$</value>
   </data>
   <data name="Localization_Greeting.Text" xml:space="preserve">
-    <value>Hello</value>
+    <value>Bonjour</value>
   </data>
 </root>

--- a/testing/TestHarness/TestHarness.Shared/TestFrameHost.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/TestFrameHost.xaml.cs
@@ -9,6 +9,11 @@ public sealed partial class TestFrameHost : UserControl
 
 	public void ExitTestClick(object sender, RoutedEventArgs e)
 	{
+		var page = TestFrame.Content as IDisposable;
+		if(page is not null)
+		{
+			page.Dispose(); // Calls Stop on the host
+		}
 		this.TestFrame.GoBack();
 	}
 }

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -96,6 +96,14 @@
       <DependentUpon>StorageOnePage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Core\Storage\StorageOneViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Localization\LocalizationHostInit.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Localization\LocalizationMainPage.xaml.cs">
+      <DependentUpon>LocalizationMainPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Localization\LocalizationOnePage.xaml.cs">
+      <DependentUpon>LocalizationOnePage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Localization\LocalizationOneViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Apps\Commerce\BaseCommerceViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Apps\Commerce\CommerceCredentials.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Apps\Commerce\CommerceDealsPage.xaml.cs">
@@ -569,7 +577,9 @@
     <None Include="$(MSBuildThisFileDirectory)Assets\SharedAssets.md" />
   </ItemGroup>
   <ItemGroup>
+    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-AU\Resources.resw" />
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en\Resources.resw" />
+    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\fr\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
     <!--
@@ -585,6 +595,7 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Msal\appsettings.msal.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Msal\appsettings.msalauthentication.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Oidc\appsettings.oidc.json" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Localization\appsettings.locale.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Navigation\Apps\Commerce\appsettings.logging.json" />
     <_Globbled_Page Include="$(MSBuildThisFileDirectory)**/*.xaml" Exclude="@(Page);@(ApplicationDefinition)">
       <SubType>Designer</SubType>

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.shproj
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.shproj
@@ -14,4 +14,8 @@
     <_Globbed_Compile Remove="Ext\Authentication\AuthenticationRouteInfo.cs" />
     <_Globbed_Compile Remove="Ext\Authentication\AuthenticationShellViewModel.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <_Globbed_PRIResource Remove="Strings\en-AU\Resources.resw" />
+    <_Globbed_PRIResource Remove="Strings\fr\Resources.resw" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
closes: #721 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Two character language code used instead of Culture name
PrimaryLanguageOverride set too late in app startup sequence

## What is the new behavior?

Added a new page to the TestHarness for Localization
PrimaryLanguageOverride  is set in a service initialization method immediately after the IHost has been created

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
