### PR TITLE
fix(feeds): Fix possible invalid generated code when using ValueType parameter

### DIFF
--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/CommandFromMethod.CommandConfigGenerator.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/CommandFromMethod.CommandConfigGenerator.cs
@@ -42,9 +42,13 @@ internal partial record CommandFromMethod
 					{
 						if (ParameterType is not null && CanExecute is not null)
 						{
-							sb.AppendLine($@"
-							if (reactive_commandParameter is not {ParameterType} reactive_arguments
-								|| !({CanExecute("reactive_arguments")}))
+							sb.AppendLine($@"if (!(reactive_commandParameter is {ParameterType}))
+							{{
+								return false;
+							}}
+
+							var reactive_arguments = ({ParameterType}) reactive_commandParameter;
+							if (!({CanExecute("reactive_arguments")}))
 							{{
 								return false;
 							}}".Align(0));
@@ -52,7 +56,7 @@ internal partial record CommandFromMethod
 						}
 						else if (ParameterType is not null)
 						{
-							sb.AppendLine($@"if (reactive_commandParameter is not {ParameterType})
+							sb.AppendLine($@"if (!(reactive_commandParameter is {ParameterType}))
 							{{
 								return false;
 							}}".Align(0));

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/CommandFromMethod.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/CommandFromMethod.cs
@@ -167,7 +167,7 @@ internal partial record CommandFromMethod : IMappedMember
 		{
 			if (parameters.Count() is 1)
 			{
-				if (parameters.First().Symbol.NullableAnnotation is NullableAnnotation.NotAnnotated)
+				if (parameters.First().Symbol is { Type.IsValueType: false, NullableAnnotation: NullableAnnotation.NotAnnotated })
 				{
 					return args => $"{args} is not null";
 				}
@@ -177,7 +177,9 @@ internal partial record CommandFromMethod : IMappedMember
 				if (parameters.Any(p => p.Symbol.NullableAnnotation is NullableAnnotation.NotAnnotated))
 				{
 					return args => parameters
-						.Select((p, i) => p.Symbol.NullableAnnotation is NullableAnnotation.NotAnnotated ? $"{args}.Item{i} is not null" : null)
+						.Select((p, i) => p.Symbol is { Type.IsValueType: false, NullableAnnotation: NullableAnnotation.NotAnnotated }
+							? $"{args}.Item{i} is not null"
+							: null)
 						.Where(s => s is not null)
 						.JoinBy(" && ");
 				}

--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_Methods_Then_GenerateCommands.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_Methods_Then_GenerateCommands.cs
@@ -63,6 +63,56 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 		vm.InvokeCount.Should().Be(1);
 	}
 
+	public partial class When_OneValueTypeParameter_Void_ViewModel
+	{
+		public int InvokeCount { get; set; }
+
+		public DateTimeOffset? LastInvokeParameter { get; set; }
+
+		public void MyMethod(DateTimeOffset parameter)
+		{
+			LastInvokeParameter = parameter;
+			InvokeCount++;
+		}
+	}
+
+	[TestMethod]
+	public async Task When_OneValueTypeParameter_Void()
+	{
+		var vm = new When_OneValueTypeParameter_Void_ViewModel.BindableWhen_OneValueTypeParameter_Void_ViewModel();
+
+		vm.MyMethod.Execute(new DateTimeOffset(1983, 9, 9, 15, 00, 00, TimeSpan.FromHours(1)));
+		await WaitFor(() => vm.InvokeCount == 1);
+
+		vm.LastInvokeParameter.Should().Be(new DateTimeOffset(1983, 9, 9, 15, 00, 00, TimeSpan.FromHours(1)));
+		vm.InvokeCount.Should().Be(1);
+	}
+
+	public partial class When_OneNullableValueTypeParameter_Void_ViewModel
+	{
+		public int InvokeCount { get; set; }
+
+		public DateTimeOffset? LastInvokeParameter { get; set; }
+
+		public void MyMethod(DateTimeOffset? parameter)
+		{
+			LastInvokeParameter = parameter;
+			InvokeCount++;
+		}
+	}
+
+	[TestMethod]
+	public async Task When_OneNullableValueTypeParameter_Void()
+	{
+		var vm = new When_OneNullableValueTypeParameter_Void_ViewModel.BindableWhen_OneNullableValueTypeParameter_Void_ViewModel();
+
+		vm.MyMethod.Execute(new DateTimeOffset(1983, 9, 9, 15, 00, 00, TimeSpan.FromHours(1)));
+		await WaitFor(() => vm.InvokeCount == 1);
+
+		vm.LastInvokeParameter.Should().Be(new DateTimeOffset(1983, 9, 9, 15, 00, 00, TimeSpan.FromHours(1)));
+		vm.InvokeCount.Should().Be(1);
+	}
+
 	public partial class When_OneParameterAndCT_Void_ViewModel
 	{
 		public int InvokeCount { get; set; }


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno.extensions/issues/728

## Bugfix
Fix possible invalid generated code when using ValueType parameter

## What is the current behavior?
We check for null using pattern matching, including for `ValueType` and `Nullable<T>`

## What is the new behavior?
* We don't check for null for `ValueType`
* We don't use pattern matching anymore (not allowed for `Nullable<T>`, and required an higher version of C# than we should)

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
