### PR TITLE
fix: Prevent Cleared event being raised when there aren't any tokens

### DIFF
--- a/src/Uno.Extensions.Authentication/AuthenticationService.cs
+++ b/src/Uno.Extensions.Authentication/AuthenticationService.cs
@@ -53,6 +53,9 @@ internal class AuthenticationService : IAuthenticationService
 
 		if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTraceMessage($"Logout successful, so clear token cache");
 		await _tokens.ClearAsync(ct);
+
+		// Don't raise LoggedOut event here - if there were tokens, then the ITokenCache.Cleared event will
+		// be raised, which in turn will trigger the LoggedOut event to be raised
 		return true;
 	}
 

--- a/src/Uno.Extensions.Authentication/Handlers/BaseAuthorizationHandler.cs
+++ b/src/Uno.Extensions.Authentication/Handlers/BaseAuthorizationHandler.cs
@@ -92,8 +92,8 @@ internal abstract class BaseAuthorizationHandler : DelegatingHandler
 				{
 					if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogDebugMessage($"The request '{request.RequestUri}' was unauthorized and the tokens cannot be refreshed. Considering the session has expired.");
 
-			// Request was unauthorized and we cannot refresh the authentication token.
-			await _tokens.ClearAsync(ct);
+					// Request was unauthorized and we cannot refresh the authentication token.
+					await _tokens.ClearAsync(ct);
 
 					return response;
 				}
@@ -104,8 +104,8 @@ internal abstract class BaseAuthorizationHandler : DelegatingHandler
 				{
 					if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogDebugMessage($"The request '{request.RequestUri}' was unauthorized and the token failed to refresh. Considering the session has expired.");
 
-			// No authentication token to use.
-			await _tokens.ClearAsync(ct);
+					// No authentication token to use.
+					await _tokens.ClearAsync(ct);
 
 					return response;
 				}
@@ -159,7 +159,7 @@ internal abstract class BaseAuthorizationHandler : DelegatingHandler
 		{
 			return await _authenticationService.RefreshAsync(ct);
 		}
-		catch(Exception ex)
+		catch (Exception ex)
 		{
 			if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogDebugMessage($"Error refreshing token - {ex.Message}");
 			return false;


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno.extensions/issues/745

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

ITokenCache.Cleared event being raised even when there's no tokens in the cache

## What is the new behavior?

Cleared event is only raised when there are existing tokens in the cache that are being cleared

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
