### PR TITLE
fix: Making sure login view is refreshed when navigation with clear backstack

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
@@ -137,7 +137,8 @@ public class FrameNavigator : ControlNavigator<Frame>, IStackNavigator
 			Control.ReassignRegionParent();
 			if (segments.Length > 1 ||
 				!string.IsNullOrWhiteSpace(request.Route.Path) ||
-				request.Route.Data?.Count > 0)
+				request.Route.Data?.Count > 0 ||
+				request.Route.IsClearBackstack())
 			{
 				refreshViewModel = true;
 			}

--- a/testing/TestHarness/TestBackend/Controllers/CustomAuthController.cs
+++ b/testing/TestHarness/TestBackend/Controllers/CustomAuthController.cs
@@ -1,7 +1,10 @@
 using System.IdentityModel.Tokens.Jwt;
+using System.Net;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
+using TestHarness;
 using SameSiteMode = Microsoft.AspNetCore.Http.SameSiteMode;
 
 namespace TestBackend.Controllers;
@@ -20,8 +23,15 @@ public class CustomAuthController : ControllerBase
 	}
 
 	[HttpGet(Name = "Login")]
-	public AuthResponse Login(string username, string password)
+	public AuthResponse? Login(string username, string password)
 	{
+		if(username != DummyJsonEndpointConstants.ValidUserName ||
+			password != DummyJsonEndpointConstants.ValidPassword)
+		{
+			Response.StatusCode = StatusCodes.Status401Unauthorized;
+			return default;
+		}
+
 		var token = $"{username}:{password}".Base64Encode();
 		_logger.LogTrace($"Token: {token}");
 		return new AuthResponse(token);
@@ -30,6 +40,13 @@ public class CustomAuthController : ControllerBase
 	[HttpPost(Name = "LoginCookie")]
 	public void LoginCookie([FromQuery] string username, [FromQuery] string password)
 	{
+		if (username != DummyJsonEndpointConstants.ValidUserName ||
+			password != DummyJsonEndpointConstants.ValidPassword)
+		{
+			Response.StatusCode = StatusCodes.Status401Unauthorized;
+			return;
+		}
+
 		var token = $"{username}:{password}".Base64Encode();
 		_logger.LogTrace($"Token: {token}");
 

--- a/testing/TestHarness/TestBackend/TestBackend.csproj
+++ b/testing/TestHarness/TestBackend/TestBackend.csproj
@@ -14,4 +14,8 @@
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="6.0.7" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <ProjectReference Include="..\TestHarness.Core\TestHarness.Core.csproj" />
+	</ItemGroup>
+
 </Project>

--- a/testing/TestHarness/TestHarness.Core/DummyJsonEndpointConstants.cs
+++ b/testing/TestHarness/TestHarness.Core/DummyJsonEndpointConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace TestHarness;
+
+public static class DummyJsonEndpointConstants
+{
+	// See https://dummyjson.com/docs/auth for username/password values
+	public const string ValidUserName = "kminchelle";
+	public const string ValidPassword = "0lelplR";
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/AuthenticationShellViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/AuthenticationShellViewModel.cs
@@ -12,10 +12,16 @@ internal record AuthenticationShellViewModel
 		IAuthenticationRouteInfo routing)
 	{
 		_authentication = auth;
+		_authentication.LoggedOut += _authentication_LoggedOut;
 		_navigator = navigator;
 		_routing = routing;
 
 		_ = Start();
+	}
+
+	private async void _authentication_LoggedOut(object? sender, EventArgs e)
+	{
+		await _navigator.NavigateViewModelAsync(this, _routing.LoginViewModel, qualifier: Qualifiers.ClearBackStack);
 	}
 
 	private async Task Start()

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/ICustomAuthenticationDummyJsonEndpoint.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/ICustomAuthenticationDummyJsonEndpoint.cs
@@ -1,11 +1,5 @@
 ﻿namespace TestHarness.Ext.Authentication.Custom;
 
-public static class DummyJsonEndpointConstants
-{
-	// See https://dummyjson.com/docs/auth for username/password values
-	public const string ValidUserName = "kminchelle";
-	public const string ValidPassword = "0lelplR";
-}
 
 [Headers("Content-Type: application/json")]
 public interface ICustomAuthenticationDummyJsonEndpoint


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Attempting to navigate to the same page with clear backstack eg -/Login when already on Login page, should cause the page to be refreshed. This doesn't happen and the navigation request is effectively ignored

## What is the new behavior?

A new instance of the viewmodel for the current page is created and data bound. This doesn't reload the page, it just recreates the viewmodel.

Note: This PR also makes changes to the test harness to make it easier to test what happens when incorrect credentials are provided for authentication scenarios.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ X ] Tested code with current [supported SDKs](../README.md#supported)
- [ N/A ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ N/A ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ N/A ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ X ] Contains **NO** breaking changes
- [ N/A ] Associated with an issue (GitHub or internal)

