### PR TITLE
feat: Making it easier to register navigation data types

### DIFF
--- a/src/Uno.Extensions.Navigation/DataMap.cs
+++ b/src/Uno.Extensions.Navigation/DataMap.cs
@@ -1,15 +1,21 @@
-﻿namespace Uno.Extensions.Navigation;
+﻿using System.Xml.Linq;
+
+namespace Uno.Extensions.Navigation;
 
 #pragma warning disable SA1313 // Parameter names should begin with lower-case letter
 
 public record DataMap(
 	Type? Data = null,
-		Func<object, IDictionary<string, string>>? UntypedToQuery = null,
+	Func<object, IDictionary<string, string>>? UntypedToQuery = null,
 	Func<IServiceProvider, IDictionary<string, object>, Task<object?>>? UntypedFromQuery = null
 )
 {
 	internal virtual void RegisterTypes(IServiceCollection services)
 	{
+		if (Data is not null)
+		{
+			services.AddViewModelData(Data);
+		}
 	}
 }
 
@@ -25,6 +31,7 @@ public record DataMap<TData>(
 	internal override void RegisterTypes(IServiceCollection services)
 	{
 		services.AddViewModelData<TData>();
+		// DO NOT call base RegisterType method as this will register an untyped version of the data lookup
 	}
 }
 

--- a/src/Uno.Extensions.Navigation/NavigationDataProvider.cs
+++ b/src/Uno.Extensions.Navigation/NavigationDataProvider.cs
@@ -9,4 +9,11 @@ internal class NavigationDataProvider
 	{
 		return (Parameters?.TryGetValue(string.Empty, out var data) ?? false) ? data as TData : default;
 	}
+
+	public object? GetData(Type dataType)
+	{
+		return (Parameters?.TryGetValue(string.Empty, out var data) ?? false) &&
+			(data.GetType() == dataType || data.GetType().IsSubclassOf(dataType)) ? data : default;
+	}
+
 }

--- a/src/Uno.Extensions.Navigation/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Navigation/ServiceCollectionExtensions.cs
@@ -11,4 +11,11 @@ public static class ServiceCollectionExtensions
 #pragma warning restore CS8603 // Possible null reference return.
 	}
 
+	public static IServiceCollection AddViewModelData(this IServiceCollection services, Type dataType)
+	{
+#pragma warning disable CS8603 // Possible null reference return - null data is possible
+		return services
+					.AddTransient(dataType, services => services.GetRequiredService<NavigationDataProvider>().GetData(dataType));
+#pragma warning restore CS8603 // Possible null reference return.
+	}
 }

--- a/src/Uno.Extensions.Navigation/ViewMap.cs
+++ b/src/Uno.Extensions.Navigation/ViewMap.cs
@@ -18,6 +18,17 @@ public record ViewMap(
 		}
 
 		Data?.RegisterTypes(services);
+
+		RegisterResultDataType(services);
+	}
+
+	internal virtual void RegisterResultDataType(IServiceCollection services)
+	{
+		if (ResultData is not null)
+		{
+			services.AddViewModelData(ResultData);
+		}
+
 	}
 }
 
@@ -52,7 +63,13 @@ public record ResultDataViewMap<TView, TViewModel, TResultData>(
 	DataMap? Data = null,
 	object? ViewAttributes = null
 ) : ViewMap(View: typeof(TView), ViewModel: typeof(TViewModel), Data: Data, ResultData: typeof(TResultData), ViewAttributes: ViewAttributes)
+		where TResultData : class
 {
+	internal override void RegisterResultDataType(IServiceCollection services)
+	{
+		services.AddViewModelData<TResultData>();
+		// DO NOT call base RegisterType method as this will register an untyped version of the data lookup
+	}
 }
 
 public record LocalizableDialogAction(Func<IStringLocalizer?, string?>? LabelProvider = default, Action? Action = null, object? Id = null) { }


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno.extensions/issues/751


## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

DataMap<T> has to be used to register data types for navigation

## What is the new behavior?

Registers data typed using untyped DataMap 
Registers result data type



## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
