### PR TITLE
fix: Avoiding exceptions loading files on android, ios and winui

### DIFF
--- a/samples/Playground/Playground.Shared/ViewModels/AdHocViewModel.cs
+++ b/samples/Playground/Playground.Shared/ViewModels/AdHocViewModel.cs
@@ -84,7 +84,7 @@ public partial class AdHocViewModel:ObservableObject
 
 	public async Task LoadWidgets()
 	{
-		var widgets = await _dataService.ReadFileAsync<Widget[]>(_serializer, "data.json");
+		var widgets = await _dataService.ReadPackageFileAsync<Widget[]>(_serializer, "data.json");
 	}
 
 	public async Task RunBackgroundTask()

--- a/src/Uno.Extensions.Authentication.Msal/MsalAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.Msal/MsalAuthenticationProvider.cs
@@ -139,7 +139,7 @@ internal record MsalAuthenticationProvider(
 #else
 			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Setting up storage location");
 
-			var folderPath = await Storage.CreateLocalFolderAsync(Name.ToLower());
+			var folderPath = await Storage.CreateFolderAsync(Name.ToLower());
 			Console.WriteLine($"Folder: {folderPath}");
 			var filePath = Path.Combine(folderPath, CacheFileName);
 			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"MSAL cache {filePath}");

--- a/src/Uno.Extensions.Configuration/ReloadService.cs
+++ b/src/Uno.Extensions.Configuration/ReloadService.cs
@@ -27,7 +27,7 @@ public class ReloadService : IHostedService, IStartupService
 
 	public async Task StartAsync(CancellationToken cancellationToken)
 	{
-		var folderPath = await Storage.CreateLocalFolderAsync(ConfigBuilderExtensions.ConfigurationFolderName);
+		var folderPath = await Storage.CreateFolderAsync(ConfigBuilderExtensions.ConfigurationFolderName);
 		if(Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($@"Folder path should be '{folderPath}'");
 
 		var fileProviders = Config.Providers;
@@ -63,13 +63,13 @@ public class ReloadService : IHostedService, IStartupService
 	{
 		try
 		{
-			var settings = await Storage.ReadFileAsync(file);
+			var settings = await Storage.ReadPackageFileAsync(file);
 			if (settings is not null &&
 				!string.IsNullOrWhiteSpace(settings))
 			{
 				if(Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($@"Settings '{settings}'");
 				var fullPath = Path.Combine(localFolderPath, file);
-				await Storage.WriteFileAsync(fullPath, settings);
+				await Storage.WriteFileAsync(fullPath, settings, false);
 			}
 		}
 		catch

--- a/src/Uno.Extensions.Storage.UI/FileStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/FileStorage.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Reflection;
+
 namespace Uno.Extensions.Storage;
 
 public class FileStorage : IStorage
@@ -10,7 +12,20 @@ public class FileStorage : IStorage
 		var files = assets?.List("");
 		filename = Path.GetFileNameWithoutExtension(filename).Replace('.', '_') + Path.GetExtension(filename);
 		return files?.Contains(filename)??false;
-#else
+#elif WINDOWS
+		var executingPath = Assembly.GetExecutingAssembly().Location;
+		if (!string.IsNullOrWhiteSpace(executingPath))
+		{
+			var path = Path.GetDirectoryName(executingPath);
+			if (path is not null &&
+				!string.IsNullOrWhiteSpace(path))
+			{
+				var fullPath = Path.Combine(path, filename);
+				return File.Exists(fullPath);
+			}
+		}
+		return true;
+#else 
 		return true;
 #endif
 

--- a/src/Uno.Extensions.Storage.UI/FileStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/FileStorage.cs
@@ -1,5 +1,8 @@
 ﻿
 using System.Reflection;
+#if __IOS__ || MACCATALYST || MACOS
+using Foundation;
+#endif
 
 namespace Uno.Extensions.Storage;
 
@@ -12,6 +15,14 @@ public class FileStorage : IStorage
 		var files = assets?.List("");
 		filename = Path.GetFileNameWithoutExtension(filename).Replace('.', '_') + Path.GetExtension(filename);
 		return files?.Contains(filename)??false;
+#elif __IOS__ || MACCATALYST || MACOS
+		var directoryName = global::System.IO.Path.GetDirectoryName(filename) + string.Empty;
+		var fileName = global::System.IO.Path.GetFileNameWithoutExtension(filename);
+		var fileExtension = global::System.IO.Path.GetExtension(filename);
+
+		var resourcePathname = NSBundle.MainBundle.PathForResource(global::System.IO.Path.Combine(directoryName, fileName), fileExtension.Substring(1));
+
+		return resourcePathname != null;
 #elif WINDOWS
 		var executingPath = Assembly.GetExecutingAssembly().Location;
 		if (!string.IsNullOrWhiteSpace(executingPath))
@@ -25,7 +36,7 @@ public class FileStorage : IStorage
 			}
 		}
 		return true;
-#else 
+#else
 		return true;
 #endif
 
@@ -42,7 +53,7 @@ public class FileStorage : IStorage
 	{
 		try
 		{
-			if(!await FileExistsInPackage(filename))
+			if (!await FileExistsInPackage(filename))
 			{
 				return default;
 			}

--- a/src/Uno.Extensions.Storage/IStorage.cs
+++ b/src/Uno.Extensions.Storage/IStorage.cs
@@ -2,11 +2,11 @@
 
 public interface IStorage
 {
-	Task<string> CreateLocalFolderAsync(string foldername);
+	Task<string> CreateFolderAsync(string foldername);
 
-	Task<string?> ReadFileAsync(string filename);
+	Task<string?> ReadPackageFileAsync(string filename);
 
-	Task<Stream> OpenFileAsync(string filename);
+	Task<Stream?> OpenPackageFileAsync(string filename);
 
-	Task WriteFileAsync(string filename, string text);
+	Task WriteFileAsync(string filename, string text, bool overwrite);
 }

--- a/src/Uno.Extensions.Storage/StorageExtensions.cs
+++ b/src/Uno.Extensions.Storage/StorageExtensions.cs
@@ -2,9 +2,13 @@ namespace Uno.Extensions.Storage;
 
 public static class StorageExtensions
 {
-	public static async Task<TData?> ReadFileAsync<TData>(this IStorage storage, ISerializer serializer, string fileName)
+	public static async Task<TData?> ReadPackageFileAsync<TData>(this IStorage storage, ISerializer serializer, string fileName)
 	{
-		using var stream = await storage.OpenFileAsync(fileName);
+		using var stream = await storage.OpenPackageFileAsync(fileName);
+		if(stream is null)
+		{
+			return default;
+		}
 		return serializer.FromStream<TData>(stream);
 	}
 }

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -620,6 +620,7 @@
 		 explicitly included in the projitem, so files can be added from vscode
 		 without manipulating the projitem file.
 	-->
+    <Content Include="$(MSBuildThisFileDirectory)appsettings.localizationconfiguration.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Http\Refit\appsettings.httprefit.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\appsettings.webauthsettings.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\appsettings.webauth.json" />

--- a/testing/TestHarness/TestHarness.Shared/appsettings.localizationconfiguration.json
+++ b/testing/TestHarness/TestHarness.Shared/appsettings.localizationconfiguration.json
@@ -1,0 +1,5 @@
+﻿{
+  "LocalizationConfiguration": {
+    "Cultures": [ "en", "fr" ]
+  }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno.extensions/issues/753

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Attempting to open a package file using IStorageFile.ReadPackageFileAsync raises an internal exception if the file doesn't exist - particularly bad on startup when application looks for files that need to contribute to configuration

## What is the new behavior?

File exists check is made for each platform before attempting to open the file

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
