### PR TITLE
fix: Makes sure that any qualifiers are trimmed when locating selectable region

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
@@ -106,7 +106,7 @@ public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
 		}
 
 		var item = (from mi in Items
-					where (mi.GetRegionOrElementName() == path)
+					where (mi.GetRegionOrElementName().WithoutQualifier() == path)
 					select mi).FirstOrDefault();
 		return item;
 	}

--- a/src/Uno.Extensions.Navigation/RouteExtensions.cs
+++ b/src/Uno.Extensions.Navigation/RouteExtensions.cs
@@ -18,6 +18,7 @@ public static class RouteExtensions
 	public static bool IsClearBackstack(this Route route) =>
 		route.Qualifier
 			.StartsWith(Qualifiers.ClearBackStack);
+
 	public static string? ExtractBase(this string? path, out string nextQualifier, out string nextPath)
 	{
 		nextPath = path ?? string.Empty;
@@ -70,6 +71,23 @@ public static class RouteExtensions
 
 		return text;
 	}
+
+	public static string? WithoutQualifier(this string? path)
+	{
+		if(path is null ||
+			string.IsNullOrWhiteSpace(path))
+		{
+			return path;
+		}
+
+		var qualifierMatch = nonAlphaRegex.Match(path);
+		if (qualifierMatch.Success && qualifierMatch.Index == 0)
+		{
+			return path.TrimStart(qualifierMatch.Value);
+		}
+		return path;
+	}
+
 
 	public static string WithQualifier(this string path, string? qualifier) => (qualifier is null || string.IsNullOrWhiteSpace(qualifier)) ? path : $"{qualifier}{path}";
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceHomePage.xaml
@@ -123,7 +123,7 @@
 						</utu:TabBarItem>
 						<utu:TabBarItem AutomationProperties.AutomationId="ProductsTabBarItem"
 										IsSelectable="True"
-										uen:Region.Name="Products">
+										uen:Region.Name="-/Products">
 							<utu:TabBarItem.Icon>
 								<PathIcon Data="{StaticResource Icon_storefront}" />
 							</utu:TabBarItem.Icon>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

If qualifiers are added to a region name, selecting the region fails

## What is the new behavior?

Qualifiers should be ignored when setting a region

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X ] Tested code with current [supported SDKs](../README.md#supported)
- [N/A ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X ] Contains **NO** breaking changes
- [N/A ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
