### PR TITLE
fix: Fixing AddClient for when service instance is specified without an interface

### DIFF
--- a/src/Uno.Extensions.Http.Refit/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Http.Refit/ServiceCollectionExtensions.cs
@@ -13,14 +13,14 @@ public static class ServiceCollectionExtensions
 		   HostBuilderContext context,
 		   string? name = null,
 		   Action<IServiceProvider, RefitSettings>? settingsBuilder = null,
-		   Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>? configure = null
+		   Func<IHttpClientBuilder, EndpointOptions?, IHttpClientBuilder>? configure = null
 	   )
 		   where TInterface : class
 	{
 		return services.AddClient<TInterface>(
 			context,
-			name,
-			(s, c) => HttpClientFactoryExtensions.AddRefitClient<TInterface>(s, settingsAction: serviceProvider =>
+			name: name,
+			httpClientFactory: (s, c) => HttpClientFactoryExtensions.AddRefitClient<TInterface>(s, settingsAction: serviceProvider =>
 			{
 				var serializer = serviceProvider.GetService<IHttpContentSerializer>();
 				var settings = serializer is not null ? new RefitSettings() { ContentSerializer = serializer } : new RefitSettings();
@@ -34,6 +34,6 @@ public static class ServiceCollectionExtensions
 				settingsBuilder?.Invoke(serviceProvider, settings);
 				return settings;
 			}),
-			configure);
+			configure: configure);
 	}
 }

--- a/testing/TestHarness/TestHarness.Core/TestSections.cs
+++ b/testing/TestHarness/TestHarness.Core/TestSections.cs
@@ -24,5 +24,7 @@ public enum TestSections
 	Authentication_Web,
 	Authentication_Web_Settings,
 	Core_Storage,
-	Localization
+	Localization,
+	Http_Endpoints,
+	Http_Refit
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsHostInit.cs
@@ -1,0 +1,29 @@
+﻿using TestHarness.Ext.Http.Endpoints;
+
+namespace TestHarness;
+
+public class HttpEndpointsHostInit : BaseHostInitialization
+{
+	protected override string[] ConfigurationFiles => new string[] { "TestHarness.Ext.Http.Endpoints.appsettings.httpendpoints.json" };
+
+	protected override IHostBuilder Custom(IHostBuilder builder)
+	{
+		return builder
+				.UseHttp(
+			configure: (context, services) =>
+			 services.AddClient<HttpEndpointsOneViewModel>(context, name: "HttpDummyJsonEndpoint"));
+
+	}
+
+	protected override void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+	{
+		views.Register();
+
+
+		// RouteMap required for Shell if initialRoute or initialViewModel isn't specified when calling NavigationHost
+		routes.Register(
+			new RouteMap(""));
+	}
+}
+
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsMainPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsMainPage.xaml
@@ -1,0 +1,37 @@
+﻿<testharness:BaseTestSectionPage xmlns:testharness="using:TestHarness"
+								 x:Class="TestHarness.Ext.Http.Endpoints.HttpEndpointsMainPage"
+								 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+								 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+								 xmlns:local="using:TestHarness.Ext.Http.Endpoints"
+								 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+								 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+								 mc:Ignorable="d"
+								 Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<TextBlock Text="HttpEndpoints Tests"
+				   Margin="20"
+				   FontSize="30" />
+
+		<ContentControl AutomationProperties.AutomationId="NavigationRoot"
+						x:Name="NavigationRoot"
+						HorizontalAlignment="Stretch"
+						VerticalAlignment="Stretch"
+						HorizontalContentAlignment="Stretch"
+						VerticalContentAlignment="Stretch"
+						Grid.Row="1" />
+
+		<StackPanel Grid.Row="2"
+					Orientation="Horizontal"
+					HorizontalAlignment="Center">
+			<Button AutomationProperties.AutomationId="ShowOnePageButton"
+					Content="One"
+					Click="OnePageClick" />
+		</StackPanel>
+	</Grid>
+
+</testharness:BaseTestSectionPage>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsMainPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsMainPage.xaml.cs
@@ -1,0 +1,16 @@
+﻿namespace TestHarness.Ext.Http.Endpoints;
+
+[TestSectionRoot("HttpEndpoints",TestSections.Http_Endpoints, typeof(HttpEndpointsHostInit))]
+public sealed partial class HttpEndpointsMainPage : BaseTestSectionPage
+{
+	public HttpEndpointsMainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public async void OnePageClick(object sender, RoutedEventArgs e)
+	{
+		await NavigationRoot.Navigator()!.NavigateViewModelAsync<HttpEndpointsOneViewModel>(this);
+	}
+
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsOnePage.xaml
@@ -1,0 +1,27 @@
+﻿<Page x:Class="TestHarness.Ext.Http.Endpoints.HttpEndpointsOnePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Http.Endpoints"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<utu:NavigationBar Content="HttpEndpoints - One"
+						   AutomationProperties.AutomationId="HttpEndpointsOne" />
+
+		
+		<StackPanel Grid.Row="1">
+			<Button Content="Add"
+					Click="{x:Bind ViewModel.Load}" />
+			<TextBlock Text="{Binding Data}" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsOnePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsOnePage.xaml.cs
@@ -1,0 +1,12 @@
+﻿
+namespace TestHarness.Ext.Http.Endpoints;
+
+public sealed partial class HttpEndpointsOnePage : Page
+{
+	public HttpEndpointsOneViewModel? ViewModel => DataContext as HttpEndpointsOneViewModel;
+	public HttpEndpointsOnePage()
+	{
+		this.InitializeComponent();
+	}
+
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/HttpEndpointsOneViewModel.cs
@@ -1,0 +1,26 @@
+﻿
+namespace TestHarness.Ext.Http.Endpoints;
+
+[ReactiveBindable(false)]
+public partial class HttpEndpointsOneViewModel : ObservableObject
+{
+	private readonly INavigator _navigator;
+	private readonly IServiceProvider _services;
+	private readonly HttpClient _client;
+
+	[ObservableProperty]
+	private string? data;
+
+	public HttpEndpointsOneViewModel(INavigator navigator, IServiceProvider services, HttpClient client)
+	{
+		_navigator = navigator;
+		_services = services;
+		_client = client;
+	}
+
+
+	public async Task Load()
+	{
+		Data = await _client.GetStringAsync("products");
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/appsettings.httpendpoints.json
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Endpoints/appsettings.httpendpoints.json
@@ -1,0 +1,6 @@
+﻿{
+  "HttpDummyJsonEndpoint": {
+    "Url": "https://DummyJson.com",
+    "UseNativeHandler": true
+  }
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitHostInit.cs
@@ -1,0 +1,29 @@
+﻿using TestHarness.Ext.Http.Refit;
+
+namespace TestHarness;
+
+public class HttpRefitHostInit : BaseHostInitialization
+{
+	protected override string[] ConfigurationFiles => new string[] { "TestHarness.Ext.Http.Refit.appsettings.httprefit.json" };
+
+	protected override IHostBuilder Custom(IHostBuilder builder)
+	{
+		return builder
+				.UseHttp(
+			configure: (context, services) =>
+			 services.AddRefitClient<IHttpRefitDummyJsonEndpoint>(context, name: "HttpRefitDummyJsonEndpoint"));
+
+	}
+
+	protected override void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+	{
+		views.Register();
+
+
+		// RouteMap required for Shell if initialRoute or initialViewModel isn't specified when calling NavigationHost
+		routes.Register(
+			new RouteMap(""));
+	}
+}
+
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitMainPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitMainPage.xaml
@@ -1,0 +1,37 @@
+﻿<testharness:BaseTestSectionPage xmlns:testharness="using:TestHarness"
+								 x:Class="TestHarness.Ext.Http.Refit.HttpRefitMainPage"
+								 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+								 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+								 xmlns:local="using:TestHarness.Ext.Http.Refit"
+								 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+								 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+								 mc:Ignorable="d"
+								 Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<TextBlock Text="HttpRefit Tests"
+				   Margin="20"
+				   FontSize="30" />
+
+		<ContentControl AutomationProperties.AutomationId="NavigationRoot"
+						x:Name="NavigationRoot"
+						HorizontalAlignment="Stretch"
+						VerticalAlignment="Stretch"
+						HorizontalContentAlignment="Stretch"
+						VerticalContentAlignment="Stretch"
+						Grid.Row="1" />
+
+		<StackPanel Grid.Row="2"
+					Orientation="Horizontal"
+					HorizontalAlignment="Center">
+			<Button AutomationProperties.AutomationId="ShowOnePageButton"
+					Content="One"
+					Click="OnePageClick" />
+		</StackPanel>
+	</Grid>
+
+</testharness:BaseTestSectionPage>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitMainPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitMainPage.xaml.cs
@@ -1,0 +1,16 @@
+﻿namespace TestHarness.Ext.Http.Refit;
+
+[TestSectionRoot("HttpRefit",TestSections.Http_Refit, typeof(HttpRefitHostInit))]
+public sealed partial class HttpRefitMainPage : BaseTestSectionPage
+{
+	public HttpRefitMainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public async void OnePageClick(object sender, RoutedEventArgs e)
+	{
+		await NavigationRoot.Navigator()!.NavigateViewModelAsync<HttpRefitOneViewModel>(this);
+	}
+
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitOnePage.xaml
@@ -1,0 +1,27 @@
+﻿<Page x:Class="TestHarness.Ext.Http.Refit.HttpRefitOnePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Http.Refit"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<utu:NavigationBar Content="HttpRefit - One"
+						   AutomationProperties.AutomationId="HttpRefitOne" />
+
+		
+		<StackPanel Grid.Row="1">
+			<Button Content="Add"
+					Click="{x:Bind ViewModel.Load}" />
+			<TextBlock Text="{Binding Data}" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitOnePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitOnePage.xaml.cs
@@ -1,0 +1,12 @@
+﻿
+namespace TestHarness.Ext.Http.Refit;
+
+public sealed partial class HttpRefitOnePage : Page
+{
+	public HttpRefitOneViewModel? ViewModel => DataContext as HttpRefitOneViewModel;
+	public HttpRefitOnePage()
+	{
+		this.InitializeComponent();
+	}
+
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/HttpRefitOneViewModel.cs
@@ -1,0 +1,27 @@
+﻿
+namespace TestHarness.Ext.Http.Refit;
+
+[ReactiveBindable(false)]
+public partial class HttpRefitOneViewModel : ObservableObject
+{
+	private readonly INavigator _navigator;
+	private readonly IServiceProvider _services;
+	private readonly IHttpRefitDummyJsonEndpoint _endpoint;
+
+	[ObservableProperty]
+	private string? data;
+
+	public HttpRefitOneViewModel(INavigator navigator, IServiceProvider services, IHttpRefitDummyJsonEndpoint endpoint)
+	{
+		_navigator = navigator;
+		_services = services;
+		_endpoint = endpoint;
+	}
+
+
+	public async Task Load()
+	{
+		var products = await _endpoint.Products(CancellationToken.None);
+		Data = $"Found {products.Products.Length} products";
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/IHttpRefitDummyJsonEndpoint.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/IHttpRefitDummyJsonEndpoint.cs
@@ -1,0 +1,31 @@
+﻿namespace TestHarness.Ext.Authentication.Custom;
+
+[Headers("Content-Type: application/json")]
+public interface IHttpRefitDummyJsonEndpoint
+{
+	[Get("/products")]
+	Task<HttpRefitProductsResponse> Products(CancellationToken ct);
+}
+
+public class HttpRefitProductsResponse : BaseHttpRefitResponse
+{
+	[JsonPropertyName("products")]
+	public HttpRefitProduct[]? Products { get; set; }
+
+}
+
+public class BaseHttpRefitResponse
+{
+	[JsonPropertyName("total")]
+	public int Total { get; set; }
+	[JsonPropertyName("skip")]
+	public int Skip { get; set; }
+	[JsonPropertyName("limit")]
+	public int Limit { get; set; }
+}
+
+public class HttpRefitProduct
+{
+	[JsonPropertyName("title")]
+	public string? Title { get; set; }
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/appsettings.httprefit.json
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Http/Refit/appsettings.httprefit.json
@@ -1,0 +1,6 @@
+﻿{
+  "HttpRefitDummyJsonEndpoint": {
+    "Url": "https://DummyJson.com",
+    "UseNativeHandler": true
+  }
+}

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -96,6 +96,23 @@
       <DependentUpon>StorageOnePage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Core\Storage\StorageOneViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Http\Endpoints\HttpEndpointsHostInit.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Http\Endpoints\HttpEndpointsMainPage.xaml.cs">
+      <DependentUpon>HttpEndpointsMainPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Http\Endpoints\HttpEndpointsOnePage.xaml.cs">
+      <DependentUpon>HttpEndpointsOnePage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Http\Endpoints\HttpEndpointsOneViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Http\Refit\IHttpRefitDummyJsonEndpoint.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Http\Refit\HttpRefitHostInit.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Http\Refit\HttpRefitMainPage.xaml.cs">
+      <DependentUpon>HttpRefitMainPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Http\Refit\HttpRefitOnePage.xaml.cs">
+      <DependentUpon>HttpRefitOnePage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Http\Refit\HttpRefitOneViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Localization\LocalizationHostInit.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Localization\LocalizationMainPage.xaml.cs">
       <DependentUpon>LocalizationMainPage.xaml</DependentUpon>
@@ -384,6 +401,22 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Ext\Http\Endpoints\HttpEndpointsMainPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Ext\Http\Endpoints\HttpEndpointsOnePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Ext\Http\Refit\HttpRefitMainPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Ext\Http\Refit\HttpRefitOnePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Ext\Navigation\Apps\Commerce\CommerceDealsPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -587,6 +620,7 @@
 		 explicitly included in the projitem, so files can be added from vscode
 		 without manipulating the projitem file.
 	-->
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Http\Refit\appsettings.httprefit.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\appsettings.webauthsettings.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\appsettings.webauth.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Custom\appsettings.testbackend.json" />
@@ -595,6 +629,7 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Msal\appsettings.msal.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Msal\appsettings.msalauthentication.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Oidc\appsettings.oidc.json" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Http\Endpoints\appsettings.httpendpoints.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Localization\appsettings.locale.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Navigation\Apps\Commerce\appsettings.logging.json" />
     <_Globbled_Page Include="$(MSBuildThisFileDirectory)**/*.xaml" Exclude="@(Page);@(ApplicationDefinition)">

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.shproj
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.shproj
@@ -10,12 +10,4 @@
   <PropertyGroup />
   <Import Project="TestHarness.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
-  <ItemGroup>
-    <_Globbed_Compile Remove="Ext\Authentication\AuthenticationRouteInfo.cs" />
-    <_Globbed_Compile Remove="Ext\Authentication\AuthenticationShellViewModel.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <_Globbed_PRIResource Remove="Strings\en-AU\Resources.resw" />
-    <_Globbed_PRIResource Remove="Strings\fr\Resources.resw" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

- Register HttpClient for a view model eg services.AddClient<MainViewModel>()
- Accept HttpClient as part of MainViewModel  constructor (eg MainViewModel(HttpClient client) )
- HttpClient should be populated with endpoint info from config files
- HttpClient has not BaseAddress set

## What is the new behavior?

- HttpClient has BaseAddress set based on config files
- Test cases for Http and Refit

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
