### PR TITLE
fix(feeds): Avoid boxing in CollectionAnalyzer

### DIFF
--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Change.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Change.cs
@@ -7,7 +7,7 @@ namespace Uno.Extensions.Collections.Tracking;
 
 partial class CollectionAnalyzer
 {
-	internal abstract class Change : ICollectionChange
+	internal abstract class Change<T> : ICollectionChange
 	{
 		public Change(int at)
 		{
@@ -28,7 +28,7 @@ partial class CollectionAnalyzer
 		/// <summary>
 		/// Gets or sets the next node of the linked list
 		/// </summary>
-		public Change? Next { get; set; }
+		public Change<T>? Next { get; set; }
 
 		public abstract RichNotifyCollectionChangedEventArgs? ToEvent();
 
@@ -64,15 +64,15 @@ partial class CollectionAnalyzer
 	/// A base change specialized from changes that are only altering entities within a collection
 	/// (i.e. they are not impacting indices - e.g. Replace and Same)
 	/// </summary>
-	private abstract class EntityChange : Change
+	private abstract class EntityChange<T> : Change<T>
 	{
 		protected readonly int _indexOffset;
-		protected readonly List<object?> _oldItems = new();
-		protected readonly List<object?> _newItems = new();
+		protected readonly List<T> _oldItems = new();
+		protected readonly List<T> _newItems = new();
 
-		public new EntityChange? Next
+		public new EntityChange<T>? Next
 		{
-			get => base.Next as EntityChange;
+			get => base.Next as EntityChange<T>;
 			set => base.Next = value;
 		}
 
@@ -83,7 +83,7 @@ partial class CollectionAnalyzer
 			Ends = at;
 		}
 
-		public void Append(object? oldItem, object? newItem)
+		public void Append(T oldItem, T newItem)
 		{
 			_oldItems.Add(oldItem);
 			_newItems.Add(newItem);

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.ListRef.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.ListRef.cs
@@ -24,12 +24,15 @@ internal partial class CollectionAnalyzer
 	/// </summary>
 	protected struct ListRef<T>
 	{
-		public ListRef(int count, ElementAtHandler<T> elementAt, IndexOfHandler<T> indexOf)
+		public ListRef(object instance, int count, ElementAtHandler<T> elementAt, IndexOfHandler<T> indexOf)
 		{
+			Instance = instance;
 			Count = count;
 			ElementAt = elementAt;
 			IndexOf = indexOf;
 		}
+
+		public object Instance { get; }
 
 		public int Count { get; }
 

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
@@ -32,10 +32,10 @@ internal class CollectionAnalyzer<T> : CollectionAnalyzer
 	}
 
 	private ListRef<T> GetRef(IList<T> list)
-		=> new(list.Count, i => list[i], list.GetIndexOf(_comparer));
+		=> new(list, list.Count, i => list[i], list.GetIndexOf(_comparer));
 
 	private ListRef<T> GetRef(IImmutableList<T> list)
-		=> new(list.Count, i => list[i], list.GetIndexOf(_comparer));
+		=> new(list, list.Count, i => list[i], list.GetIndexOf(_comparer));
 
 	/// <summary>
 	/// Determines the set of changes between two snapshot of an <see cref="IList{T}"/>
@@ -57,10 +57,10 @@ internal class CollectionAnalyzer<T> : CollectionAnalyzer
 	/// <param name="newItems">The target snapshot</param>
 	/// <returns>A list of changes that have to be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
 	public CollectionChangeSet GetChanges(IList<T> oldItems, IList<T> newItems)
-		=> new(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer));
+		=> new CollectionChangeSet<T>(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer));
 
 	internal CollectionChangeSet GetChanges(IImmutableList<T> oldItems, IImmutableList<T> newItems)
-		=> new(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer));
+		=> new CollectionChangeSet<T>(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer));
 
 	internal CollectionChangeSet GetResetChange(IImmutableList<T> oldItems, IImmutableList<T> newItems)
 		=> base.GetResetChange(oldItems.AsUntypedList(), newItems.AsUntypedList());

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Add.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Add.cs
@@ -8,10 +8,10 @@ namespace Uno.Extensions.Collections.Tracking;
 
 partial class CollectionAnalyzer
 {
-	private sealed class _Add : Change
+	private sealed class _Add<T> : Change<T>
 	{
 		private readonly int _indexOffset;
-		private readonly List<object?> _items;
+		private readonly List<T> _items;
 
 		public _Add(int at, int capacity)
 			: this(at, 0, capacity)
@@ -22,10 +22,10 @@ partial class CollectionAnalyzer
 			: base(at)
 		{
 			_indexOffset = indexOffset;
-			_items = new List<object?>(capacity);
+			_items = new List<T>(capacity);
 		}
 
-		public void Append(object? item)
+		public void Append(T item)
 		{
 			_items.Add(item);
 			Ends++;

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Event.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Event.cs
@@ -7,7 +7,7 @@ namespace Uno.Extensions.Collections.Tracking;
 
 partial class CollectionAnalyzer
 {
-	private class _Event : Change
+	private class _Event<T> : Change<T>
 	{
 		private readonly RichNotifyCollectionChangedEventArgs _args;
 
@@ -32,10 +32,10 @@ partial class CollectionAnalyzer
 			switch (arg.Action)
 			{
 				case Add:
-					return _Add.Visit(arg, visitor);
+					return _Add<T>.Visit(arg, visitor);
 
 				case Remove:
-					return _Remove.Visit(arg, visitor);
+					return _Remove<T>.Visit(arg, visitor);
 
 				case Move:
 					return new CollectionUpdater.Update(_args);

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Move.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Move.cs
@@ -8,11 +8,11 @@ namespace Uno.Extensions.Collections.Tracking;
 
 partial class CollectionAnalyzer
 {
-	private sealed class _Move : Change
+	private sealed class _Move<T> : Change<T>
 	{
 		private readonly int _to;
 		private readonly int _indexOffset;
-		private readonly List<object?> _items;
+		private readonly List<T> _items;
 
 		public _Move(int from, int to, int capacity)
 			: this(from, to, 0, capacity)
@@ -27,7 +27,7 @@ partial class CollectionAnalyzer
 			_items = new(capacity);
 		}
 
-		public void Append(object? item)
+		public void Append(T item)
 		{
 			_items.Add(item);
 			Ends++;

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Remove.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Remove.cs
@@ -6,10 +6,10 @@ namespace Uno.Extensions.Collections.Tracking;
 
 partial class CollectionAnalyzer
 {
-	private sealed class _Remove : Change
+	private sealed class _Remove<T> : Change<T>
 	{
 		private readonly int _indexOffset;
-		private readonly List<object?> _items;
+		private readonly List<T> _items;
 
 		public _Remove(int at, int capacity)
 			: this(at, 0, capacity)
@@ -20,10 +20,10 @@ partial class CollectionAnalyzer
 			: base(at)
 		{
 			_indexOffset = indexOffset;
-			_items = new List<object?>(capacity);
+			_items = new List<T>(capacity);
 		}
 
-		public void Append(object? item)
+		public void Append(T item)
 		{
 			_items.Add(item);
 		}

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Replace.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Replace.cs
@@ -9,7 +9,7 @@ namespace Uno.Extensions.Collections.Tracking;
 
 partial class CollectionAnalyzer
 {
-	private sealed class _Replace : EntityChange
+	private sealed class _Replace<T> : EntityChange<T>
 	{
 		/// <inheritdoc />
 		public _Replace(int at, int indexOffset)

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Same.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Same.cs
@@ -5,7 +5,7 @@ namespace Uno.Extensions.Collections.Tracking;
 
 partial class CollectionAnalyzer
 {
-	private sealed class _Same : EntityChange
+	private sealed class _Same<T> : EntityChange<T>
 	{
 		/// <inheritdoc />
 		public _Same(int at, int indexOffset)
@@ -32,6 +32,6 @@ partial class CollectionAnalyzer
 
 		/// <inheritdoc />
 		public override string ToString()
-			=> $"Keep {_oldItems.Count} items at {Starts} (Same instance that may require a deep diff)";
+			=> $"Keep {_oldItems.Count} items at {Starts} (Same instance or Comparer.Version.Equals that may require a deep diff)";
 	}
 }

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionChangeSet.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionChangeSet.cs
@@ -6,53 +6,19 @@ using Uno.Extensions.Reactive;
 
 namespace Uno.Extensions.Collections.Tracking;
 
-internal sealed partial record CollectionChangeSet : IChangeSet
+internal abstract partial record CollectionChangeSet : IChangeSet
 {
-	private readonly CollectionAnalyzer.Change? _head;
-
-	public static CollectionChangeSet Empty { get; } = new(head: default);
-
-	internal CollectionChangeSet(CollectionAnalyzer.Change? head)
-	{
-		_head = head;
-	}
-
-	internal ICollection<RichNotifyCollectionChangedEventArgs> ToCollectionChanges()
-		=> Enumerate().ToList();
-
-	private IEnumerable<RichNotifyCollectionChangedEventArgs> Enumerate()
-	{
-		var node = _head;
-		while (node is not null)
-		{
-			var args = node.ToEvent();
-			if (args is not null)
-			{
-				yield return args;
-			}
-
-			node = node.Next;
-		}
-	}
-
-	/// <inheritdoc />
-	public IEnumerator<IChange> GetEnumerator()
-	{
-		var node = _head;
-		while (node is not null)
-		{
-			yield return node;
-
-			node = node.Next;
-		}
-	}
-
 	/// <inheritdoc />
 	IEnumerator IEnumerable.GetEnumerator()
 		=> GetEnumerator();
 
-	public CollectionUpdater ToUpdater(ICollectionUpdaterVisitor visitor)
-		=> _head is null
-			? CollectionUpdater.Empty
-			: new(_head.ToUpdater(visitor));
+	/// <inheritdoc />
+	public abstract IEnumerator<IChange> GetEnumerator();
+
+	internal ICollection<RichNotifyCollectionChangedEventArgs> ToCollectionChanges()
+		=> Enumerate().ToList();
+
+	protected abstract IEnumerable<RichNotifyCollectionChangedEventArgs> Enumerate();
+
+	public abstract CollectionUpdater ToUpdater(ICollectionUpdaterVisitor visitor);
 }

--- a/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
+++ b/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
@@ -103,7 +103,7 @@ internal class FeedToListFeedAdapter<TCollection, TItem> : IListFeed<TItem>
 			(true, true) => collectionAnalyzer.GetChanges(previousItems, updatedItems),
 			(true, false) => collectionAnalyzer.GetResetChange(previousItems, ImmutableList<TItem>.Empty),
 			(false, true) => collectionAnalyzer.GetResetChange(ImmutableList<TItem>.Empty, updatedItems),
-			(false, false) => CollectionChangeSet.Empty,
+			(false, false) => CollectionChangeSet<TItem>.Empty,
 		};
 	}
 

--- a/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
@@ -167,10 +167,10 @@ internal class PaginatedListFeed<TCursor, TItem> : IListFeed<TItem>, IRefreshabl
 
 			(items, changes) = (hadItems, hasItems, isFirstPage) switch
 			{
-				(false, false, _) => (DifferentialImmutableList<TItem>.Empty, CollectionChangeSet.Empty),
+				(false, false, _) => (DifferentialImmutableList<TItem>.Empty, CollectionChangeSet<TItem>.Empty),
 				(false, true, _) => Reset(items, page.Items),
 				(true, false, true) => Clear(items),
-				(true, false, false) => (items, CollectionChangeSet.Empty),
+				(true, false, false) => (items, CollectionChangeSet<TItem>.Empty),
 				(true, true, true) => Reset(items, page.Items),
 				(true, true, false) => Add(items, page.Items),
 			};


### PR DESCRIPTION
## Bugfix
Avoid boxing in CollectionAnalyzer

## What is the current behavior?
Diff analyzer is working with `object?` which will box `ValueType` and requires us to have a specific path for them. Doing this we are also loosing the nullable annotions and prevents us to add helpers for tracking in `ListFeed<T>`

## What is the new behavior?
We are using generic everywhere and using `object?` as `T` when we don't have type like for `CollectionChangedEventArgs`.

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
