### PR TITLE
feat(feeds): Entity tracking in list feeds

### DIFF
--- a/src/Uno.Extensions.Reactive.Testing/ConstraintParts/Items.cs
+++ b/src/Uno.Extensions.Reactive.Testing/ConstraintParts/Items.cs
@@ -38,6 +38,9 @@ public static class Items
 	public static ItemsChanged Replace<T>(int at, IEnumerable<T> oldItems, IEnumerable<T> newItems)
 		=> ItemsChanged.Replace(at, oldItems, newItems);
 
+	public static ItemsChanged Replace<T>(int at, T oldItem, T newItem)
+		=> ItemsChanged.Replace(at, oldItem, newItem);
+
 	public static ItemsChanged Move<T>(int from, int to, params T[] items)
 		=> ItemsChanged.Move(from, to, items);
 

--- a/src/Uno.Extensions.Reactive.Testing/ConstraintParts/ItemsChanged.cs
+++ b/src/Uno.Extensions.Reactive.Testing/ConstraintParts/ItemsChanged.cs
@@ -30,6 +30,9 @@ public sealed class ItemsChanged : ChangesConstraint
 	public static ItemsChanged Replace<T>(int index, IEnumerable<T> oldItems, IEnumerable<T> newItems)
 		=> new(RichNotifyCollectionChangedEventArgs.ReplaceSome(oldItems.ToList(), newItems.ToList(), index));
 
+	public static ItemsChanged Replace<T>(int index, T oldItem, T newItem)
+		=> new(RichNotifyCollectionChangedEventArgs.Replace(oldItem, newItem, index));
+
 	public static ItemsChanged Move<T>(int oldIndex, int newIndex, params T[] items)
 		=> new(RichNotifyCollectionChangedEventArgs.MoveSome(items.ToList(), oldIndex, newIndex));
 
@@ -42,8 +45,15 @@ public sealed class ItemsChanged : ChangesConstraint
 	public static ItemsChanged Reset<T>(IEnumerable<T> newItems)
 		=> new(RichNotifyCollectionChangedEventArgs.Reset(null, newItems.ToList()));
 
+	public static ItemsChanged operator &(ItemsChanged left, ItemsChanged right)
+		=> new(left._expectedArgs.Concat(right._expectedArgs).ToImmutableList());
+
 	internal ItemsChanged(params RichNotifyCollectionChangedEventArgs[] expectedArgs)
 		=> _expectedArgs = expectedArgs.ToImmutableList();
+
+	internal ItemsChanged(IImmutableList<RichNotifyCollectionChangedEventArgs> expectedArgs)
+		=> _expectedArgs = expectedArgs.ToImmutableList();
+
 
 	/// <inheritdoc />
 	public override void Assert(ChangeCollection actual)

--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_FeedToListFeedAdapter.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_FeedToListFeedAdapter.cs
@@ -2,10 +2,14 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Equality;
+using Uno.Extensions.Reactive.Operators;
 using Uno.Extensions.Reactive.Testing;
 
 namespace Uno.Extensions.Reactive.Tests.Operators;
@@ -35,5 +39,105 @@ public partial class Given_FeedToListFeedAdapter : FeedTests
 		await result.Should().BeAsync(r => r
 			.Message(Changed.Data, Data.None, Error.No, Progress.Final)
 		);
+	}
+
+	[TestMethod]
+	public async Task When_KeyEquatableNoComparerAndUpdate_Then_TrackItemsUsingKeyEquality()
+	{
+		var original = new MyKeyedRecord[] { new(1, 1), new(2, 1), new(3, 1), new(4, 1) };
+		var updated = new MyKeyedRecord[] { new(1, 1), new(2, 2), new(4, 1), new(5, 1) };
+
+		async IAsyncEnumerable<IImmutableList<MyKeyedRecord>> GetSource([EnumeratorCancellation] CancellationToken ct = default)
+		{
+			yield return original.ToImmutableList();
+			yield return updated.ToImmutableList();
+		}
+
+		var source = Feed.AsyncEnumerable(GetSource);
+		var sut = new FeedToListFeedAdapter<MyKeyedRecord>(source);
+		var result = sut.Record();
+
+		await result.Should().BeAsync(r => r
+			.Message(m => m
+				.Current(Items.Some(original), Error.No, Progress.Final)
+				.Changed(Items.Reset(original)))
+			.Message(m => m
+				.Current(Items.Some(updated), Error.No, Progress.Final)
+				.Changed(Items.Replace(1, new MyKeyedRecord(2,1), new MyKeyedRecord(2,2))
+					& Items.Remove(2, new MyKeyedRecord(3,1))
+					& Items.Add(3, new MyKeyedRecord(5,1))))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_NotKeyEquatableNoComparerAndUpdate_Then_TrackItemsUsingKeyEquality()
+	{
+		var original = new MyNotKeyedRecord[] { new(1, 1), new(2, 1), new(3, 1), new(4, 1) };
+		var updated = new MyNotKeyedRecord[] { new(1, 1), new(2, 2), new(4, 1), new(5, 1) };
+
+		async IAsyncEnumerable<IImmutableList<MyNotKeyedRecord>> GetSource([EnumeratorCancellation] CancellationToken ct = default)
+		{
+			yield return original.ToImmutableList();
+			yield return updated.ToImmutableList();
+		}
+
+		var source = Feed.AsyncEnumerable(GetSource);
+		var sut = new FeedToListFeedAdapter<MyNotKeyedRecord>(source);
+		var result = sut.Record();
+
+		await result.Should().BeAsync(r => r
+			.Message(m => m
+				.Current(Items.Some(original), Error.No, Progress.Final)
+				.Changed(Items.Reset(original)))
+			.Message(m => m
+				.Current(Items.Some(updated), Error.No, Progress.Final)
+				.Changed(Items.Remove(1, new MyNotKeyedRecord(2, 1), new MyNotKeyedRecord(3, 1))
+					& Items.Add(1, new MyNotKeyedRecord(2, 2))
+					& Items.Add(3, new MyNotKeyedRecord(5, 1))))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_ClassNoComparerAndUpdate_Then_TrackItemsUsingKeyEquality()
+	{
+		var original = new MyNotKeyedClass[] { new(1, 1), new(2, 1), new(3, 1), new(4, 1) };
+		var updated = new MyNotKeyedClass[] { new(1, 1), new(2, 2), new(4, 1), new(5, 1) };
+
+		async IAsyncEnumerable<IImmutableList<MyNotKeyedClass>> GetSource([EnumeratorCancellation] CancellationToken ct = default)
+		{
+			yield return original.ToImmutableList();
+			yield return updated.ToImmutableList();
+		}
+
+		var source = Feed.AsyncEnumerable(GetSource);
+		var sut = new FeedToListFeedAdapter<MyNotKeyedClass>(source);
+		var result = sut.Record();
+
+		await result.Should().BeAsync(r => r
+			.Message(m => m
+				.Current(Items.Some(original), Error.No, Progress.Final)
+				.Changed(Items.Reset(original)))
+			.Message(m => m
+				.Current(Items.Some(updated), Error.No, Progress.Final)
+				.Changed(Items.Remove(0, original)
+					& Items.Add(0, updated)))
+		);
+	}
+
+	public partial record MyKeyedRecord(int Id, int Version);
+
+	[ImplicitKeyEquality(IsEnabled = false)]
+	public partial record MyNotKeyedRecord(int Id, int Version);
+
+	public partial class MyNotKeyedClass
+	{
+		public MyNotKeyedClass(int id, int version)
+		{
+			Id = id;
+			Version = version;
+		}
+
+		public int Id { get; init; }
+		public int Version { get; init; }
 	}
 }

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
@@ -12,6 +12,7 @@ using Uno.Extensions.Reactive.Bindings.Collections._BindableCollection;
 using Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data;
 using Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets;
 using Uno.Extensions.Reactive.Bindings.Collections.Services;
+using Uno.Extensions.Reactive.Collections;
 using Uno.Extensions.Reactive.Dispatching;
 using Uno.Extensions.Reactive.Utils;
 using ISchedulersProvider = Uno.Extensions.Reactive.Dispatching.DispatcherHelper.FindDispatcher;
@@ -32,21 +33,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 		/// Creates a new instance of a <see cref="BindableCollection"/>.
 		/// </summary>
 		/// <param name="initial">The initial items in the collection.</param>
-		/// <param name="itemComparer">
-		/// Comparer used to detect multiple versions of the **same entity (T)**, or null to use default.
-		/// <remarks>Usually this should only compare the ID of the entities in order to properly track the changes made on an entity.</remarks>
-		/// <remarks>For better performance, prefer provide null instead of <see cref="EqualityComparer{T}.Default"/> (cf. MapObservableCollection).</remarks>
-		/// </param>
-		/// <param name="itemVersionComparer">
-		/// Comparer used to detect multiple instance of the **same version** of the **same entity (T)**, or null to rely only on the <paramref name="itemComparer"/> (not recommanded).
-		/// <remarks>
-		/// This comparer will determine if two instances of the same entity (which was considered as equals by the <paramref name="itemComparer"/>),
-		/// are effectively equals or not (i.e. same version or not).
-		/// <br />
-		/// * If **Equals**: it's 2 **instances** of the **same version** of the **same entity** (all properties are equals), so we don't have to raise a <see cref="NotifyCollectionChangedAction.Replace"/>.<br />
-		/// * If **NOT Equals**: it's 2 **distinct versions** of the **same entity** (not all properties are equals) and we have to raise a 'Replace' to re-evaluate those properties.
-		/// </remarks>
-		/// </param>
+		/// <param name="itemComparer">Comparer used to track items.</param>
 		/// <param name="schedulersProvider">Schedulers provider to use to handle concurrency.</param>
 		/// <param name="services">A set of services that the collection can use (cf. Remarks)</param>
 		/// <param name="resetThreshold">Threshold on which the a single reset is raised instead of multiple collection changes.</param>
@@ -55,16 +42,12 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 		/// </remarks>
 		internal static BindableCollection Create<T>(
 			IObservableCollection<T>? initial = null,
-			IEqualityComparer<T>? itemComparer = null,
-			IEqualityComparer<T>? itemVersionComparer = null,
+			ItemComparer<T> itemComparer = default,
 			ISchedulersProvider? schedulersProvider = null,
 			IServiceProvider? services = null,
 			int resetThreshold = DataStructure.DefaultResetThreshold)
 		{
-			var dataStructure = new DataStructure
-			(
-				(itemComparer?.ToEqualityComparer(), itemVersionComparer?.ToEqualityComparer())
-			)
+			var dataStructure = new DataStructure((ItemComparer)itemComparer)
 			{
 				ResetThreshold = resetThreshold
 			};
@@ -77,16 +60,12 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 		/// </summary>
 		internal static BindableCollection CreateUntyped(
 			IObservableCollection? initial = null,
-			IEqualityComparer? itemComparer = null,
-			IEqualityComparer? itemVersionComparer = null,
+			ItemComparer itemComparer = default,
 			ISchedulersProvider? schedulersProvider = null,
 			int resetThreshold = DataStructure.DefaultResetThreshold
 		)
 		{
-			var dataStructure = new DataStructure
-			(
-				(itemComparer, itemVersionComparer)
-			)
+			var dataStructure = new DataStructure(itemComparer)
 			{
 				ResetThreshold = resetThreshold
 			};
@@ -96,19 +75,13 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 
 		internal static BindableCollection CreateGrouped<TKey, T>(
 			IObservableCollection<TKey> initial,
-			IEqualityComparer<TKey>? keyComparer,
-			IEqualityComparer<TKey>? keyVersionComparer,
-			IEqualityComparer<T>? itemComparer = null,
-			IEqualityComparer<T>? itemVersionComparer = null,
+			ItemComparer<TKey> keyComparer,
+			ItemComparer<T> itemComparer = default,
 			ISchedulersProvider? schedulersProvider = null,
 			int resetThreshold = DataStructure.DefaultResetThreshold)
 			where TKey : IObservableGroup<T>
 		{
-			var dataStructure = new DataStructure
-			(
-				(keyComparer?.ToEqualityComparer(), keyVersionComparer?.ToEqualityComparer()),
-				(itemComparer?.ToEqualityComparer(), itemVersionComparer?.ToEqualityComparer())
-			)
+			var dataStructure = new DataStructure((ItemComparer)keyComparer, (ItemComparer)itemComparer)
 			{
 				ResetThreshold = resetThreshold
 			};
@@ -118,19 +91,13 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 
 		internal static BindableCollection CreateGrouped<TGroup>(
 			IObservableCollection initial,
-			IEqualityComparer<TGroup>? groupComparer,
-			IEqualityComparer<TGroup>? groupVersionComparer,
-			IEqualityComparer? itemComparer,
-			IEqualityComparer? itemVersionComparer,
+			ItemComparer<TGroup> groupComparer,
+			ItemComparer itemComparer,
 			ISchedulersProvider? schedulersProvider = null,
 			int resetThreshold = DataStructure.DefaultResetThreshold)
 			where TGroup : IObservableGroup
 		{
-			var dataStructure = new DataStructure
-			(
-				(groupComparer?.ToEqualityComparer(), groupVersionComparer?.ToEqualityComparer()),
-				(itemComparer, itemVersionComparer)
-			)
+			var dataStructure = new DataStructure((ItemComparer)groupComparer, itemComparer)
 			{
 				ResetThreshold = resetThreshold
 			};
@@ -140,18 +107,12 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 
 		internal static BindableCollection CreateUntypedGrouped(
 			IObservableCollection initial,
-			IEqualityComparer? groupComparer,
-			IEqualityComparer? groupVersionComparer,
-			IEqualityComparer? itemComparer,
-			IEqualityComparer? itemVersionComparer,
+			ItemComparer groupComparer,
+			ItemComparer itemComparer,
 			ISchedulersProvider? schedulersProvider = null,
 			int resetThreshold = DataStructure.DefaultResetThreshold)
 		{
-			var dataStructure = new DataStructure
-			(
-				(groupComparer, groupVersionComparer),
-				(itemComparer, itemVersionComparer)
-			)
+			var dataStructure = new DataStructure(groupComparer, itemComparer)
 			{
 				ResetThreshold = resetThreshold
 			};

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataStructure.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataStructure.cs
@@ -11,9 +11,9 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 	{
 		public const int DefaultResetThreshold = 5;
 
-		private readonly (IEqualityComparer? itemComparer, IEqualityComparer? itemVersionComparer)[] _comparersStructure;
+		private readonly ItemComparer[] _comparersStructure;
 
-		public DataStructure(params (IEqualityComparer? itemComparer, IEqualityComparer? itemVersionComparer)[] comparersStructure)
+		public DataStructure(params ItemComparer[] comparersStructure)
 		{
 			_comparersStructure = comparersStructure;
 		}
@@ -33,7 +33,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 			}
 
 			var comparers = _comparersStructure[level];
-			var tracker = new CollectionAnalyzer(new ItemComparer(comparers.itemComparer, comparers.itemVersionComparer));
+			var tracker = new CollectionAnalyzer(comparers);
 
 			if (level + 1 == _comparersStructure.Length)
 			{

--- a/src/Uno.Extensions.Reactive/Collections/ItemComparer.T.cs
+++ b/src/Uno.Extensions.Reactive/Collections/ItemComparer.T.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Uno.Extensions.Equality;
 
 namespace Uno.Extensions.Reactive.Collections;
 
@@ -20,13 +21,43 @@ namespace Uno.Extensions.Reactive.Collections;
 /// The typical usage of this structure is for item tracking in collections.
 /// We first try to match the items using the <paramref name="Entity"/> comparer to detect insertions and removes.
 /// When 2 items are consider as not equals, we generate some add / remove collection changed args.
-/// If they are considered as equals by the <paramref name="Entity" /> comparer, they are compared using teh <see cref="Version"/> comparer.
-/// If **not** equals (i.e. 2 **distinct version** of the **same entity**, a replace collection changed args is generated,
+/// If they are considered as equals by the <paramref name="Entity" /> comparer, they are compared using the <paramref name="Version"/> comparer.
+/// If **not** equals (i.e. 2 **distinct version** of the **same entity**), a replace collection changed args is generated,
 /// so the binding engine kicks-in to update the properties of the item.
-/// If equals (i.e. 2 **instances** of the **same version** of the **same entity** (all properties are equals) no event is raised at all.
+/// If equals (i.e. 2 **instances** of the **same version** of the **same entity**), all properties are equals no event is raised at all.
 /// </remarks>
 /// <remarks>
-///	For both comparer, prefer to provide `null` than <see cref="EqualityComparer{T}.Default"/>.
-/// This allow user of this struct to use fast-paths when possible.
+/// The common usages are: <br />
+///	* If the <typeparamref name="T"/> is an immutable record, with a notion of key
+///   (so a new instance of the record, with the same key, is created on each update, and a new immutable collection is created using that new instance)
+///   use the <see cref="KeyEqualityComparer{T}"/> as <paramref name="Entity"/> and the <see cref="EqualityComparer{T}.Default"/> for <paramref name="Version"/>.
+/// * For immutable records that does not have a notion of key / version,
+///   use the <see cref="EqualityComparer{T}.Default"/> as <paramref name="Entity"/> and keep the for <paramref name="Version"/> `null`.
+/// * For an entity that as no notion of key (only relies on instance equality),
+///   use `null` for both <paramref name="Entity"/> and <paramref name="Version"/>.
+/// <br />
+/// The general rules are:
+/// * The <paramref name="Version"/> should be more restrictive than the <paramref name="Entity"/> comparer.
+/// * If there is no notion of key/version for your items, the <paramref name="Version"/> should be `null` (rely only on <paramref name="Entity"/> for tracking).
+/// * If the <paramref name="Entity"/> is `null` (lets to the list the responsibility to choose the right comparer,
+///   so usually ref-equals for classes, deep-equals for records and ValueTypes), the <paramref name="Version"/> should also be `null`.
+/// * Do not use the same comparer for both
+/// * Prefer to keep <paramref name="Entity"/> `null` than <see cref="EqualityComparer{T}.Default"/>, it allows user of this struct to use fast-paths when possible.
+///   (so the <paramref name="Version"/> should also be null then).
 /// </remarks>
-internal record struct ItemComparer<T>(IEqualityComparer<T>? Entity, IEqualityComparer<T>? Version);
+internal record struct ItemComparer<T>(IEqualityComparer<T>? Entity, IEqualityComparer<T>? Version)
+{
+	public static ItemComparer<T> Null => new();
+
+	public static ItemComparer<T> Default => new(null, null);
+
+	// A bool which indicates that we went trough a constructor instead of using default(ItemComparer<T>) (both comparers can still be null)
+	public bool IsSet { get; init; } = true;
+	public bool IsNull => !IsSet;
+
+	public static explicit operator ItemComparer(ItemComparer<T> typed)
+		=> new(typed.Entity?.ToEqualityComparer(), typed.Version?.ToEqualityComparer()) { IsSet = typed.IsSet };
+
+	public static explicit operator ItemComparer<T>(ItemComparer untyped)
+		=> new(untyped.Entity?.ToEqualityComparer<T>(), untyped.Version?.ToEqualityComparer<T>()) { IsSet = untyped.IsSet };
+}

--- a/src/Uno.Extensions.Reactive/Collections/ItemComparer.cs
+++ b/src/Uno.Extensions.Reactive/Collections/ItemComparer.cs
@@ -29,4 +29,13 @@ namespace Uno.Extensions.Reactive.Collections;
 ///	For both comparer, prefer to provide `null` than <see cref="EqualityComparer{T}.Default"/>.
 /// This allow user of this struct to use fast-paths when possible.
 /// </remarks>
-internal record struct ItemComparer(IEqualityComparer? Entity, IEqualityComparer? Version);
+internal record struct ItemComparer(IEqualityComparer? Entity, IEqualityComparer? Version)
+{
+	public static ItemComparer Null => new();
+
+	public static ItemComparer Default => new(null, null);
+
+	// A bool which indicates that we went trough a constructor instead of using default(ItemComparer<T>) (both comparers can still be null)
+	public bool IsSet { get; init; } = true;
+	public bool IsNull => !IsSet;
+}

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
@@ -15,8 +15,6 @@ namespace Uno.Extensions.Collections.Tracking;
 /// </summary>
 internal class CollectionAnalyzer<T> : CollectionAnalyzer
 {
-	public static CollectionAnalyzer<T> Default { get; } = new(default);
-
 	private readonly IEqualityComparer<T>? _comparer;
 	private readonly ComparerRef<T>? _versionComparer;
 

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.T.Internal.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.T.Internal.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Uno.Extensions.Collections.Tracking;
+using Uno.Extensions.Equality;
+using Uno.Extensions.Reactive.Collections;
+
+namespace Uno.Extensions.Reactive;
+
+static partial class ListFeed<T>
+{
+	/// <summary>
+	/// The default comparer to use in feed when not configured by user.
+	/// </summary>
+	internal static ItemComparer<T> DefaultComparer { get; } = KeyEqualityComparer.Find<T>() is {} keyComparer
+		? new (keyComparer, EqualityComparer<T>.Default)
+		: ItemComparer<T>.Default; // No comparers, use default behavior of the list
+
+	internal static ItemComparer<T> GetComparer(ItemComparer<T> comparer)
+		=> comparer is { IsNull: true } ? DefaultComparer : comparer;
+
+	/// <summary>
+	/// The default analyzer that should be used in feeds that should not offer a way to customize the <see cref="ItemComparer{T}"/>,
+	/// like all operators.
+	/// </summary>
+	internal static CollectionAnalyzer<T> DefaultAnalyzer { get; } = new(DefaultComparer);
+
+	internal static CollectionAnalyzer<T> GetAnalyzer(ItemComparer<T> comparer)
+		=> comparer is { IsNull: true } ? DefaultAnalyzer : new(comparer);
+}

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.T.cs
@@ -14,7 +14,7 @@ namespace Uno.Extensions.Reactive;
 /// Provides a set of static methods to create and manipulate <see cref="IListFeed{T}"/>.
 /// </summary>
 /// <typeparam name="T">The type of the items.</typeparam>
-public static class ListFeed<T>
+public static partial class ListFeed<T>
 {
 	/// <summary>
 	/// Creates a custom feed from a raw <see cref="IAsyncEnumerable{T}"/> sequence of <see cref="Uno.Extensions.Reactive.Message{T}"/>.

--- a/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
+++ b/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
@@ -37,8 +37,8 @@ internal class FeedToListFeedAdapter<TCollection, TItem> : IListFeed<TItem>
 	{
 		_source = source;
 		_toImmutable = toImmutable;
-		_itemComparer = itemComparer;
-		_analyzer = new(itemComparer);
+		_itemComparer = ListFeed<TItem>.GetComparer(itemComparer);
+		_analyzer = ListFeed<TItem>.GetAnalyzer(itemComparer);
 	}
 
 	/// <inheritdoc />

--- a/src/Uno.Extensions.Reactive/Operators/WhereListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/WhereListFeed.cs
@@ -10,9 +10,9 @@ using Uno.Extensions.Reactive.Core;
 
 namespace Uno.Extensions.Reactive.Operators;
 
-internal class WhereListFeed<T> : IListFeed<T>
+internal sealed class WhereListFeed<T> : IListFeed<T>
 {
-	private static readonly CollectionAnalyzer<T> _analyzer = CollectionAnalyzer<T>.Default;
+	private static readonly CollectionAnalyzer<T> _analyzer = ListFeed<T>.DefaultAnalyzer;
 
 	private readonly IListFeed<T> _parent;
 	private readonly Predicate<T> _predicate;

--- a/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Uno.Extensions.Collections;
 using Uno.Extensions.Collections.Facades.Differential;
 using Uno.Extensions.Collections.Tracking;
+using Uno.Extensions.Reactive.Collections;
 using Uno.Extensions.Reactive.Core;
 using Uno.Extensions.Reactive.Utils;
 
@@ -18,11 +19,11 @@ internal class PaginatedListFeed<TCursor, TItem> : IListFeed<TItem>, IRefreshabl
 	private readonly GetPage<TCursor, TItem> _getPage;
 	private readonly CollectionAnalyzer<TItem> _diffAnalyzer;
 
-	public PaginatedListFeed(TCursor firstPage, GetPage<TCursor, TItem> getPage)
+	public PaginatedListFeed(TCursor firstPage, GetPage<TCursor, TItem> getPage, ItemComparer<TItem> itemComparer = default)
 	{
 		_firstPage = firstPage;
 		_getPage = getPage;
-		_diffAnalyzer = new CollectionAnalyzer<TItem>(default);
+		_diffAnalyzer = ListFeed<TItem>.GetAnalyzer(itemComparer);
 	}
 
 	/// <inheritdoc />


### PR DESCRIPTION
linked to https://github.com/unoplatform/uno.extensions/issues/688

## Feature
Entity tracking in list feeds

## What is the current behavior?
We rely only on `Equals` to track entities in messages of ListFeed. This cause the UI to animate remove + add when we update an entity in a `ListState`

## What is the new behavior?
We are using the generated key equality to properly track entities

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~~ _comming with last PR for this feature_
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
