### PR TITLE
updated the dotnet command

### DIFF
--- a/doc/Overview/ExtensionsOverviewAndGettingStarted.md
+++ b/doc/Overview/ExtensionsOverviewAndGettingStarted.md
@@ -35,7 +35,7 @@ The `dotnet` templates included in the `Uno.Extensions.Templates` package are us
 
 * Open a command prompt and run the following
 
-    `dotnet new -i Uno.Extensions.Templates`
+    `dotnet new install Uno.Extensions.Templates`
 
 * Navigate to the desired projects directory, and use the `unoapp-extensions` template to generate the starter solution discussed above
 


### PR DESCRIPTION
The `-i` is obsolete and produce warnings.

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

When install the uno-extension template using the 
`dotnet new -i Uno.Extensions.Templates` the tooling prints a warning message. 

![image](https://user-images.githubusercontent.com/20712372/192376301-8d1c0789-6cc0-455e-8a52-209931dbd3f1.png)


## What is the new behavior?

No warning message and everyone was happy (:


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
