### PR TITLE
feat: Add support of the DataAnnotations.KeyAttribute

### DIFF
--- a/src/Uno.Extensions.Reactive.Generator/KeyEquality/KeyEqualityGenerationContext.cs
+++ b/src/Uno.Extensions.Reactive.Generator/KeyEquality/KeyEqualityGenerationContext.cs
@@ -13,7 +13,8 @@ internal record KeyEqualityGenerationContext(
 
 	// Config
 	[ContextType(typeof(ImplicitKeyEqualityAttribute))] INamedTypeSymbol ImplicitKeyAttribute,
-	[ContextType(typeof(KeyAttribute))] INamedTypeSymbol KeyAttribute
+	[ContextType(typeof(KeyAttribute))] INamedTypeSymbol KeyAttribute,
+	[ContextType("System.ComponentModel.DataAnnotations.KeyAttribute?")] INamedTypeSymbol? DataAnnotationsKeyAttribute
 )
 {
 	private IMethodSymbol? _getKeyHashCode;

--- a/src/Uno.Extensions.Reactive.Generator/KeyEquality/KeyEqualityGenerationTool.cs
+++ b/src/Uno.Extensions.Reactive.Generator/KeyEquality/KeyEqualityGenerationTool.cs
@@ -128,10 +128,11 @@ internal class KeyEqualityGenerationTool : ICodeGenTool
 
 	private List<IPropertySymbol> SearchKeys(INamedTypeSymbol type, ImplicitKeyEqualityAttribute assemblyImplicit)
 	{
-		// Search for properties flagged with [Key] attribute
+		// Search for properties flagged with [Key] attribute (Using Uno's attribute or System.ComponentModel.DataAnnotations.KeyAttribute)
 		var keys = type
 			.GetProperties()
-			.Where(prop => prop.FindAttribute(_ctx.KeyAttribute) is not null)
+			.Where(prop => prop.FindAttribute(_ctx.KeyAttribute) is not null
+				|| (_ctx.DataAnnotationsKeyAttribute is {} daKey && prop.FindAttribute(daKey) is not null))
 			.ToList();
 
 		// If none found, search for implicit key properties

--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_KeyEquatableRecord_Then_Generate.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_KeyEquatableRecord_Then_Generate.cs
@@ -115,6 +115,25 @@ public class Given_KeyEquatableRecord_Then_Generate
 		inst1.GetKeyHashCode().Should().Be(inst2.GetKeyHashCode());
 		inst1.KeyEquals(inst2).Should().BeTrue();
 	}
+	[TestMethod]
+	public void When_CustomDataAnnotationsKeyEquatable_Then_CustomKeyUsed()
+	{
+		var inst1 = new MyCustomDataAnnotationsKeyEquatableRecord(42, 1);
+		var inst2 = new MyCustomDataAnnotationsKeyEquatableRecord(42, 2);
+
+		inst1.GetKeyHashCode().Should().NotBe(inst2.GetKeyHashCode());
+		inst1.KeyEquals(inst2).Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void When_CustomDataAnnotationsKeyEquatable_Then_OnlyCustomKeyIsUsed()
+	{
+		var inst1 = new MyCustomDataAnnotationsKeyEquatableRecord(1, 42);
+		var inst2 = new MyCustomDataAnnotationsKeyEquatableRecord(2, 42);
+
+		inst1.GetKeyHashCode().Should().Be(inst2.GetKeyHashCode());
+		inst1.KeyEquals(inst2).Should().BeTrue();
+	}
 
 	[TestMethod]
 	public void When_CustomKeyWithImplicitEquatable_Then_CustomKeyUsed()
@@ -365,6 +384,8 @@ public partial record MyNotKeyEquatableRecord(int Id);
 public partial record MyCustomImplicitKeyEquatableRecord(int Id, int MyKey);
 
 public partial record MyCustomKeyEquatableRecord(int Id, [property:Key] int MyKey);
+
+public partial record MyCustomDataAnnotationsKeyEquatableRecord(int Id, [property: System.ComponentModel.DataAnnotations.KeyAttribute] int MyKey);
 
 [ImplicitKeyEquality("MyOtherKey")]
 public partial record MyCustomKeyWithImplicitEquatableRecord(int Id, [property: Key] int MyKey, int MyOtherKey);


### PR DESCRIPTION
## Feature
Add support of the DataAnnotations.KeyAttribute

## What is the current behavior?
We support only the Uno's KeyAttrbute

## What is the new behavior?
We support both

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~~ _the whole feature will be documented in a future PR_
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
