### PR TITLE
Improve collection analyzer

### DIFF
--- a/src/Uno.Extensions.Core/_Compat/MemberNotNullWhenAttribute.cs
+++ b/src/Uno.Extensions.Core/_Compat/MemberNotNullWhenAttribute.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+	/// <summary>Specifies that the method or property will ensure that the listed field and property members have non-null values when returning with the specified return value condition.</summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+	public sealed class MemberNotNullWhenAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+		/// <param name="returnValue">The return value condition. If the method returns this value, the associated parameter will not be <see langword="null" />.</param>
+		/// <param name="member">The field or property member that is promised to be non-null.</param>
+		public MemberNotNullWhenAttribute(bool returnValue, string member)
+		{
+			ReturnValue = returnValue;
+			Members = new string[1] { member };
+		}
+
+		/// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+		/// <param name="returnValue">The return value condition. If the method returns this value, the associated parameter will not be <see langword="null" />.</param>
+		/// <param name="members">The list of field and property members that are promised to be non-null.</param>
+		public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+		{
+			ReturnValue = returnValue;
+			Members = members;
+		}
+
+		/// <summary>Gets the return value condition.</summary>
+		public bool ReturnValue { get; }
+
+		/// <summary>Gets field or property member names.</summary>
+		public string[] Members { get; }
+	}
+}

--- a/src/Uno.Extensions.Reactive.Generator/Compat/CompatibilityTypesGenerationContext.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Compat/CompatibilityTypesGenerationContext.cs
@@ -9,6 +9,7 @@ internal record CompatibilityTypesGenerationContext(
 
 	[ContextType("System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute?")] INamedTypeSymbol? NotNullIfNotNullAttribute, // .net std 2.1 and above
 	[ContextType("System.Diagnostics.CodeAnalysis.NotNullWhenAttribute?")] INamedTypeSymbol? NotNullWhenAttribute, // .net std 2.1 and above
+	[ContextType("System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute?")] INamedTypeSymbol? MemberNotNullWhenAttribute, // .net std 2.1 and above
 
 	[ContextType("System.Runtime.CompilerServices.IsExternalInit?")] INamedTypeSymbol? IsExternalInit, // .net 5 and above only
 	[ContextType("System.Runtime.CompilerServices.ModuleInitializerAttribute?")] INamedTypeSymbol? ModuleInitializerAttribute // .net 5 and above only

--- a/src/Uno.Extensions.Reactive.Generator/Compat/CompatibilityTypesGenerationTool.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Compat/CompatibilityTypesGenerationTool.cs
@@ -26,6 +26,10 @@ internal class CompatibilityTypesGenerationTool : ICodeGenTool
 		{
 			yield return (nameof(_context.NotNullWhenAttribute), GetNotNullWhenAttribute());
 		}
+		if (_context.MemberNotNullWhenAttribute is null && !GetIsDisabled("UnoExtensionsGeneration_DisableMemberNotNullWhenAttribute"))
+		{
+			yield return (nameof(_context.MemberNotNullWhenAttribute), GetMemberNotNullWhenAttribute());
+		}
 		if (_context.IsExternalInit is null && !GetIsDisabled("UnoExtensionsGeneration_DisableIsExternalInit"))
 		{
 			yield return (nameof(_context.IsExternalInit), GetIsExternalInit());
@@ -106,6 +110,44 @@ internal class CompatibilityTypesGenerationTool : ICodeGenTool
 					{{
 						ParameterName = parameterName;
 					}}
+				}}
+			}}
+			".Align(0);
+
+	private string GetMemberNotNullWhenAttribute()
+		=> $@"{this.GetFileHeader(3)}
+
+			using global::System;
+
+			namespace System.Diagnostics.CodeAnalysis
+			{{
+				/// <summary>Specifies that the method or property will ensure that the listed field and property members have non-null values when returning with the specified return value condition.</summary>
+				[global::System.AttributeUsage(global::System.AttributeTargets.Method | global::System.AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+				public sealed class MemberNotNullWhenAttribute : global::System.Attribute
+				{{
+					/// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+					/// <param name=""returnValue"">The return value condition. If the method returns this value, the associated parameter will not be <see langword=""null"" />.</param>
+					/// <param name=""member"">The field or property member that is promised to be non-null.</param>
+					public MemberNotNullWhenAttribute(bool returnValue, string member)
+					{{
+						ReturnValue = returnValue;
+						Members = new string[1] {{ member }};
+					}}
+
+					/// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+					/// <param name=""returnValue"">The return value condition. If the method returns this value, the associated parameter will not be <see langword=""null"" />.</param>
+					/// <param name=""members"">The list of field and property members that are promised to be non-null.</param>
+					public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+					{{
+						ReturnValue = returnValue;
+						Members = members;
+					}}
+
+					/// <summary>Gets the return value condition.</summary>
+					public bool ReturnValue {{ get; }}
+
+					/// <summary>Gets field or property member names.</summary>
+					public string[] Members {{ get; }}
 				}}
 			}}
 			".Align(0);

--- a/src/Uno.Extensions.Reactive.Generator/buildTransitive/Uno.Extensions.Reactive.props
+++ b/src/Uno.Extensions.Reactive.Generator/buildTransitive/Uno.Extensions.Reactive.props
@@ -2,6 +2,7 @@
 	<ItemGroup>
 		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableNotNullIfNotNullAttribute" />
 		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableNotNullWhenAttribute" />
+		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableMemberNotNullWhenAttribute" />
 		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableIsExternalInit" />
 		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableModuleInitializerAttribute" />
 	</ItemGroup>

--- a/src/Uno.Extensions.Reactive.Testing/ConstraintParts/ItemsChanged.cs
+++ b/src/Uno.Extensions.Reactive.Testing/ConstraintParts/ItemsChanged.cs
@@ -16,34 +16,37 @@ public sealed class ItemsChanged : ChangesConstraint
 	public static ItemsChanged Empty { get; } = new();
 
 	public static ItemsChanged Add<T>(int index, params T[] items)
-		=> new(RichNotifyCollectionChangedEventArgs.AddSome(items, index));
+		=> new(RichNotifyCollectionChangedEventArgs.AddSome<T>(items, index));
 
 	public static ItemsChanged Add<T>(int index, IEnumerable<T> items)
-		=> new(RichNotifyCollectionChangedEventArgs.AddSome(items.ToList(), index));
+		=> new(RichNotifyCollectionChangedEventArgs.AddSome<T>(items.ToList(), index));
 
 	public static ItemsChanged Remove<T>(int index, params T[] items)
-		=> new(RichNotifyCollectionChangedEventArgs.RemoveSome(items, index));
+		=> new(RichNotifyCollectionChangedEventArgs.RemoveSome<T>(items, index));
 
 	public static ItemsChanged Remove<T>(int index, IEnumerable<T> items)
-		=> new(RichNotifyCollectionChangedEventArgs.RemoveSome(items.ToList(), index));
+		=> new(RichNotifyCollectionChangedEventArgs.RemoveSome<T>(items.ToList(), index));
 
 	public static ItemsChanged Replace<T>(int index, IEnumerable<T> oldItems, IEnumerable<T> newItems)
-		=> new(RichNotifyCollectionChangedEventArgs.ReplaceSome(oldItems.ToList(), newItems.ToList(), index));
+		=> new(RichNotifyCollectionChangedEventArgs.ReplaceSome<T>(oldItems.ToList(), newItems.ToList(), index));
+
+	public static ItemsChanged Replace<T>(int index, T oldItem, T newItem)
+		=> new(RichNotifyCollectionChangedEventArgs.Replace<T>(oldItem, newItem, index));
 
 	public static ItemsChanged Replace<T>(int index, T oldItem, T newItem)
 		=> new(RichNotifyCollectionChangedEventArgs.Replace(oldItem, newItem, index));
 
 	public static ItemsChanged Move<T>(int oldIndex, int newIndex, params T[] items)
-		=> new(RichNotifyCollectionChangedEventArgs.MoveSome(items.ToList(), oldIndex, newIndex));
+		=> new(RichNotifyCollectionChangedEventArgs.MoveSome<T>(items.ToList(), oldIndex, newIndex));
 
 	public static ItemsChanged Move<T>(int oldIndex, int newIndex, IEnumerable<T> items)
-		=> new(RichNotifyCollectionChangedEventArgs.MoveSome(items.ToList(), oldIndex, newIndex));
+		=> new(RichNotifyCollectionChangedEventArgs.MoveSome<T>(items.ToList(), oldIndex, newIndex));
 
 	public static ItemsChanged Reset<T>(IEnumerable<T> oldItems, IEnumerable<T> newItems)
-		=> new(RichNotifyCollectionChangedEventArgs.Reset(oldItems.ToList(), newItems.ToList()));
+		=> new(RichNotifyCollectionChangedEventArgs.Reset<T>(oldItems.ToList(), newItems.ToList()));
 
 	public static ItemsChanged Reset<T>(IEnumerable<T> newItems)
-		=> new(RichNotifyCollectionChangedEventArgs.Reset(null, newItems.ToList()));
+		=> new(RichNotifyCollectionChangedEventArgs.Reset<T>(null, newItems.ToList()));
 
 	public static ItemsChanged operator &(ItemsChanged left, ItemsChanged right)
 		=> new(left._expectedArgs.Concat(right._expectedArgs).ToImmutableList());
@@ -64,7 +67,7 @@ public sealed class ItemsChanged : ChangesConstraint
 		{
 			AssertionScope.Current.Fail("is not set, but the collection of items was expected to have been updated.");
 		}
-		changeSet.Should().BeOfType<CollectionChangeSet>();
+		changeSet.Should().BeAssignableTo<CollectionChangeSet>();
 
 		if (changeSet is CollectionChangeSet changes)
 		{

--- a/src/Uno.Extensions.Reactive.Testing/ConstraintParts/ItemsChanged.cs
+++ b/src/Uno.Extensions.Reactive.Testing/ConstraintParts/ItemsChanged.cs
@@ -33,9 +33,6 @@ public sealed class ItemsChanged : ChangesConstraint
 	public static ItemsChanged Replace<T>(int index, T oldItem, T newItem)
 		=> new(RichNotifyCollectionChangedEventArgs.Replace<T>(oldItem, newItem, index));
 
-	public static ItemsChanged Replace<T>(int index, T oldItem, T newItem)
-		=> new(RichNotifyCollectionChangedEventArgs.Replace(oldItem, newItem, index));
-
 	public static ItemsChanged Move<T>(int oldIndex, int newIndex, params T[] items)
 		=> new(RichNotifyCollectionChangedEventArgs.MoveSome<T>(items.ToList(), oldIndex, newIndex));
 

--- a/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.Immutable.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.Immutable.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions.Collections.Tracking;
+using Uno.Extensions.Reactive.Collections;
 using Uno.Extensions.Reactive.Tests._Utils;
 using static Uno.Extensions.Collections.CollectionChanged;
 
@@ -2215,7 +2216,11 @@ public partial class Given_CollectionAnalyzer_Immutable
 			=> collection;
 
 		/// <inheritdoc />
-		protected override CollectionUpdater GetUpdater(CollectionAnalyzer<T> analyzer, IImmutableList<T> previous, IImmutableList<T> updated, ICollectionUpdaterVisitor visitor)
-			=> analyzer.GetUpdater(previous, updated, visitor);
+		protected override CollectionUpdater GetUpdater(ItemComparer<T> comparer, IImmutableList<T> previous, IImmutableList<T> updated, ICollectionUpdaterVisitor visitor)
+			=> new CollectionAnalyzer<T>(comparer).GetUpdater(previous, updated, visitor);
+
+		/// <inheritdoc />
+		protected override CollectionChangeSet<T> GetChanges(ItemComparer<T> comparer, IImmutableList<T> previous, IImmutableList<T> updated)
+			=> new CollectionAnalyzer<T>(comparer).GetChanges(previous, updated);
 	}
 }

--- a/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.ImmutableNonIList.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.ImmutableNonIList.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions.Collections.Tracking;
+using Uno.Extensions.Reactive.Collections;
 using Uno.Extensions.Reactive.Tests._Utils;
 using static Uno.Extensions.Collections.CollectionChanged;
 
@@ -2215,8 +2216,12 @@ public partial class Given_CollectionAnalyzer_ImmutableNonIList
 			=> collection;
 
 		/// <inheritdoc />
-		protected override CollectionUpdater GetUpdater(CollectionAnalyzer<T> analyzer, ImmutableListWhichIsNotIList<T> previous, ImmutableListWhichIsNotIList<T> updated, ICollectionUpdaterVisitor visitor)
-			=> analyzer.GetUpdater(previous, updated, visitor);
+		protected override CollectionUpdater GetUpdater(ItemComparer<T> comparer, ImmutableListWhichIsNotIList<T> previous, ImmutableListWhichIsNotIList<T> updated, ICollectionUpdaterVisitor visitor)
+			=> new CollectionAnalyzer<T>(comparer).GetUpdater(previous, updated, visitor);
+
+		/// <inheritdoc />
+		protected override CollectionChangeSet<T> GetChanges(ItemComparer<T> comparer, ImmutableListWhichIsNotIList<T> previous, ImmutableListWhichIsNotIList<T> updated)
+			=> new CollectionAnalyzer<T>(comparer).GetChanges(previous, updated);
 	}
 
 	private class ImmutableListWhichIsNotIList<T> : IImmutableList<T>

--- a/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.List.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.List.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions.Collections.Tracking;
 using Uno.Extensions.Equality;
+using Uno.Extensions.Reactive.Collections;
 using Uno.Extensions.Reactive.Tests._Utils;
 using Uno.Extensions.Reactive.Utils;
 using static Uno.Extensions.Collections.CollectionChanged;
@@ -2220,8 +2221,12 @@ public partial class Given_CollectionAnalyzer_List
 			=> new ArrayList(items.Select(_cast).ToArray()); // Make sure to lost the IList<object?>
 
 		/// <inheritdoc />
-		protected override CollectionUpdater GetUpdater(CollectionAnalyzer<object?> analyzer, IList previous, IList updated, ICollectionUpdaterVisitor visitor)
-			=> analyzer.GetUpdater(previous, updated, visitor);
+		protected override CollectionUpdater GetUpdater(ItemComparer<object?> comparer, IList previous, IList updated, ICollectionUpdaterVisitor visitor)
+			=> new CollectionAnalyzer(new(comparer.Entity?.ToEqualityComparer(), comparer.Version?.ToEqualityComparer())).GetUpdater(previous, updated, visitor);
+
+		/// <inheritdoc />
+		protected override CollectionChangeSet GetChanges(ItemComparer<object?> comparer, IList previous, IList updated)
+			=> new CollectionAnalyzer(new(comparer.Entity?.ToEqualityComparer(), comparer.Version?.ToEqualityComparer())).GetChanges(previous, updated);
 
 		/// <inheritdoc />
 		protected override IEnumerable<object?> AsEnumerable(IList collection)

--- a/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.ListOfT.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.ListOfT.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions.Collections.Tracking;
+using Uno.Extensions.Reactive.Collections;
 using Uno.Extensions.Reactive.Tests._Utils;
 using Uno.Extensions.Reactive.Utils;
 using static Uno.Extensions.Collections.CollectionChanged;
@@ -2210,8 +2211,12 @@ public partial class Given_CollectionAnalyzer_ListOfT
 			=> items;
 
 		/// <inheritdoc />
-		protected override CollectionUpdater GetUpdater(CollectionAnalyzer<T> analyzer, IList<T> previous, IList<T> updated, ICollectionUpdaterVisitor visitor)
-			=> analyzer.GetUpdater(previous, updated, visitor);
+		protected override CollectionUpdater GetUpdater(ItemComparer<T> comparer, IList<T> previous, IList<T> updated, ICollectionUpdaterVisitor visitor)
+			=> new CollectionAnalyzer<T>(comparer).GetUpdater(previous, updated, visitor);
+
+		/// <inheritdoc />
+		protected override CollectionChangeSet<T> GetChanges(ItemComparer<T> comparer, IList<T> previous, IList<T> updated)
+			=> new CollectionAnalyzer<T>(comparer).GetChanges(previous, updated);
 
 		/// <inheritdoc />
 		protected override IEnumerable<T> AsEnumerable(IList<T> collection)

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/ICollectionAdapter.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/ICollectionAdapter.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive.Collections.Facades.Adapters;
+
+internal interface ICollectionAdapter
+{
+	object Adaptee { get; }
+}

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/ImmutableListToUntypedList.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/ImmutableListToUntypedList.cs
@@ -7,32 +7,44 @@ using System.Text;
 
 namespace Uno.Extensions.Reactive.Collections.Facades.Adapters;
 
-internal struct ImmutableListToUntypedList<T> : IList
+internal class ImmutableListToUntypedList<T> : IList, IList<T>, IImmutableList<T>, IReadOnlyList<T>, ICollectionAdapter
 {
 	private readonly IImmutableList<T> _inner;
+
+	object ICollectionAdapter.Adaptee => _inner;
 
 	public ImmutableListToUntypedList(IImmutableList<T> inner)
 	{
 		_inner = inner;
 	}
 
-	/// <inheritdoc />
+	/// <inheritdoc cref="IList" />
 	public int Count => _inner.Count;
 
 	/// <inheritdoc />
 	public bool IsFixedSize => true;
 
-	/// <inheritdoc />
+	/// <inheritdoc cref="IList" />
 	public bool IsReadOnly => true;
 
 	/// <inheritdoc />
-	public bool IsSynchronized => true;
+	public bool IsSynchronized => false;
 
 	/// <inheritdoc />
 	public object SyncRoot { get; } = new();
 
 	/// <inheritdoc />
-	public object? this[int index]
+	T IReadOnlyList<T>.this[int index] => _inner[index];
+
+	/// <inheritdoc />
+	object? IList.this[int index]
+	{
+		get => _inner[index];
+		set => throw NotSupported();
+	}
+
+	/// <inheritdoc />
+	T IList<T>.this[int index]
 	{
 		get => _inner[index];
 		set => throw NotSupported();
@@ -43,11 +55,31 @@ internal struct ImmutableListToUntypedList<T> : IList
 		=> IndexOf(value) >= 0;
 
 	/// <inheritdoc />
+	public bool Contains(T item)
+		=> IndexOf(item) >= 0;
+
+	/// <inheritdoc />
 	public int IndexOf(object value)
 		=> value is T t ? _inner.IndexOf(t) : -1;
 
 	/// <inheritdoc />
+	public int IndexOf(T item)
+		=> _inner.IndexOf(item);
+
+	/// <inheritdoc />
+	public int IndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
+		=> _inner.IndexOf(item, index, count, equalityComparer);
+
+	/// <inheritdoc />
+	public int LastIndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
+		=> _inner.LastIndexOf(item, index, count, equalityComparer);
+
+	/// <inheritdoc />
 	public IEnumerator GetEnumerator()
+		=> _inner.GetEnumerator();
+
+	/// <inheritdoc />
+	IEnumerator<T> IEnumerable<T>.GetEnumerator()
 		=> _inner.GetEnumerator();
 
 	/// <inheritdoc />
@@ -55,24 +87,96 @@ internal struct ImmutableListToUntypedList<T> : IList
 		=> ((ICollection)_inner).CopyTo(array, index);
 
 	/// <inheritdoc />
-	public int Add(object value)
+	public void CopyTo(T[] array, int arrayIndex)
+		=> ((ICollection<T>)_inner).CopyTo(array, arrayIndex);
+
+	/// <inheritdoc />
+	int IList.Add(object value)
 		=> throw NotSupported();
 
 	/// <inheritdoc />
-	public void Insert(int index, object value)
+	void ICollection<T>.Add(T item)
 		=> throw NotSupported();
 
 	/// <inheritdoc />
-	public void Remove(object value)
+	public IImmutableList<T> Add(T value)
+		=> _inner.Add(value);
+
+	/// <inheritdoc />
+	public IImmutableList<T> AddRange(IEnumerable<T> items)
+		=> _inner.AddRange(items);
+
+	/// <inheritdoc />
+	void IList.Insert(int index, object value)
 		=> throw NotSupported();
 
 	/// <inheritdoc />
-	public void RemoveAt(int index)
+	void IList<T>.Insert(int index, T item)
 		=> throw NotSupported();
 
 	/// <inheritdoc />
-	public void Clear()
+	public IImmutableList<T> InsertRange(int index, IEnumerable<T> items)
+		=> _inner.InsertRange(index, items);
+
+	/// <inheritdoc />
+	public IImmutableList<T> Insert(int index, T element)
+		=> _inner.Insert(index, element);
+
+	/// <inheritdoc />
+	public IImmutableList<T> SetItem(int index, T value)
+		=> _inner.SetItem(index, value);
+
+	/// <inheritdoc />
+	public IImmutableList<T> Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer)
+		=> _inner.Replace(oldValue, newValue, equalityComparer);
+
+	/// <inheritdoc />
+	void IList.Remove(object value)
 		=> throw NotSupported();
+
+	/// <inheritdoc />
+	public bool Remove(T item)
+		=> throw NotSupported();
+
+	/// <inheritdoc />
+	public IImmutableList<T> Remove(T value, IEqualityComparer<T> equalityComparer)
+		=> _inner.Remove(value, equalityComparer);
+
+	/// <inheritdoc />
+	public IImmutableList<T> RemoveAll(Predicate<T> match)
+		=> _inner.RemoveAll(match);
+
+	/// <inheritdoc />
+	public IImmutableList<T> RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer)
+		=> _inner.RemoveRange(items, equalityComparer);
+
+	/// <inheritdoc />
+	public IImmutableList<T> RemoveRange(int index, int count)
+		=> _inner.RemoveRange(index, count);
+
+	/// <inheritdoc />
+	void IList.RemoveAt(int index)
+		=> throw NotSupported();
+
+	/// <inheritdoc />
+	void IList<T>.RemoveAt(int index)
+		=> throw NotSupported();
+
+	/// <inheritdoc />
+	public IImmutableList<T> RemoveAt(int index)
+		=> _inner.RemoveAt(index);
+
+	/// <inheritdoc />
+	void IList.Clear()
+		=> throw NotSupported();
+
+	/// <inheritdoc />
+	void ICollection<T>.Clear()
+		=> throw NotSupported();
+
+	/// <inheritdoc />
+	public IImmutableList<T> Clear()
+		=> _inner.Clear();
 
 	private InvalidOperationException NotSupported([CallerMemberName] string? method = null)
 		=> new($"Cannot '{method}' on a read only list.");

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/ListToUntypedList.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/ListToUntypedList.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Uno.Extensions.Reactive.Collections.Facades.Adapters;
+
+internal class ListToUntypedList<T> : IList, IList<T>, IReadOnlyList<T>, ICollectionAdapter
+{
+	private readonly IList<T> _inner;
+
+	object ICollectionAdapter.Adaptee => _inner;
+
+	public ListToUntypedList(IList<T> inner)
+	{
+		_inner = inner;
+	}
+
+	/// <inheritdoc cref="IList" />
+	public int Count => _inner.Count;
+
+	/// <inheritdoc />
+	public bool IsSynchronized => false;
+
+	/// <inheritdoc />
+	public object SyncRoot { get; } = new();
+
+	/// <inheritdoc cref="IList" />
+	public bool IsReadOnly => _inner.IsReadOnly;
+
+	/// <inheritdoc />
+	public bool IsFixedSize => ((IList)_inner).IsFixedSize;
+
+	/// <inheritdoc />
+	object? IList.this[int index]
+	{
+		get => _inner[index];
+		set => _inner[index] = (T)(value ?? throw new ArgumentNullException(nameof(value)));
+	}
+
+	/// <inheritdoc cref="IList" />
+	public T this[int index]
+	{
+		get => _inner[index];
+		set => _inner[index] = value;
+	}
+
+	/// <inheritdoc />
+	public bool Contains(object value)
+		=> _inner.Contains((T)value);
+
+	/// <inheritdoc />
+	public bool Contains(T item)
+		=> _inner.Contains(item);
+
+	/// <inheritdoc />
+	public int IndexOf(object value)
+		=> _inner.IndexOf((T)value);
+
+	/// <inheritdoc />
+	public int IndexOf(T item)
+		=> _inner.IndexOf(item);
+
+	/// <inheritdoc />
+	IEnumerator IEnumerable.GetEnumerator()
+		=> _inner.GetEnumerator();
+
+	/// <inheritdoc />
+	public IEnumerator<T> GetEnumerator()
+		=> _inner.Cast<T>().GetEnumerator();
+
+	/// <inheritdoc />
+	public void CopyTo(Array array, int index)
+		=> ((ICollection)_inner).CopyTo(array, index);
+
+	/// <inheritdoc />
+	public void CopyTo(T[] array, int arrayIndex)
+		=> _inner.CopyTo(array, arrayIndex);
+
+	/// <inheritdoc />
+	public int Add(object value)
+	{
+		_inner.Add((T)value);
+		return _inner.Count - 1;
+	}
+
+	/// <inheritdoc />
+	public void Add(T item)
+		=> _inner.Add(item);
+
+	/// <inheritdoc />
+	public void Insert(int index, object value)
+		=> _inner.Insert(index, (T)value);
+
+	/// <inheritdoc />
+	public void Insert(int index, T item)
+		=> _inner.Insert(index, item);
+
+	/// <inheritdoc cref="IList" />
+	public void RemoveAt(int index)
+		=> _inner.RemoveAt(index);
+
+	/// <inheritdoc />
+	public void Remove(object value)
+		=> _inner.Remove((T)value);
+
+	/// <inheritdoc />
+	public bool Remove(T item)
+	{
+		var previousCount = _inner.Count;
+		_inner.Remove(item);
+
+		return _inner.Count != previousCount;
+	}
+
+	/// <inheritdoc cref="IList" />
+	public void Clear()
+		=> _inner.Clear();
+}

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/UntypedListToList.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/UntypedListToList.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Uno.Extensions.Reactive.Collections.Facades.Adapters;
+
+internal class UntypedListToList<T> : IList, IList<T>, IReadOnlyList<T>, ICollectionAdapter
+{
+	private readonly IList _inner;
+
+	object ICollectionAdapter.Adaptee => _inner;
+
+	public UntypedListToList(IList inner)
+	{
+		_inner = inner;
+	}
+
+	/// <inheritdoc cref="IList" />
+	public int Count => _inner.Count;
+
+	/// <inheritdoc />
+	public bool IsSynchronized => _inner.IsSynchronized;
+
+	/// <inheritdoc />
+	public object SyncRoot => _inner.SyncRoot;
+
+	/// <inheritdoc cref="IList" />
+	public bool IsReadOnly => _inner.IsReadOnly;
+
+	/// <inheritdoc />
+	public bool IsFixedSize => _inner.IsFixedSize;
+
+	/// <inheritdoc cref="IList{T}" />
+	public T this[int index]
+	{
+		get => (T)_inner[index];
+		set => _inner[index] = value;
+	}
+
+	/// <inheritdoc />
+	object IList.this[int index]
+	{
+		get => _inner[index];
+		set => _inner[index] = value;
+	}
+
+	/// <inheritdoc />
+	public bool Contains(object value)
+		=> _inner.Contains(value);
+
+	/// <inheritdoc />
+	public bool Contains(T item)
+		=> _inner.Contains(item);
+
+	/// <inheritdoc />
+	public int IndexOf(object value)
+		=> _inner.IndexOf(value);
+
+	/// <inheritdoc />
+	public int IndexOf(T item)
+		=> _inner.IndexOf(item);
+
+	/// <inheritdoc />
+	public void CopyTo(Array array, int index)
+		=> _inner.CopyTo(array, index);
+
+	/// <inheritdoc />
+	public void CopyTo(T[] array, int arrayIndex)
+		=> _inner.CopyTo(array, arrayIndex);
+
+	/// <inheritdoc />
+	IEnumerator IEnumerable.GetEnumerator()
+		=> _inner.GetEnumerator();
+
+	/// <inheritdoc />
+	public IEnumerator<T> GetEnumerator()
+		=> _inner.Cast<T>().GetEnumerator();
+
+	/// <inheritdoc />
+	public void Add(T item)
+		=> _inner.Add(item);
+
+	/// <inheritdoc />
+	public int Add(object value)
+		=> _inner.Add(value);
+
+	/// <inheritdoc />
+	public void Insert(int index, object value)
+		=> _inner.Insert(index, value);
+
+	/// <inheritdoc />
+	public void Insert(int index, T item)
+		=> _inner.Insert(index, item);
+
+	/// <inheritdoc cref="IList{T}" />
+	public void RemoveAt(int index)
+		=> _inner.RemoveAt(index);
+
+	/// <inheritdoc />
+	public void Remove(object value)
+		=> _inner.Remove(value);
+
+	/// <inheritdoc />
+	public bool Remove(T item)
+	{
+		var previousCount = _inner.Count;
+		_inner.Remove(item);
+
+		return _inner.Count != previousCount;
+	}
+
+	/// <inheritdoc cref="IList" />
+	public void Clear()
+		=> _inner.Clear();
+}

--- a/src/Uno.Extensions.Reactive/Collections/RichNotifyCollectionChangedEventArgs.cs
+++ b/src/Uno.Extensions.Reactive/Collections/RichNotifyCollectionChangedEventArgs.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.Specialized;
 using System.Linq;
+using Uno.Extensions.Reactive.Utils;
 
 namespace Uno.Extensions.Collections;
 
@@ -16,8 +19,20 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Add"/> collection changed event args
 	/// </summary>
+	public static RichNotifyCollectionChangedEventArgs Add<T>(T item, int index)
+		=> new(NotifyCollectionChangedAction.Add, new[] { item }, index);
+
+	/// <summary>
+	/// Creates a <see cref="NotifyCollectionChangedAction.Add"/> collection changed event args
+	/// </summary>
 	public static RichNotifyCollectionChangedEventArgs AddSome(IList items, int index)
 		=> new(NotifyCollectionChangedAction.Add, items, index);
+
+	/// <summary>
+	/// Creates a <see cref="NotifyCollectionChangedAction.Add"/> collection changed event args
+	/// </summary>
+	public static RichNotifyCollectionChangedEventArgs AddSome<T>(IList<T> items, int index)
+		=> new(NotifyCollectionChangedAction.Add, items.AsUntypedList(), index);
 
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Remove"/> collection changed event args
@@ -28,8 +43,20 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Remove"/> collection changed event args
 	/// </summary>
+	public static RichNotifyCollectionChangedEventArgs Remove<T>(T item, int index)
+		=> new(NotifyCollectionChangedAction.Remove, new [] { item }, index);
+
+	/// <summary>
+	/// Creates a <see cref="NotifyCollectionChangedAction.Remove"/> collection changed event args
+	/// </summary>
 	public static RichNotifyCollectionChangedEventArgs RemoveSome(IList items, int index)
 		=> new(NotifyCollectionChangedAction.Remove, items, index);
+
+	/// <summary>
+	/// Creates a <see cref="NotifyCollectionChangedAction.Remove"/> collection changed event args
+	/// </summary>
+	public static RichNotifyCollectionChangedEventArgs RemoveSome<T>(IList<T> items, int index)
+		=> new(NotifyCollectionChangedAction.Remove, items.AsUntypedList(), index);
 
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Replace"/> collection changed event args
@@ -40,8 +67,20 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Replace"/> collection changed event args
 	/// </summary>
+	public static RichNotifyCollectionChangedEventArgs Replace<T>(T oldItem, T newItem, int index)
+		=> new(NotifyCollectionChangedAction.Replace, new[] { newItem }, new[] { oldItem }, index);
+
+	/// <summary>
+	/// Creates a <see cref="NotifyCollectionChangedAction.Replace"/> collection changed event args
+	/// </summary>
 	public static RichNotifyCollectionChangedEventArgs ReplaceSome(IList oldItems, IList newItems, int index)
 		=> new(NotifyCollectionChangedAction.Replace, newItems, oldItems, index);
+
+	/// <summary>
+	/// Creates a <see cref="NotifyCollectionChangedAction.Replace"/> collection changed event args
+	/// </summary>
+	public static RichNotifyCollectionChangedEventArgs ReplaceSome<T>(IList<T> oldItems, IList<T> newItems, int index)
+		=> new(NotifyCollectionChangedAction.Replace, newItems.AsUntypedList(), oldItems.AsUntypedList(), index);
 
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Move"/> collection changed event args
@@ -52,8 +91,20 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Move"/> collection changed event args
 	/// </summary>
+	public static RichNotifyCollectionChangedEventArgs Move<T>(T item, int oldIndex, int newIndex)
+		=> new(NotifyCollectionChangedAction.Move, new [] { item }, newIndex, oldIndex);
+
+	/// <summary>
+	/// Creates a <see cref="NotifyCollectionChangedAction.Move"/> collection changed event args
+	/// </summary>
 	public static RichNotifyCollectionChangedEventArgs MoveSome(IList items, int oldIndex, int newIndex)
 		=> new(NotifyCollectionChangedAction.Move, items, newIndex, oldIndex);
+
+	/// <summary>
+	/// Creates a <see cref="NotifyCollectionChangedAction.Move"/> collection changed event args
+	/// </summary>
+	public static RichNotifyCollectionChangedEventArgs MoveSome<T>(IList<T> items, int oldIndex, int newIndex)
+		=> new(NotifyCollectionChangedAction.Move, items.AsUntypedList(), newIndex, oldIndex);
 
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Reset"/> collection changed event args
@@ -63,6 +114,26 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 		{
 			ResetOldItems = oldItems ?? Array.Empty<object>(),
 			ResetNewItems = newItems ?? Array.Empty<object>()
+		};
+
+	/// <summary>
+	/// Creates a <see cref="NotifyCollectionChangedAction.Reset"/> collection changed event args
+	/// </summary>
+	public static RichNotifyCollectionChangedEventArgs Reset<T>(IList<T>? oldItems, IList<T>? newItems)
+		=> new(NotifyCollectionChangedAction.Reset)
+		{
+			ResetOldItems = oldItems?.AsUntypedList() ?? Array.Empty<T>(),
+			ResetNewItems = newItems?.AsUntypedList() ?? Array.Empty<T>()
+		};
+
+	/// <summary>
+	/// Creates a <see cref="NotifyCollectionChangedAction.Reset"/> collection changed event args
+	/// </summary>
+	public static RichNotifyCollectionChangedEventArgs Reset<T>(IImmutableList<T>? oldItems, IImmutableList<T>? newItems)
+		=> new(NotifyCollectionChangedAction.Reset)
+		{
+			ResetOldItems = oldItems?.AsUntypedList() ?? Array.Empty<T>(),
+			ResetNewItems = newItems?.AsUntypedList() ?? Array.Empty<T>()
 		};
 
 	private RichNotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action)

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Change.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Change.cs
@@ -58,6 +58,8 @@ partial class CollectionAnalyzer
 		}
 
 		protected abstract CollectionUpdater.Update ToUpdaterCore(ICollectionUpdaterVisitor visitor);
+
+		protected internal abstract void Visit(ICollectionChangeSetVisitor<T> visitor);
 	}
 
 	/// <summary>

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Core.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Core.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+
+namespace Uno.Extensions.Collections.Tracking;
+
+internal partial class CollectionAnalyzer
+{
+	internal static ComparerRef<object?>? GetRef(IEqualityComparer? comparer)
+		=> comparer is null ? null : comparer.Equals;
+
+	internal static ComparerRef<T>? GetRef<T>(IEqualityComparer<T>? comparer)
+		=> comparer is null ? null : comparer.Equals;
+
+	// DEPRECATED: We need to complete extraction of the CollectionUpdater concept
+	internal static CollectionUpdater ToUpdater<T>(Change<T>? changed, ICollectionUpdaterVisitor visitor)
+	{
+		var updaterHead = changed?.ToUpdater(visitor);
+
+		return updaterHead is null
+			? CollectionUpdater.Empty
+			: new(updaterHead);
+	}
+
+	internal static Change<T>? GetChangesCore<T>(
+		RichNotifyCollectionChangedEventArgs arg,
+		Func<IList, ListRef<T>> getRef,
+		ComparerRef<T>? versionComparer)
+	{
+		switch (arg.Action)
+		{
+			case NotifyCollectionChangedAction.Add:
+			case NotifyCollectionChangedAction.Remove:
+			case NotifyCollectionChangedAction.Move:
+			case NotifyCollectionChangedAction.Reset:
+				return new _Event<T>(arg);
+
+			// For the replace, we are digging in the collection to determine if we could simplify the change considering the given comparers
+			case NotifyCollectionChangedAction.Replace:
+				return GetChangesCore(getRef(arg.OldItems), getRef(arg.NewItems), versionComparer, arg.OldStartingIndex);
+
+			default:
+				throw new ArgumentOutOfRangeException(nameof(arg), arg.Action, $"Action '{arg.Action}' not supported.");
+		}
+	}
+
+	internal static Change<T>? GetChangesCore<T>(
+		ListRef<T> oldItems,
+		ListRef<T> newItems,
+		ComparerRef<T>? versionComparer,
+		int eventArgsOffset = 0)
+	{
+		//if (oldItems.Instance is IDifferentialCollection oldDiff
+		//	&& newItems.Instance is IDifferentialCollection newDiff
+		//	&& oldDiff.FindCommonAncestor(newDiff) is { } ancestor
+		//	&& ancestor == oldDiff.Head) // Temp
+		//{
+		//	// 1. Rollback changes from oldDiff to ancestor
+		//	// => Not supported yet, see condition 'ancestor == oldDiff.Head' above
+
+		//	// 2. Apply changes from ancestor to newDiff
+		//	new 
+		//}
+
+		/*
+		* OLD: the source collection we are going to update to the NEW
+		* NEW: the collection that we want to go to
+		* RESULT (a.k.a. virtual old) : This makes sense only while synchronizing, it's represents the OLD with the changes already applied. 
+		*								 At the end it's expected to be sequence equals to the NEW.
+		* 
+		* We detect changes to update from OLD to NEW. We could have choose the other way, but as the consumer (i.e. the view) knows the OLD, it's a bit more logical.
+		* 
+		* Note: comparer may be null for IObservableCollectionSnapshot.IndexOf(). 
+		*		 It's more performant to forward the 'null' instead of defaulting to EqualityComparer.Default
+		* 
+		*/
+
+		int added = 0, moved = 0, removed = 0;
+		var buffer = new ChangesBuffer<T>(oldItems.Count, newItems.Count, eventArgsOffset);
+
+		var oldEnumerator = new SourceEnumerator<T>(oldItems);
+		while (oldEnumerator.MoveNext())
+		{
+			var oldIndex = oldEnumerator.CurrentIndex;
+			var oldItem = oldEnumerator.Current!;
+			var resultIndex = oldIndex - removed + added + moved - oldEnumerator.Ignored; // The current index in the (virtual) result collection (i.e. oldIndex ignoring the removed/added items)
+			var newIndex = newItems.IndexOf(oldItem, resultIndex, newItems.Count - resultIndex);
+
+			if (newIndex < 0)
+			{
+				// Item is no more present in the new collection : Remove it
+
+				buffer.Remove(oldItem, resultIndex);
+				removed++;
+
+				continue;
+			}
+
+			if (newIndex < resultIndex)
+			{
+				throw new InvalidOperationException("The index return by the IndexOf is invalid");
+			}
+
+			// First raise replace if the instance/version of the item changed
+			UpdateInstanceFromOld(oldItem, oldIndex, newIndex);
+
+			if (newIndex > resultIndex)
+			{
+				// Item is AFTER the expected index in old, this means that some items was inserted / moved before
+
+				for (var missingItemNewIndex = resultIndex; missingItemNewIndex < newIndex; missingItemNewIndex++)
+				{
+					var missingItem = newItems.ElementAt(missingItemNewIndex); // The item that is missing in the old collection
+					var (missingItemOldIndex, missingItemOldIndexOffset) = oldEnumerator.NextIndexOf(missingItem);
+					if (missingItemOldIndex >= 0)
+					{
+						// The missing item was already present in the old snapshot. We only have to move it.
+
+						// The 'fromOffset' counts only the number of items that have been move from 'after' the item to 'before' it.
+						// We include this backward moves as they are already offsetting the virtual old index, but we do not include
+						// any other moves (so we are not using 'moved') as they haven't any impact on the virtual old index.
+						var from = missingItemOldIndex - removed + added;
+						var fromOffset = missingItemOldIndexOffset;
+
+						// As the item will be handle here (moved), ignore the index to ensure that we won't try to move it again later
+						oldEnumerator.Ignore(missingItemOldIndex);
+
+						// First update the instance if needed, then move it to it new position
+						UpdateInstanceFromNew(missingItem, missingItemOldIndex);
+						buffer.Move(missingItem, from: from, fromOffset: fromOffset, to: missingItemNewIndex, max: newIndex);
+						moved++;
+					}
+					else
+					{
+						// The missing item is a new item, we have to add it.
+
+						buffer.Add(missingItem, at: missingItemNewIndex, max: newIndex);
+						added++;
+					}
+				}
+			}
+
+			Debug.Assert(newIndex == oldIndex - removed + added + moved - oldEnumerator.Ignored);
+		}
+
+		Debug.Assert(moved - oldEnumerator.Ignored == 0);
+
+		// Finally add items that remains at the end of the newItems (i.e. was missing in the previous)
+		var resultItemsCount = oldItems.Count - removed + added;
+		var toAddCount = newItems.Count - resultItemsCount;
+		if (toAddCount > 0)
+		{
+			var add = new _Add<T>(at: resultItemsCount, indexOffset: eventArgsOffset, capacity: toAddCount);
+			for (var i = 0; i < toAddCount; i++)
+			{
+				var item = newItems.ElementAt(i + resultItemsCount);
+				add.Append(item);
+			}
+
+			buffer.Append(add);
+		}
+
+		return buffer.GetChanges();
+
+
+		/*
+		*	About equality checks and instance update:
+		*
+		*	Usually the 'itemVersionComparer' checks for full Equality, while the 'itemComparer' only checks for the KeyEquality.
+		*	The idea is to be able to properly track multiple versions of the same item (for instance if a property of the item changed).
+		*
+		*	Here, the "item tracking" was already done, and we are only validating 2 versions of the same item
+		*  (we already determined that they have the same key using the 'itemComparer').
+		*
+		*	If the 'itemVersionComparer' is 'null' we assume that there is no
+		*	notion of version of an item and we rely only on the `itemComparer` to check equality.
+		*	Note: in this case we don't raise any 'Replace'.
+		*
+		*	If the 'itemVersionComparer' returns 'true' (or if it's 'null') that means that they are not only KeyEquals but also Equals.
+		*	So as we are usually working with immutable objects, we can ignore that a new instance is available and
+		*  we don't raise any event ('changesBuffer.Update'). Note: We still have to notify the visitor!
+		*
+		*  If the 'itemVersionComparer' returns 'false' that means items are only key equals, but not same version.
+		*  So we have to raise a 'Replace' event.
+		*/
+
+		void UpdateInstanceFromOld(T oldItem, int oldIndex, int newIndex)
+		{
+			if (versionComparer is null)
+			{
+				buffer.Update(oldItem, oldItem, oldIndex);
+
+				return;
+			}
+
+			var newItem = newItems.ElementAt(newIndex);
+			if (versionComparer(oldItem, newItem))
+			{
+				buffer.Update(oldItem, newItem, oldIndex);
+			}
+			else
+			{
+				buffer.Replace(oldItem, newItem, oldIndex);
+			}
+		}
+
+		void UpdateInstanceFromNew(T newItem, int oldIndex)
+		{
+			if (versionComparer is null)
+			{
+				buffer.Update(newItem, newItem, oldIndex);
+
+				return;
+			}
+
+			var oldItem = oldItems.ElementAt(oldIndex);
+			if (versionComparer(oldItem, newItem))
+			{
+				buffer.Update(oldItem, newItem, oldIndex);
+			}
+			else
+			{
+				buffer.Replace(oldItem, newItem, oldIndex);
+			}
+		}
+	}
+}

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Core.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Core.cs
@@ -89,7 +89,7 @@ internal partial class CollectionAnalyzer
 
 			if (newIndex < resultIndex)
 			{
-				throw new InvalidOperationException("The index return by the IndexOf is invalid");
+				throw new InvalidOperationException("The index returned by the IndexOf is invalid");
 			}
 
 			// First raise replace if the instance/version of the item changed

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Core.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Core.cs
@@ -52,17 +52,6 @@ internal partial class CollectionAnalyzer
 		ComparerRef<T>? versionComparer,
 		int eventArgsOffset = 0)
 	{
-		//if (oldItems.Instance is IDifferentialCollection oldDiff
-		//	&& newItems.Instance is IDifferentialCollection newDiff
-		//	&& oldDiff.FindCommonAncestor(newDiff) is { } ancestor
-		//	&& ancestor == oldDiff.Head) // Temp
-		//{
-		//	// 1. Rollback changes from oldDiff to ancestor
-		//	// => Not supported yet, see condition 'ancestor == oldDiff.Head' above
-
-		//	// 2. Apply changes from ancestor to newDiff
-		//	new 
-		//}
 
 		/*
 		* OLD: the source collection we are going to update to the NEW
@@ -84,7 +73,7 @@ internal partial class CollectionAnalyzer
 		while (oldEnumerator.MoveNext())
 		{
 			var oldIndex = oldEnumerator.CurrentIndex;
-			var oldItem = oldEnumerator.Current!;
+			var oldItem = oldEnumerator.Current;
 			var resultIndex = oldIndex - removed + added + moved - oldEnumerator.Ignored; // The current index in the (virtual) result collection (i.e. oldIndex ignoring the removed/added items)
 			var newIndex = newItems.IndexOf(oldItem, resultIndex, newItems.Count - resultIndex);
 

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.ListRef.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.ListRef.cs
@@ -22,7 +22,7 @@ internal partial class CollectionAnalyzer
 	/// An helper struct that abstract contract miss-matches between different types of list
 	/// (noticeably <see cref="IList"/> and <see cref="IImmutableList{T}"/>).
 	/// </summary>
-	protected struct ListRef<T>
+	internal struct ListRef<T>
 	{
 		public ListRef(object instance, int count, ElementAtHandler<T> elementAt, IndexOfHandler<T> indexOf)
 		{

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.SourceEnumerator.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.SourceEnumerator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Uno;
 
@@ -27,6 +28,9 @@ partial class CollectionAnalyzer
 		/// </summary>
 		public int Ignored { get; private set; }
 
+#pragma warning disable CS0436
+		[MemberNotNullWhen(true, nameof(Current))]
+#pragma warning restore CS0436
 		public bool MoveNext()
 		{
 			var index = CurrentIndex;
@@ -45,7 +49,7 @@ partial class CollectionAnalyzer
 			else
 			{
 				CurrentIndex = index;
-				Current = _source.ElementAt(index);
+				Current = _source.ElementAt(index)!;
 
 				return true;
 			}

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
@@ -7,13 +7,14 @@ using System.Linq;
 using Uno.Extensions.Equality;
 using Uno.Extensions.Reactive.Collections;
 using Uno.Extensions.Reactive.Utils;
+using static Uno.Extensions.Collections.Tracking.CollectionAnalyzer;
 
 namespace Uno.Extensions.Collections.Tracking;
 
 /// <summary>
 /// Set of helpers to track changes on collections
 /// </summary>
-internal class CollectionAnalyzer<T> : CollectionAnalyzer
+internal class CollectionAnalyzer<T>
 {
 	private readonly IEqualityComparer<T>? _comparer;
 	private readonly ComparerRef<T>? _versionComparer;
@@ -23,11 +24,13 @@ internal class CollectionAnalyzer<T> : CollectionAnalyzer
 	/// </summary>
 	/// <param name="comparer">The set of comparer to use to track items.</param>
 	public CollectionAnalyzer(ItemComparer<T> comparer)
-		: base(new(comparer.Entity?.ToEqualityComparer(), comparer.Version?.ToEqualityComparer()))
 	{
 		_comparer = comparer.Entity;
-		_versionComparer = GetRef(comparer.Version);
+		_versionComparer = CollectionAnalyzer.GetRef(comparer.Version);
 	}
+
+	private ListRef<T> GetRef(IList list)
+		=> new(list, list.Count, i => (T)list[i], list.GetIndexOf(_comparer));
 
 	private ListRef<T> GetRef(IList<T> list)
 		=> new(list, list.Count, i => list[i], list.GetIndexOf(_comparer));
@@ -36,17 +39,22 @@ internal class CollectionAnalyzer<T> : CollectionAnalyzer
 		=> new(list, list.Count, i => list[i], list.GetIndexOf(_comparer));
 
 	/// <summary>
-	/// Determines the set of changes between two snapshot of an <see cref="IList{T}"/>
+	/// Creates a set of changes that contains only a reset event.
 	/// </summary>
 	/// <param name="oldItems">The source snapshot</param>
 	/// <param name="newItems">The target snapshot</param>
-	/// <param name="visitor">A visitor that can be used to track changes while detecting them.</param>
-	/// <returns>A list of changes that have to be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
-	public CollectionUpdater GetUpdater(IList<T> oldItems, IList<T> newItems, ICollectionUpdaterVisitor visitor)
-		=> base.CreateUpdaterCore(GetRef(oldItems), GetRef(newItems), _versionComparer, visitor);
+	/// <returns>A list of changes containing only a 'Reset' event that can be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
+	internal CollectionChangeSet<T> GetResetChange(IList<T> oldItems, IList<T> newItems)
+		=> new(GetChangesCore(RichNotifyCollectionChangedEventArgs.Reset(oldItems, newItems), GetRef, _versionComparer));
 
-	internal CollectionUpdater GetUpdater(IImmutableList<T> oldItems, IImmutableList<T> newItems, ICollectionUpdaterVisitor visitor)
-		=> base.CreateUpdaterCore(GetRef(oldItems), GetRef(newItems), _versionComparer, visitor);
+	/// <summary>
+	/// Creates a set of changes that contains only a reset event.
+	/// </summary>
+	/// <param name="oldItems">The source snapshot</param>
+	/// <param name="newItems">The target snapshot</param>
+	/// <returns>A list of changes containing only a 'Reset' event that can be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
+	internal CollectionChangeSet<T> GetResetChange(IImmutableList<T> oldItems, IImmutableList<T> newItems)
+		=> new(GetChangesCore(RichNotifyCollectionChangedEventArgs.Reset(oldItems, newItems), GetRef, _versionComparer));
 
 	/// <summary>
 	/// Determines the set of changes between two snapshot of an <see cref="IList{T}"/>
@@ -54,12 +62,38 @@ internal class CollectionAnalyzer<T> : CollectionAnalyzer
 	/// <param name="oldItems">The source snapshot</param>
 	/// <param name="newItems">The target snapshot</param>
 	/// <returns>A list of changes that have to be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
-	public CollectionChangeSet GetChanges(IList<T> oldItems, IList<T> newItems)
-		=> new CollectionChangeSet<T>(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer));
+	public CollectionChangeSet<T> GetChanges(IList<T> oldItems, IList<T> newItems)
+		=> new(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer));
 
-	internal CollectionChangeSet GetChanges(IImmutableList<T> oldItems, IImmutableList<T> newItems)
-		=> new CollectionChangeSet<T>(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer));
+	/// <summary>
+	/// Determines the set of changes between two snapshot of an <see cref="IImmutableList{T}"/>
+	/// </summary>
+	/// <param name="oldItems">The source snapshot</param>
+	/// <param name="newItems">The target snapshot</param>
+	/// <returns>A list of changes that have to be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
+	internal CollectionChangeSet<T> GetChanges(IImmutableList<T> oldItems, IImmutableList<T> newItems)
+		=> new(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer));
 
-	internal CollectionChangeSet GetResetChange(IImmutableList<T> oldItems, IImmutableList<T> newItems)
-		=> base.GetResetChange(oldItems.AsUntypedList(), newItems.AsUntypedList());
+	/// <summary>
+	/// Determines the set of effective changes produced by a <see cref="NotifyCollectionChangedEventArgs"/>.
+	/// </summary>
+	/// <param name="arg">The event arg to adjust</param>
+	/// <returns>A list of changes that have to be applied to move properly apply the provided event arg.</returns>
+	public CollectionChangeSet<T> GetChanges(RichNotifyCollectionChangedEventArgs arg)
+		=> new(GetChangesCore(arg, GetRef, _versionComparer));
+
+	/// <summary>
+	/// Determines the set of changes between two snapshot of an <see cref="IList{T}"/>
+	/// </summary>
+	/// <param name="oldItems">The source snapshot</param>
+	/// <param name="newItems">The target snapshot</param>
+	/// <param name="visitor">A visitor that can be used to track changes while detecting them.</param>
+	/// <returns>A list of changes that have to be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
+	// DEPRECATED: We need to complete extraction of the CollectionUpdater concept
+	public CollectionUpdater GetUpdater(IList<T> oldItems, IList<T> newItems, ICollectionUpdaterVisitor visitor)
+		=> ToUpdater(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer), visitor);
+
+	// DEPRECATED: We need to complete extraction of the CollectionUpdater concept
+	internal CollectionUpdater GetUpdater(IImmutableList<T> oldItems, IImmutableList<T> newItems, ICollectionUpdaterVisitor visitor)
+		=> ToUpdater(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer), visitor);
 }

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
@@ -39,11 +39,11 @@ internal class CollectionAnalyzer<T>
 		=> new(list, list.Count, i => list[i], list.GetIndexOf(_comparer));
 
 	/// <summary>
-	/// Creates a set of changes that contains only a reset event.
+	/// Creates a set of changes that only contains a reset event.
 	/// </summary>
 	/// <param name="oldItems">The source snapshot</param>
 	/// <param name="newItems">The target snapshot</param>
-	/// <returns>A list of changes containing only a 'Reset' event that can be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
+	/// <returns>A list of changes only containing a 'Reset' event that can be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
 	internal CollectionChangeSet<T> GetResetChange(IList<T> oldItems, IList<T> newItems)
 		=> new(GetChangesCore(RichNotifyCollectionChangedEventArgs.Reset(oldItems, newItems), GetRef, _versionComparer));
 
@@ -52,7 +52,7 @@ internal class CollectionAnalyzer<T>
 	/// </summary>
 	/// <param name="oldItems">The source snapshot</param>
 	/// <param name="newItems">The target snapshot</param>
-	/// <returns>A list of changes containing only a 'Reset' event that can be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
+	/// <returns>A list of changes only containing a 'Reset' event that can be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
 	internal CollectionChangeSet<T> GetResetChange(IImmutableList<T> oldItems, IImmutableList<T> newItems)
 		=> new(GetChangesCore(RichNotifyCollectionChangedEventArgs.Reset(oldItems, newItems), GetRef, _versionComparer));
 

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Add.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Add.cs
@@ -32,7 +32,11 @@ partial class CollectionAnalyzer
 		}
 
 		public override RichNotifyCollectionChangedEventArgs ToEvent()
-			=> RichNotifyCollectionChangedEventArgs.AddSome(_items, Starts + _indexOffset);
+			=> RichNotifyCollectionChangedEventArgs.AddSome<T>(_items, Starts + _indexOffset);
+
+		/// <inheritdoc />
+		protected internal override void Visit(ICollectionChangeSetVisitor<T> visitor)
+			=> visitor.Add(_items, Starts + _indexOffset);
 
 		/// <inheritdoc />
 		protected override CollectionUpdater.Update ToUpdaterCore(ICollectionUpdaterVisitor visitor)

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Event.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Event.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Linq;
-
+using Uno.Extensions.Reactive.Utils;
 using static System.Collections.Specialized.NotifyCollectionChangedAction;
 
 namespace Uno.Extensions.Collections.Tracking;
@@ -24,6 +24,36 @@ partial class CollectionAnalyzer
 
 		public override RichNotifyCollectionChangedEventArgs ToEvent()
 			=> _args;
+
+		/// <inheritdoc />
+		protected internal override void Visit(ICollectionChangeSetVisitor<T> visitor)
+		{
+			switch (_args.Action)
+			{
+				case Add:
+					visitor.Add(_args.NewItems!.AsTypedReadOnlyList<T>(), _args.NewStartingIndex);
+					return;
+
+				case Remove:
+					visitor.Remove(_args.OldItems!.AsTypedReadOnlyList<T>(), _args.OldStartingIndex);
+					return;
+
+				case Move:
+					visitor.Move(_args.OldItems!.AsTypedReadOnlyList<T>(), _args.OldStartingIndex, _args.NewStartingIndex);
+					break;
+
+				case Replace:
+					visitor.Replace(_args.OldItems!.AsTypedReadOnlyList<T>(), _args.NewItems!.AsTypedReadOnlyList<T>(), _args.OldStartingIndex);
+					return;
+
+				case Reset:
+					visitor.Reset(_args.ResetOldItems!.AsTypedReadOnlyList<T>(), _args.ResetNewItems!.AsTypedReadOnlyList<T>());
+					return;
+
+				default:
+					throw new ArgumentOutOfRangeException(nameof(_args), _args.Action, $"Action '{_args.Action}' not supported.");
+			}
+		}
 
 		/// <inheritdoc />
 		protected override CollectionUpdater.Update ToUpdaterCore(ICollectionUpdaterVisitor visitor)

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Move.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Move.cs
@@ -34,7 +34,11 @@ partial class CollectionAnalyzer
 		}
 
 		public override RichNotifyCollectionChangedEventArgs ToEvent()
-			=> RichNotifyCollectionChangedEventArgs.MoveSome(_items, Starts + _indexOffset, _to + _indexOffset);
+			=> RichNotifyCollectionChangedEventArgs.MoveSome<T>(_items, Starts + _indexOffset, _to + _indexOffset);
+
+		/// <inheritdoc />
+		protected internal override void Visit(ICollectionChangeSetVisitor<T> visitor)
+			=> visitor.Move(_items, Starts + _indexOffset, _to + _indexOffset);
 
 		/// <inheritdoc />
 		protected override CollectionUpdater.Update ToUpdaterCore(ICollectionUpdaterVisitor visitor)

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Remove.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Remove.cs
@@ -29,7 +29,11 @@ partial class CollectionAnalyzer
 		}
 
 		public override RichNotifyCollectionChangedEventArgs ToEvent()
-			=> RichNotifyCollectionChangedEventArgs.RemoveSome(_items, Starts + _indexOffset);
+			=> RichNotifyCollectionChangedEventArgs.RemoveSome<T>(_items, Starts + _indexOffset);
+
+		/// <inheritdoc />
+		protected internal override void Visit(ICollectionChangeSetVisitor<T> visitor)
+			=> visitor.Remove(_items, Starts + _indexOffset);
 
 		/// <inheritdoc />
 		protected override CollectionUpdater.Update ToUpdaterCore(ICollectionUpdaterVisitor visitor)

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Replace.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Replace.cs
@@ -18,7 +18,12 @@ partial class CollectionAnalyzer
 		}
 
 		public override RichNotifyCollectionChangedEventArgs ToEvent()
-			=> RichNotifyCollectionChangedEventArgs.ReplaceSome(_oldItems, _newItems, Starts + _indexOffset);
+			=> RichNotifyCollectionChangedEventArgs.ReplaceSome<T>(_oldItems, _newItems, Starts + _indexOffset);
+
+		/// <inheritdoc />
+		protected internal override void Visit(ICollectionChangeSetVisitor<T> visitor)
+			=> visitor.Replace(_oldItems, _newItems, Starts + _indexOffset);
+
 
 		/// <inheritdoc />
 		protected override CollectionUpdater.Update ToUpdaterCore(ICollectionUpdaterVisitor visitor)

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Same.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Same.cs
@@ -18,6 +18,10 @@ partial class CollectionAnalyzer
 			=> null;
 
 		/// <inheritdoc />
+		protected internal override void Visit(ICollectionChangeSetVisitor<T> visitor)
+			=> visitor.Same(_oldItems, _newItems, Starts + _indexOffset);
+
+		/// <inheritdoc />
 		protected override CollectionUpdater.Update ToUpdaterCore(ICollectionUpdaterVisitor visitor)
 		{
 			var callback = new CollectionUpdater.Update(ToEvent());

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.cs
@@ -2,9 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Linq;
-using Uno.Extensions.Collections.Facades.Differential;
 using Uno.Extensions.Reactive.Collections;
 using Uno.Extensions.Reactive.Utils;
 
@@ -15,7 +13,6 @@ namespace Uno.Extensions.Collections.Tracking;
 /// </summary>
 internal partial class CollectionAnalyzer
 {
-
 	private readonly IEqualityComparer? _entityComparer;
 	private readonly ComparerRef<object?>? _versionComparer;
 
@@ -31,12 +28,6 @@ internal partial class CollectionAnalyzer
 
 	private ListRef<object?> GetRef(IList list)
 		=> new(list, list.Count, i => list[i], list.GetIndexOf(_entityComparer));
-
-	private ComparerRef<object?>? GetRef(IEqualityComparer? comparer)
-		=> comparer is null ? null : comparer.Equals;
-
-	protected ComparerRef<T>? GetRef<T>(IEqualityComparer<T>? comparer)
-		=> comparer is null ? null : comparer.Equals;
 
 	/// <summary>
 	/// Creates a set of changes that contains only a reset event.
@@ -62,7 +53,7 @@ internal partial class CollectionAnalyzer
 	/// <param name="arg">The event arg to adjust</param>
 	/// <returns>A list of changes that have to be applied to move properly apply the provided event arg.</returns>
 	public CollectionChangeSet GetChanges(RichNotifyCollectionChangedEventArgs arg)
-		=> new CollectionChangeSet<object?>(GetChangesCore(arg));
+		=> new CollectionChangeSet<object?>(GetChangesCore(arg, GetRef, _versionComparer));
 
 	/// <summary>
 	/// Creates a set of changes that contains only a reset event.
@@ -71,6 +62,7 @@ internal partial class CollectionAnalyzer
 	/// <param name="newItems">The target snapshot</param>
 	/// <param name="visitor">A visitor that can be used to track changes while detecting them.</param>
 	/// <returns>A list of changes containing only a 'Reset' event that can be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
+	// DEPRECATED: We need to complete extraction of the CollectionUpdater concept
 	public CollectionUpdater GetResetUpdater(IList? oldItems, IList newItems, ICollectionUpdaterVisitor visitor)
 		=> GetUpdater(RichNotifyCollectionChangedEventArgs.Reset(oldItems, newItems), visitor);
 
@@ -81,8 +73,9 @@ internal partial class CollectionAnalyzer
 	/// <param name="newItems">The target snapshot</param>
 	/// <param name="visitor">A visitor that can be used to track changes while detecting them.</param>
 	/// <returns>A list of changes that have to be applied to move a collection from <paramref name="oldItems"/> to <paramref name="newItems"/>.</returns>
+	// DEPRECATED: We need to complete extraction of the CollectionUpdater concept
 	public CollectionUpdater GetUpdater(IList oldItems, IList newItems, ICollectionUpdaterVisitor visitor)
-		=> CreateUpdaterCore(GetRef(oldItems), GetRef(newItems), _versionComparer, visitor);
+		=> ToUpdater(GetChangesCore(GetRef(oldItems), GetRef(newItems), _versionComparer), visitor);
 
 	/// <summary>
 	/// Determines the set of effective changes produced by a <see cref="NotifyCollectionChangedEventArgs"/>.
@@ -90,215 +83,7 @@ internal partial class CollectionAnalyzer
 	/// <param name="arg">The event arg to adjust</param>
 	/// <param name="visitor">A visitor that can be used to track changes while detecting them.</param>
 	/// <returns>A list of changes that have to be applied to move properly apply the provided event arg.</returns>
+	// DEPRECATED: We need to complete extraction of the CollectionUpdater concept
 	public CollectionUpdater GetUpdater(RichNotifyCollectionChangedEventArgs arg, ICollectionUpdaterVisitor visitor)
-	{
-		var changesHead = GetChangesCore(arg);
-		var updaterHead = changesHead?.ToUpdater(visitor);
-
-		return updaterHead is null
-			? CollectionUpdater.Empty
-			: new(updaterHead);
-	}
-
-	private protected CollectionUpdater CreateUpdaterCore<T>(
-		ListRef<T> oldItems,
-		ListRef<T> newItems,
-		ComparerRef<T>? itemVersionComparer,
-		ICollectionUpdaterVisitor visitor,
-		int eventArgsOffset = 0)
-	{
-		var changesHead = GetChangesCore(oldItems, newItems, itemVersionComparer, eventArgsOffset);
-		var updaterHead = changesHead?.ToUpdater(visitor);
-
-		return updaterHead is null
-			? CollectionUpdater.Empty
-			: new(updaterHead);
-	}
-
-	private protected Change<object?>? GetChangesCore(RichNotifyCollectionChangedEventArgs arg)
-	{
-		switch (arg.Action)
-		{
-			case NotifyCollectionChangedAction.Add:
-			case NotifyCollectionChangedAction.Remove:
-			case NotifyCollectionChangedAction.Move:
-			case NotifyCollectionChangedAction.Reset:
-				return new _Event<object?>(arg);
-
-			case NotifyCollectionChangedAction.Replace:
-				return GetChangesCore(GetRef(arg.OldItems), GetRef(arg.NewItems), _versionComparer, arg.OldStartingIndex);
-
-			default:
-				throw new ArgumentOutOfRangeException(nameof(arg), arg.Action, $"Action '{arg.Action}' not supported.");
-		}
-	}
-
-	private protected static Change<T>? GetChangesCore<T>(
-		ListRef<T> oldItems,
-		ListRef<T> newItems,
-		ComparerRef<T>? versionComparer,
-		int eventArgsOffset = 0)
-	{
-		/*
-		* OLD: the source collection we are going to update to the NEW
-		* NEW: the collection that we want to go to
-		* RESULT (a.k.a. virtual old) : This makes sense only while synchronizing, it's represents the OLD with the changes already applied. 
-		*								 At the end it's expected to be sequence equals to the NEW.
-		* 
-		* We detect changes to update from OLD to NEW. We could have choose the other way, but as the consumer (i.e. the view) knows the OLD, it's a bit more logical.
-		* 
-		* Note: comparer may be null for IObservableCollectionSnapshot.IndexOf(). 
-		*		 It's more performant to forward the 'null' instead of defaulting to EqualityComparer.Default
-		* 
-		*/
-
-		int added = 0, moved = 0, removed = 0;
-		var buffer = new ChangesBuffer<T>(oldItems.Count, newItems.Count, eventArgsOffset);
-
-		var oldEnumerator = new SourceEnumerator<T>(oldItems);
-		while (oldEnumerator.MoveNext())
-		{
-			var oldIndex = oldEnumerator.CurrentIndex;
-			var oldItem = oldEnumerator.Current!;
-			var resultIndex = oldIndex - removed + added + moved - oldEnumerator.Ignored; // The current index in the (virtual) result collection (i.e. oldIndex ignoring the removed/added items)
-			var newIndex = newItems.IndexOf(oldItem, resultIndex, newItems.Count - resultIndex);
-
-			if (newIndex < 0)
-			{
-				// Item is no more present in the new collection : Remove it
-
-				buffer.Remove(oldItem, resultIndex);
-				removed++;
-
-				continue;
-			}
-
-			if (newIndex < resultIndex)
-			{
-				throw new InvalidOperationException("The index return by the IndexOf is invalid");
-			}
-
-			// First raise replace if the instance/version of the item changed
-			UpdateInstanceFromOld(oldItem, oldIndex, newIndex);
-
-			if (newIndex > resultIndex)
-			{
-				// Item is AFTER the expected index in old, this means that some items was inserted / moved before
-
-				for (var missingItemNewIndex = resultIndex; missingItemNewIndex < newIndex; missingItemNewIndex++)
-				{
-					var missingItem = newItems.ElementAt(missingItemNewIndex); // The item that is missing in the old collection
-					var (missingItemOldIndex, missingItemOldIndexOffset) = oldEnumerator.NextIndexOf(missingItem);
-					if (missingItemOldIndex >= 0)
-					{
-						// The missing item was already present in the old snapshot. We only have to move it.
-
-						// The 'fromOffset' counts only the number of items that have been move from 'after' the item to 'before' it.
-						// We include this backward moves as they are already offsetting the virtual old index, but we do not include
-						// any other moves (so we are not using 'moved') as they haven't any impact on the virtual old index.
-						var from = missingItemOldIndex - removed + added;
-						var fromOffset = missingItemOldIndexOffset;
-
-						// As the item will be handle here (moved), ignore the index to ensure that we won't try to move it again later
-						oldEnumerator.Ignore(missingItemOldIndex);
-
-						// First update the instance if needed, then move it to it new position
-						UpdateInstanceFromNew(missingItem, missingItemOldIndex);
-						buffer.Move(missingItem, from: from, fromOffset: fromOffset, to: missingItemNewIndex, max: newIndex);
-						moved++;
-					}
-					else
-					{
-						// The missing item is a new item, we have to add it.
-
-						buffer.Add(missingItem, at: missingItemNewIndex, max: newIndex);
-						added++;
-					}
-				}
-			}
-
-			Debug.Assert(newIndex == oldIndex - removed + added + moved - oldEnumerator.Ignored);
-		}
-
-		Debug.Assert(moved - oldEnumerator.Ignored == 0);
-
-		// Finally add items that remains at the end of the newItems (i.e. was missing in the previous)
-		var resultItemsCount = oldItems.Count - removed + added;
-		var toAddCount = newItems.Count - resultItemsCount;
-		if (toAddCount > 0)
-		{
-			var add = new _Add<T>(at: resultItemsCount, indexOffset: eventArgsOffset, capacity: toAddCount);
-			for (var i = 0; i < toAddCount; i++)
-			{
-				var item = newItems.ElementAt(i + resultItemsCount);
-				add.Append(item);
-			}
-
-			buffer.Append(add);
-		}
-
-		return buffer.GetChanges();
-
-
-		/*
-		*	About equality checks and instance update:
-		*
-		*	Usually the 'itemVersionComparer' checks for full Equality, while the 'itemComparer' only checks for the KeyEquality.
-		*	The idea is to be able to properly track multiple versions of the same item (for instance if a property of the item changed).
-		*
-		*	Here, the "item tracking" was already done, and we are only validating 2 versions of the same item
-		*  (we already determined that they have the same key using the 'itemComparer').
-		*
-		*	If the 'itemVersionComparer' is 'null' we assume that there is no
-		*	notion of version of an item and we rely only on the `itemComparer` to check equality.
-		*	Note: in this case we don't raise any 'Replace'.
-		*
-		*	If the 'itemVersionComparer' returns 'true' (or if it's 'null') that means that they are not only KeyEquals but also Equals.
-		*	So as we are usually working with immutable objects, we can ignore that a new instance is available and
-		*  we don't raise any event ('changesBuffer.Update'). Note: We still have to notify the visitor!
-		*
-		*  If the 'itemVersionComparer' returns 'false' that means items are only key equals, but not same version.
-		*  So we have to raise a 'Replace' event.
-		*/
-
-		void UpdateInstanceFromOld(T oldItem, int oldIndex, int newIndex)
-		{
-			if (versionComparer is null)
-			{
-				buffer.Update(oldItem, oldItem, oldIndex);
-
-				return;
-			}
-
-			var newItem = newItems.ElementAt(newIndex);
-			if (versionComparer(oldItem, newItem))
-			{
-				buffer.Update(oldItem, newItem, oldIndex);
-			}
-			else
-			{
-				buffer.Replace(oldItem, newItem, oldIndex);
-			}
-		}
-
-		void UpdateInstanceFromNew(T newItem, int oldIndex)
-		{
-			if (versionComparer is null)
-			{
-				buffer.Update(newItem, newItem, oldIndex);
-
-				return;
-			}
-
-			var oldItem = oldItems.ElementAt(oldIndex);
-			if (versionComparer(oldItem, newItem))
-			{
-				buffer.Update(oldItem, newItem, oldIndex);
-			}
-			else
-			{
-				buffer.Replace(oldItem, newItem, oldIndex);
-			}
-		}
-	}
+		=> ToUpdater(GetChangesCore(arg, GetRef, _versionComparer), visitor);
 }

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionChangeSet.T.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionChangeSet.T.cs
@@ -46,4 +46,23 @@ internal sealed partial record CollectionChangeSet<T> : CollectionChangeSet
 		=> _head is null
 			? CollectionUpdater.Empty
 			: new(_head.ToUpdater(visitor));
+
+	/// <summary>
+	/// Visits this change set.
+	/// </summary>
+	/// <param name="visitor">The visitor.</param>
+	/// <remarks>
+	/// This is almost equivalent to <see cref="Enumerate"/> and interpret each event args,
+	/// but in a lighter way since it avoid the creation of all event args.
+	/// </remarks>
+	internal void Visit(ICollectionChangeSetVisitor<T> visitor)
+	{
+		var node = _head;
+		while (node is not null)
+		{
+			node.Visit(visitor);
+
+			node = node.Next;
+		}
+	}
 }

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionChangeSetVisitorBase.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionChangeSetVisitorBase.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Uno.Extensions.Collections.Tracking;
+
+/// <summary>
+/// An helper base case to ease implementation of <see cref="ICollectionChangeSetVisitor{T}"/>
+/// </summary>
+/// <typeparam name="T">Type of the items.</typeparam>
+/// <remarks>
+/// This base class allows you to implement only operations you are interested in.
+/// A typical minimum implementation interested only in object instances would override AddItem and RemoveItem.
+/// For index tracking you should consider to override almost all actions (Add, Replace, Move, Remove, Reset).
+/// </remarks>
+internal class CollectionChangeSetVisitorBase<T> : ICollectionChangeSetVisitor<T>
+{
+	/// <inheritdoc />
+	/// <remarks>The default implementation will invoke <see cref="AddItem"/> for each item in <paramref name="items"/>.</remarks>
+	public virtual void Add(IReadOnlyList<T> items, int index)
+	{
+		for (var i = 0; i < items.Count; i++)
+		{
+			AddItem(items[i], index + i);
+		}
+	}
+
+	/// <summary>
+	/// Invoked when an item has been kept as is.
+	/// </summary>
+	/// <param name="index">The index where the item has been added.</param>
+	/// <param name="item">The added item.</param>
+	/// <remarks>The default implementation does nothing.</remarks>
+	protected virtual void AddItem(T item, int index)
+	{
+	}
+
+	/// <inheritdoc />
+	/// <remarks>The default implementation will invoke <see cref="SameItem"/> for each item in <paramref name="original"/> and <paramref name="updated" />.</remarks>
+	public virtual void Same(IReadOnlyList<T> original, IReadOnlyList<T> updated, int index)
+	{
+		if (original.Count != updated.Count)
+		{
+			throw new InvalidOperationException("CollectionChangeSet is expected to always have same number of items for Replace operation.");
+		}
+
+		for (var i = 0; i < original.Count; i++)
+		{
+			SameItem(original[i], updated[i], index + i);
+		}
+	}
+
+	/// <summary>
+	/// Invoked when an item has been kept as is.
+	/// </summary>
+	/// <param name="index">The index where the item has been kept.</param>
+	/// <param name="original">The old item.</param>
+	/// <param name="updated">The updated item.</param>
+	/// <remarks>The default implementation does nothing.</remarks>
+	protected virtual void SameItem(T original, T updated, int index)
+	{
+	}
+
+	/// <inheritdoc />
+	/// <remarks>
+	/// The default implementation will invoke <see cref="Remove"/> with the <paramref name="original"/>
+	/// and then <see cref="Add"/> with the <paramref name="updated"/>.
+	/// </remarks>
+	public virtual void Replace(IReadOnlyList<T> original, IReadOnlyList<T> updated, int index)
+	{
+		if (original.Count != updated.Count)
+		{
+			throw new InvalidOperationException("CollectionChangeSet is expected to always have same number of items for Replace operation.");
+		}
+
+		Remove(original, index);
+		Add(updated, index);
+	}
+
+	/// <summary>
+	/// Invoked when an item has been replaced.
+	/// </summary>
+	/// <param name="index">The index where the item has been replaced.</param>
+	/// <param name="original">The old item.</param>
+	/// <param name="updated">The updated item.</param>
+	/// <remarks>The default implementation will do <see cref="RemoveItem"/> then <see cref="AddItem"/>.</remarks>
+	protected virtual void ReplaceItem(T original, T updated, int index)
+	{
+		RemoveItem(original, index);
+		AddItem(updated, index);
+	}
+
+	/// <inheritdoc />
+	public virtual void Move(IReadOnlyList<T> items, int fromIndex, int toIndex)
+	{
+		for (var i = 0; i < items.Count; i++)
+		{
+			MoveItem(items[i], fromIndex + i, toIndex + i);
+		}
+	}
+
+	/// <summary>
+	/// Invoked when an item has been moved from an index to another one.
+	/// </summary>
+	/// <param name="from">The index where the item was.</param>
+	/// <param name="to">The index where the item is.</param>
+	/// <param name="item">The moved item.</param>
+	/// <remarks>The default implementation does nothing.</remarks>
+	protected virtual void MoveItem(T item, int from, int to)
+	{
+	}
+
+	/// <inheritdoc />
+	/// <remarks>The default implementation will invoke <see cref="RemoveItem"/> for each item in <paramref name="items"/>.</remarks>
+	public virtual void Remove(IReadOnlyList<T> items, int index)
+	{
+		for (var i = 0; i < items.Count; i++)
+		{
+			RemoveItem(items[i], index + i);
+		}
+	}
+
+	/// <summary>
+	/// Invoked when an item has been kept as is.
+	/// </summary>
+	/// <param name="index">The index where the item has been added.</param>
+	/// <param name="item">The added item.</param>
+	/// <remarks>The default implementation does nothing.</remarks>
+	protected virtual void RemoveItem(T item, int index)
+	{
+	}
+
+	/// <inheritdoc />
+	/// <remarks>
+	/// The default implementation will invoke <see cref="Remove"/> with the <paramref name="oldItems"/>
+	/// and then <see cref="Add"/> with the <paramref name="newItems"/>.
+	/// </remarks>
+	public virtual void Reset(IReadOnlyList<T> oldItems, IReadOnlyList<T> newItems)
+	{
+		Remove(oldItems, 0);
+		Add(newItems, 0);
+	}
+}

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/ICollectionChangeSetVisitor.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/ICollectionChangeSetVisitor.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Uno.Extensions.Collections.Tracking;
+
+/// <summary>
+/// A visitor which can be used when tracking changes between 2 collections.
+/// </summary>
+internal interface ICollectionChangeSetVisitor<in T>
+{
+	/// <summary>
+	/// Invoked when an item is added in the target collection.
+	/// </summary>
+	/// <param name="items">The added items</param>
+	/// <param name="index">The index where the items have been added.</param>
+	void Add(IReadOnlyList<T> items, int index);
+
+	/// <summary>
+	/// Invoked when an Equals item appears in both previous and target collections.
+	/// </summary>
+	/// <remarks>No collection changed event is created for this item.</remarks>
+	/// <param name="original">The instance of the item in the previous collection.</param>
+	/// <param name="updated">The instance of the item in the target collection.</param>
+	/// <param name="index">The index where the items have been kept.</param>
+	void Same(IReadOnlyList<T> original, IReadOnlyList<T> updated, int index);
+
+	/// <summary>
+	/// Invoked when a new version of an item is present in the target collection.
+	/// </summary>
+	/// <param name="original">The previous version</param>
+	/// <param name="updated">The updated version</param>
+	/// <param name="index">The index where the items have been replaced.</param>
+	void Replace(IReadOnlyList<T> original, IReadOnlyList<T> updated, int index);
+
+	/// <summary>
+	/// Invoked when items have been moved in the collection.
+	/// </summary>
+	/// <param name="items">The moved items.</param>
+	/// <param name="fromIndex">The index where the items was.</param>
+	/// <param name="toIndex">The index where the items are.</param>
+	void Move(IReadOnlyList<T> items, int fromIndex, int toIndex);
+
+	/// <summary>
+	/// Invoked when an item is removed in the target collection.
+	/// </summary>
+	/// <param name="items">The removed item</param>
+	/// <param name="index">The index where the items have been removed.</param>
+	void Remove(IReadOnlyList<T> items, int index);
+
+	/// <summary>
+	/// Invoked when a reset event is raised instead of properly tracking the changes between the collections.
+	/// </summary>
+	/// <param name="oldItems">A list of all the items removed from the target collection</param>
+	/// <param name="newItems">A list of all the new items present in the target collection</param>
+	void Reset(IReadOnlyList<T> oldItems, IReadOnlyList<T> newItems);
+}

--- a/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
@@ -226,12 +226,12 @@ internal class PaginatedListFeed<TCursor, TItem> : IListFeed<TItem>, IRefreshabl
 	{
 		var updated = new DifferentialImmutableList<TItem>(page);
 
-		return (updated, ((CollectionAnalyzer)_diffAnalyzer).GetResetChange(current, updated));
+		return (updated, _diffAnalyzer.GetResetChange(current, updated));
 	}
 
 	private (DifferentialImmutableList<TItem> items, CollectionChangeSet changes) Clear(DifferentialImmutableList<TItem> current)
 	{
-		return (DifferentialImmutableList<TItem>.Empty, ((CollectionAnalyzer)_diffAnalyzer).GetResetChange(current, Array.Empty<TItem>()));
+		return (DifferentialImmutableList<TItem>.Empty, _diffAnalyzer.GetResetChange(current, DifferentialImmutableList<TItem>.Empty));
 	}
 
 	private (DifferentialImmutableList<TItem> items, CollectionChangeSet changes) Add(DifferentialImmutableList<TItem> current, IImmutableList<TItem> page)

--- a/src/Uno.Extensions.Reactive/Utils/ListExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/ListExtensions.cs
@@ -65,6 +65,58 @@ internal static class ListExtensions
 		}
 	}
 
+	public static CollectionAnalyzer.IndexOfHandler<T> GetIndexOf<T>(this IList list, IEqualityComparer<T>? comparer)
+	{
+		if (comparer is null)
+		{
+			switch (list)
+			{
+				case IImmutableList<T> immutable:
+					return immutable.IndexOf;
+				case List<T> impl:
+					return impl.IndexOf;
+				case Array array:
+					return (value, index, count) => Array.IndexOf(array, value, index, count);
+				default:
+					return (value, index, count) =>
+					{
+						for (var i = index; i < index + count; i++)
+						{
+							if (object.Equals(list[i], value))
+							{
+								return i;
+							}
+						}
+
+						return -1;
+					};
+			}
+		}
+		else
+		{
+			switch (list)
+			{
+				case IImmutableList<T> immutable:
+				{
+					return (value, index, count) => immutable.IndexOf(value, index, count, comparer);
+				}
+				default:
+					return (value, index, count) =>
+					{
+						for (var i = index; i < index + count; i++)
+						{
+							if (comparer.Equals((T)list[i], value))
+							{
+								return i;
+							}
+						}
+
+						return -1;
+					};
+			}
+		}
+	}
+
 	public static CollectionAnalyzer.IndexOfHandler<T> GetIndexOf<T>(this IList<T> list, IEqualityComparer<T>? comparer)
 	{
 		if (comparer is null)
@@ -291,6 +343,15 @@ internal static class ListExtensions
 	public static IList Slice(this IList list, int index, int count)
 		=> new SliceList(list, index, count);
 
+	public static IList AsUntypedList<T>(this IList<T> list)
+		=> list as IList ?? (list is ICollectionAdapter { Adaptee: IList untyped } ? untyped : new ListToUntypedList<T>(list));
+
 	public static IList AsUntypedList<T>(this IImmutableList<T> immutable)
-		=> immutable as IList ?? new ImmutableListToUntypedList<T>(immutable);
+		=> immutable as IList ?? (immutable is ICollectionAdapter { Adaptee: IList untyped } ? untyped : new ImmutableListToUntypedList<T>(immutable));
+
+	public static IList<T> AsTypedList<T>(this IList list)
+		=> list as IList<T> ?? (list is ICollectionAdapter { Adaptee: IList<T> typed } ? typed : new UntypedListToList<T>(list));
+
+	public static IReadOnlyList<T> AsTypedReadOnlyList<T>(this IList list)
+		=> list as IReadOnlyList<T> ?? (list is ICollectionAdapter { Adaptee: IReadOnlyList<T> @readonly } ? @readonly : new UntypedListToList<T>(list));
 }


### PR DESCRIPTION
## Refactoring (no functional changes, no api changes)
Use generics in more cases in order to avoid boxing of value types, and add a visitor pattern for collection change set.

## What is the current behavior?
* We are boxing value types, which is causing issues in comparison and with the nullable annotations.
* Each time we are digging in a collection change set, we are creating multiple `NotifyCollectionChangedEventArgs`  that are throw away right after and we are losing the "Same" (indicates that an item has been kept) as there is no event action for it.

## What is the new behavior?
🙃

## PR Checklist

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
