### PR TITLE
feat: Adjusting logic for switching views in grid during navigation

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigators/PanelVisiblityNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/PanelVisiblityNavigator.cs
@@ -60,12 +60,17 @@ public class PanelVisiblityNavigator : ControlNavigator<Panel>
 
 				if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Creating instance of type '{viewType.Name}'");
 				controlToShow = Activator.CreateInstance(viewType) as FrameworkElement;
-				if (!string.IsNullOrWhiteSpace(regionName) &&
-					controlToShow is FrameworkElement fe)
+				if (controlToShow is not null)
 				{
-					fe.SetName(regionName!);
+					if (!string.IsNullOrWhiteSpace(regionName) &&
+						controlToShow is FrameworkElement fe)
+					{
+						fe.SetName(regionName!);
+					}
+					controlToShow.Visibility = Visibility.Visible;
+					controlToShow.Opacity = 0;
+					Control.Children.Add(controlToShow);
 				}
-				Control.Children.Add(controlToShow);
 				if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage("Instance created");
 			}
 			catch (Exception ex)
@@ -83,12 +88,8 @@ public class PanelVisiblityNavigator : ControlNavigator<Panel>
 		{
 			if (controlToShow is not null)
 			{
+				controlToShow.Opacity = 0;
 				controlToShow.Visibility = Visibility.Visible;
-			}
-
-			if (CurrentlyVisibleControl != null)
-			{
-				CurrentlyVisibleControl.Visibility = Visibility.Collapsed;
 			}
 			CurrentlyVisibleControl = controlToShow;
 		}
@@ -96,6 +97,29 @@ public class PanelVisiblityNavigator : ControlNavigator<Panel>
 		Control.ReassignRegionParent();
 
 		return path;
+	}
+
+	protected override Task PostNavigateAsync()
+	{
+		if (Control is not null)
+		{
+			foreach (var child in Control.Children.OfType<FrameworkElement>())
+			{
+				if(child == CurrentlyVisibleControl)
+				{
+					child.Opacity = 1;
+					child.Visibility = Visibility.Visible;
+				}
+				else
+				{
+					child.Opacity = 0;
+					child.Visibility = Visibility.Collapsed;
+
+				}
+			}
+		}
+
+		return Task.CompletedTask;
 	}
 
 	private FrameworkElement? FindByPath(string? path)


### PR DESCRIPTION
GitHub Issue (If applicable): #797

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Switching tabs collapses current tab and sets visible new tab, causing a white flicker particularly the first time navigation to a tab

## What is the new behavior?

Switching tabs adjusts opacity (currently setting to a fixed value of 0 or 1) to allow new tabs an opportunity to render before they become visible

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
