### PR TITLE
chore: SoftInput.AdjustNothing for droid template

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/Android/MainActivity.Android.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/Android/MainActivity.Android.cs
@@ -9,7 +9,7 @@ namespace MyExtensionsApp
 	[Activity(
 			MainLauncher = true,
 			ConfigurationChanges = global::Uno.UI.ActivityHelper.AllConfigChanges,
-			WindowSoftInputMode = SoftInput.AdjustPan | SoftInput.StateHidden
+			WindowSoftInputMode = SoftInput.AdjustNothing | SoftInput.StateHidden
 		)]
 	public class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
 	{


### PR DESCRIPTION
With the Toolkit containing the [SafeArea](https://platform.uno/docs/articles/external/uno.toolkit.ui/doc/controls/SafeArea.html?tabs=none) control/behavior, we should change the `WindowSoftInputMode` on Android to `AdjustNothing` so that the system does not clash with the SafeArea's logic when the [SoftInput](https://platform.uno/docs/articles/external/uno.toolkit.ui/doc/controls/SafeArea.html?tabs=none#using-insetmasksoftinput-for-on-screen-keyboards) flag is set on SafeArea.