### PR TITLE
feat: Adding initialNavigate callback

### DIFF
--- a/samples/Playground/Playground.Shared/App.xaml.cs
+++ b/samples/Playground/Playground.Shared/App.xaml.cs
@@ -31,7 +31,7 @@ public sealed partial class App : Application
 		_window = Window.Current;
 #endif
 
-		var hostingOption = InitOption.Splash;
+		var hostingOption = InitOption.NoShellViewModel;
 
 		switch (hostingOption)
 		{
@@ -132,7 +132,7 @@ public sealed partial class App : Application
 							{
 
 								// Uncomment to view splashscreen for longer
-								await Task.Delay(5000);
+								// await Task.Delay(5000);
 								return BuildAppHost();
 							},
 							navigationRoot: appRoot.SplashScreen,
@@ -142,6 +142,33 @@ public sealed partial class App : Application
 							// initialRoute: "Shell"
 							// Option 3: Specify the view model. To avoid reflection, you can still define a routemap
 							initialViewModel: typeof(ShellViewModel)
+						);
+
+				break;
+
+			case InitOption.NoShellViewModel:
+				// InitializeNavigationAsync with splash screen and async callback to determine where
+				// initial navigation should go
+
+				var appRootNoShell = new AppRoot();
+				appRootNoShell.SplashScreen.Initialize(_window, args);
+
+				_window.Content = appRootNoShell;
+				_window.Activate();
+
+				_host = await _window.InitializeNavigationAsync(
+							async () =>
+							{
+								return BuildAppHost();
+							},
+							navigationRoot: appRootNoShell.SplashScreen,
+							initialNavigate: async (sp, nav)=>
+							{
+								// Uncomment to view splashscreen for longer
+								await Task.Delay(5000);
+
+								await nav.NavigateViewAsync<HomePage>(this);
+							}
 						);
 
 				break;
@@ -166,7 +193,8 @@ public sealed partial class App : Application
 		NavigationRoot,
 		AttachNavigation,
 		InitializeNavigation,
-		Splash
+		Splash,
+		NoShellViewModel
 	}
 
 

--- a/src/Uno.Extensions.Navigation.Toolkit/GlobalUsings.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/GlobalUsings.cs
@@ -9,6 +9,7 @@ global using Microsoft.Extensions.Hosting;
 global using Microsoft.Extensions.Logging;
 global using Windows.Foundation;
 global using Windows.UI.Popups;
+global using Uno.Extensions.Navigation;
 global using Uno.Extensions.Navigation.Navigators;
 global using Uno.Extensions.Navigation.Regions;
 global using Uno.Extensions.Navigation.Toolkit;

--- a/src/Uno.Extensions.Navigation.Toolkit/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/ServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ public static class ServiceCollectionExtensions
 	/// <param name="initialRoute">[optional] Initial navigation route</param>
 	/// <param name="initialView">[optional] Initial navigation view</param>
 	/// <param name="initialViewModel">[optional] Initial navigation viewmodel</param>
+	/// <param name="initialNavigate">[optional] Callback to drive initial navigation for app</param>
 	/// <returns>The created IHost</returns>
 	public static Task<IHost> InitializeNavigationAsync(
 		this Window window,
@@ -40,7 +41,8 @@ public static class ServiceCollectionExtensions
 		LoadingView navigationRoot,
 		string? initialRoute = "",
 		Type? initialView = null,
-		Type? initialViewModel = null)
+		Type? initialViewModel = null,
+		Func<IServiceProvider, INavigator, Task>? initialNavigate = null)
 	{
 		return window.InternalInitializeNavigationAsync(
 			buildHost,
@@ -53,7 +55,8 @@ public static class ServiceCollectionExtensions
 					{
 						lv.Source = loading;
 					}
-				}
+				},
+			initialNavigate
 			);
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
@@ -17,7 +17,11 @@ public static class FrameworkElementExtensions
 		return scopedServices;
 	}
 
-	public static Task HostAsync(this FrameworkElement root, IServiceProvider sp, string? initialRoute = "", Type? initialView = null, Type? initialViewModel = null)
+	public static Task HostAsync(
+		this FrameworkElement root,
+		IServiceProvider sp,
+		string? initialRoute = "", Type? initialView = null, Type? initialViewModel = null,
+		Func<IServiceProvider, INavigator, Task>? initialNavigate = null)
 	{
 		var services = sp.CreateNavigationScope();
 
@@ -28,7 +32,11 @@ public static class FrameworkElementExtensions
 		if (nav is not null)
 		{
 			var start = () => Task.CompletedTask;
-			if (initialView is not null)
+			if (initialNavigate is not null)
+			{
+				start = () => initialNavigate(services, nav);
+			}
+			else if (initialView is not null)
 			{
 				start = () => nav.NavigateViewAsync(root, initialView);
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): #843 

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Navigate on app startup to either login or home depending on logged in status is handled in the constructor of shellviewmodel

## What is the new behavior?

InitializeNavigation now has an additional parameter that is a callback, which takes IServiceProvider and INavigator and returns a Task. This should be used to do initial navigation and can optionally do other actions, such as checking for auth, before calling navigate method on the INavigator instance. The IServiceProvider can be queried for any registered services

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
