### PR TITLE
feat: Update to Android 12, dropping Android 11

### DIFF
--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -29,16 +29,16 @@
 		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.0-dev.75" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.75" />
 		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.0-dev.75" />
-		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.6.0-dev.573" />
+		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.692" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.692" />
+		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.0-dev.692" />
+		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.6.0-dev.692" />
+		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.6.0-dev.692" />
+		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.6.0-dev.692" />
+		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.6.0-dev.692" />
 		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.33" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.573" />
+		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.692" />
 	</ItemGroup>
 </Project>

--- a/samples/Playground/Playground.Droid/Playground.Droid.csproj
+++ b/samples/Playground/Playground.Droid/Playground.Droid.csproj
@@ -20,7 +20,7 @@
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\Playground.Shared\Strings</ResourcesDirectory>
@@ -70,10 +70,10 @@
     <PackageReference Include="Refit.HttpClientFactory" />
     <PackageReference Include="Uno.UI" />
     <PackageReference Include="Uno.UI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging"  />
-    <PackageReference Include="Uno.UniversalImageLoader"   />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console"  />
-    <PackageReference Include="Microsoft.Extensions.Logging"  />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
+    <PackageReference Include="Uno.UniversalImageLoader" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/Playground/Playground.Droid/Properties/AndroidManifest.xml
+++ b/samples/Playground/Playground.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="Playground" android:versionCode="1" android:versionName="1.0">
-  <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="30" />
-  <application android:label="Playground"></application>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="Playground.Playground" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="31" />
+	<application android:label="Playground"></application>
 </manifest>

--- a/src/Uno.Extensions.Navigation.Toolkit/common.props
+++ b/src/Uno.Extensions.Navigation.Toolkit/common.props
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<Choose>
-		<When Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid10.0' or '$(TargetFramework)'=='monoandroid11.0' or '$(TargetFramework)'=='net6.0-ios' or '$(TargetFramework)'=='net6.0-android'">
+		<When Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid12.0' or '$(TargetFramework)'=='net6.0-ios' or '$(TargetFramework)'=='net6.0-android'">
 			<ItemGroup>
 				<IncludeXamlNamespaces Include="mobile" />
 				<ExcludeXamlNamespaces Include="not_mobile" />

--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -1,16 +1,31 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
-    <!-- 
-    This property allows the override of the nuget local cache.
-    Set it to the version you want to override, used in another app.
-		
-		Rename the crosstargeting_override.props.sample to crosstargeting_override.props
-		and uncomment the line below.
-		
-    -->
-    <!--<UnoNugetOverrideVersion>2.23.2-dev.667</UnoNugetOverrideVersion>-->
+		<!--
+			The UnoTargetFrameworkOverride property is used to control the platforms compiled by Visual Studio, and
+			allows for a faster build when testing for a single platform.
 
-    <!-- Include netstandard2.0 to make sure all projects build -->
+				Instructions:
+				1) Copy this file and remove the ".sample" name
+				2) Adjust the NugetOverrideVersion property below
+				3) Make sure to do a Rebuild, so that nuget restores the proper packages for the new target
+
+			Available build targets
+
+				uap10.0.18362 (Windows)
+				net5.0-windows10.0.18362 (WinAppSDK Windows)
+				xamarinios10 (iOS)
+				MonoAndroid12.0 (Android 12.0)
+				netstandard2.0 (WebAssembly, Skia)
+				net6.0-ios (.NET 6 iOS)
+				net6.0-android (.NET 6 Android)
+				net6.0-maccatalyst (.NET 6 macOS Catalyst)
+				net6.0-macos (.NET 6 macOS AppKit)
+				xamarinmac20 (macOS)
+
+			Include netstandard2.0 to make sure all projects build
+
+      The UnoTargetFrameworkMobileOverride property is use only in Mobile (i.e. the single-project used by net6-ios/android/mac/catalyst)
+		-->
     <UnoTargetFrameworkMobileOverride>net6.0-ios</UnoTargetFrameworkMobileOverride>
     <UnoTargetFrameworkOverride>$(UnoTargetFrameworkMobileOverride);netstandard2.0</UnoTargetFrameworkOverride>
   </PropertyGroup>

--- a/src/tfms-ui-all.props
+++ b/src/tfms-ui-all.props
@@ -8,7 +8,7 @@
 		<TargetFrameworks>$(TargetFrameworks);netstandard2.0;</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_iOS)'=='true'">$(TargetFrameworks);xamarinios10</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_MacOS)'=='true'">$(TargetFrameworks);xamarinmac20</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Build_Android)'=='true'">$(TargetFrameworks);monoandroid11.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Build_Android)'=='true'">$(TargetFrameworks);monoandroid12.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_Windows)'=='true'">$(TargetFrameworks);uap10.0.18362</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_iOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-ios</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_MacOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-macos;net6.0-maccatalyst</TargetFrameworks>

--- a/src/tfms-ui-uwp.props
+++ b/src/tfms-ui-uwp.props
@@ -7,7 +7,7 @@
 		<TargetFrameworks>$(TargetFrameworks);netstandard2.0;</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_iOS)'=='true'">$(TargetFrameworks);xamarinios10</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_MacOS)'=='true'">$(TargetFrameworks);xamarinmac20</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Build_Android)'=='true'">$(TargetFrameworks);monoandroid11.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Build_Android)'=='true'">$(TargetFrameworks);monoandroid12.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_Windows)'=='true'">$(TargetFrameworks);uap10.0.18362</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_iOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-ios</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_MacOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-macos;net6.0-maccatalyst</TargetFrameworks>

--- a/src/tfms-ui-winui.props
+++ b/src/tfms-ui-winui.props
@@ -7,7 +7,7 @@
 		<TargetFrameworks>$(TargetFrameworks);netstandard2.0;</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_iOS)'=='true'">$(TargetFrameworks);xamarinios10</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_MacOS)'=='true'">$(TargetFrameworks);xamarinmac20</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Build_Android)'=='true'">$(TargetFrameworks);monoandroid11.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Build_Android)'=='true'">$(TargetFrameworks);monoandroid12.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_iOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-ios</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_MacOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-macos;net6.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_Android)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-android</TargetFrameworks>


### PR DESCRIPTION
## PR Type
- Feature

## What is the current behavior?

Extensions target android11

## What is the new behavior?

Extensions target android12 (Uno 4.6.0 will drop monoandroid11.0)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
