### PR TITLE
feat: Adding caching to each of the native keyvalue stores

### DIFF
--- a/samples/Playground/Directory.Build.props
+++ b/samples/Playground/Directory.Build.props
@@ -3,13 +3,14 @@
 		<LangVersion>10.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors>enable</WarningsAsErrors>
-	  <NoWarn>$(NoWarn);NU5104;CS1591;MSB3277;XA0101;CS8785;CS8669</NoWarn>
-	  <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>	  
+		<NoWarn>$(NoWarn);NU5104;CS1591;MSB3277;XA0101;CS8785;CS8669</NoWarn>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+		<DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
 	</PropertyGroup>
 
 	<PropertyGroup>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>True</DebugSymbols>
-		<SynthesizeLinkMetadata>true</SynthesizeLinkMetadata> 
+		<SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
 	</PropertyGroup>
 </Project>

--- a/samples/Playground/Directory.Build.targets
+++ b/samples/Playground/Directory.Build.targets
@@ -34,4 +34,9 @@
   </Choose>
 
 	<Import Project="..\..\src\xamarinmac-workaround.targets" Condition="exists('..\..\src\xamarinmac-workaround.targets') and $(TargetFramework.ToLower().StartsWith('xamarin')) and $(TargetFramework.ToLower().Contains('mac'))" />
+
+	<!-- Uno.WinUI.MSAL references Uno.WinUI for windows10 tfm. This target
+		overrides the protection in uno.winui.targets that raises an error 
+		that breaks build -->
+	<Target Name="_WinAppSDKNotSupported" BeforeTargets="BeforeBuild" />
 </Project>

--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -18,27 +18,27 @@
 		<PackageVersion Include="Refit" Version="6.3.2"/>
 		<PackageVersion Include="Refit.HttpClientFactory" Version="6.3.2" />
 		<PackageVersion Include="SkiaSharp.Views" Version="2.80.3" />
-		<PackageVersion Include="System.Text.Json" Version="6.0.3" />
+		<PackageVersion Include="System.Text.Json" Version="6.0.6" />
 		<PackageVersion Include="Uno.Core" Version="4.0.1" />
 		<PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
 		<PackageVersion Include="Uno.Extensions.Logging.OSLog " Version="1.4.0" />
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
 		<PackageVersion Include="Uno.Material" Version="2.3.0" />
 		<PackageVersion Include="Uno.Material.WinUI" Version="2.3.0" />
-		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.0-dev.75" />
-		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.0-dev.75" />
-		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.75" />
-		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.0-dev.75" />
-		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.692" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.692" />
-		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.0-dev.692" />
-		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.6.0-dev.692" />
-		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.6.0-dev.692" />
-		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.6.0-dev.692" />
-		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.6.0-dev.692" />
-		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.33" />
+		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.0-dev.85" />
+		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.0-dev.85" />
+		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.85" />
+		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.0-dev.85" />
+		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.692" />
+		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.947" />
 	</ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -43,15 +43,15 @@
 		<PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
 		<PackageVersion Include="Uno.Roslyn" Version="1.3.0-dev.12" />
-		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.0-dev.83" />
-		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.83" />
-		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.701"/>
-		<PackageVersion Include="Uno.UI.MSAL"  Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.0-dev.85" />
+		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.85" />
+		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.947"/>
+		<PackageVersion Include="Uno.UI.MSAL"  Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.6.0-dev.947" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />
 		<PackageVersion Include="xunit" Version="2.4.1" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -43,15 +43,15 @@
 		<PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
 		<PackageVersion Include="Uno.Roslyn" Version="1.3.0-dev.12" />
-		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.0-dev.75" />
-		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.75" />
-		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.573"/>
-		<PackageVersion Include="Uno.UI.MSAL"  Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.6.0-dev.573" />
+		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.0-dev.83" />
+		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.83" />
+		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.701"/>
+		<PackageVersion Include="Uno.UI.MSAL"  Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.6.0-dev.701" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />
 		<PackageVersion Include="xunit" Version="2.4.1" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/Uno.Extensions.Authentication.MSAL/Directory.Build.targets
+++ b/src/Uno.Extensions.Authentication.MSAL/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project ToolsVersion="15.0">
+	<Import Project="..\Directory.Build.targets" />
+
+	<!-- Uno.WinUI.MSAL references Uno.WinUI for windows10 tfm. This target
+		overrides the protection in uno.winui.targets that raises an error 
+		that breaks build -->
+	<Target Name="_WinAppSDKNotSupported" BeforeTargets="BeforeBuild" />
+</Project>

--- a/src/Uno.Extensions.Authentication.Msal/Uno.Extensions.Authentication.Msal.WinUI.csproj
+++ b/src/Uno.Extensions.Authentication.Msal/Uno.Extensions.Authentication.Msal.WinUI.csproj
@@ -4,7 +4,6 @@
 	<PropertyGroup>
 		<Description>MSAL Authentication Extensions for the Uno Platform (WinUI)</Description>
 		<EnableDefaultPageItems>false</EnableDefaultPageItems>
-
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -48,9 +47,12 @@
 		<TargetPlatformMinVersion>14.2</TargetPlatformMinVersion>
 		<TargetPlatformVersion>15.4</TargetPlatformVersion>
 	</PropertyGroup>
-	
-	<ItemGroup>
+
+	<ItemGroup  Condition="'$(_IsWinUI)'=='false'">
 		<PackageReference Include="Uno.WinUI" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Uno.WinUI.MSAL" />
 	</ItemGroup>
 
@@ -61,4 +63,5 @@
 	<ItemGroup>
 	  <SourceGeneratorInput Remove="buildTransitive\Uno.Extensions.Authentication.MSAL.WinUI.props" />
 	</ItemGroup>
+
 </Project>

--- a/src/Uno.Extensions.Authentication.Oidc/Uno.Extensions.Authentication.Oidc.WinUI.csproj
+++ b/src/Uno.Extensions.Authentication.Oidc/Uno.Extensions.Authentication.Oidc.WinUI.csproj
@@ -14,9 +14,12 @@
 		<PackageId>Uno.Extensions.Authentication.Oidc.WinUI</PackageId>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 	</PropertyGroup>
+
+	<ItemGroup  Condition="'$(_IsWinUI)'=='false'">
+		<PackageReference Include="Uno.WinUI" />
+	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI" />
 		<ProjectReference Include="..\Uno.Extensions.Authentication.UI\Uno.Extensions.Authentication.WinUI.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Extensions.Authentication.UI/Uno.Extensions.Authentication.WinUI.csproj
+++ b/src/Uno.Extensions.Authentication.UI/Uno.Extensions.Authentication.WinUI.csproj
@@ -13,8 +13,11 @@
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(_IsWinUI)'=='false'">
 		<PackageReference Include="Uno.WinUI" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\Uno.Extensions.Navigation.UI\Uno.Extensions.Navigation.WinUI.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Extensions.Core/DependencyInjection/NamedInstance.cs
+++ b/src/Uno.Extensions.Core/DependencyInjection/NamedInstance.cs
@@ -3,14 +3,15 @@
 internal record NamedInstance<TService, TImplementation>(IServiceProvider Services, string Name) : INamedInstance<TService>
 	where TService : class where TImplementation : class, TService
 {
+	private TService? _service;
 	public TService? Get()
 	{
-		return Services.GetService<TImplementation>();
+		return _service ??= Services.GetService<TImplementation>();
 	}
 
 	public TService GetRequired()
 	{
-		return Services.GetRequiredService<TImplementation>();
+		return _service ??= Services.GetRequiredService<TImplementation>();
 	}
 }
 

--- a/src/Uno.Extensions.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,15 +4,33 @@ public static class ServiceCollectionExtensions
 {
 	private const string DefaultInstanceKey = "Default";
 
+	public static IServiceCollection AddNamedSingleton<TService, TImplementation>(this IServiceCollection services, string Name, Func<IServiceProvider, TImplementation> implementationFactory)
+	where TService : class where TImplementation : class, TService
+	{
+		// Register the concrete type (the NamedInstance will use this
+		// rather than iterating through all the registered implementations
+		// of TService
+		services.TryAddTransient(implementationFactory);
+		return services.AddNamedSingletonImplementation<TService, TImplementation>(Name);
+
+	}
+
 	public static IServiceCollection AddNamedSingleton<TService, TImplementation>(this IServiceCollection services, string Name)
 		where TService : class where TImplementation : class, TService
 	{
 		// Register the concrete type (the NamedInstance will use this
 		// rather than iterating through all the registered implementations
 		// of TService
-		services.TryAddSingleton<TImplementation>();
+		services.TryAddTransient<TImplementation>();
+		return services.AddNamedSingletonImplementation<TService, TImplementation>(Name);
+	}
+
+
+	private static IServiceCollection AddNamedSingletonImplementation<TService, TImplementation>(this IServiceCollection services, string Name)
+		where TService : class where TImplementation : class, TService
+	{
 		// Register for TService
-		services.TryAddSingleton<TService>(sp => sp.GetRequiredService<TImplementation>());
+		services.TryAddTransient<TService>(sp => sp.GetRequiredService<TImplementation>());
 		return services
 				// Register the named resolve
 				.AddSingleton<INamedInstance<TService>>(sp=>new NamedInstance<TService,TImplementation>(sp,Name));

--- a/src/Uno.Extensions.Hosting.UI/AppHostingEnvironment.cs
+++ b/src/Uno.Extensions.Hosting.UI/AppHostingEnvironment.cs
@@ -1,4 +1,6 @@
-﻿using Uno.Foundation;
+﻿#if __WASM__
+using Uno.Foundation;
+#endif
 
 namespace Uno.Extensions.Hosting;
 

--- a/src/Uno.Extensions.Hosting.UI/Uno.Extensions.Hosting.WinUI.Skia.csproj
+++ b/src/Uno.Extensions.Hosting.UI/Uno.Extensions.Hosting.WinUI.Skia.csproj
@@ -14,7 +14,7 @@
 	</PropertyGroup>
 
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(_IsWinUI)'=='false'">
 		<PackageReference Include="Uno.WinUI" />
 	</ItemGroup>
 

--- a/src/Uno.Extensions.Hosting.UI/Uno.Extensions.Hosting.WinUI.csproj
+++ b/src/Uno.Extensions.Hosting.UI/Uno.Extensions.Hosting.WinUI.csproj
@@ -17,7 +17,7 @@
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(_IsWinUI)'=='false'">
 		<PackageReference Include="Uno.WinUI" />
 	</ItemGroup>
 

--- a/src/Uno.Extensions.Localization.UI/Uno.Extensions.Localization.WinUI.csproj
+++ b/src/Uno.Extensions.Localization.UI/Uno.Extensions.Localization.WinUI.csproj
@@ -10,8 +10,8 @@
 	<PropertyGroup>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 	</PropertyGroup>
-	
-	<ItemGroup>
+
+	<ItemGroup Condition="'$(_IsWinUI)'=='false'">
 		<PackageReference Include="Uno.WinUI" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Extensions.Logging/Uno.Extensions.Logging.WinUI.Skia.csproj
+++ b/src/Uno.Extensions.Logging/Uno.Extensions.Logging.WinUI.Skia.csproj
@@ -9,7 +9,7 @@
 		<AssemblyName>Uno.Extensions.Logging.WinUI</AssemblyName>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(_IsWinUI)'=='false'">
 		<PackageReference Include="Uno.WinUI" />
 	</ItemGroup>
 

--- a/src/Uno.Extensions.Logging/Uno.Extensions.Logging.WinUI.csproj
+++ b/src/Uno.Extensions.Logging/Uno.Extensions.Logging.WinUI.csproj
@@ -21,7 +21,7 @@
 		<PackageReference Include="Uno.Extensions.Logging.OSLog" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(_IsWinUI)'=='false'">
 		<PackageReference Include="Uno.WinUI" />
 	</ItemGroup>
 

--- a/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.WinUI.csproj
+++ b/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.WinUI.csproj
@@ -17,8 +17,10 @@
 	  <None Remove="LinkerDefinition.xml" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(_IsWinUI)'=='false'">
 		<PackageReference Include="Uno.WinUI" />
+	</ItemGroup>
+	<ItemGroup>
 		<PackageReference Include="Uno.Toolkit.WinUI" />
 		<ProjectReference Include="..\Uno.Extensions.Navigation.UI\Uno.Extensions.Navigation.WinUI.csproj" />
 	</ItemGroup>

--- a/src/Uno.Extensions.Navigation.UI/Uno.Extensions.Navigation.WinUI.csproj
+++ b/src/Uno.Extensions.Navigation.UI/Uno.Extensions.Navigation.WinUI.csproj
@@ -13,7 +13,7 @@
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(_IsWinUI)'=='false'">
 		<PackageReference Include="Uno.WinUI" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.WinUI.csproj
+++ b/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.WinUI.csproj
@@ -14,8 +14,11 @@
 
 	<Import Project="common.props" />
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(_IsWinUI)'=='false'">
 		<PackageReference Include="Uno.WinUI" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Uno.Toolkit.WinUI" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Extensions.Storage.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Storage.UI/GlobalUsings.cs
@@ -14,6 +14,7 @@ global using Uno.Extensions.Serialization;
 global using Uno.Extensions.Storage;
 global using Uno.Extensions.Storage.KeyValueStorage;
 global using Uno.Extensions.Threading;
+global using Windows.Security.Credentials;
 global using Windows.Storage;
 
 #if WINUI
@@ -27,7 +28,7 @@ global using Microsoft.UI.Dispatching;
 	global using Microsoft.UI.Xaml.Data;
 	global using Microsoft.UI.Xaml.Media;
 #else
-	global using Windows.System;
+global using Windows.System;
 	global using Windows.UI.Xaml;
 	global using Windows.UI.Xaml.Controls;
 	global using Windows.UI.Xaml.Controls.Primitives;

--- a/src/Uno.Extensions.Storage.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Storage.UI/GlobalUsings.cs
@@ -7,15 +7,17 @@ global using System.Threading.Tasks;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Hosting;
 global using Microsoft.Extensions.Logging;
+global using Microsoft.Extensions.Options;
+global using Uno.Extensions.Configuration;
 global using Uno.Extensions.Logging;
 global using Uno.Extensions.Serialization;
 global using Uno.Extensions.Storage;
 global using Uno.Extensions.Storage.KeyValueStorage;
-global using Windows.Security.Credentials;
+global using Uno.Extensions.Threading;
 global using Windows.Storage;
 
 #if WINUI
-	global using Microsoft.UI.Dispatching;
+global using Microsoft.UI.Dispatching;
 	global using Microsoft.UI.Xaml;
 	global using Microsoft.UI.Xaml.Controls;
 	global using Microsoft.UI.Xaml.Controls.Primitives;
@@ -25,13 +27,13 @@ global using Windows.Storage;
 	global using Microsoft.UI.Xaml.Data;
 	global using Microsoft.UI.Xaml.Media;
 #else
-global using Windows.System;
-global using Windows.UI.Xaml;
-global using Windows.UI.Xaml.Controls;
-global using Windows.UI.Xaml.Controls.Primitives;
-global using Windows.UI.Xaml.Input;
-global using Windows.UI.Xaml.Navigation;
-global using Windows.UI.Xaml.Markup;
-global using Windows.UI.Xaml.Data;
-global using Windows.UI.Xaml.Media;
+	global using Windows.System;
+	global using Windows.UI.Xaml;
+	global using Windows.UI.Xaml.Controls;
+	global using Windows.UI.Xaml.Controls.Primitives;
+	global using Windows.UI.Xaml.Input;
+	global using Windows.UI.Xaml.Navigation;
+	global using Windows.UI.Xaml.Markup;
+	global using Windows.UI.Xaml.Data;
+	global using Windows.UI.Xaml.Media;
 #endif

--- a/src/Uno.Extensions.Storage.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Storage.UI/HostBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions;
+﻿
+
+namespace Uno.Extensions;
 
 public static class HostBuilderExtensions
 {
@@ -14,6 +16,11 @@ public static class HostBuilderExtensions
 		Action<HostBuilderContext, IServiceCollection>? configure = default)
 	{
 		return builder
+			.UseConfiguration(
+				configure: configBuilder =>
+				configBuilder
+						.Section<KeyValueStorageConfiguration>(nameof(KeyValueStorageConfiguration))
+					)
 			.ConfigureServices((ctx, services) =>
 		{
 			_ = services

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/BaseKeyValueStorageWithCaching.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/BaseKeyValueStorageWithCaching.cs
@@ -1,0 +1,90 @@
+﻿namespace Uno.Extensions.Storage.KeyValueStorage;
+
+internal abstract record BaseKeyValueStorageWithCaching(
+	InMemoryKeyValueStorage InMemoryStorage,
+	KeyValueStorageSettings settings
+	) : IKeyValueStorage
+{
+	private readonly FastAsyncLock _lock = new FastAsyncLock();
+	private IList<string>? _inMemoryKeys;
+
+	public abstract bool IsEncrypted { get; }
+
+	public async ValueTask ClearAsync(string key, CancellationToken ct)
+	{
+		using (await _lock.LockAsync(ct))
+		{
+			await InternalClearAsync(key, ct);
+			await InMemoryStorage.ClearAsync(key, ct);
+			if (_inMemoryKeys?.Contains(key)??false)
+			{
+				_inMemoryKeys.Remove(key);
+			}
+		}
+	}
+
+	protected abstract ValueTask InternalClearAsync(string key, CancellationToken ct) ;
+
+
+	public async ValueTask<TValue?> GetAsync<TValue>(string key, CancellationToken ct)
+	{
+		using (await _lock.LockAsync(ct))
+		{
+			if (!settings.DisableInMemoryCache)
+			{
+				var val = await InMemoryStorage.GetAsync<TValue>(key, ct);
+				if (val is not null)
+				{
+					return val;
+				}
+			}
+			var internalVal = await InternalGetAsync<TValue>(key, ct);
+			if (!settings.DisableInMemoryCache &&
+				internalVal is not null)
+			{
+#pragma warning disable CS8714 // Incorrect Nullability warning
+				await InMemoryStorage.SetAsync(key, internalVal, ct);
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
+			}
+			return internalVal;
+		}
+	}
+
+	protected abstract ValueTask<TValue?> InternalGetAsync<TValue>(string key, CancellationToken ct);
+
+	public async ValueTask<string[]> GetKeysAsync(CancellationToken ct)
+	{
+		using (await _lock.LockAsync(ct))
+		{
+			if (!settings.DisableInMemoryCache &&
+				_inMemoryKeys is not null)
+			{
+				return _inMemoryKeys.ToArray();
+			}
+			var keys = await InternalGetKeysAsync(ct);
+			_inMemoryKeys = keys.ToList();
+			return keys;
+		}
+	}
+	protected abstract ValueTask<string[]> InternalGetKeysAsync(CancellationToken ct) ;
+
+	public async ValueTask SetAsync<TValue>(string key, TValue value, CancellationToken ct) where TValue : notnull
+	{
+		using (await _lock.LockAsync(ct))
+		{
+			if (!settings.DisableInMemoryCache 
+				)
+			{
+				if(_inMemoryKeys is not null &&
+					!_inMemoryKeys.Contains(key))
+				{
+					_inMemoryKeys.Add(key);
+				}
+				await InMemoryStorage.SetAsync(key, value, ct);
+			}
+			await InternalSetAsync(key, value, ct);
+		}
+	}
+
+	protected abstract ValueTask InternalSetAsync<TValue>(string key, TValue value, CancellationToken ct) where TValue : notnull ;
+}

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/EncryptedApplicationDataKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/EncryptedApplicationDataKeyValueStorage.cs
@@ -6,8 +6,12 @@ using Windows.Security.Cryptography.DataProtection;
 
 namespace Uno.Extensions.Storage.KeyValueStorage;
 
-internal record EncryptedApplicationDataKeyValueStorage(ILogger<ApplicationDataKeyValueStorage> EncryptedLogger, ISerializer Serializer)
-	: ApplicationDataKeyValueStorage(EncryptedLogger, Serializer)
+internal record EncryptedApplicationDataKeyValueStorage(
+	ILogger<ApplicationDataKeyValueStorage> EncryptedLogger,
+	InMemoryKeyValueStorage InMemoryStorage,
+	KeyValueStorageSettings Settings,
+	ISerializer Serializer)
+	: ApplicationDataKeyValueStorage(EncryptedLogger, InMemoryStorage, Settings, Serializer)
 {
 	public new const string Name = "EncryptedApplicationData";
 

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyStoreKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyStoreKeyValueStorage.cs
@@ -43,7 +43,7 @@ internal record KeyStoreSettingsStorage : IKeyValueStorage
 	/// <summary>
 	/// Creates a new <see cref="KeyStoreSettingsStorage"/> using a specific filename as the destination storage.
 	/// </summary>
-	public KeyStoreSettingsStorage(ILogger<KeyStoreSettingsStorage> logger, ISerializer serializer)
+	public KeyStoreSettingsStorage(ILogger<KeyStoreSettingsStorage> logger, KeyValueStorageSettings settings, ISerializer serializer)
 	{
 		_serializer = serializer;
 		_logger = logger;

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyStoreKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyStoreKeyValueStorage.cs
@@ -10,22 +10,22 @@ using Java.Security;
 using Javax.Crypto;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
-using Uno.Logging;
 using Uno.Extensions.Threading;
+using Uno.Logging;
 
 namespace Uno.Extensions.Storage.KeyValueStorage;
 
 /// <summary>
 /// Allows saving settings in a secure storage using Android's <see cref="KeyStore"/>.
 /// </summary>
-internal record KeyStoreSettingsStorage : BaseKeyValueStorageWithCaching
+internal record KeyStoreKeyValueStorage : BaseKeyValueStorageWithCaching
 {
 	public const string Name = "KeyStore";
 
 	// It is not an issue if this password becomes public, as it's simply added encryption
 	// above the app-level encryption.
 	private const string DefaultPrivatePassword = "95407C28724B42F78A035C55987FDB21C7C2CB53529148B5A3021B715447E593";
-	private const string DefaultFileName = "KeyStoreSettingsStorage";
+	private const string DefaultFileName = "KeyStoreKeyValueStorage";
 
 	private readonly ILogger _logger;
 	private readonly ISerializer _serializer;
@@ -41,10 +41,10 @@ internal record KeyStoreSettingsStorage : BaseKeyValueStorageWithCaching
 	private static readonly Encoding _utf8 = new UTF8Encoding(false);
 
 	/// <summary>
-	/// Creates a new <see cref="KeyStoreSettingsStorage"/> using a specific filename as the destination storage.
+	/// Creates a new <see cref="KeyStoreKeyValueStorage"/> using a specific filename as the destination storage.
 	/// </summary>
-	public KeyStoreSettingsStorage(
-		ILogger<KeyStoreSettingsStorage> logger,
+	public KeyStoreKeyValueStorage(
+		ILogger<KeyStoreKeyValueStorage> logger,
 		InMemoryKeyValueStorage inMemoryStorage,
 		KeyValueStorageSettings settings,
 		ISerializer serializer) : base(inMemoryStorage, settings)

--- a/src/Uno.Extensions.Storage.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Storage.UI/ServiceCollectionExtensions.cs
@@ -34,9 +34,10 @@ public static class ServiceCollectionExtensions
 					{
 						var l = sp.GetRequiredService<ILogger<KeyStoreSettingsStorage>>();
 						var s = sp.GetRequiredService<ISerializer>();
+						var inmem = sp.GetRequiredService<InMemoryKeyValueStorage>();
 						var config = sp.GetRequiredService<IOptions<KeyValueStorageConfiguration>>();
 						var settings = config.Value.GetSettingsOrDefault(KeyStoreSettingsStorage.Name);
-						return new KeyStoreSettingsStorage(l, settings, s);
+						return new KeyStoreSettingsStorage(l,inmem, settings, s);
 					})
 #endif
 #if __IOS__

--- a/src/Uno.Extensions.Storage.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Storage.UI/ServiceCollectionExtensions.cs
@@ -13,49 +13,67 @@ public static class ServiceCollectionExtensions
 			.AddSingleton<IStorage, FileStorage>();
 	}
 
+	private static TKeyValueStorage CreateKeyValueStorage<TKeyValueStorage>(
+		this IServiceProvider sp,
+		string name,
+		Func<ILogger<TKeyValueStorage>, InMemoryKeyValueStorage, KeyValueStorageSettings, ISerializer, TKeyValueStorage> creator)
+	{
+		var l = sp.GetRequiredService<ILogger<TKeyValueStorage>>();
+		var s = sp.GetRequiredService<ISerializer>();
+		var inmem = sp.GetRequiredService<InMemoryKeyValueStorage>();
+		var config = sp.GetRequiredService<IOptions<KeyValueStorageConfiguration>>();
+		var settings = config.Value.GetSettingsOrDefault(name);
+		return creator(l, inmem, settings, s);
+	}
+
 	public static IServiceCollection AddKeyedStorage(this IServiceCollection services)
 	{
 		return services
 				.AddNamedSingleton<IKeyValueStorage, InMemoryKeyValueStorage>(InMemoryKeyValueStorage.Name)
-				.AddNamedSingleton<IKeyValueStorage, ApplicationDataKeyValueStorage>(ApplicationDataKeyValueStorage.Name,
-				sp =>
-				{
-					var l = sp.GetRequiredService<ILogger<ApplicationDataKeyValueStorage>>();
-					var s = sp.GetRequiredService<ISerializer>();
-					var inmem = sp.GetRequiredService<InMemoryKeyValueStorage>();
-					var config = sp.GetRequiredService<IOptions<KeyValueStorageConfiguration>>();
-					var settings = config.Value.GetSettingsOrDefault(ApplicationDataKeyValueStorage.Name);
-					return new ApplicationDataKeyValueStorage(l, inmem, settings, s);
-				})
+				.AddNamedSingleton<IKeyValueStorage, ApplicationDataKeyValueStorage>(
+					ApplicationDataKeyValueStorage.Name,
+					sp => sp.CreateKeyValueStorage<ApplicationDataKeyValueStorage>(
+								ApplicationDataKeyValueStorage.Name,
+								(l,inmem, settings,s)=>new ApplicationDataKeyValueStorage(l, inmem, settings, s)
+								)
+					)
 #if __ANDROID__
-				.AddNamedSingleton<IKeyValueStorage, KeyStoreSettingsStorage>(
-					KeyStoreSettingsStorage.Name,
-					sp =>
-					{
-						var l = sp.GetRequiredService<ILogger<KeyStoreSettingsStorage>>();
-						var s = sp.GetRequiredService<ISerializer>();
-						var inmem = sp.GetRequiredService<InMemoryKeyValueStorage>();
-						var config = sp.GetRequiredService<IOptions<KeyValueStorageConfiguration>>();
-						var settings = config.Value.GetSettingsOrDefault(KeyStoreSettingsStorage.Name);
-						return new KeyStoreSettingsStorage(l,inmem, settings, s);
-					})
+				.AddNamedSingleton<IKeyValueStorage, KeyStoreKeyValueStorage>(
+					KeyStoreKeyValueStorage.Name,
+					sp => sp.CreateKeyValueStorage<KeyStoreKeyValueStorage>(
+								KeyStoreKeyValueStorage.Name,
+								(l, inmem, settings, s) => new KeyStoreKeyValueStorage(l, inmem, settings, s)
+								)
+					)
 #endif
 #if __IOS__
-				.AddNamedSingleton<IKeyValueStorage, KeyChainSettingsStorage>(KeyChainSettingsStorage.Name)
+				.AddNamedSingleton<IKeyValueStorage, KeyChainKeyValueStorage>(
+					KeyChainKeyValueStorage.Name,
+					sp => sp.CreateKeyValueStorage<KeyChainKeyValueStorage>(
+								KeyChainKeyValueStorage.Name,
+								(l, inmem, settings, s) => new KeyChainKeyValueStorage(l, inmem, settings, s)
+								)
+					)
 #endif
 #if !WINUI && (__ANDROID__ || __IOS__ || WINDOWS_UWP)
 				.AddSingleton(new PasswordVaultResourceNameProvider((Assembly.GetEntryAssembly()?? Assembly.GetCallingAssembly()?? Assembly.GetExecutingAssembly()).GetName().Name??nameof(PasswordVaultKeyValueStorage)))
 				.AddNamedSingleton<IKeyValueStorage, PasswordVaultKeyValueStorage>(PasswordVaultKeyValueStorage.Name)
 #endif
 #if WINDOWS
-				.AddNamedSingleton<IKeyValueStorage, EncryptedApplicationDataKeyValueStorage>(EncryptedApplicationDataKeyValueStorage.Name)
+				.AddNamedSingleton<IKeyValueStorage, EncryptedApplicationDataKeyValueStorage>(
+					EncryptedApplicationDataKeyValueStorage.Name,
+					sp => sp.CreateKeyValueStorage<EncryptedApplicationDataKeyValueStorage>(
+								EncryptedApplicationDataKeyValueStorage.Name,
+								(l, inmem, settings, s) => new EncryptedApplicationDataKeyValueStorage(l, inmem, settings, s)
+								)
+					)
 #endif
 				.SetDefaultInstance<IKeyValueStorage>(
 #if WINUI
 #if __ANDROID__
-					KeyStoreSettingsStorage.Name
+					KeyStoreKeyValueStorage.Name
 #elif __IOS__
-					KeyChainSettingsStorage.Name
+					KeyChainKeyValueStorage.Name
 #elif WINDOWS
 					EncryptedApplicationDataKeyValueStorage.Name
 #else

--- a/src/Uno.Extensions.Storage.UI/Uno.Extensions.Storage.WinUI.csproj
+++ b/src/Uno.Extensions.Storage.UI/Uno.Extensions.Storage.WinUI.csproj
@@ -13,7 +13,7 @@
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(_IsWinUI)'=='false'">
 		<PackageReference Include="Uno.WinUI" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Extensions.Storage.UI/common.props
+++ b/src/Uno.Extensions.Storage.UI/common.props
@@ -12,6 +12,7 @@
 		<ProjectReference Include="..\Uno.Extensions.Core\Uno.Extensions.Core.csproj" />
 		<ProjectReference Include="..\Uno.Extensions.Storage\Uno.Extensions.Storage.csproj" />
 		<ProjectReference Include="..\Uno.Extensions.Serialization\Uno.Extensions.Serialization.csproj" />
+		<ProjectReference Include="..\Uno.Extensions.Configuration\Uno.Extensions.Configuration.csproj" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(_IsUWP)' == 'true'">
@@ -29,5 +30,10 @@
 			<DependentUpon>%(Filename)</DependentUpon>
 		</Compile>
 		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+	</ItemGroup>
+
+
+	<ItemGroup>
+		<InternalsVisibleTo Include="TestHarnessApp" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Extensions.Storage/KeyValueStorage/InMemoryKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage/KeyValueStorage/InMemoryKeyValueStorage.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Storage.KeyValueStorage;
+﻿using FastAsyncLock = Uno.Extensions.Threading.FastAsyncLock;
+
+namespace Uno.Extensions.Storage.KeyValueStorage;
 
 internal record InMemoryKeyValueStorage(ILogger<InMemoryKeyValueStorage> Logger) : IKeyValueStorage
 {

--- a/src/Uno.Extensions.Storage/KeyValueStorage/InMemoryKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage/KeyValueStorage/InMemoryKeyValueStorage.cs
@@ -1,9 +1,4 @@
-﻿
-
-
-
-
-namespace Uno.Extensions.Storage.KeyValueStorage;
+﻿namespace Uno.Extensions.Storage.KeyValueStorage;
 
 internal record InMemoryKeyValueStorage(ILogger<InMemoryKeyValueStorage> Logger) : IKeyValueStorage
 {
@@ -68,7 +63,7 @@ internal record InMemoryKeyValueStorage(ILogger<InMemoryKeyValueStorage> Logger)
 				Logger.LogInformationMessage($"Key '{name}' not found.");
 			}
 
-			throw new KeyNotFoundException($"Key '{name}' not found");
+			return default(T?);
 		}
 	}
 

--- a/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageConfiguration.cs
+++ b/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageConfiguration.cs
@@ -1,0 +1,25 @@
+﻿namespace Uno.Extensions.Storage.KeyValueStorage;
+
+public record KeyValueStorageConfiguration
+{
+	public IDictionary<string, KeyValueStorageSettings> StorageProviders { get; init; } = new Dictionary<string, KeyValueStorageSettings>();
+
+
+}
+
+internal static class KeyValueStorageConfigurationExtensions
+{
+	public static KeyValueStorageSettings GetSettingsOrDefault(this KeyValueStorageConfiguration? config, string name)
+	{
+		if (config?.StorageProviders.TryGetValue(name, out var settings) ?? false)
+		{
+			return settings;
+		}
+		return new KeyValueStorageSettings();
+	}
+}
+
+public record KeyValueStorageSettings
+{
+	public bool DisableInMemoryCache { get; init; }
+}

--- a/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageConfiguration.cs
+++ b/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageConfiguration.cs
@@ -1,8 +1,8 @@
 ﻿namespace Uno.Extensions.Storage.KeyValueStorage;
 
-public record KeyValueStorageConfiguration
+public record KeyValueStorageConfiguration : KeyValueStorageSettings
 {
-	public IDictionary<string, KeyValueStorageSettings> StorageProviders { get; init; } = new Dictionary<string, KeyValueStorageSettings>();
+	public IDictionary<string, KeyValueStorageSettings> Providers { get; init; } = new Dictionary<string, KeyValueStorageSettings>();
 
 
 }
@@ -11,11 +11,14 @@ internal static class KeyValueStorageConfigurationExtensions
 {
 	public static KeyValueStorageSettings GetSettingsOrDefault(this KeyValueStorageConfiguration? config, string name)
 	{
-		if (config?.StorageProviders.TryGetValue(name, out var settings) ?? false)
+		if (config?.Providers.TryGetValue(name, out var settings) ?? false)
 		{
 			return settings;
 		}
-		return new KeyValueStorageSettings();
+
+		// If there isn't a match for settings for the supplied name, return
+		// the default settings
+		return config ?? new KeyValueStorageSettings();
 	}
 }
 

--- a/src/Uno.Extensions.Storage/Uno.Extensions.Storage.csproj
+++ b/src/Uno.Extensions.Storage/Uno.Extensions.Storage.csproj
@@ -30,6 +30,7 @@
 		<InternalsVisibleTo Include="$(AssemblyName).UI" />
 		<InternalsVisibleTo Include="$(AssemblyName).WinUI" />
 		<InternalsVisibleTo Include="Uno.Extensions.Authentication" />
+		<InternalsVisibleTo Include="TestHarnessApp" />
 	</ItemGroup>
 
 </Project>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
@@ -10,18 +10,18 @@
     <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
     <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
     <PackageVersion Include="Uno.Material.WinUI" Version="2.3.0" />
-    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version=" 2.4.0-dev.75" />
-    <PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.75" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.573" />
+    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version=" 2.4.0-dev.85" />
+    <PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.85" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.947" />
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-    <PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.573" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.6.0-dev.573" />
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.6.0-dev.573" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.6.0-dev.573" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.6.0-dev.573" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.6.0-dev.573" />
+    <PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.947" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.6.0-dev.947" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.6.0-dev.947" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.6.0-dev.947" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.6.0-dev.947" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.6.0-dev.947" />
     <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.4.0.4" />
     <PackageVersion Include="Uno.Extensions.Authentication.WinUI" Version="255.255.255.255" />
     <PackageVersion Include="Uno.Extensions.Hosting.WinUI" Version="255.255.255.255" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
@@ -43,7 +43,6 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
-		<PackageReference Include="Uno.WinUI" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
 		<PackageReference Include="Uno.Material.WinUI" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" />

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,6 @@
 {
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44"
-  }
+  },
+  "sdk": { "version": "6.0.402" }
 }

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,5 @@
 {
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44"
-  },
-  "sdk": { "version": "6.0.402" }
+  }
 }

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -35,19 +35,19 @@
 		<PackageVersion Include="Uno.Material" Version="2.3.0" />
 		<PackageVersion Include="Uno.Material.WinUI" Version="2.3.0" />
 		<PackageVersion Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="7.1.11" />
-		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.0-dev.83" />
-		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.0-dev.83" />
-		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.83" />
-		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.0-dev.83" />
-		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.UI.MSAL" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.0-dev.85" />
+		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.0-dev.85" />
+		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.85" />
+		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.0-dev.85" />
+		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.MSAL" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.6.0-dev.947" />
 		<PackageVersion Include="Uno.UITest" Version="1.1.0-dev.32" />
 		<PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.32" />
 		<PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.32" />
@@ -55,13 +55,13 @@
 		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.6.0-dev.701" />
-		<PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.6.0-dev.947" />
+		<PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.6.0-dev.947" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 		<PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageVersion Include="NUnit" Version="3.13.3" />

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -35,19 +35,19 @@
 		<PackageVersion Include="Uno.Material" Version="2.3.0" />
 		<PackageVersion Include="Uno.Material.WinUI" Version="2.3.0" />
 		<PackageVersion Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="7.1.11" />
-		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.0-dev.75" />
-		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.0-dev.75" />
-		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.75" />
-		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.0-dev.75" />
-		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.MSAL" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.6.0-dev.573" />
+		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.0-dev.83" />
+		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.0-dev.83" />
+		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.83" />
+		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.0-dev.83" />
+		<PackageVersion Include="Uno.UI" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.UI.MSAL" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.6.0-dev.701" />
 		<PackageVersion Include="Uno.UITest" Version="1.1.0-dev.32" />
 		<PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.32" />
 		<PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.32" />
@@ -55,13 +55,13 @@
 		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.6.0-dev.573" />
-		<PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.6.0-dev.573" />
+		<PackageVersion Include="Uno.WinUI" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.6.0-dev.701" />
+		<PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.6.0-dev.701" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 		<PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageVersion Include="NUnit" Version="3.13.3" />

--- a/testing/TestHarness/TestHarness.Legacy.Skia.Gtk/app.manifest
+++ b/testing/TestHarness/TestHarness.Legacy.Skia.Gtk/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="$ext_safeprojectname$.Gtk"/>
+  <assemblyIdentity version="1.0.0.0" name="TestHarness.Gtk"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/testing/TestHarness/TestHarness.Legacy.Skia.WPF.Host/app.manifest
+++ b/testing/TestHarness/TestHarness.Legacy.Skia.WPF.Host/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="$ext_safeprojectname$.WPF.Host"/>
+  <assemblyIdentity version="1.0.0.0" name="TestHarness.WPF.Host"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/testing/TestHarness/TestHarness.Mobile/TestHarness.Mobile.csproj
+++ b/testing/TestHarness/TestHarness.Mobile/TestHarness.Mobile.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkMobileOverride)'!=''">$(UnoTargetFrameworkMobileOverride)</TargetFrameworks>
 		<TargetFrameworks Condition="'$(UnoTargetFrameworkMobileOverride)'==''">net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0-macos</TargetFrameworks>
@@ -30,7 +30,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
 		<PackageReference Include="Refit" />
-		<PackageReference Include="Refit.HttpClientFactory"  />
+		<PackageReference Include="Refit.HttpClientFactory" />
 		<PackageReference Include="System.Text.Json" />
 		<PackageReference Include="Uno.Material.WinUI" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" />
@@ -61,6 +61,11 @@
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Http.Refit\Uno.Extensions.Http.Refit.csproj" />
 		<ProjectReference Include="..\TestHarness.Core\TestHarness.Core.csproj" />
 	</ItemGroup>
+	<ItemGroup>
+	  <None Update="iOS\Entitlements.plist">
+	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net6.0-android'">
 			<ItemGroup>
@@ -76,6 +81,7 @@
 				<MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
 				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
 				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
+				<CodesignEntitlements>iOS\Entitlements.plist</CodesignEntitlements>
 			</PropertyGroup>
 			<ItemGroup>
 				<PackageReference Include="Uno.Extensions.Logging.OSLog" />

--- a/testing/TestHarness/TestHarness.Mobile/iOS/Entitlements.plist
+++ b/testing/TestHarness/TestHarness.Mobile/iOS/Entitlements.plist
@@ -2,5 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
+		<key>keychain-access-groups</key>
+		<array>
+			<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+		</array>
 	</dict>
 </plist>

--- a/testing/TestHarness/TestHarness.Shared/App.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/App.xaml.cs
@@ -21,13 +21,13 @@ public sealed partial class App : Application
 
 	protected override void OnLaunched(LaunchActivatedEventArgs args)
 	{
-#if DEBUG && !__WASM__
-		// This seems 
-		if (!Debugger.IsAttached)
-		{
-			Debugger.Launch();
-		}
-#endif
+//#if DEBUG && !__WASM__
+//		// This seems 
+//		if (!Debugger.IsAttached)
+//		{
+//			Debugger.Launch();
+//		}
+//#endif
 
 #if WINDOWS
 		// This is only required because we don't run UnoHost.CreateDefaultHost until a

--- a/testing/TestHarness/TestHarness.Shared/BaseHostInitialization.cs
+++ b/testing/TestHarness/TestHarness.Shared/BaseHostInitialization.cs
@@ -84,7 +84,7 @@ public abstract class BaseHostInitialization : IHostInitialization
 				{
 					var host = context.HostingEnvironment;
 					// Configure log levels for different categories of logging
-					logBuilder.SetMinimumLevel(host.IsDevelopment() ? LogLevel.Trace : LogLevel.Warning);
+					logBuilder.SetMinimumLevel(host.IsDevelopment() ? LogLevel.Warning : LogLevel.Warning);
 				});
 	}
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/StorageHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/StorageHostInit.cs
@@ -19,10 +19,11 @@ public class StorageHostInit : BaseHostInitialization
 					sp =>
 					{
 						var l = sp.GetRequiredService<ILogger<TestingKeyValueStorage>>();
+						var inmem = sp.GetRequiredService<InMemoryKeyValueStorage>();
 						var s = sp.GetRequiredService<ISerializer>();
 						var config = sp.GetRequiredService<IOptions<KeyValueStorageConfiguration>>();
 						var settings = config.Value.GetSettingsOrDefault(NoCacheStorage);
-						return new TestingKeyValueStorage(l, settings, s);
+						return new TestingKeyValueStorage(l,inmem, settings, s);
 					}));
 #else
 			.AddNamedSingleton<IKeyValueStorage, TestingKeyValueStorage>(
@@ -58,8 +59,9 @@ internal record  TestingKeyValueStorage
 			{
 	public TestingKeyValueStorage(
 		ILogger<TestingKeyValueStorage> logger,
+		InMemoryKeyValueStorage inmem,
 		KeyValueStorageSettings settings,
-		ISerializer serializer) : base(logger, settings, serializer)
+		ISerializer serializer) : base(logger, inmem, settings, serializer)
 	{
 
 	}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/StorageHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/StorageHostInit.cs
@@ -1,9 +1,45 @@
 ﻿using System.Collections.Immutable;
+using Microsoft.Extensions.Options;
+using Uno.Extensions.Storage.KeyValueStorage;
 
 namespace TestHarness;
 
 public class StorageHostInit : BaseHostInitialization
 {
+	protected override string[] ConfigurationFiles => new string[] { "TestHarness.Ext.Core.Storage.appsettings.storage.json" };
+
+	public const string NoCacheStorage = "NoCache";
+	protected override IHostBuilder Custom(IHostBuilder builder)
+	{
+		return builder
+			.ConfigureServices(services => services
+#if __ANDROID__
+			.AddNamedSingleton<IKeyValueStorage, TestingKeyValueStorage>(
+					NoCacheStorage,
+					sp =>
+					{
+						var l = sp.GetRequiredService<ILogger<TestingKeyValueStorage>>();
+						var s = sp.GetRequiredService<ISerializer>();
+						var config = sp.GetRequiredService<IOptions<KeyValueStorageConfiguration>>();
+						var settings = config.Value.GetSettingsOrDefault(NoCacheStorage);
+						return new TestingKeyValueStorage(l, settings, s);
+					}));
+#else
+			.AddNamedSingleton<IKeyValueStorage, TestingKeyValueStorage>(
+				NoCacheStorage,
+				sp =>
+				{
+					var l = sp.GetRequiredService<ILogger<TestingKeyValueStorage>>();
+					var s = sp.GetRequiredService<ISerializer>();
+					var inmem = sp.GetRequiredService<InMemoryKeyValueStorage>();
+					var config = sp.GetRequiredService<IOptions<KeyValueStorageConfiguration>>();
+					var settings = config.Value.GetSettingsOrDefault(NoCacheStorage);
+					return new TestingKeyValueStorage(l, inmem, settings, s);
+				}));
+#endif
+	}
+
+
 
 	protected override void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
 	{
@@ -14,6 +50,27 @@ public class StorageHostInit : BaseHostInitialization
 		routes.Register(
 			new RouteMap(""));
 	}
+}
+
+internal record  TestingKeyValueStorage
+#if __ANDROID__
+			: KeyStoreSettingsStorage
+			{
+	public TestingKeyValueStorage(
+		ILogger<TestingKeyValueStorage> logger,
+		KeyValueStorageSettings settings,
+		ISerializer serializer) : base(logger, settings, serializer)
+	{
+
+	}
+#else
+			(ILogger<TestingKeyValueStorage> TestingLogger,
+	InMemoryKeyValueStorage InMemoryStorage,
+	KeyValueStorageSettings Settings,
+	ISerializer Serializer) : ApplicationDataKeyValueStorage(TestingLogger, InMemoryStorage, Settings, Serializer)
+{
+#endif
+
 }
 
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/StorageOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/StorageOnePage.xaml
@@ -15,6 +15,7 @@
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
 			<RowDefinition />
+			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
 		<utu:NavigationBar Content="Storage - One"
 						   AutomationProperties.AutomationId="StorageOne" />
@@ -53,5 +54,10 @@
 				</DataTemplate>
 			</ListView.ItemTemplate>
 		</ListView>
-	</Grid>
+		<StackPanel Grid.Row="4">
+			<Button Content="Perf Test"
+					Click="{x:Bind ViewModel.PerfTest}" />
+			<TextBlock Text="{Binding PerfTestOutput}" />
+		</StackPanel>
+		</Grid>
 </Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/StorageOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/StorageOneViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using Uno.Extensions.Storage;
 using Uno.Extensions.Storage.KeyValueStorage;
 using Uno.Extensions.DependencyInjection;
+using System.Diagnostics;
+
 
 namespace TestHarness.Ext.Navigation.Storage;
 
@@ -11,6 +13,9 @@ public partial class StorageOneViewModel : ObservableObject
 	private readonly IServiceProvider _services;
 	private readonly IEnumerable<INamedInstance<IKeyValueStorage>> _storage;
 	public IEnumerable<INamedInstance<IKeyValueStorage>> Storage => _storage;
+
+	[ObservableProperty]
+	private string? _perfTestOutput;
 
 	public StorageOneViewModel(INavigator navigator, IServiceProvider services, IEnumerable<INamedInstance<IKeyValueStorage>> storage)
 	{
@@ -77,5 +82,76 @@ public partial class StorageOneViewModel : ObservableObject
 		await LoadAll();
 	}
 
+	public async Task PerfTest()
+	{
+		if(_selectedStorage is null)
+		{
+			PerfTestOutput = "Select storage to test";
+			return;
+		}
+
+
+		var sw = new Stopwatch();
+		sw.Start();
+		var iterationCount = 5;
+		for (int iterationIndex = 0; iterationIndex < iterationCount; iterationIndex++)
+		{
+			PerfTestOutput = $"Iteration {iterationIndex}";
+			await Task.Delay(50);
+
+			await _selectedStorage.ClearAllAsync(CancellationToken.None);
+
+			var keyCount = 100;
+			var keyValues = new List<(string Key, string Value)>();
+			for (int i = 0; i < keyCount; i++)
+			{
+				var key = GenerateString(Random.Shared.Next(0, 100));
+				var value = GenerateString(Random.Shared.Next(0, 1000));
+				keyValues.Add((key, value));
+			}
+
+			// Set all kv pairs
+			foreach (var kv in keyValues)
+			{
+				await _selectedStorage.SetAsync(kv.Key, kv.Value, CancellationToken.None);
+			}
+
+			PerfTestOutput = $"Write complete";
+			await Task.Delay(50);
+
+			// Randomly read kv pairs - 5 x keyCount
+			var max = (5 * keyCount);
+			for (int i = 0; i < max; i++)
+			{
+				var key = Random.Shared.Next(0, keyCount);
+				var val = await _selectedStorage.GetAsync<string>(keyValues[key].Key, CancellationToken.None);
+				if (i % 20 == 0)
+				{
+					PerfTestOutput = $"{i}:{max}";
+					await Task.Delay(50);
+				}
+			}
+		}
+
+		sw.Stop();
+		var totalTime = sw.ElapsedMilliseconds;
+		var iterationTime = (int)(totalTime / iterationCount);
+		PerfTestOutput = $"{iterationTime}ms";
+
+	}
+
+
+	public const string Alphabet =
+	"abcdefghijklmnopqrstuvwyxzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+	public string GenerateString(int size)
+	{
+		char[] chars = new char[size];
+		for (int i = 0; i < size; i++)
+		{
+			chars[i] = Alphabet[Random.Shared.Next(Alphabet.Length)];
+		}
+		return new string(chars);
+	}
 }
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/appsettings.storage.json
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/appsettings.storage.json
@@ -1,0 +1,9 @@
+﻿{
+  "KeyValueStorageConfiguration": {
+    "StorageProviders": {
+      "NoCache": {
+        "DisableInMemoryCache": true
+      }
+    }
+  }
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/appsettings.storage.json
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/appsettings.storage.json
@@ -1,6 +1,7 @@
 ﻿{
   "KeyValueStorageConfiguration": {
-    "StorageProviders": {
+    "DisableInMemoryCache": false,
+    "Providers": {
       "NoCache": {
         "DisableInMemoryCache": true
       }

--- a/testing/TestHarness/TestHarness.Shared/Strings/en-AU/Resources.resw
+++ b/testing/TestHarness/TestHarness.Shared/Strings/en-AU/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>$ext_safeprojectname$</value>
+    <value>TestHarness</value>
   </data>
   <data name="Localization_Greeting.Text" xml:space="preserve">
     <value>G'Day Mate</value>

--- a/testing/TestHarness/TestHarness.Shared/Strings/en/Resources.resw
+++ b/testing/TestHarness/TestHarness.Shared/Strings/en/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>$ext_safeprojectname$</value>
+    <value>TestHarness</value>
   </data>
   <data name="Localization_Greeting.Text" xml:space="preserve">
     <value>Hello</value>

--- a/testing/TestHarness/TestHarness.Shared/Strings/fr/Resources.resw
+++ b/testing/TestHarness/TestHarness.Shared/Strings/fr/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>$ext_safeprojectname$</value>
+    <value>TestHarness</value>
   </data>
   <data name="Localization_Greeting.Text" xml:space="preserve">
     <value>Bonjour</value>

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -621,6 +621,7 @@
 		 without manipulating the projitem file.
 	-->
     <Content Include="$(MSBuildThisFileDirectory)appsettings.localizationconfiguration.json" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Core\Storage\appsettings.storage.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Http\Refit\appsettings.httprefit.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\appsettings.webauthsettings.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Ext\Authentication\Web\appsettings.webauth.json" />

--- a/testing/TestHarness/TestHarness.Skia.Gtk/app.manifest
+++ b/testing/TestHarness/TestHarness.Skia.Gtk/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="$ext_safeprojectname$.Gtk"/>
+  <assemblyIdentity version="1.0.0.0" name="TestHarness.Gtk"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/testing/TestHarness/TestHarness.Skia.WPF.Host/app.manifest
+++ b/testing/TestHarness/TestHarness.Skia.WPF.Host/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="$ext_safeprojectname$.WPF.Host"/>
+  <assemblyIdentity version="1.0.0.0" name="TestHarness.WPF.Host"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/testing/TestHarness/global.json
+++ b/testing/TestHarness/global.json
@@ -1,5 +1,6 @@
 {
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44"
-  }
+  },
+  "sdk": { "version": "6.0.402" }
 }

--- a/testing/TestHarness/global.json
+++ b/testing/TestHarness/global.json
@@ -1,6 +1,5 @@
 {
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44"
-  },
-  "sdk": { "version": "6.0.402" }
+  }
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #847

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Each of the native keyvalue storage providers currently read/writes directly to store, which is slow

## What is the new behavior?

Reads/Writes are cached in memory (this can be configured to be disabled)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
