### PR TITLE
feat: Making CPM optional

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/dotnetcli.host.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/dotnetcli.host.json
@@ -45,6 +45,10 @@
       "longName": "reactive",
       "shortName": "reactive"
     },
+    "cpm": {
+      "longName": "cpm",
+      "shortName": "cpm"
+    },
     "wasm-pwa-manifest": {
       "longName": "wasm-pwa-manifest",
       "shortName": "pwa"
@@ -54,8 +58,8 @@
       "shortName": "vscode"
     },
     "skipRestore": {
-      "longName": "skipPackageRestore",
-      "shortName": "skipRestore"
+      "longName": "skipRestore",
+      "shortName": "skip"
     }
   }
 }

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/ide.host.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/ide.host.json
@@ -131,7 +131,7 @@
       "isVisible":true
     },
     {
-      "id": "Reactive",
+      "id": "reactive",
       "name": {
         "text": "Data - Reactive Extensions"
       },
@@ -141,6 +141,18 @@
       },
       "defaultValue": "true",
       "isVisible":true
+    },
+    {
+      "id": "cpm",
+      "name": {
+        "text": "Central Package Management"
+      },
+      "description":
+      {
+        "text": "Enables Central Package Management - packages are versioned in central Directory.Packages.props file"
+      },
+      "defaultValue": "false",
+      "isVisible":false
     }
   ]
 }

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -112,6 +112,12 @@
       "defaultValue": "true",
       "description": "Whether or not to use Reactive extensions"
     },
+    "cpm": {
+      "type": "parameter",
+      "dataType": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to use Central Package Management - package versions are via central Directory.Packages.props file"
+    },
     "mobile": {
       "type": "computed",
       "dataType": "bool",
@@ -153,6 +159,10 @@
     {
       "condition": "tests",
       "path": "MyExtensionsApp.UITests\\MyExtensionsApp.UITests.csproj"
+    },
+    {
+      "condition": "cpm",
+      "path": "Directory.Packages.props"
     },
     {
       "condition": "mobile",
@@ -264,6 +274,29 @@
           ]
         },
         {
+          "condition": "(!cpm)",
+          "exclude": [
+            "MyExtensionsApp//MyExtensionsApp.csproj",
+            "MyExtensionsApp.Mobile//MyExtensionsApp.Mobile.csproj",
+            "MyExtensionsApp.Skia.Gtk//MyExtensionsApp.Skia.Gtk.csproj",
+            "MyExtensionsApp.Skia.Linux.FrameBuffer//MyExtensionsApp.Skia.Linux.FrameBuffer.csproj",
+            "MyExtensionsApp.Skia.WPF//MyExtensionsApp.Skia.WPF.csproj",
+            "MyExtensionsApp.Tests//MyExtensionsApp.Tests.csproj",
+            "MyExtensionsApp.UITests//MyExtensionsApp.UITests.csproj",
+            "MyExtensionsApp.Wasm//MyExtensionsApp.Wasm.csproj",
+            "MyExtensionsApp.Windows//MyExtensionsApp.Windows.csproj",
+            "Directory.Build.props",
+            "Directory.Packages.props"
+          ]
+        },
+        {
+          "condition": "(cpm)",
+          "exclude": [
+            "**/*.nocpm.props",
+            "**/*.nocpm.csproj"
+          ]
+        },
+        {
           "condition": "(!vscode)",
           "exclude": [
             ".vscode/**/*"
@@ -275,6 +308,13 @@
           "MyExtensionsApp.Wasm/manifest.json",
           "MyExtensionsApp.Wasm/Assets/AppIcon-*"
         ]
+        },
+        {
+          "condition": "(!cpm)",
+          "rename": {
+              ".nocpm.csproj": ".csproj",
+              "Directory.Build.nocpm.props": "Directory.Build.props"
+          }
         }
       ]
     }

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Build.nocpm.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Build.nocpm.props
@@ -1,0 +1,19 @@
+<Project ToolsVersion="15.0">
+	<PropertyGroup>
+		<LangVersion>10.0</LangVersion>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<DebugType>portable</DebugType>
+		<DebugSymbols>True</DebugSymbols>
+		<SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
+
+		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+	  	<NoWarn>$(NoWarn);Uno0001;CS1998;CA1416;NU1507</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<!--This override is used to validate the use of specific version of the C# Compiler-->
+		<PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0"  PrivateAssets="all" />
+	</ItemGroup>
+</Project>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
@@ -1,0 +1,104 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+<!--#if (android)
+<TargetFrameworks>$(TargetFrameworks);net6.0-android</TargetFrameworks>
+#endif -->
+<!--#if (ios)
+<TargetFrameworks>$(TargetFrameworks);net6.0-ios</TargetFrameworks>
+#endif -->
+<!--#if (macos)
+<TargetFrameworks>$(TargetFrameworks);net6.0-macos</TargetFrameworks>
+#endif -->
+<!--#if (maccatalyst)
+<TargetFrameworks>$(TargetFrameworks);net6.0-maccatalyst</TargetFrameworks>
+#endif -->
+		<SingleProject>true</SingleProject>
+		<OutputType>Exe</OutputType>
+		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">iossimulator-x64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-macos'">osx-x64</RuntimeIdentifier>
+		<!-- Debugger workaround https://github.com/dotnet/maui-samples/blob/8aa6b8780b12e97b157514c3bdc54bb4a13001cd/HelloMacCatalyst/HelloMacCatalyst.csproj#L7 -->
+		<!-- <MtouchExtraArgs Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">$(MtouchExtraArgs) -setenv:MONO_THREADS_SUSPEND=preemptive</MtouchExtraArgs> -->
+		<!-- Required for C# Hot Reload -->
+		<UseInterpreter Condition="'$(Configuration)' == 'Debug' and '$(TargetFramework)' != 'net6.0-maccatalyst'">True</UseInterpreter>
+		<IsUnoHead>true</IsUnoHead>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)'=='net6.0-macos'">10.14</SupportedOSPlatformVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Uno.WinUI" Version="4.6.0-dev.962" />
+		<PackageReference Include="Uno.WinUI.RemoteControl"  Version="4.6.0-dev.962" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging"  Version="4.6.0-dev.962" />
+		<PackageReference Include="Uno.Material.WinUI"  Version="2.4.0-dev.42"/>
+		<PackageReference Include="Uno.Toolkit.WinUI.Material"  Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Authentication" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Configuration" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Core" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="255.255.255.255"/>
+	</ItemGroup>
+	<Choose>
+		<When Condition="'$(TargetFramework)'=='net6.0-android'">
+			<ItemGroup>
+				<PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.4"/>
+				<PackageReference Include="Uno.UniversalImageLoader" Version="1.9.36" />
+			</ItemGroup>
+			<ItemGroup>
+				<AndroidEnvironment Include="Android/environment.conf" />
+			</ItemGroup>
+		</When>
+		<When Condition="'$(TargetFramework)'=='net6.0-ios'">
+			<PropertyGroup Condition="'$(TargetFramework)'=='net6.0-ios'">
+				<MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
+				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
+				<MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
+			</PropertyGroup>
+			<ItemGroup>
+				<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
+			</ItemGroup>
+		</When>
+		<When Condition="'$(TargetFramework)'=='net6.0-maccatalyst'">
+			<PropertyGroup>
+				<!-- Configure the GC -->
+				<MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+				<!-- Required for unknown crash as of .NET 6 Mobile Preview 13 -->
+				<MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
+				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
+				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
+				<!-- Full globalization is required for Uno -->
+				<InvariantGlobalization>false</InvariantGlobalization>
+			</PropertyGroup>
+			<ItemGroup>
+				<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0"/>
+			</ItemGroup>
+		</When>
+		<When Condition="'$(TargetFramework)'=='net6.0-macos'">
+			<PropertyGroup>
+			</PropertyGroup>
+		</When>
+	</Choose>
+	<ItemGroup>
+		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
+	</ItemGroup>
+
+	<Import Project="..\MyExtensionsApp.UI\MyExtensionsApp.UI.projitems" Label="Shared" />
+</Project>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
@@ -1,0 +1,54 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
+		<OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
+	</PropertyGroup>
+	<ItemGroup Condition="exists('..\MyExtensionsApp.Windows')">
+		<EmbeddedResource Include="..\MyExtensionsApp.Windows\Package.appxmanifest" LogicalName="Package.appxmanifest" />
+		<Content Include="..\MyExtensionsApp.Windows\Images\StoreLogo.png" Link="Assets\StoreLogo.png" />
+	</ItemGroup>
+	<ItemGroup>
+		<UpToDateCheckInput Include="..\MyExtensionsApp.UI\**\*.xaml" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Content Include="Assets\Fonts\uno-fluentui-assets.ttf" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.2" />
+		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.2" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.6.0-dev.962" />
+		<PackageReference Include="Uno.WinUI.RemoteControl"  Version="4.6.0-dev.962" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging"  Version="4.6.0-dev.962" />
+		<PackageReference Include="Uno.Material.WinUI"  Version="2.4.0-dev.42"/>
+		<PackageReference Include="Uno.Toolkit.WinUI.Material"  Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Authentication" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Configuration" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Core" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="255.255.255.255"/>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
+	</ItemGroup>
+
+	<Import Project="..\MyExtensionsApp.UI\MyExtensionsApp.UI.projitems" Label="Shared" />
+</Project>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
+		<OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
+	<ItemGroup Condition="exists('..\MyExtensionsApp.Windows')">
+		<EmbeddedResource Include="..\MyExtensionsApp.Windows\Package.appxmanifest" LogicalName="Package.appxmanifest" />
+		<Content Include="..\MyExtensionsApp.Windows\Images\StoreLogo.png" Link="Assets\StoreLogo.png" />
+		<Content Include="Assets\Fonts\uno-fluentui-assets.ttf" />
+	</ItemGroup>
+	<ItemGroup>
+		<UpToDateCheckInput Include="..\MyExtensionsApp.UI\**\*.xaml" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.2" />
+		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.2" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.6.0-dev.962" />
+		<PackageReference Include="Uno.WinUI.RemoteControl"  Version="4.6.0-dev.962" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging"  Version="4.6.0-dev.962" />
+		<PackageReference Include="Uno.Material.WinUI"  Version="2.4.0-dev.42"/>
+		<PackageReference Include="Uno.Toolkit.WinUI.Material"  Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Authentication" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Configuration" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Core" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="255.255.255.255"/>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
+	</ItemGroup>
+
+	<Import Project="..\MyExtensionsApp.UI\MyExtensionsApp.UI.projitems" Label="Shared" />
+</Project>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
@@ -1,0 +1,59 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
+		<OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<UseWPF>true</UseWPF>
+	</PropertyGroup>
+	<ItemGroup Label="AssemblyInfo">
+		<AssemblyAttribute Include="System.Runtime.InteropServices.ComVisibleAttribute">
+			<_Parameter1>false</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Windows.ThemeInfo">
+			<_Parameter1>System.Windows.ResourceDictionaryLocation.None</_Parameter1>
+			<_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+			<_Parameter2>System.Windows.ResourceDictionaryLocation.SourceAssembly</_Parameter2>
+			<_Parameter2_IsLiteral>true</_Parameter2_IsLiteral>
+		</AssemblyAttribute>
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.2" />
+		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.2" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.6.0-dev.962" />
+		<PackageReference Include="Uno.WinUI.RemoteControl"  Version="4.6.0-dev.962" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging"  Version="4.6.0-dev.962" />
+		<PackageReference Include="Uno.Material.WinUI"  Version="2.4.0-dev.42"/>
+		<PackageReference Include="Uno.Toolkit.WinUI.Material"  Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Authentication" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Configuration" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Core" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="255.255.255.255"/>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
+	</ItemGroup>
+
+	<Import Project="..\MyExtensionsApp.UI\MyExtensionsApp.UI.projitems" Label="Shared" />
+
+	<ItemGroup>
+		<Content Include="Assets\Fonts\uno-fluentui-assets.ttf" />
+	</ItemGroup>
+</Project>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Tests/MyExtensionsApp.Tests.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Tests/MyExtensionsApp.Tests.nocpm.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="6.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+		<PackageReference Include="NUnit" Version="3.13.2"/>
+		<PackageReference Include="NUnit3TestAdapter"  Version="4.0.0"/>
+		<PackageReference Include="coverlet.collector"  Version="3.1.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.UITests/MyExtensionsApp.UITests.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.UITests/MyExtensionsApp.UITests.nocpm.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net48</TargetFramework>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="6.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
+		<PackageReference Include="NUnit" Version="3.13.2"/>
+		<PackageReference Include="NUnit3TestAdapter"  Version="4.0.0"/>
+		<PackageReference Include="Uno.UITest.Helpers"   Version="1.1.0-dev.32" />
+		<PackageReference Include="Xamarin.UITest" Version="3.2.6" />
+	</ItemGroup>
+</Project>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
@@ -1,0 +1,86 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+		<NoWarn>$(NoWarn);NU1504;NU1505;NU1701</NoWarn>
+		<!-- Disabled due to issue with Central Package Management with implicit using -->
+		<ImplicitUsings>disable</ImplicitUsings>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
+		<MonoRuntimeDebuggerEnabled>true</MonoRuntimeDebuggerEnabled>
+		<DefineConstants>$(DefineConstants);TRACE;DEBUG</DefineConstants>
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+		<!--
+		IL Linking is disabled in Debug configuration.
+		When building in Release, see https://platform.uno/docs/articles/features/using-il-linker-webassembly.html
+		-->
+		<WasmShellILLinkerEnabled>false</WasmShellILLinkerEnabled>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(IsUiAutomationMappingEnabled)'=='True'">
+		<IsUiAutomationMappingEnabled>True</IsUiAutomationMappingEnabled>
+		<DefineConstants>$(DefineConstants);USE_UITESTS</DefineConstants>
+	</PropertyGroup>
+	<ItemGroup>
+		<Content Include="Assets\SplashScreen.png" />
+	</ItemGroup>
+	<ItemGroup>
+		<UpToDateCheckInput Include="..\MyExtensionsApp.UI\**\*.xaml" />
+	</ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="WasmCSS\Fonts.css" />
+		<EmbeddedResource Include="WasmScripts\AppManifest.js" />
+	</ItemGroup>
+	<ItemGroup>
+		<LinkerDescriptor Include="LinkerConfig.xml" />
+	</ItemGroup>
+	<ItemGroup>
+		<!--
+		This item group is required by the project template because of the
+		new SDK-Style project, otherwise some files are not added automatically.
+
+		You can safely remove this ItemGroup completely.
+		-->
+		<None Include="Program.cs" />
+		<None Include="LinkerConfig.xml" />
+		<None Include="wwwroot\web.config" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0"/>
+		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
+		<PackageReference Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
+		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.6.0-dev.962" />
+		<PackageReference Include="Uno.WinUI.RemoteControl"  Version="4.6.0-dev.962" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging"  Version="4.6.0-dev.962" />
+		<PackageReference Include="Uno.Material.WinUI"  Version="2.4.0-dev.42"/>
+		<PackageReference Include="Uno.Toolkit.WinUI.Material"  Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Authentication" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Configuration" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Core" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="255.255.255.255"/>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
+	</ItemGroup>
+
+	<Import Project="..\MyExtensionsApp.UI\MyExtensionsApp.UI.projitems" Label="Shared" Condition="Exists('..\MyExtensionsApp.UI\MyExtensionsApp.UI.projitems')" />
+</Project>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
@@ -1,0 +1,97 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+		<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
+		<RootNamespace>MyExtensionsApp</RootNamespace>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
+		<Platforms>x86;x64;arm64</Platforms>
+		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+		<PublishProfile>win10-$(Platform).pubxml</PublishProfile>
+		<UseWinUI>true</UseWinUI>
+		<EnableMsixTooling>true</EnableMsixTooling>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<!-- Bundles the WinAppSDK binaries (Uncomment for unpackaged builds) -->
+		<!-- <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained> -->
+		<!-- This bundles the .NET Core libraries (Uncomment for packaged builds)  -->
+		<SelfContained>true</SelfContained>
+		<DefaultLanguage>en</DefaultLanguage>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Content Include="Images\LockScreenLogo.scale-200.png" />
+		<Content Include="Images\SplashScreen.png" />
+		<Content Include="Images\SplashScreen.scale-100.png" />
+		<Content Include="Images\SplashScreen.scale-125.png" />
+		<Content Include="Images\SplashScreen.scale-150.png" />
+		<Content Include="Images\SplashScreen.scale-200.png" />
+		<Content Include="Images\SplashScreen.scale-400.png" />
+		<Content Include="Images\Square150x150Logo.scale-200.png" />
+		<Content Include="Images\Square44x44Logo.scale-200.png" />
+		<Content Include="Images\Square44x44Logo.targetsize-24_altform-unplated.png" />
+		<Content Include="Images\StoreLogo.png" />
+		<Content Include="Images\Wide310x150Logo.scale-200.png" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Manifest Include="$(ApplicationManifest)" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.4" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.197"/>
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton"  Version="4.0.1" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.0-dev.962"/>
+		<PackageReference Include="Uno.Material.WinUI"  Version="2.4.0-dev.42"/>
+		<PackageReference Include="Uno.Toolkit.WinUI.Material"  Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="2.4.0-dev.99"/>
+		<PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Authentication" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Configuration" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Core" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Hosting" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Http.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Localization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Navigation" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Http" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive" Version="255.255.255.255"/>
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="255.255.255.255"/>
+	</ItemGroup>
+
+	<!-- Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
+       Tools extension to be activated for this project even if the Windows App SDK Nuget
+       package has not yet been restored -->
+	<ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnablePreviewMsixTooling)'=='true'">
+		<ProjectCapability Include="Msix" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<!--
+		If you encounter this error message:
+		
+			error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.
+
+		This means that the two packages below must be aligned with the "build" version number of
+		the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
+		must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
+		-->
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
+	</ItemGroup>
+
+	<Import Project="..\MyExtensionsApp.UI\MyExtensionsApp.UI.projitems" Label="Shared" />
+</Project>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.sln
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.sln
@@ -54,7 +54,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+#//#if (cpm)
 		Directory.Packages.props = Directory.Packages.props
+#//#endif
 		global.json = global.json
 	EndProjectSection
 EndProject

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<!--#if (!reactive) -->
+		<PackageReference Include="CommunityToolkit.Mvvm"  Version="8.0.0" />
+		<!--#endif -->
+
+		<PackageReference Include="Uno.Extensions.Authentication" Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Configuration"  Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Core"  Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Hosting"  Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Http"  Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Http.Refit"  Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Localization"  Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Logging.Serilog"  Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Navigation"  Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Serialization"  Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Serialization.Http"  Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Reactive"  Version="255.255.255.255" />
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI"  Version="255.255.255.255" />
+	</ItemGroup>
+</Project>


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Template uses central package management (cpm) which causes issue with the mobile project not restoring correctly in VS without calling dotnet restore in mobile folder.

## What is the new behavior?

cpm is disabled by default with an optional flag (cpm) that can be used to enable cpm

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
