### PR TITLE
fix: [Perf] Make sure to avoid to much work on UI thread

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_BasicViewModel_Then_Generate.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_BasicViewModel_Then_Generate.cs
@@ -6,6 +6,7 @@ using Windows.ApplicationModel.AppService;
 using Windows.UI.Xaml.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Uno.Extensions.Reactive.Tests.Generator;
 
@@ -15,19 +16,19 @@ public partial class Given_BasicViewModel_Then_Generate : FeedUITests
 	// Those are mostly compilation tests!
 
 	[TestMethod]
-	public void Test_Constructors()
+	public async Task Test_Constructors()
 	{
-		var bindableCtor1 = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel();
+		await using var bindableCtor1 = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel();
 
-		var bindableCtor2 = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel(aRandomService: "aRandomService");
+		await using var bindableCtor2 = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel(aRandomService: "aRandomService");
 
-		var bindableCtor3 = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel(
+		await using var bindableCtor3 = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel(
 			anExternalInput: default(IFeed<string>)!,
 			anExternalReadWriteInput: default(IState<string>)!,
 			anExternalRecordInput: default(IFeed<MyRecord>)!,
 			anExternalWeirdRecordInput: default(IFeed<MyWeirdRecord>)!);
 
-		var bindableCtor4 = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel(
+		await using var bindableCtor4 = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel(
 			aParameterToNotBeAParameterLessCtor1: (short)0,
 			defaultAnInput: default(string)!,
 			defaultAReadWriteInput: default(string)!,
@@ -36,19 +37,19 @@ public partial class Given_BasicViewModel_Then_Generate : FeedUITests
 			defaultARecordWithAValuePropertyInput: default(MyRecordWithAValueProperty)!,
 			defaultAnInputConflictingWithAProperty: (int)42);
 
-		var bindableCtor5 = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel(
+		await using var bindableCtor5 = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel(
 			aParameterToNotBeAParameterLessCtor2: (int)0);
 	}
 
 	[TestMethod]
-	public void Test_PublicMembers()
+	public async Task Test_PublicMembers()
 	{
 		var mysSubRecord = new MySubRecord("prop1", 42);
 		var myWeirdRecord = new MyWeirdRecord();
 		var myRecord = new MyRecord("prop1", 42, mysSubRecord, myWeirdRecord);
 		var myRecordWithAValueProperty = new MyRecordWithAValueProperty("42");
 
-		var bindable = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel(
+		await using var bindable = new Given_BasicViewModel_Then_Generate__ViewModel.BindableGiven_BasicViewModel_Then_Generate__ViewModel(
 			aParameterToNotBeAParameterLessCtor1: (short)42,
 			defaultAnInput: "anInput",
 			defaultAReadWriteInput: "aReadWriteInput",
@@ -184,9 +185,9 @@ public partial class Given_BasicViewModel_Then_Generate : FeedUITests
 	}
 
 	[TestMethod]
-	public void When_FeedOfKindOfImmutableList_Then_TreatAsListFeed()
+	public async Task When_FeedOfKindOfImmutableList_Then_TreatAsListFeed()
 	{
-		var bindable = new When_FeedOfKindOfImmutableList_Then_TreatAsListFeed_ViewModel.BindableWhen_FeedOfKindOfImmutableList_Then_TreatAsListFeed_ViewModel();
+		await using var bindable = new When_FeedOfKindOfImmutableList_Then_TreatAsListFeed_ViewModel.BindableWhen_FeedOfKindOfImmutableList_Then_TreatAsListFeed_ViewModel();
 
 		AssertIsValid(bindable.AFeedOfArray);
 		AssertIsValid(bindable.AFeedOfImmutableList);
@@ -231,9 +232,9 @@ public partial class Given_BasicViewModel_Then_Generate : FeedUITests
 	}
 
 	[TestMethod]
-	public void When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed()
+	public async Task When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed()
 	{
-		var bindable = new When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_ViewModel.BindableWhen_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_ViewModel();
+		await using var bindable = new When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_ViewModel.BindableWhen_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_ViewModel();
 
 		AssertIsValid(bindable.AFeedOfEnumerable);
 

--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_Methods_Then_GenerateCommands.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_Methods_Then_GenerateCommands.cs
@@ -30,7 +30,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_ParameterLess_Void()
 	{
-		var vm = new When_ParameterLess_Void_ViewModel.BindableWhen_ParameterLess_Void_ViewModel();
+		await using var vm = new When_ParameterLess_Void_ViewModel.BindableWhen_ParameterLess_Void_ViewModel();
 
 		vm.MyMethod.Execute(null);
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -54,7 +54,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneParameter_Void()
 	{
-		var vm = new When_OneParameter_Void_ViewModel.BindableWhen_OneParameter_Void_ViewModel();
+		await using var vm = new When_OneParameter_Void_ViewModel.BindableWhen_OneParameter_Void_ViewModel();
 
 		vm.MyMethod.Execute("42");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -79,7 +79,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneValueTypeParameter_Void()
 	{
-		var vm = new When_OneValueTypeParameter_Void_ViewModel.BindableWhen_OneValueTypeParameter_Void_ViewModel();
+		await using var vm = new When_OneValueTypeParameter_Void_ViewModel.BindableWhen_OneValueTypeParameter_Void_ViewModel();
 
 		vm.MyMethod.Execute(new DateTimeOffset(1983, 9, 9, 15, 00, 00, TimeSpan.FromHours(1)));
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -104,7 +104,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneNullableValueTypeParameter_Void()
 	{
-		var vm = new When_OneNullableValueTypeParameter_Void_ViewModel.BindableWhen_OneNullableValueTypeParameter_Void_ViewModel();
+		await using var vm = new When_OneNullableValueTypeParameter_Void_ViewModel.BindableWhen_OneNullableValueTypeParameter_Void_ViewModel();
 
 		vm.MyMethod.Execute(new DateTimeOffset(1983, 9, 9, 15, 00, 00, TimeSpan.FromHours(1)));
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -129,7 +129,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneParameterAndCT_Void()
 	{
-		var vm = new When_OneParameterAndCT_Void_ViewModel.BindableWhen_OneParameterAndCT_Void_ViewModel();
+		await using var vm = new When_OneParameterAndCT_Void_ViewModel.BindableWhen_OneParameterAndCT_Void_ViewModel();
 
 		vm.MyMethod.Execute("42");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -161,7 +161,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_ParameterLess_Task()
 	{
-		var vm = new When_ParameterLess_Task_ViewModel.BindableWhen_ParameterLess_Task_ViewModel();
+		await using var vm = new When_ParameterLess_Task_ViewModel.BindableWhen_ParameterLess_Task_ViewModel();
 
 		vm.MyMethod.Execute(null);
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -201,7 +201,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneParameter_Task()
 	{
-		var vm = new When_OneParameter_Task_ViewModel.BindableWhen_OneParameter_Task_ViewModel();
+		await using var vm = new When_OneParameter_Task_ViewModel.BindableWhen_OneParameter_Task_ViewModel();
 
 		vm.MyMethod.Execute("42");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -239,7 +239,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_ParameterLess_ValueTask()
 	{
-		var vm = new When_ParameterLess_ValueTask_ViewModel.BindableWhen_ParameterLess_ValueTask_ViewModel();
+		await using var vm = new When_ParameterLess_ValueTask_ViewModel.BindableWhen_ParameterLess_ValueTask_ViewModel();
 
 		vm.MyMethod.Execute(null);
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -279,7 +279,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneParameter_ValueTask()
 	{
-		var vm = new When_OneParameter_ValueTask_ViewModel.BindableWhen_OneParameter_ValueTask_ViewModel();
+		await using var vm = new When_OneParameter_ValueTask_ViewModel.BindableWhen_OneParameter_ValueTask_ViewModel();
 
 		vm.MyMethod.Execute("42");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -320,7 +320,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneParameterAndCT_ValueTask()
 	{
-		var vm = new When_OneParameterAndCT_ValueTask_ViewModel.BindableWhen_OneParameterAndCT_ValueTask_ViewModel();
+		await using var vm = new When_OneParameterAndCT_ValueTask_ViewModel.BindableWhen_OneParameterAndCT_ValueTask_ViewModel();
 
 		vm.MyMethod.Execute("42");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -357,7 +357,10 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameter_Void_WithoutCommandParameter()
 	{
-		var vm = new When_OneFeedParameter_Void_ViewModel.BindableWhen_OneFeedParameter_Void_ViewModel();
+		await using var vm = new When_OneFeedParameter_Void_ViewModel.BindableWhen_OneFeedParameter_Void_ViewModel();
+
+		// We have to wait for the external parameter to be provided by the feed
+		await WaitFor(() => vm.MyMethod.CanExecute(null));
 
 		vm.MyMethod.Execute(null);
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -369,7 +372,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameter_Void_WithCommandParameter()
 	{
-		var vm = new When_OneFeedParameter_Void_ViewModel.BindableWhen_OneFeedParameter_Void_ViewModel();
+		await using var vm = new When_OneFeedParameter_Void_ViewModel.BindableWhen_OneFeedParameter_Void_ViewModel();
 
 		vm.MyMethod.Execute("43");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -400,7 +403,10 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameterAndCT_Void_WithoutCommandParameter()
 	{
-		var vm = new When_OneFeedParameterAndCT_Void_ViewModel.BindableWhen_OneFeedParameterAndCT_Void_ViewModel();
+		await using var vm = new When_OneFeedParameterAndCT_Void_ViewModel.BindableWhen_OneFeedParameterAndCT_Void_ViewModel();
+
+		// We have to wait for the external parameter to be provided by the feed
+		await WaitFor(() => vm.MyMethod.CanExecute(null));
 
 		vm.MyMethod.Execute(null);
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -412,7 +418,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameterAndCT_Void_WithCommandParameter()
 	{
-		var vm = new When_OneFeedParameterAndCT_Void_ViewModel.BindableWhen_OneFeedParameterAndCT_Void_ViewModel();
+		await using var vm = new When_OneFeedParameterAndCT_Void_ViewModel.BindableWhen_OneFeedParameterAndCT_Void_ViewModel();
 
 		vm.MyMethod.Execute("43");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -449,7 +455,10 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameter_ValueTask_WithoutCommandParameter()
 	{
-		var vm = new When_OneFeedParameter_ValueTask_ViewModel.BindableWhen_OneFeedParameter_ValueTask_ViewModel();
+		await using var vm = new When_OneFeedParameter_ValueTask_ViewModel.BindableWhen_OneFeedParameter_ValueTask_ViewModel();
+
+		// We have to wait for the external parameter to be provided by the feed
+		await WaitFor(() => vm.MyMethod.CanExecute(null));
 
 		vm.MyMethod.Execute(null);
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -467,7 +476,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameter_ValueTask_WithCommandParameter()
 	{
-		var vm = new When_OneFeedParameter_ValueTask_ViewModel.BindableWhen_OneFeedParameter_ValueTask_ViewModel();
+		await using var vm = new When_OneFeedParameter_ValueTask_ViewModel.BindableWhen_OneFeedParameter_ValueTask_ViewModel();
 
 		vm.MyMethod.Execute("43");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -510,7 +519,10 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneListFeedParameter_ValueTask_WithoutCommandParameter()
 	{
-		var vm = new When_OneListFeedParameter_ValueTask_ViewModel.BindableWhen_OneListFeedParameter_ValueTask_ViewModel();
+		await using var vm = new When_OneListFeedParameter_ValueTask_ViewModel.BindableWhen_OneListFeedParameter_ValueTask_ViewModel();
+
+		// We have to wait for the external parameter to be provided by the feed
+		await WaitFor(() => vm.MyMethod.CanExecute(null));
 
 		vm.MyMethod.Execute(null);
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -528,7 +540,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneListFeedParameter_ValueTask_WithCommandParameter()
 	{
-		var vm = new When_OneListFeedParameter_ValueTask_ViewModel.BindableWhen_OneListFeedParameter_ValueTask_ViewModel();
+		await using var vm = new When_OneListFeedParameter_ValueTask_ViewModel.BindableWhen_OneListFeedParameter_ValueTask_ViewModel();
 
 		vm.MyMethod.Execute(ImmutableList.Create("51", "52", "53"));
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -571,7 +583,10 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameterAndCT_ValueTask_WithoutCommandParameter()
 	{
-		var vm = new When_OneFeedParameterAndCT_ValueTask_ViewModel.BindableWhen_OneFeedParameterAndCT_ValueTask_ViewModel();
+		await using var vm = new When_OneFeedParameterAndCT_ValueTask_ViewModel.BindableWhen_OneFeedParameterAndCT_ValueTask_ViewModel();
+
+		// We have to wait for the external parameter to be provided by the feed
+		await WaitFor(() => vm.MyMethod.CanExecute(null));
 
 		vm.MyMethod.Execute(null);
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -589,7 +604,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameterAndCT_ValueTask_WithCommandParameter()
 	{
-		var vm = new When_OneFeedParameterAndCT_ValueTask_ViewModel.BindableWhen_OneFeedParameterAndCT_ValueTask_ViewModel();
+		await using var vm = new When_OneFeedParameterAndCT_ValueTask_ViewModel.BindableWhen_OneFeedParameterAndCT_ValueTask_ViewModel();
 
 		vm.MyMethod.Execute("43");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -658,13 +673,16 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[DataRow(nameof(When_MixedViewAndFeedParameter_ViewModel.MyMethodWithCt))]
 	public async Task When_MixedViewAndFeedParameter_ViewModel_CanExecuteWithParameter(string method)
 	{
-		var vm = new When_MixedViewAndFeedParameter_ViewModel.BindableWhen_MixedViewAndFeedParameter_ViewModel();
+		await using var vm = new When_MixedViewAndFeedParameter_ViewModel.BindableWhen_MixedViewAndFeedParameter_ViewModel();
 
 		var commandInfo = vm.GetType().GetMember(method).Single();
 		commandInfo.Should().BeAssignableTo<PropertyInfo>(because: "a command should have been generated for that method");
 
 		var command = ((PropertyInfo)commandInfo).GetValue(vm) as ICommand;
 		command.Should().NotBeNull();
+
+		// We have to wait for the external parameter to be provided by the feed
+		await WaitFor(() => command!.CanExecute(_viewParam));
 
 		command!.CanExecute(_viewParam).Should().BeTrue();
 	}
@@ -678,7 +696,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[DataRow(nameof(When_MixedViewAndFeedParameter_ViewModel.MyMethodWithCt))]
 	public async Task When_MixedViewAndFeedParameter_ViewModel_CanExecuteOnlyWithParameter(string method)
 	{
-		var vm = new When_MixedViewAndFeedParameter_ViewModel.BindableWhen_MixedViewAndFeedParameter_ViewModel();
+		await using var vm = new When_MixedViewAndFeedParameter_ViewModel.BindableWhen_MixedViewAndFeedParameter_ViewModel();
 
 		var commandInfo = vm.GetType().GetMember(method).Single();
 		commandInfo.Should().BeAssignableTo<PropertyInfo>(because: "a command should have been generated for that method");
@@ -701,7 +719,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[DataRow(nameof(When_MixedViewAndFeedParameter_ViewModel.MyMethodWithCt), _viewParam, nameof(When_MixedViewAndFeedParameter_ViewModel.MyParameter), nameof(When_MixedViewAndFeedParameter_ViewModel.MyParameter2), _ct)]
 	private async Task When_MixedViewAndFeedParameter_ArgsReDispatchedProperly(string method, params string[] expectedArgs)
 	{
-		var vm = new When_MixedViewAndFeedParameter_ViewModel.BindableWhen_MixedViewAndFeedParameter_ViewModel();
+		await using var vm = new When_MixedViewAndFeedParameter_ViewModel.BindableWhen_MixedViewAndFeedParameter_ViewModel();
 
 		var commandInfo = vm.GetType().GetMember(method).Single();
 		commandInfo.Should().BeAssignableTo<PropertyInfo>(because: "a command should have been generated for that method");
@@ -773,7 +791,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_ImplicitFeedCommandDisabled_ViewModel_Then_ParameterNotUsed()
 	{
-		var vm = new When_ImplicitFeedCommandDisabled_ViewModel.BindableWhen_ImplicitFeedCommandDisabled_ViewModel();
+		await using var vm = new When_ImplicitFeedCommandDisabled_ViewModel.BindableWhen_ImplicitFeedCommandDisabled_ViewModel();
 
 		var subs = GetSubCommands(vm.SyncWithParameter);
 		subs.Should().HaveCount(1);
@@ -791,7 +809,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_ImplicitFeedCommandDisabledWithExplicitAttribute_ViewModel_Then_ParameterUsed()
 	{
-		var vm = new When_ImplicitFeedCommandDisabled_ViewModel.BindableWhen_ImplicitFeedCommandDisabled_ViewModel();
+		await using var vm = new When_ImplicitFeedCommandDisabled_ViewModel.BindableWhen_ImplicitFeedCommandDisabled_ViewModel();
 
 		// We wait for the feed parameter to be full-filed
 		await WaitFor(() => vm.WithExplicitAttribute.CanExecute(null));

--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_RecordWithList_Then_GenerateListOfBindable.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_RecordWithList_Then_GenerateListOfBindable.cs
@@ -16,9 +16,9 @@ namespace Uno.Extensions.Reactive.Tests.Generator;
 public partial class Given_RecordWithList_Then_GenerateListOfBindable : FeedUITests
 {
 	[TestMethod]
-	public void IsListOfBindable()
+	public async Task IsListOfBindable()
 	{
-		var sut = new MyViewModel.BindableMyViewModel();
+		await using var sut = new MyViewModel.BindableMyViewModel();
 
 		sut.MyFeed.Items.Should().BeAssignableTo<IEnumerable<BindableMyRecordWithListItem>>();
 	}
@@ -26,7 +26,7 @@ public partial class Given_RecordWithList_Then_GenerateListOfBindable : FeedUITe
 	[TestMethod]
 	public async Task SupportsAdd()
 	{
-		var sut = new MyViewModel.BindableMyViewModel();
+		await using var sut = new MyViewModel.BindableMyViewModel();
 		var args = new List<NotifyCollectionChangedEventArgs>();
 		var result = sut.Model.MyFeed.Select(r => r.Items).Record();
 
@@ -48,7 +48,7 @@ public partial class Given_RecordWithList_Then_GenerateListOfBindable : FeedUITe
 	[TestMethod]
 	public async Task SupportsRemove()
 	{
-		var sut = new MyViewModel.BindableMyViewModel();
+		await using var sut = new MyViewModel.BindableMyViewModel();
 		var args = new List<NotifyCollectionChangedEventArgs>();
 		var result = sut.Model.MyFeed.Select(r => r.Items).Record();
 

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Commands/AsyncCommand.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Commands/AsyncCommand.cs
@@ -136,6 +136,7 @@ public sealed partial class AsyncCommand : IAsyncCommand, IDisposable
 	/// <inheritdoc />
 	public bool CanExecute(object? parameter)
 	{
+		// No matter if we are on the UI thread or not, we must make sure that the command is fully initialized.
 		_dispatcher.RunCallback();
 
 		return _children.Any(child => child.CanExecute(parameter));
@@ -144,6 +145,7 @@ public sealed partial class AsyncCommand : IAsyncCommand, IDisposable
 	/// <inheritdoc />
 	public void Execute(object? parameter)
 	{
+		// No matter if we are on the UI thread or not, we must make sure that the command is fully initialized.
 		_dispatcher.RunCallback();
 
 		if (_children.Aggregate(false, (isExecuting, child) => isExecuting | child.TryExecute(parameter, _context, _ct.Token)))

--- a/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispactherHelper.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispactherHelper.cs
@@ -16,4 +16,6 @@ internal class DispatcherHelper
 			?? throw new InvalidOperationException("Failed to get dispatcher to use. Either explicitly provide the dispatcher to use, either make sure to invoke this on the UI thread.");
 
 	public static FindDispatcher GetForCurrentThread = DispatcherQueueProvider.GetForCurrentThread;
+
+	public static bool HasThreadAccess => GetForCurrentThread()?.HasThreadAccess ?? false;
 }

--- a/src/Uno.Extensions.Reactive.UI/Utils/FeedUIHelper.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/FeedUIHelper.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Dispatching;
+using Uno.Extensions.Reactive.Utils;
+
+namespace Uno.Extensions.Reactive.UI.Utils;
+
+/// <summary>
+/// Helpers to work with feed from the UI thread.
+/// </summary>
+internal static class FeedUIHelper
+{
+	/// <summary>
+	/// Get the source of a feed making sure that everything is dispatched on background thread (GetSource and enumeration of the source itself).
+	/// </summary>
+	/// <param name="feed">The feed to get the source for.</param>
+	/// <param name="context">The context to use to get the source.</param>
+	/// <returns>The async enumeration of items produced by this signal optimized to be UI friendly (i.e. do the less work possible on UI thread).</returns>
+	public static async IAsyncEnumerable<IMessage> GetSource(ISignal<IMessage> feed, SourceContext context)
+	{
+		var ct = context.Token;
+		var enumerator = await GetSourceEnumerator(feed, context).ConfigureAwait(false);
+		while (!ct.IsCancellationRequested && await MoveNext(enumerator, ct).ConfigureAwait(false))
+		{
+			yield return enumerator.Current;
+		}
+	}
+
+	/// <summary>
+	/// Get the source of a feed making sure that everything is dispatched on background thread (GetSource and enumeration of the source itself).
+	/// </summary>
+	/// <param name="feed">The feed to get the source for.</param>
+	/// <param name="context">The context to use to get the source.</param>
+	/// <returns>The async enumeration of items produced by this signal optimized to be UI friendly (i.e. do the less work possible on UI thread).</returns>
+	public static async IAsyncEnumerable<Message<T>> GetSource<T>(IFeed<T> feed, SourceContext context)
+	{
+		var ct = context.Token;
+		var enumerator = await GetSourceEnumerator(feed, context).ConfigureAwait(false);
+		while (!ct.IsCancellationRequested && await MoveNext(enumerator, ct).ConfigureAwait(false))
+		{
+			yield return enumerator.Current;
+		}
+	}
+
+	private static async ValueTask<IAsyncEnumerator<T>> GetSourceEnumerator<T>(ISignal<T> signal, SourceContext context)
+	{
+		var ct = context.Token;
+		var src = DispatcherHelper.HasThreadAccess
+			? await Task.Run(() => signal.GetSource(context, ct), ct).ConfigureAwait(false)
+			: signal.GetSource(context, ct);
+
+		return src.GetAsyncEnumerator(ct);
+	}
+
+	private static async ValueTask<bool> MoveNext<T>(IAsyncEnumerator<T> enumerator, CancellationToken ct)
+	{
+		if (DispatcherHelper.HasThreadAccess)
+		{
+			return await Task.Run(() => enumerator.MoveNextAsync().AsTask(), ct).ConfigureAwait(false);
+		}
+		else
+		{
+			return await enumerator.MoveNextAsync().ConfigureAwait(false);
+		}
+	}
+}

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.Subscription.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.Subscription.cs
@@ -2,9 +2,11 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Uno.Extensions.Reactive.Bindings;
 using Uno.Extensions.Reactive.Core;
 using Uno.Extensions.Reactive.Logging;
 using Uno.Extensions.Reactive.Sources;
+using Uno.Extensions.Reactive.UI.Utils;
 using Uno.Extensions.Reactive.Utils;
 #if WINUI
 using _Page = Microsoft.UI.Xaml.Controls.Page;
@@ -52,8 +54,9 @@ public partial class FeedView
 				var ctx = SourceContext.Find(_view.DataContext)
 					?? SourceContext.Find(FindPage()?.DataContext)
 					?? SourceContext.GetOrCreate(_view);
+				ctx = ctx.CreateChild(_requests);
 
-				await foreach (var message in Feed.GetSource(ctx.CreateChild(_requests), _ct.Token).WithCancellation(_ct.Token).ConfigureAwait(true))
+				await foreach (var message in FeedUIHelper.GetSource(Feed, ctx).WithCancellation(_ct.Token).ConfigureAwait(true))
 				{
 					Update(message);
 

--- a/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/AsyncEnumerableExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/AsyncEnumerableExtensions.cs
@@ -52,4 +52,10 @@ internal static class AsyncEnumerableExtensions
 
 	public static IAsyncEnumerable<T> Merge<T>(params IAsyncEnumerable<T>[] asyncEnumerables)
 		=> new MergeAsyncEnumerable<T>(asyncEnumerables);
+
+	public static IAsyncEnumerable<T> ToDeferredEnumerable<T>(this IAsyncEnumerable<T> source)
+		=> new DeferredAsyncEnumerable<T>(source);
+
+	public static IAsyncEnumerable<T> ToDeferredEnumerable<T>(this IAsyncEnumerable<T> source, Func<bool> deferringCondition)
+		=> new ConditionalDeferredAsyncEnumerable<T>(source, deferringCondition);
 }

--- a/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/ConditionalDeferredAsyncEnumerable.cs
+++ b/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/ConditionalDeferredAsyncEnumerable.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Uno.Extensions.Reactive.Utils;
+
+internal class ConditionalDeferredAsyncEnumerable<T> : IAsyncEnumerable<T>
+{
+	private readonly IAsyncEnumerable<T> _inner;
+	private readonly Func<bool> _deferringCondition;
+
+	public ConditionalDeferredAsyncEnumerable(IAsyncEnumerable<T> inner, Func<bool> deferringCondition)
+	{
+		_inner = inner;
+		_deferringCondition = deferringCondition;
+	}
+
+	/// <inheritdoc />
+	public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken ct = default)
+		=> new ConditionalDeferredAsyncEnumerator<T>(_inner.GetAsyncEnumerator(ct), _deferringCondition);
+}

--- a/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/ConditionalDeferredAsyncEnumerator.cs
+++ b/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/ConditionalDeferredAsyncEnumerator.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Uno.Extensions.Reactive.Utils;
+
+internal class ConditionalDeferredAsyncEnumerator<T> : IAsyncEnumerator<T>
+{
+	private readonly IAsyncEnumerator<T> _inner;
+	private readonly Func<bool> _deferringCondition;
+
+	public ConditionalDeferredAsyncEnumerator(IAsyncEnumerator<T> inner, Func<bool> deferringCondition)
+	{
+		_inner = inner;
+		_deferringCondition = deferringCondition;
+	}
+
+	/// <inheritdoc />
+	public T Current => _inner.Current;
+
+	/// <inheritdoc />
+	public async ValueTask DisposeAsync()
+	{
+		if (_deferringCondition())
+		{
+			await Task.Run(() => _inner.DisposeAsync().AsTask()).ConfigureAwait(true);
+		}
+		else
+		{
+			await _inner.DisposeAsync().ConfigureAwait(false);
+		}
+	}
+
+	/// <inheritdoc />
+	public async ValueTask<bool> MoveNextAsync()
+	{
+		if (_deferringCondition())
+		{
+			return await Task.Run(() => _inner.MoveNextAsync().AsTask()).ConfigureAwait(true);
+		}
+		else
+		{
+			return await _inner.MoveNextAsync().ConfigureAwait(false);
+		}
+	}
+}

--- a/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/DeferredAsyncEnumerable.cs
+++ b/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/DeferredAsyncEnumerable.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Uno.Extensions.Reactive.Utils;
+
+internal class DeferredAsyncEnumerable<T> : IAsyncEnumerable<T>
+{
+	private readonly IAsyncEnumerable<T> _inner;
+
+	public DeferredAsyncEnumerable(IAsyncEnumerable<T> inner)
+	{
+		_inner = inner;
+	}
+
+	/// <inheritdoc />
+	public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken ct = default)
+		=> new DeferredAsyncEnumerator<T>(_inner.GetAsyncEnumerator(ct));
+}

--- a/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/DeferredAsyncEnumerator.cs
+++ b/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/DeferredAsyncEnumerator.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Uno.Extensions.Reactive.Utils;
+
+internal class DeferredAsyncEnumerator<T> : IAsyncEnumerator<T>
+{
+	private readonly IAsyncEnumerator<T> _inner;
+
+	public DeferredAsyncEnumerator(IAsyncEnumerator<T> inner)
+	{
+		_inner = inner;
+	}
+
+	/// <inheritdoc />
+	public T Current => _inner.Current;
+
+	/// <inheritdoc />
+	public async ValueTask DisposeAsync()
+		=> await Task.Run(() => _inner.DisposeAsync().AsTask()).ConfigureAwait(true);
+
+	/// <inheritdoc />
+	public async ValueTask<bool> MoveNextAsync()
+		=> await Task.Run(() => _inner.MoveNextAsync().AsTask()).ConfigureAwait(true);
+}


### PR DESCRIPTION
## Bugfix
[Perf] Make sure to avoid to much work on UI thread

## What is the current behavior?
Feed enumeration might occurs on UI thread in FeedView and Commands

## What is the new behavior?
They are deferred on background thread

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

