### PR TITLE
chore: Ensure building delegates are static

### DIFF
--- a/src/Uno.Extensions.Reactive/Core/Feed.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.T.cs
@@ -19,7 +19,7 @@ public static class Feed<T> // We set the T on the class to it greatly helps typ
 	/// <param name="sourceProvider">The provider of the message enumerable sequence.</param>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IFeed<T> Create(Func<CancellationToken, IAsyncEnumerable<Message<T>>> sourceProvider)
-		=> AttachedProperty.GetOrCreate(sourceProvider, sp => new CustomFeed<T>(sp));
+		=> AttachedProperty.GetOrCreate(sourceProvider, static sp => new CustomFeed<T>(sp));
 
 	/// <summary>
 	/// Gets or create a custom feed from a raw <see cref="IAsyncEnumerable{T}"/> sequence of <see cref="Message{T}"/>.
@@ -27,7 +27,7 @@ public static class Feed<T> // We set the T on the class to it greatly helps typ
 	/// <param name="sourceProvider">The provider of the message enumerable sequence.</param>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IFeed<T> Create(Func<IAsyncEnumerable<Message<T>>> sourceProvider)
-		=> AttachedProperty.GetOrCreate(sourceProvider, sp => new CustomFeed<T>(_ => sp()));
+		=> AttachedProperty.GetOrCreate(sourceProvider, static sp => new CustomFeed<T>(_ => sp()));
 
 	/// <summary>
 	/// Gets or create a custom feed from an async method.
@@ -38,7 +38,7 @@ public static class Feed<T> // We set the T on the class to it greatly helps typ
 	public static IFeed<T> Async(AsyncFunc<Option<T>> valueProvider, Signal? refresh = null)
 		=> refresh is null
 			? AttachedProperty.GetOrCreate(valueProvider, vp => new AsyncFeed<T>(vp))
-			: AttachedProperty.GetOrCreate(refresh, valueProvider, (r, vp) => new AsyncFeed<T>(vp, r));
+			: AttachedProperty.GetOrCreate(refresh, valueProvider, static (r, vp) => new AsyncFeed<T>(vp, r));
 
 	/// <summary>
 	/// Gets or create a custom feed from an async method.
@@ -49,7 +49,7 @@ public static class Feed<T> // We set the T on the class to it greatly helps typ
 	public static IFeed<T> Async(AsyncFunc<T> valueProvider, Signal? refresh = null)
 		=> refresh is null
 			? AttachedProperty.GetOrCreate(valueProvider, vp => new AsyncFeed<T>(vp))
-			: AttachedProperty.GetOrCreate(refresh, valueProvider, (r, vp) => new AsyncFeed<T>(vp, r));
+			: AttachedProperty.GetOrCreate(refresh, valueProvider, static (r, vp) => new AsyncFeed<T>(vp, r));
 
 	/// <summary>
 	/// Gets or create a custom feed from an async enumerable sequence of value.
@@ -57,7 +57,7 @@ public static class Feed<T> // We set the T on the class to it greatly helps typ
 	/// <param name="enumerableProvider">The async enumerable sequence of value of the resulting feed.</param>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IFeed<T> AsyncEnumerable(Func<IAsyncEnumerable<Option<T>>> enumerableProvider)
-		=> AttachedProperty.GetOrCreate(enumerableProvider, ep => new AsyncEnumerableFeed<T>(ep));
+		=> AttachedProperty.GetOrCreate(enumerableProvider, static ep => new AsyncEnumerableFeed<T>(ep));
 
 	/// <summary>
 	/// Gets or create a custom feed from an async enumerable sequence of value.
@@ -65,7 +65,7 @@ public static class Feed<T> // We set the T on the class to it greatly helps typ
 	/// <param name="enumerableProvider">The async enumerable sequence of value of the resulting feed.</param>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IFeed<T> AsyncEnumerable(Func<CancellationToken, IAsyncEnumerable<Option<T>>> enumerableProvider)
-		=> AttachedProperty.GetOrCreate(enumerableProvider, ep => new AsyncEnumerableFeed<T>(ep));
+		=> AttachedProperty.GetOrCreate(enumerableProvider, static ep => new AsyncEnumerableFeed<T>(ep));
 
 	/// <summary>
 	/// Gets or create a custom feed from an async enumerable sequence of value.
@@ -73,7 +73,7 @@ public static class Feed<T> // We set the T on the class to it greatly helps typ
 	/// <param name="enumerableProvider">The async enumerable sequence of value of the resulting feed.</param>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IFeed<T> AsyncEnumerable(Func<IAsyncEnumerable<T>> enumerableProvider)
-		=> AttachedProperty.GetOrCreate(enumerableProvider, ep => new AsyncEnumerableFeed<T>(ep));
+		=> AttachedProperty.GetOrCreate(enumerableProvider, static ep => new AsyncEnumerableFeed<T>(ep));
 
 	/// <summary>
 	/// Gets or create a custom feed from an async enumerable sequence of value.
@@ -81,5 +81,5 @@ public static class Feed<T> // We set the T on the class to it greatly helps typ
 	/// <param name="enumerableProvider">The async enumerable sequence of value of the resulting feed.</param>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IFeed<T> AsyncEnumerable(Func<CancellationToken, IAsyncEnumerable<T>> enumerableProvider)
-		=> AttachedProperty.GetOrCreate(enumerableProvider, ep => new AsyncEnumerableFeed<T>(ep));
+		=> AttachedProperty.GetOrCreate(enumerableProvider, static ep => new AsyncEnumerableFeed<T>(ep));
 }

--- a/src/Uno.Extensions.Reactive/Core/Feed.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.cs
@@ -65,7 +65,7 @@ public static partial class Feed
 	public static IFeed<TSource> Where<TSource>(
 		this IFeed<TSource> source,
 		Predicate<TSource> predicate)
-		=> AttachedProperty.GetOrCreate(source, predicate, (src, p) => new WhereFeed<TSource>(src, p));
+		=> AttachedProperty.GetOrCreate(source, predicate, static (src, p) => new WhereFeed<TSource>(src, p));
 
 	/// <summary>
 	/// Gets or create a feed that projects each value of a source feed.
@@ -78,7 +78,7 @@ public static partial class Feed
 	public static IFeed<TResult> Select<TSource, TResult>(
 		this IFeed<TSource> source,
 		Func<TSource, TResult> selector)
-		=> AttachedProperty.GetOrCreate(source, selector, (src, s) => new SelectFeed<TSource, TResult>(src, s));
+		=> AttachedProperty.GetOrCreate(source, selector, static (src, s) => new SelectFeed<TSource, TResult>(src, s));
 
 	/// <summary>
 	/// Gets or create a feed that asynchronously projects each value of a source feed.
@@ -91,6 +91,6 @@ public static partial class Feed
 	public static IFeed<TResult> SelectAsync<TSource, TResult>(
 		this IFeed<TSource> source,
 		AsyncFunc<TSource, TResult> selector)
-		=> AttachedProperty.GetOrCreate(source, selector, (src, s) => new SelectAsyncFeed<TSource, TResult>(src, s));
+		=> AttachedProperty.GetOrCreate(source, selector, static (src, s) => new SelectAsyncFeed<TSource, TResult>(src, s));
 	#endregion
 }

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.T.cs
@@ -74,7 +74,7 @@ public static partial class ListFeed<T>
 	/// <param name="getPage">The async method to load a page of items.</param>
 	/// <returns>A paginated list feed.</returns>
 	public static IListFeed<T> AsyncPaginatedByCursor<TCursor>(TCursor firstPage, GetPage<TCursor, T> getPage)
-		=> AttachedProperty.GetOrCreate(getPage.Target ?? getPage.Method, (firstPage, getPage), (_, args) => new PaginatedListFeed<TCursor,T>(args.firstPage, args.getPage));
+		=> AttachedProperty.GetOrCreate(getPage.Target ?? getPage.Method, (firstPage, getPage), static (_, args) => new PaginatedListFeed<TCursor,T>(args.firstPage, args.getPage));
 
 	/// <summary>
 	/// Creates a list feed for a paginated collection.
@@ -82,5 +82,5 @@ public static partial class ListFeed<T>
 	/// <param name="getPage">The async method to load a page of items.</param>
 	/// <returns>A paginated list feed.</returns>
 	public static IListFeed<T> AsyncPaginated(AsyncFunc<PageRequest, IImmutableList<T>> getPage)
-		=> AttachedProperty.GetOrCreate(getPage, gp => new PaginatedListFeed<ByIndexCursor<T>, T>(ByIndexCursor<T>.First, ByIndexCursor<T>.GetPage(gp)));
+		=> AttachedProperty.GetOrCreate(getPage, static gp => new PaginatedListFeed<ByIndexCursor<T>, T>(ByIndexCursor<T>.First, ByIndexCursor<T>.GetPage(gp)));
 }

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.cs
@@ -81,7 +81,7 @@ public static partial class ListFeed
 	public static IListFeed<TSource> Where<TSource>(
 		this IListFeed<TSource> source,
 		Predicate<TSource> predicate)
-		=> AttachedProperty.GetOrCreate(source, predicate, (src, p) => new WhereListFeed<TSource>(src, p));
+		=> AttachedProperty.GetOrCreate(source, predicate, static (src, p) => new WhereListFeed<TSource>(src, p));
 
 	//public static IListFeed<TResult> Select<TSource, TResult>(
 	//	this IListFeed<TSource> source,

--- a/src/Uno.Extensions.Reactive/Core/State.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/State.T.cs
@@ -25,7 +25,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IState<T> Create<TOwner>(TOwner owner, Func<CancellationToken, IAsyncEnumerable<Message<T>>> sourceProvider)
 		where TOwner : class
-		=> AttachedProperty.GetOrCreate(owner, sourceProvider, (o, sp) => S(o, new CustomFeed<T>(sp)));
+		=> AttachedProperty.GetOrCreate(owner, sourceProvider, static (o, sp) => S(o, new CustomFeed<T>(sp)));
 
 	/// <summary>
 	/// Creates a custom feed from a raw <see cref="IAsyncEnumerable{T}"/> sequence of <see cref="Message{T}"/>.
@@ -34,7 +34,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	internal static IState<T> Create(Func<CancellationToken, IAsyncEnumerable<Message<T>>> sourceProvider)
-		=> AttachedProperty.GetOrCreate(Validate(sourceProvider), sp => S(sp, new CustomFeed<T>(sp)));
+		=> AttachedProperty.GetOrCreate(Validate(sourceProvider), static sp => S(sp, new CustomFeed<T>(sp)));
 
 	/// <summary>
 	/// Creates a custom feed from a raw <see cref="IAsyncEnumerable{T}"/> sequence of <see cref="Message{T}"/>.
@@ -45,7 +45,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IState<T> Create<TOwner>(TOwner owner, Func<IAsyncEnumerable<Message<T>>> sourceProvider)
 		where TOwner : class
-		=> AttachedProperty.GetOrCreate(owner, sourceProvider, (o, sp) => S(o, new CustomFeed<T>(_ => sp())));
+		=> AttachedProperty.GetOrCreate(owner, sourceProvider, static (o, sp) => S(o, new CustomFeed<T>(_ => sp())));
 
 	/// <summary>
 	/// Creates a custom feed from a raw <see cref="IAsyncEnumerable{T}"/> sequence of <see cref="Message{T}"/>.
@@ -54,7 +54,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	internal static IState<T> Create(Func<IAsyncEnumerable<Message<T>>> sourceProvider)
-		=> AttachedProperty.GetOrCreate(Validate(sourceProvider), sp => S(sp, new CustomFeed<T>(_ => sp())));
+		=> AttachedProperty.GetOrCreate(Validate(sourceProvider), static sp => S(sp, new CustomFeed<T>(_ => sp())));
 
 	/// <summary>
 	/// Gets or creates an empty state.
@@ -72,7 +72,7 @@ public static partial class State<T>
 				name ?? throw new InvalidOperationException("The name of the state must not be null"),
 				line <0 ? throw new InvalidOperationException("The provided line number is invalid.") : line
 			),
-			(o, _) => SourceContext.GetOrCreate(o).CreateState(Option<T>.None()));
+			static (o, _) => SourceContext.GetOrCreate(o).CreateState(Option<T>.None()));
 
 	/// <summary>
 	/// Gets or creates a state from a static initial value.
@@ -84,7 +84,7 @@ public static partial class State<T>
 	public static IState<T> Value<TOwner>(TOwner owner, Func<T> valueProvider)
 		where TOwner : class
 		// Note: We force the usage of delegate so 2 properties which are doing State.Value(this, () => 42) will effectively have 2 distinct states.
-		=> AttachedProperty.GetOrCreate(owner, valueProvider, (o, v) => SourceContext.GetOrCreate(o).CreateState(Option<T>.Some(v())));
+		=> AttachedProperty.GetOrCreate(owner, valueProvider, static (o, v) => SourceContext.GetOrCreate(o).CreateState(Option<T>.Some(v())));
 
 	/// <summary>
 	/// Gets or creates a state from a static initial value.
@@ -96,7 +96,7 @@ public static partial class State<T>
 	public static IState<T> Value<TOwner>(TOwner owner, Func<Option<T>> valueProvider)
 		where TOwner : class
 		// Note: We force the usage of delegate so 2 properties which are doing State.Value(this, () => 42) will effectively have 2 distinct states.
-		=> AttachedProperty.GetOrCreate(owner, valueProvider, (o, v) => SourceContext.GetOrCreate(owner).CreateState(v()));
+		=> AttachedProperty.GetOrCreate(owner, valueProvider, static (o, v) => SourceContext.GetOrCreate(o).CreateState(v()));
 
 	/// <summary>
 	/// Gets or creates a state from an async method.
@@ -108,7 +108,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IState<T> Async<TOwner>(TOwner owner, AsyncFunc<Option<T>> valueProvider, Signal? refresh = null)
 		where TOwner : class
-		=> AttachedProperty.GetOrCreate(owner, (valueProvider, refresh), (o, args) => S(o, new AsyncFeed<T>(args.valueProvider, args.refresh)));
+		=> AttachedProperty.GetOrCreate(owner, (valueProvider, refresh), static (o, args) => S(o, new AsyncFeed<T>(args.valueProvider, args.refresh)));
 
 	/// <summary>
 	/// Gets or creates a state from an async method.
@@ -120,7 +120,7 @@ public static partial class State<T>
 	internal static IState<T> Async(AsyncFunc<Option<T>> valueProvider, Signal? refresh = null)
 		=> refresh is null
 			? AttachedProperty.GetOrCreate(Validate(valueProvider), vp => S(vp, new AsyncFeed<T>(vp)))
-			: AttachedProperty.GetOrCreate(refresh, Validate(valueProvider), (r, vp) => S(vp, new AsyncFeed<T>(vp, r)));
+			: AttachedProperty.GetOrCreate(refresh, Validate(valueProvider), static (r, vp) => S(vp, new AsyncFeed<T>(vp, r)));
 
 	/// <summary>
 	/// Gets or creates a state from an async method.
@@ -132,7 +132,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IState<T> Async<TOwner>(TOwner owner, AsyncFunc<T> valueProvider, Signal? refresh = null)
 		where TOwner : class
-		=> AttachedProperty.GetOrCreate(owner, (valueProvider, refresh), (o, args) => S(o, new AsyncFeed<T>(args.valueProvider, args.refresh)));
+		=> AttachedProperty.GetOrCreate(owner, (valueProvider, refresh), static (o, args) => S(o, new AsyncFeed<T>(args.valueProvider, args.refresh)));
 
 	/// <summary>
 	/// Gets or creates a state from an async method.
@@ -143,8 +143,8 @@ public static partial class State<T>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	internal static IState<T> Async(AsyncFunc<T> valueProvider, Signal? refresh = null)
 		=> refresh is null
-			? AttachedProperty.GetOrCreate(Validate(valueProvider), vp => S(vp, new AsyncFeed<T>(vp)))
-			: AttachedProperty.GetOrCreate(refresh, Validate(valueProvider), (r, vp) => S(vp, new AsyncFeed<T>(vp, r)));
+			? AttachedProperty.GetOrCreate(Validate(valueProvider), static vp => S(vp, new AsyncFeed<T>(vp)))
+			: AttachedProperty.GetOrCreate(refresh, Validate(valueProvider), static (r, vp) => S(vp, new AsyncFeed<T>(vp, r)));
 
 	/// <summary>
 	/// Gets or creates a state from an async enumerable sequence of value.
@@ -155,7 +155,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IState<T> AsyncEnumerable<TOwner>(TOwner owner, Func<IAsyncEnumerable<Option<T>>> enumerableProvider)
 		where TOwner : class
-		=> AttachedProperty.GetOrCreate(owner, enumerableProvider, (o, ep) => S(o, new AsyncEnumerableFeed<T>(ep)));
+		=> AttachedProperty.GetOrCreate(owner, enumerableProvider, static (o, ep) => S(o, new AsyncEnumerableFeed<T>(ep)));
 
 	/// <summary>
 	/// Gets or creates a state from an async enumerable sequence of value.
@@ -166,7 +166,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IState<T> AsyncEnumerable<TOwner>(TOwner owner, Func<CancellationToken, IAsyncEnumerable<Option<T>>> enumerableProvider)
 		where TOwner : class
-		=> AttachedProperty.GetOrCreate(owner, enumerableProvider, (o, ep) => S(o, new AsyncEnumerableFeed<T>(ep)));
+		=> AttachedProperty.GetOrCreate(owner, enumerableProvider, static (o, ep) => S(o, new AsyncEnumerableFeed<T>(ep)));
 
 	/// <summary>
 	/// Gets or creates a state from an async enumerable sequence of value.
@@ -175,7 +175,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	internal static IState<T> AsyncEnumerable(Func<IAsyncEnumerable<Option<T>>> enumerableProvider)
-		=> AttachedProperty.GetOrCreate(Validate(enumerableProvider), ep => S(ep, new AsyncEnumerableFeed<T>(ep)));
+		=> AttachedProperty.GetOrCreate(Validate(enumerableProvider), static ep => S(ep, new AsyncEnumerableFeed<T>(ep)));
 
 	/// <summary>
 	/// Gets or creates a state from an async enumerable sequence of value.
@@ -186,7 +186,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IState<T> AsyncEnumerable<TOwner>(TOwner owner, Func<IAsyncEnumerable<T>> enumerableProvider)
 		where TOwner : class
-		=> AttachedProperty.GetOrCreate(owner, enumerableProvider, (o, ep) => S(o, new AsyncEnumerableFeed<T>(ep)));
+		=> AttachedProperty.GetOrCreate(owner, enumerableProvider, static (o, ep) => S(o, new AsyncEnumerableFeed<T>(ep)));
 
 	/// <summary>
 	/// Gets or creates a state from an async enumerable sequence of value.
@@ -197,7 +197,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IState<T> AsyncEnumerable<TOwner>(TOwner owner, Func<CancellationToken, IAsyncEnumerable<T>> enumerableProvider)
 		where TOwner : class
-		=> AttachedProperty.GetOrCreate(owner, enumerableProvider, (o, ep) => S(o, new AsyncEnumerableFeed<T>(ep)));
+		=> AttachedProperty.GetOrCreate(owner, enumerableProvider, static (o, ep) => S(o, new AsyncEnumerableFeed<T>(ep)));
 
 	/// <summary>
 	/// Gets or creates a state from an async enumerable sequence of value.
@@ -206,7 +206,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	internal static IState<T> AsyncEnumerable(Func<IAsyncEnumerable<T>> enumerableProvider)
-		=> AttachedProperty.GetOrCreate(Validate(enumerableProvider), ep => S(ep, new AsyncEnumerableFeed<T>(ep)));
+		=> AttachedProperty.GetOrCreate(Validate(enumerableProvider), static ep => S(ep, new AsyncEnumerableFeed<T>(ep)));
 
 	/// <summary>
 	/// Gets or creates a state from an async enumerable sequence of value.
@@ -217,7 +217,7 @@ public static partial class State<T>
 	/// <returns>A feed that encapsulate the source.</returns>
 	public static IState<T> FromFeed<TOwner>(TOwner owner, IFeed<T> feed)
 		where TOwner : class
-		=> AttachedProperty.GetOrCreate(owner, feed, (o, f) => S(o, f));
+		=> AttachedProperty.GetOrCreate(owner, feed, static (o, f) => S(o, f));
 
 	private static TKey Validate<TKey>(TKey key, [CallerMemberName] string? caller = null)
 		where TKey : Delegate


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## Refactoring
Ensure building delegates are static

## What is the current behavior?
Building delegates are not flagged as `static` allowing invalid usage

## What is the new behavior?
They are flagged as `static` so it's  clear when we use a closure

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
