### PR TITLE
feat: Adding performance timers to navigation

### DIFF
--- a/src/Uno.Extensions.Core/Diagnostics/PerformanceTimer.cs
+++ b/src/Uno.Extensions.Core/Diagnostics/PerformanceTimer.cs
@@ -1,0 +1,109 @@
+﻿namespace Uno.Extensions.Diagnostics;
+
+/// <summary>
+/// Defines static methods for starting/stopping timers for measuring performance
+/// </summary>
+public static class PerformanceTimer
+{
+	/// <summary>
+	/// Conditiona compliation symbol to enable performance timers for internal
+	/// extensions logic. Define constant in Directory.Build.props to enable
+	/// performance timers eg
+	/// <DefineConstants>$(DefineConstants);UNO_EXT_TIMERS</DefineConstants>
+	/// Call InitializeTimers from App.xaml.cs, then call Start and Stop
+	/// to control timers for different scenarios
+	/// </summary>
+	public const string ConditionalSymbol = "UNO_EXT_TIMERS";
+
+	private static IDictionary<Guid, Stopwatch> Timers = new Dictionary<Guid, Stopwatch>();
+
+	private static Action<ILogger, LogLevel, Guid, string> _startAction = static (logger, level, key, caller) => { };
+	private static Func<Guid, TimeSpan> _splitAction = static (key) => TimeSpan.Zero;
+	private static Func<ILogger, LogLevel, Guid, string, TimeSpan> _stopAction = static (logger, level, key, caller) => TimeSpan.Zero;
+
+	/// <summary>
+	/// Initializes performance timing methods. Make sure you also define the
+	/// UNO_EXT_TIMERS constant to prevent this method from being removed during compilation
+	/// </summary>
+	[Conditional(ConditionalSymbol)]
+	public static void InitializeTimers()
+	{
+		_startAction = InternalStart;
+		_splitAction = InternalSplit;
+		_stopAction = InternalStop;
+	}
+
+	/// <summary>
+	/// Start a timer
+	/// </summary>
+	/// <param name="logger">Logger to output start message to</param>
+	/// <param name="level">LogLevel to output start message at</param>
+	/// <param name="key">Unique identifier for timer</param>
+	/// <param name="caller">The method calling the start method</param>
+	public static void Start(ILogger logger, LogLevel level, Guid key, [CallerMemberName] string caller = "") => _startAction(logger, level, key, caller);
+
+	/// <summary>
+	/// Returns an in-progress timespan for the specified timer
+	/// </summary>
+	/// <param name="key">The unique identifier for the timer</param>
+	/// <returns>Elapsed time since timer was started</returns>
+	public static TimeSpan Split(Guid key) => _splitAction(key);
+
+	/// <summary>
+	/// Stops a timer
+	/// </summary>
+	/// <param name="logger">Logger to output stop message to</param>
+	/// <param name="level">LogLevel to output stop message at</param>
+	/// <param name="key">Unique identifier for timer</param>
+	/// <param name="caller">The method calling the stop method</param>
+	/// <returns>Elapsed time since timer was started</returns>
+	public static TimeSpan Stop(ILogger logger, LogLevel level, Guid key, [CallerMemberName] string caller = "") => _stopAction(logger, level, key, caller);
+
+
+	private static void InternalStart(ILogger logger, LogLevel level, Guid key, [CallerMemberName] string caller = "")
+	{
+		var timer = new Stopwatch();
+		timer.Start();
+		Timers[key] = timer;
+		if (logger?.IsEnabled(level) ?? false)
+		{
+			logger.Log(level, $"[{key}:{caller}] Start");
+		}
+	}
+
+
+	private static TimeSpan InternalSplit(Guid key)
+	{
+		if (Timers.TryGetValue(key, out var timer))
+		{
+			return timer.Elapsed;
+		}
+		else
+		{
+			return TimeSpan.Zero;
+		}
+	}
+
+	private static TimeSpan InternalStop(ILogger logger, LogLevel level, Guid key, [CallerMemberName] string caller = "")
+	{
+		if (Timers.TryGetValue(key, out var timer))
+		{
+			Timers.Remove(key);
+			timer.Stop();
+			if (logger?.IsEnabled(level) ?? false)
+			{
+				logger.Log(level, $"[{key}:{caller}] {timer.ElapsedMilliseconds}ms");
+			}
+			return timer.Elapsed;
+		}
+		else
+		{
+			if (logger?.IsEnabled(level) ?? false)
+			{
+				logger.Log(level, $"[{key}:{caller}] MISSING - Either Start hasn't been called, or Stop has already been called");
+			}
+			return TimeSpan.Zero;
+		}
+
+	}
+}

--- a/src/Uno.Extensions.Core/GlobalUsings.cs
+++ b/src/Uno.Extensions.Core/GlobalUsings.cs
@@ -1,6 +1,8 @@
 ﻿global using System;
 global using System.Collections.Generic;
+global using System.Diagnostics;
 global using System.Linq;
+global using System.Runtime.CompilerServices;
 global using System.Runtime.InteropServices;
 global using System.Threading;
 global using System.Threading.Tasks;
@@ -8,5 +10,4 @@ global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.DependencyInjection.Extensions;
 global using Microsoft.Extensions.Logging;
 global using Uno.Extensions.DependencyInjection;
-
 

--- a/src/Uno.Extensions.Navigation.UI/IRouteUpdater.cs
+++ b/src/Uno.Extensions.Navigation.UI/IRouteUpdater.cs
@@ -2,8 +2,8 @@
 
 internal interface IRouteUpdater
 {
-	Guid StartNavigation(IRegion region);
+	void StartNavigation(INavigator navigator, IRegion region, NavigationRequest request);
 
-	Task EndNavigation(Guid regionUpdateId);
+	void EndNavigation(INavigator navigator, IRegion region, NavigationRequest request);
 }
 

--- a/src/Uno.Extensions.Navigation.UI/Regions/RegionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/Regions/RegionExtensions.cs
@@ -12,14 +12,16 @@ public static class RegionExtensions
 
 	public static Task<NavigationResponse?> NavigateAsync(this IRegion region, NavigationRequest request) => (region.Navigator()?.NavigateAsync(request)) ?? Task.FromResult<NavigationResponse?>(default);
 
-	public static bool IsUnnamed(this IRegion region, Route? parentRoute=null) =>
+	public static bool IsUnnamed(this IRegion region, Route? parentRoute = null) =>
 		string.IsNullOrEmpty(region.Name) ||
 		(region.Name == parentRoute?.Base);  // Where an un-named region is nested, the name is updated to the current route
 
-	public static IRegion Root(this IRegion region)
-	{
-		return region.Parent is not null ? region.Parent.Root() : region;
-	}
+	/// <summary>
+	/// Returns the root region at the top of the region hierarchy
+	/// </summary>
+	/// <param name="region">The start point of the hierarchy search</param>
+	/// <returns>The root region</returns>
+	public static IRegion Root(this IRegion region) => region.Parent?.Root() ?? region;
 
 	internal static (Route?, IRegion, INavigator?)[] Ancestors(
 		this IRegion region,

--- a/src/Uno.Extensions.Navigation/NavigationRequest.cs
+++ b/src/Uno.Extensions.Navigation/NavigationRequest.cs
@@ -4,6 +4,8 @@
 public record NavigationRequest(object Sender, Route Route, CancellationToken? Cancellation = default, Type? Result = null, INavigator? Source = null)
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
 {
+	internal Guid Id { get; } = Guid.NewGuid();
+
 	internal bool InProgress { get; init; }
 
 	public override string ToString() => $"Request [Sender: {Sender.GetType().Name}, Route:{Route}, Result: {Result?.Name ?? "N/A"}]";

--- a/testing/TestHarness/Directory.Build.props
+++ b/testing/TestHarness/Directory.Build.props
@@ -5,6 +5,14 @@
 		<NoWarn>$(NoWarn);NU5104;NU1504;NU1505;CS1591;MSB3277;XA0101;CS8785;CS8669;CA1416</NoWarn>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 		<DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
+
+
+		<ConditionalCompilationSymbols>
+			<ConditionalCompilationSymbol Name="UNO_EXT_TIMERS" Comment="Controls whether performance timers are enabled (off by default)" />
+		</ConditionalCompilationSymbols>
+
+		
+		<!--<DefineConstants>$(DefineConstants);UNO_EXT_TIMERS</DefineConstants>-->
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/testing/TestHarness/TestHarness.Shared/BaseHostInitialization.cs
+++ b/testing/TestHarness/TestHarness.Shared/BaseHostInitialization.cs
@@ -84,7 +84,7 @@ public abstract class BaseHostInitialization : IHostInitialization
 				{
 					var host = context.HostingEnvironment;
 					// Configure log levels for different categories of logging
-					logBuilder.SetMinimumLevel(host.IsDevelopment() ? LogLevel.Warning : LogLevel.Warning);
+					logBuilder.SetMinimumLevel(host.IsDevelopment() ? LogLevel.Trace : LogLevel.Warning);
 				});
 	}
 

--- a/testing/TestHarness/TestHarness.Shared/BaseTestSectionPage.cs
+++ b/testing/TestHarness/TestHarness.Shared/BaseTestSectionPage.cs
@@ -1,5 +1,6 @@
 ﻿
 
+using Uno.Extensions.Diagnostics;
 using Uno.Toolkit.UI;
 
 namespace TestHarness;
@@ -10,6 +11,7 @@ public partial class BaseTestSectionPage : Page, IDisposable
 
 	public BaseTestSectionPage()
 	{
+		PerformanceTimer.InitializeTimers();
 		Loaded += BaseTestSectionPage_Loaded;
 	}
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

No way to time how long navigation takes

## What is the new behavior?

Define UNO_EXT_TIMERS in csproj or Directory.Build.info to enable performance timers

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
