### PR TITLE
feat: [Navigation] Adding handler for ItemsRepeater

### DIFF
--- a/samples/Playground/Directory.Build.props
+++ b/samples/Playground/Directory.Build.props
@@ -5,7 +5,6 @@
 		<WarningsAsErrors>enable</WarningsAsErrors>
 		<NoWarn>$(NoWarn);NU5104;CS1591;MSB3277;XA0101;CS8785;CS8669</NoWarn>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-		<DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/samples/Playground/Playground.Shared/Views/XamlPage.xaml
+++ b/samples/Playground/Playground.Shared/Views/XamlPage.xaml
@@ -1,14 +1,14 @@
-﻿<Page
-    x:Class="Playground.Views.XamlPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Playground.Views"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+﻿<Page x:Class="Playground.Views.XamlPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Playground.Views"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  mc:Ignorable="d"
 	  xmlns:ui="using:Uno.Toolkit.UI"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
-	NavigationCacheMode="Required"
+	  NavigationCacheMode="Required"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 	<Grid>
 		<Grid.RowDefinitions>
@@ -27,28 +27,22 @@
 			</ui:NavigationBar.MainCommand>
 		</ui:NavigationBar>
 
-		<StackPanel Grid.Row="1">
-			<Button Content="NavigateRouteAsync(...);"
-					uen:Navigation.Request="Second" />
-			<Button Content="NavigateDataAsync&lt;TData&gt;(...);"
-					uen:Navigation.Request=""
-					uen:Navigation.Data="{Binding Country, Mode=TwoWay}"/>
-			
 
-
-			<!--<Button Content="NavigateDataForResultAsync&lt;TData, TResultData&gt;(...);"
-					Click="{x:Bind ViewModel.NavigateDataForResultAsyncClick}" />
-			<Button Content="NavigateForResultAsync&lt;TResultData&gt;(...);"
-					Click="{x:Bind ViewModel.NavigateForResultAsyncClick}" />
-			<Button Content="NavigateBackAsync(...);"
-					Click="{x:Bind ViewModel.NavigateBackAsyncClick}" />
-			<Button Content="NavigateBackWithResultAsync&lt;TResult&gt;(...);"
-					Click="{x:Bind ViewModel.NavigateBackWithResultAsyncClick}" />
-			<Button Content="ShowMessageDialogAsync(...);"
-					Click="{x:Bind ViewModel.ShowMessageDialogAsyncClick}" />-->
-			<StackPanel x:Name="CountryStackPanel" >
-				<TextBlock Text="{Binding Country.Name}" />
-			</StackPanel>
-		</StackPanel>
+		<ScrollViewer Grid.Row="1">
+			<muxc:ItemsRepeater ItemsSource="{x:Bind Items}">
+				<muxc:ItemsRepeater.ItemTemplate>
+					<DataTemplate>
+						<Border Height="200"
+								Width="200"
+								Background="Red"
+								uen:Navigation.Request="Second">
+							<TextBlock Text="{Binding}"
+									   VerticalAlignment="Center"
+									   HorizontalAlignment="Center" />
+						</Border>
+					</DataTemplate>
+				</muxc:ItemsRepeater.ItemTemplate>
+			</muxc:ItemsRepeater>
+		</ScrollViewer>
 	</Grid>
 </Page>

--- a/samples/Playground/Playground.Shared/Views/XamlPage.xaml.cs
+++ b/samples/Playground/Playground.Shared/Views/XamlPage.xaml.cs
@@ -3,6 +3,7 @@
 public sealed partial class XamlPage : Page
 {
 	public XamlViewModel? ViewModel { get; private set; }
+	public List<int> Items => Enumerable.Range(0, 50).ToList();
 
 	public XamlPage()
 	{

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -104,8 +104,6 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(_IsAndroid)">
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
 		<DefineConstants>$(DefineConstants);__ANDROID__;XAMARIN;MONOANDROID5_0;XAMARIN_ANDROID</DefineConstants>
 		<SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion>21.0</TargetPlatformMinVersion>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -61,6 +61,37 @@
 		</When>
 	</Choose>
 
+	<Choose>
+		<When Condition="$(_IsAndroid)">
+			<PropertyGroup >
+				<AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
+				<AndroidUseIntermediateDesignerFile>false</AndroidUseIntermediateDesignerFile>
+			</PropertyGroup>
+		</When>
+		<Otherwise>
+			<PropertyGroup>
+				<!--
+				This works around the fact that AndroidResgenFile is
+				automatically included as compiled file, even if AndroidUseIntermediateDesignerFile
+				is set to true.
+				-->
+				<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
+				<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
+			</PropertyGroup>
+		</Otherwise>
+	</Choose>
+
+	<Target Name="AndroidResourceGenWorkaround" BeforeTargets="Build" Condition="'$(AndroidUseIntermediateDesignerFile)'=='True' and $(IsMonoAndroid) and '$(TargetFramework)'!='net6.0-android'">
+		<Message Importance="high" Text="************************* Making Resources DIR" />
+		<MakeDir Directories="obj\$(TargetFramework)\Resources" />
+		<WriteLinesToFile File="$(AndroidResgenFile)" Lines="// Empty Content from uno.ui Directory.Build.targets." />
+	</Target>
+
+	<Target Name="AndroidResourceGenWorkaround_16_2" AfterTargets="_UpdateAndroidResgen" Condition="'$(AndroidUseIntermediateDesignerFile)'=='True' and !Exists($(_AndroidResourceDesignerFile))">
+		<Message Importance="high" Text="************************* Empyt designer file" />
+		<WriteLinesToFile File="$(_AndroidResourceDesignerFile)" Lines="// Empty Content from uno.ui Directory.Build.targets." />
+	</Target>
+
 	<Import Project="winappsdk-workaround.targets" Condition="exists('winappsdk-workaround.targets')" />
 	<Import Project="xamarinmac-workaround.targets" Condition="exists('xamarinmac-workaround.targets') and $(TargetFramework.ToLower().StartsWith('xamarin')) and $(TargetFramework.ToLower().Contains('mac'))" />
 </Project>

--- a/src/Uno.Extensions.Navigation.Toolkit/Controls/TabBarItemRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/Controls/TabBarItemRequestHandler.cs
@@ -15,7 +15,7 @@ public class TabBarItemRequestHandler : ActionRequestHandlerBase<TabBarItem>
 		}
 
 		return BindAction(viewButton,
-			action => new RoutedEventHandler((sender, args) => action((TabBarItem)sender)),
+			action => new RoutedEventHandler((sender, args) => action((TabBarItem)sender, args)),
 			(element, handler) => element.Click += handler,
 			(element, handler) => element.Click -= handler);
 	}

--- a/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
@@ -13,14 +13,14 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 
 	protected IRequestBinding? BindAction<TElement, TEventHandler>(
 		TElement view,
-		Func<Action<FrameworkElement>, TEventHandler> eventHandler,
+		Func<Action<FrameworkElement, RoutedEventArgs?>, TEventHandler> eventHandler,
 		Action<TElement, TEventHandler> subscribe,
 		Action<TElement, TEventHandler> unsubscribe
 		)
 		where TElement : FrameworkElement
 	{
 		var viewToBind = view;
-		Action<FrameworkElement> action = async (element) =>
+		Action<FrameworkElement, RoutedEventArgs?> action = async (element, eventArgs) =>
 		{
 			var path = element.GetRequest();
 			var nav = element.Navigator();
@@ -32,7 +32,7 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 
 			var routeHint = new RouteHint { Route = path };
 
-			var data = element.GetData();
+			var data = element.GetData() ?? element.GetDataFromOriginalSource(eventArgs?.OriginalSource);
 			var resultType = data?.GetType();
 
 			var binding = element.GetBindingExpression(Navigation.DataProperty);
@@ -59,9 +59,11 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 					}
 				}
 			}
-			routeHint = routeHint with {
+			routeHint = routeHint with
+			{
 				//Data = data?.GetType(),
-				Result = resultType };
+				Result = resultType
+			};
 
 			var qualifier = path.HasQualifier() ? Qualifiers.None : DefaultQualifier;
 

--- a/src/Uno.Extensions.Navigation.UI/Controls/ButtonBaseRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ButtonBaseRequestHandler.cs
@@ -15,7 +15,7 @@ public class ButtonBaseRequestHandler : ActionRequestHandlerBase<ButtonBase>
 		}
 
 		return BindAction(viewButton,
-			action => new RoutedEventHandler((sender, args) => action((ButtonBase)sender)),
+			action => new RoutedEventHandler((sender, args) => action((ButtonBase)sender, args)),
 			(element, handler) => element.Click += handler,
 			(element, handler) => element.Click -= handler);
 	}

--- a/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
@@ -1,0 +1,75 @@
+﻿#if !WINUI
+using Microsoft.UI.Xaml.Controls;
+#endif
+
+namespace Uno.Extensions.Navigation.UI;
+
+public class ItemsRepeaterRequestHandler : ControlRequestHandlerBase<ItemsRepeater>
+{
+	public override IRequestBinding? Bind(FrameworkElement view)
+	{
+		var viewToBind = view;
+		var viewList = view as ItemsRepeater;
+		if (viewList is null)
+		{
+			return default;
+		}
+
+		Func<FrameworkElement, object?, Task> action = async (sender, data) =>
+		{
+			var navdata = data;
+			var path = sender.GetRequest();
+			var nav = sender.Navigator();
+			if (nav is null)
+			{
+				return;
+			}
+
+			await nav.NavigateRouteAsync(sender, path, Qualifiers.None, navdata);
+		};
+
+		TappedEventHandler tappedAction = async (actionSender, actionArgs) =>
+		{
+			var sender = actionSender as ItemsRepeater;
+			if (sender is null)
+			{
+				return;
+			}
+
+			var elt = actionArgs.OriginalSource as DependencyObject;
+			while (elt is not null)
+			{
+				var parent = VisualTreeHelper.GetParent(elt);
+				if (parent == sender)
+				{
+					var itemClicked = (elt as ContentControl)?.Content ?? (elt as FrameworkElement)?.DataContext;
+					await action(sender, itemClicked);
+
+				}
+				elt = parent;
+			}
+
+		};
+
+
+		Action connect = () => viewList.Tapped += tappedAction;
+		Action disconnect = () => viewList.Tapped -= tappedAction;
+
+		if (viewList.IsLoaded)
+		{
+			connect();
+		}
+
+		RoutedEventHandler loadedHandler = (s, e) =>
+		{
+			connect();
+		};
+		viewList.Loaded += loadedHandler;
+		RoutedEventHandler unloadedHandler = (s, e) =>
+		{
+			disconnect();
+		};
+		viewList.Unloaded += unloadedHandler;
+		return new RequestBinding(viewToBind, loadedHandler, unloadedHandler);
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/Controls/NavigationViewItemRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/NavigationViewItemRequestHandler.cs
@@ -31,7 +31,7 @@ public class NavigationViewItemRequestHandler : ActionRequestHandlerBase<Navigat
 			{
 				if ((args.InvokedItemContainer is FrameworkElement navItem && navItem == viewButton))
 				{
-					action((FrameworkElement)args.InvokedItemContainer);
+					action((FrameworkElement)args.InvokedItemContainer, default);
 				}
 			}),
 			(element, handler) => element.ItemInvoked += handler,

--- a/src/Uno.Extensions.Navigation.UI/Controls/TapRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/TapRequestHandler.cs
@@ -14,7 +14,7 @@ public class TapRequestHandler : ActionRequestHandlerBase<FrameworkElement>
 		}
 
 		return BindAction(view,
-			action => new TappedEventHandler((sender, args) => action((FrameworkElement)sender)),
+			action => new TappedEventHandler((sender, args) => action((FrameworkElement)sender, args)),
 			(element, handler) => element.Tapped += handler,
 			(element, handler) => element.Tapped -= handler);
 	}

--- a/src/Uno.Extensions.Navigation.UI/Navigation.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigation.cs
@@ -51,11 +51,21 @@ public static class Navigation
         element.SetValue(DataProperty, value);
     }
 
-    public static object GetData(this FrameworkElement element)
+    public static object? GetData(this FrameworkElement element)
     {
         return (object)element.GetValue(DataProperty);
     }
 
+	internal static object? GetDataFromOriginalSource(this FrameworkElement element, object? originalSource)
+	{
+		if(originalSource is FrameworkElement fe &&
+			element != fe)
+		{
+			return fe.GetData() ?? element.GetDataFromOriginalSource(VisualTreeHelper.GetParent(fe));
+		}
+
+		return default;
+	}
 
 	public static void SetRequestBinding(this FrameworkElement element, IRequestBinding value)
 	{

--- a/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
@@ -58,6 +58,7 @@ public static class ServiceCollectionExtensions
 					.AddSingleton<IRequestHandler, SelectorRequestHandler>()
 					.AddSingleton<IRequestHandler, NavigationViewItemRequestHandler>()
 					.AddSingleton<IRequestHandler, NavigationViewRequestHandler>()
+					.AddSingleton<IRequestHandler, ItemsRepeaterRequestHandler>()
 
 					// Register the navigation mappings repository
 

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Build.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Build.props
@@ -9,8 +9,6 @@
 		<SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
 
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-		<!-- Workaround for CPM with multi-target projects https://github.com/dotnet/sdk/issues/27840 -->
-		<DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
 
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	  	<NoWarn>$(NoWarn);Uno0001;CS1998;CA1416;NU1507</NoWarn>

--- a/testing/TestHarness/Directory.Build.props
+++ b/testing/TestHarness/Directory.Build.props
@@ -4,9 +4,7 @@
 		<Nullable>enable</Nullable>
 		<NoWarn>$(NoWarn);NU5104;NU1504;NU1505;CS1591;MSB3277;XA0101;CS8785;CS8669;CA1416</NoWarn>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-		<DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
-
-
+		
 		<ConditionalCompilationSymbols>
 			<ConditionalCompilationSymbol Name="UNO_EXT_TIMERS" Comment="Controls whether performance timers are enabled (off by default)" />
 		</ConditionalCompilationSymbols>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
@@ -7,10 +7,12 @@
 	  mc:Ignorable="d"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	  xmlns:utu="using:Uno.Toolkit.UI"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<Grid>
 		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
 			<RowDefinition />
 		</Grid.RowDefinitions>
@@ -35,5 +37,21 @@
 					Content="Settings Write Test"
 					Click="{x:Bind ViewModel.SettingsWriteTest}" />
 		</StackPanel>
+		<ScrollViewer Grid.Row="2">
+			<muxc:ItemsRepeater ItemsSource="{Binding Items}"
+								uen:Navigation.Request="PageNavigationTwo">
+				<muxc:ItemsRepeater.ItemTemplate>
+					<DataTemplate>
+						<Border Height="200"
+								Width="200"
+								Background="Red">
+							<TextBlock Text="{Binding}"
+									   VerticalAlignment="Center"
+									   HorizontalAlignment="Center" />
+						</Border>
+					</DataTemplate>
+				</muxc:ItemsRepeater.ItemTemplate>
+			</muxc:ItemsRepeater>
+		</ScrollViewer>
 	</Grid>
 </Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOneViewModel.cs
@@ -6,6 +6,7 @@ public record PageNavigationOneViewModel(IServiceProvider Services, INavigator N
 	: BasePageNavigationViewModel(Dispatcher)
 {
 
+	public List<PageNavigationModel> Items { get; } = Enumerable.Range(0, 50).Select(x => new PageNavigationModel(x)).ToList();
 
 	public async void GoToTwo()
 	{
@@ -18,7 +19,7 @@ public record PageNavigationOneViewModel(IServiceProvider Services, INavigator N
 		var tasks = new List<Task>();
 		for (int i = 0; i < 5; i++)
 		{
-			tasks.Add(Task.Run(()=>ReadWriteTest()));
+			tasks.Add(Task.Run(() => ReadWriteTest()));
 		}
 		await Task.WhenAll(tasks);
 	}
@@ -40,6 +41,8 @@ public record PageNavigationOneViewModel(IServiceProvider Services, INavigator N
 	}
 
 }
+
+public record PageNavigationModel(int Value);
 
 public record BasePageNavigationViewModel
 {

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationRegisterHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationRegisterHostInit.cs
@@ -1,4 +1,6 @@
-﻿namespace TestHarness.Ext.Navigation.PageNavigation;
+﻿using System.Reflection;
+
+namespace TestHarness.Ext.Navigation.PageNavigation;
 
 public class PageNavigationRegisterHostInit: PageNavigationHostInit
 {
@@ -6,7 +8,7 @@ public class PageNavigationRegisterHostInit: PageNavigationHostInit
 	{
 		views.Register(
 			new ViewMap<PageNavigationOnePage, PageNavigationOneViewModel>(),
-			new ViewMap<PageNavigationTwoPage, PageNavigationTwoViewModel>(),
+			new DataViewMap<PageNavigationTwoPage, PageNavigationTwoViewModel, PageNavigationModel>(),
 			new ViewMap<PageNavigationThreePage, PageNavigationThreeViewModel>(),
 			new ViewMap<PageNavigationFourPage, PageNavigationFourViewModel>(),
 			new ViewMap<PageNavigationFivePage, PageNavigationFiveViewModel>(),

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationTwoPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationTwoPage.xaml
@@ -1,11 +1,10 @@
-﻿<Page
-    x:Class="TestHarness.Ext.Navigation.PageNavigation.PageNavigationTwoPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:TestHarness.Ext.Navigation.PageNavigation"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
+﻿<Page x:Class="TestHarness.Ext.Navigation.PageNavigation.PageNavigationTwoPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.PageNavigation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	  xmlns:utu="using:Uno.Toolkit.UI"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
@@ -22,6 +21,7 @@
 			<TextBlock>
 	<Run Text="Created on UI Thread: " /><Run Text="{Binding CreatedOnUIThread}" />
 			</TextBlock>
+			<TextBlock Text="{Binding Model.Value}" />
 			<Button AutomationProperties.AutomationId="TwoPageToThreePageButton"
 					Content="Three"
 					uen:Navigation.Request="PageNavigationThree" />
@@ -30,16 +30,16 @@
 					uen:Navigation.Request="-" />
 			<Button AutomationProperties.AutomationId="TwoPageToThreePageCodebehindButton"
 					Content="Three (Codebehind)"
-					Click="TwoPageToThreePageCodebehindClick"/>
+					Click="TwoPageToThreePageCodebehindClick" />
 			<Button AutomationProperties.AutomationId="TwoPageBackCodebehindButton"
 					Content="Back (Codebehind)"
-					Click="TwoPageBackCodebehindClick"/>
+					Click="TwoPageBackCodebehindClick" />
 			<Button AutomationProperties.AutomationId="TwoPageToThreePageViewModelButton"
 					Content="Three (ViewModel)"
 					Click="{x:Bind ViewModel.GoToThree}" />
 			<Button AutomationProperties.AutomationId="TwoPageBackViewModelButton"
 					Content="Back (ViewModel)"
-					Click="{x:Bind ViewModel.GoBack}"/>
+					Click="{x:Bind ViewModel.GoBack}" />
 
 		</StackPanel>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationTwoViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationTwoViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace TestHarness.Ext.Navigation.PageNavigation;
 
-public record PageNavigationTwoViewModel (INavigator Navigator, IDispatcher Dispatcher, IWritableOptions<PageNavigationSettings> Settings)
+public record PageNavigationTwoViewModel (INavigator Navigator, IDispatcher Dispatcher, IWritableOptions<PageNavigationSettings> Settings, PageNavigationModel? Model)
 	: BasePageNavigationViewModel(Dispatcher)
 {
 	public async void GoToThree()


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno.toolkit.ui/issues/395

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

No handling for ItemsRepeater

## What is the new behavior?

Handler added for ItemsRepeater which will walk the visual tree to work out the item to send as Data with the navigation request

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
