### PR TITLE
feat: Add ListState.FromFeed

### DIFF
--- a/src/Uno.Extensions.Reactive/Core/ListState.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.T.cs
@@ -216,6 +216,17 @@ public static class ListState<T>
 	internal static IListState<T> AsyncEnumerable(Func<IAsyncEnumerable<IImmutableList<T>>> enumerableProvider)
 		=> AttachedProperty.GetOrCreate(Validate(enumerableProvider), static ep => S(ep, new AsyncEnumerableFeed<IImmutableList<T>>(ep)));
 
+	/// <summary>
+	/// Gets or creates a state from an async enumerable sequence of value.
+	/// </summary>
+	/// <typeparam name="TOwner">Type of the owner of the state.</typeparam>
+	/// <param name="owner">The owner of the state.</param>
+	/// <param name="feed">The source feed of the resulting state.</param>
+	/// <returns>A feed that encapsulate the source.</returns>
+	public static IListState<T> FromFeed<TOwner>(TOwner owner, IListFeed<T> feed)
+		where TOwner : class
+		=> AttachedProperty.GetOrCreate(owner, feed, static (o, f) => S(o, f));
+
 	// WARNING: This not implemented for restrictions described in the remarks section of the AsyncPaginated
 	//			While restrictions are acceptable for a paginated by index ListState, it would be invalid for custom cursors.
 	///// <summary>

--- a/src/Uno.Extensions.Reactive/Core/ListState.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.cs
@@ -22,7 +22,7 @@ public static partial class ListState
 	/// <typeparam name="TValue">The type of the value of the resulting feed.</typeparam>
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="sourceProvider">The provider of the message enumerable sequence.</param>
-	/// <returns>A feed that encapsulate the source.</returns>
+	/// <returns>A state that encapsulate the source.</returns>
 	public static IListState<TValue> Create<TOwner, TValue>(TOwner owner, Func<CancellationToken, IAsyncEnumerable<Message<IImmutableList<TValue>>>> sourceProvider)
 		where TOwner : class
 		=> ListState<TValue>.Create(owner, sourceProvider);
@@ -34,7 +34,7 @@ public static partial class ListState
 	/// <typeparam name="TValue">The type of the value of the resulting feed.</typeparam>
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="valueProvider">The provider of the initial value of the state.</param>
-	/// <returns>A feed that encapsulate the source.</returns>
+	/// <returns>A state that encapsulate the source.</returns>
 	public static IListState<TValue> Value<TOwner, TValue>(TOwner owner, Func<IImmutableList<TValue>> valueProvider)
 		where TOwner : class
 	// Note: We force the usage of delegate so 2 properties which are doing State.Value(this, () => 42) will effectively have 2 distinct states.
@@ -47,7 +47,7 @@ public static partial class ListState
 	/// <typeparam name="TValue">The type of the value of the resulting feed.</typeparam>
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="valueProvider">The provider of the initial value of the state.</param>
-	/// <returns>A feed that encapsulate the source.</returns>
+	/// <returns>A state that encapsulate the source.</returns>
 	public static IListState<TValue> Value<TOwner, TValue>(TOwner owner, Func<ImmutableList<TValue>> valueProvider)
 		where TOwner : class
 	// Note: We force the usage of delegate so 2 properties which are doing State.Value(this, () => 42) will effectively have 2 distinct states.
@@ -61,7 +61,7 @@ public static partial class ListState
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="valueProvider">The async method to use to load the value of the resulting feed.</param>
 	/// <param name="refresh">A refresh trigger to reload the <paramref name="valueProvider"/>.</param>
-	/// <returns>A feed that encapsulate the source.</returns>
+	/// <returns>A state that encapsulate the source.</returns>
 	public static IListState<TValue> Async<TOwner, TValue>(TOwner owner, AsyncFunc<IImmutableList<TValue>> valueProvider, Signal? refresh = null)
 		where TOwner : class
 		=> ListState<TValue>.Async(owner, valueProvider, refresh);
@@ -74,7 +74,7 @@ public static partial class ListState
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="valueProvider">The async method to use to load the value of the resulting feed.</param>
 	/// <param name="refresh">A refresh trigger to reload the <paramref name="valueProvider"/>.</param>
-	/// <returns>A feed that encapsulate the source.</returns>
+	/// <returns>A state that encapsulate the source.</returns>
 	public static IListState<TValue> Async<TOwner, TValue>(TOwner owner, AsyncFunc<ImmutableList<TValue>> valueProvider, Signal? refresh = null)
 		where TOwner : class
 		=> ListState<TValue>.Async(owner, valueProvider, refresh);
@@ -86,9 +86,21 @@ public static partial class ListState
 	/// <typeparam name="TValue">The type of the value of the resulting feed.</typeparam>
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="enumerableProvider">The async enumerable sequence of value of the resulting feed.</param>
-	/// <returns>A feed that encapsulate the source.</returns>
+	/// <returns>A state that encapsulate the source.</returns>
 	public static IListState<TValue> AsyncEnumerable<TOwner, TValue>(TOwner owner, Func<IAsyncEnumerable<IImmutableList<TValue>>> enumerableProvider)
 		where TOwner : class
 		=> ListState<TValue>.AsyncEnumerable(owner, enumerableProvider);
+
+	/// <summary>
+	/// Gets or creates a state from an async enumerable sequence of value.
+	/// </summary>
+	/// <typeparam name="TOwner">Type of the owner of the state.</typeparam>
+	/// <typeparam name="TValue">The type of the value of the resulting state.</typeparam>
+	/// <param name="owner">The owner of the state.</param>
+	/// <param name="feed">The source list feed of the resulting list state.</param>
+	/// <returns>A state that encapsulate the source.</returns>
+	public static IListState<TValue> FromFeed<TOwner, TValue>(TOwner owner, IListFeed<TValue> feed)
+		where TOwner : class
+		=> ListState<TValue>.FromFeed(owner, feed);
 	#endregion
 }


### PR DESCRIPTION
## Feature
Add ability to create a ListState from a ListFeed (on the model of State.FromFeed)

## What is the current behavior?
Not helper for that

## What is the new behavior?
🙃

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
