### PR TITLE
fix: Fix possible null in Bindable init

### DIFF
--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableImmutableList.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableImmutableList.cs
@@ -41,7 +41,9 @@ public class BindableImmutableList<TItem, TBindableItem> : BindableEnumerable<II
 
 	/// <inheritdoc />
 	private protected override CollectionChangeSet<TItem> GetChanges(IImmutableList<TItem> previous, IImmutableList<TItem> current)
-		=> _analyzer.GetChanges(previous ?? ImmutableList<TItem>.Empty, current);
+		// '_analyzer' might be null when the base.ctor subscribe to the 'property' and invokes the 'OnOwnerUpdated'
+		// We can safely fallback on ListFeed<TItem>.DefaultAnalyzer as in that case the 'previous' will be null/empty anyway.
+		=> (_analyzer ?? ListFeed<TItem>.DefaultAnalyzer).GetChanges(previous ?? ImmutableList<TItem>.Empty, current);
 
 	private protected override IImmutableList<TItem> Replace(IImmutableList<TItem>? items, TItem oldItem, TItem newItem)
 	{


### PR DESCRIPTION
## Bugfix
Possible null ref when instantiating `BindableImmutableList`.

## What is the current behavior?
In ctor of `Bindable` we apply the initial value, but the inheriting object might **internally** override the `GetChanges`. This drives to invoke `virtual` method in ctor and in the case of the `BindableImmutableList`, invoke it before the `_analyzer` field is initialized.

## What is the new behavior?
As this method can be override only in internal code, and the `Bindable` can be used by application code (at least generated code), we fixed it only in the `BindableImmutableList` by using the default analyzer of `ListFeed<T>`.

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
