### PR TITLE
fix: Possible null ref when initialiazing BindableImmutableList

### DIFF
--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableEnumerable.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableEnumerable.cs
@@ -33,7 +33,7 @@ public abstract class BindableEnumerable<TCollection, TItem, TBindableItem> : Bi
 	private readonly BindablePropertyInfo<TCollection> _listProperty;
 	private readonly Func<BindablePropertyInfo<TItem>, TBindableItem> _bindableFactory;
 
-	private readonly Visitor _visitor;
+	private Visitor? _visitor;
 
 	/// <summary>
 	/// Creates a new instance
@@ -47,7 +47,6 @@ public abstract class BindableEnumerable<TCollection, TItem, TBindableItem> : Bi
 	{
 		_listProperty = property;
 		_bindableFactory = bindableFactory;
-		_visitor = new Visitor(this);
 	}
 
 	private protected abstract CollectionChangeSet<TItem> GetChanges(TCollection previous, TCollection current);
@@ -58,7 +57,7 @@ public abstract class BindableEnumerable<TCollection, TItem, TBindableItem> : Bi
 	{
 		var collectionChanges = (changes as CollectionChangeSet<TItem> ?? GetChanges(previous, current));
 		base.UpdateSubProperties(previous, current, collectionChanges);
-		collectionChanges.Visit(_visitor);
+		collectionChanges.Visit(_visitor ??= new(this));
 	}
 
 	#region IList (read-only)


### PR DESCRIPTION
## Bugfix
Possible null ref when initialiazing BindableImmutableList

Continuation of https://github.com/unoplatform/uno.extensions/pull/922

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
