### PR TITLE
feat: Remove net5windows tfm

### DIFF
--- a/src/tfms-ui-all.props
+++ b/src/tfms-ui-all.props
@@ -13,6 +13,6 @@
 		<TargetFrameworks Condition="'$(Build_iOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-ios</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_MacOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-macos;net6.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_Android)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-android</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Build_Windows)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net5.0-windows10.0.18362;net6.0-windows10.0.18362</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Build_Windows)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
 	</PropertyGroup>
 </Project>

--- a/src/tfms-ui-net6-only.props
+++ b/src/tfms-ui-net6-only.props
@@ -8,6 +8,6 @@
 		<TargetFrameworks Condition="'$(Build_iOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-ios</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_MacOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-macos;net6.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_Android)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-android</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Build_Windows)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net5.0-windows10.0.18362;net6.0-windows10.0.18362</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Build_Windows)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
 	</PropertyGroup>
 </Project>

--- a/src/tfms-ui-winui.props
+++ b/src/tfms-ui-winui.props
@@ -11,6 +11,6 @@
 		<TargetFrameworks Condition="'$(Build_iOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-ios</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_MacOS)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-macos;net6.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="'$(Build_Android)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-android</TargetFrameworks>
-		<TargetFrameworks Condition="'$(Build_Windows)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net5.0-windows10.0.18362;net6.0-windows10.0.18362</TargetFrameworks>
+		<TargetFrameworks Condition="'$(Build_Windows)'=='true' and '$(UnoExtensionsDisableNet6)'==''">$(TargetFrameworks);net6.0-windows10.0.18362</TargetFrameworks>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Includes net5windows tfm as well as net6windows

## What is the new behavior?

Only includes net6windows

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
