### PR TITLE
perf: Enable XAML trimming for reactive

### DIFF
--- a/samples/Playground/Directory.Build.props
+++ b/samples/Playground/Directory.Build.props
@@ -13,11 +13,6 @@
 		<SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<!--This override is used to validate the use of specific version of the C# Compiler-->
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" PrivateAssets="all" />
-	</ItemGroup>
-	
 	<!-- Reference generators props. This required only when referencing extensions project as source code (instead of packages) -->
 	<Import Project="$(MSBuildThisFileDirectory)\..\..\src\Uno.Extensions.Core.Generators\buildTransitive\Uno.Extensions.Core.props" />
 	<Import Project="$(MSBuildThisFileDirectory)\..\..\src\Uno.Extensions.Reactive.Generator\buildTransitive\Uno.Extensions.Reactive.props" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,12 +29,6 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<!--This override is used to validate the use of specific version of the C# Compiler-->
-		<PackageReference Include="Microsoft.Net.Compilers.Toolset" PrivateAssets="all" />
-	</ItemGroup>
-
-
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>

--- a/src/Uno.Extensions.Reactive.UI/AssemblyInfo.cs
+++ b/src/Uno.Extensions.Reactive.UI/AssemblyInfo.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using Uno.Extensions.Equality;
 
 [assembly: ImplicitKeys(IsEnabled = false)]
+[assembly: AssemblyMetadata("IsTrimmable", "True")]

--- a/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.WinUI.csproj
+++ b/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.WinUI.csproj
@@ -10,6 +10,8 @@
 		<EnableDefaultPageItems>false</EnableDefaultPageItems>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 		<PackageId>Uno.Extensions.Reactive.WinUI</PackageId>
+		
+		<UnoXamlResourcesTrimming Condition="'$(MSBuildRuntimeType)'=='Core' and '$(Configuration)'=='Release'">true</UnoXamlResourcesTrimming>
 	</PropertyGroup>
 
 	<Import Project="common.props" />

--- a/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.csproj
+++ b/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.UI.csproj
@@ -8,6 +8,8 @@
 	<PropertyGroup>
 		<Description>Reactive Extensions for the Uno Platform (UWP)</Description>
 		<PackageId>Uno.Extensions.Reactive.UI</PackageId>
+
+		<UnoXamlResourcesTrimming Condition="'$(MSBuildRuntimeType)'=='Core' and '$(Configuration)'=='Release'">true</UnoXamlResourcesTrimming>
 	</PropertyGroup>
 	
 	<Import Project="common.props" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Enables XAML Trimming capabilities for Reactive.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
