### PR TITLE
fix: ShowAsync should be part of Hosting

### DIFF
--- a/samples/Playground/Playground.Shared/App.xaml.cs
+++ b/samples/Playground/Playground.Shared/App.xaml.cs
@@ -148,7 +148,7 @@ public sealed partial class App : Application
 
 			case InitOption.AppBuilderShell:
 
-				_host = await appBuilder.ShowAsync<AppRoot>();
+				_host = await appBuilder.NavigateAsync<AppRoot>();
 				break;
 
 			case InitOption.NoShellViewModel:

--- a/src/Uno.Extensions.Hosting.UI/ApplicationExtensions.cs
+++ b/src/Uno.Extensions.Hosting.UI/ApplicationExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.UI.Xaml;
-
-namespace Uno.Extensions.Hosting;
+﻿namespace Uno.Extensions.Hosting;
 
 /// <summary>
 /// Extensions for the <see cref="IApplicationBuilder" />

--- a/src/Uno.Extensions.Hosting.UI/IApplicationBuilder.cs
+++ b/src/Uno.Extensions.Hosting.UI/IApplicationBuilder.cs
@@ -20,6 +20,9 @@ public interface IApplicationBuilder
 	/// </summary>
 	Window Window { get; }
 
+	/// <summary>
+	/// Gets stateful properties that Extensions can use to work with each other.
+	/// </summary>
 	IDictionary<object, object> Properties { get; }
 
 	/// <summary>

--- a/src/Uno.Extensions.Navigation.UI/ApplicationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ApplicationBuilderExtensions.cs
@@ -2,16 +2,15 @@
 
 public static class ApplicationBuilderExtensions
 {
-	public static Task<IHost> ShowAsync<TShell>(this IApplicationBuilder appBuilder)
-		where TShell : UIElement, new() =>
-		NavigateInternalAsync<TShell>(appBuilder, null);
-
-	public static Task<IHost> NavigateAsync<TShell>(this IApplicationBuilder appBuilder,
-		Func<IServiceProvider, INavigator, Task> initialNavigate)
-		where TShell : UIElement, new() =>
-		NavigateInternalAsync<TShell>(appBuilder, initialNavigate);
-
-	private static async Task<IHost> NavigateInternalAsync<TShell>(IApplicationBuilder appBuilder,
+	/// <summary>
+	/// Creates the Application Shell and will initialize the Shell Content before creating
+	/// the <see cref="IHost" /> and initializing the app with the initial navigation.
+	/// </summary>
+	/// <typeparam name="TShell">The <see cref="UIElement" /> to use for the App Shell.</typeparam>
+	/// <param name="appBuilder">The <see cref="IApplicationBuilder" />.</param>
+	/// <param name="initialNavigate">An optional Navigation Delegate to conditionally control where the app should navigate on launch.</param>
+	/// <returns>The <see cref="IHost" />.</returns>
+	public static async Task<IHost> NavigateAsync<TShell>(this IApplicationBuilder appBuilder,
 		Func<IServiceProvider, INavigator, Task>? initialNavigate = null)
 		where TShell : UIElement, new()
 	{

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.UI/App.xaml.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.UI/App.xaml.cs
@@ -80,7 +80,7 @@ public sealed partial class App : Application
 			.UseToolkitNavigation();
 		_window = builder.Window;
 
-		_host = await builder.ShowAsync<Shell>();
+		_host = await builder.NavigateAsync<Shell>();
 	}
 
 	/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): #

n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

ShowAsync is a parameterless option for the NavigateAsync extension in the Navigation library

## What is the new behavior?

NavigateAsync is available with/without specifying an initial navigation callback.
ShowAsync is an extension in the Hosting Library which simply sets the Shell and initializes the host.

