### PR TITLE
fix(reactive): Fix possible null ref in list feed init

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Presentation/Bindings/Given_BindableImmutableList.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Presentation/Bindings/Given_BindableImmutableList.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Bindings;
+using Uno.Extensions.Reactive.Testing;
+using Uno.Extensions.Reactive.Tests.Generator;
+
+namespace Uno.Extensions.Reactive.Tests.Presentation.Bindings;
+
+[TestClass]
+public partial class Given_BindableImmutableList : FeedTests
+{
+	[TestMethod]
+	public void When_Init()
+	{
+		var prop = new BindablePropertyInfo<IImmutableList<int>>(
+			new TestBindable(),
+			"sut",
+			(default!, changed => changed(ImmutableList.Create(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))),
+			async (_, __, ct) => { });
+
+		var createdItemBindable = 0;
+		var sut = new BindableImmutableList<int, Bindable<int>>(prop, itemProp =>
+		{
+			createdItemBindable++;
+			return new Bindable<int>(itemProp);
+		});
+
+		createdItemBindable.Should().Be(10);
+		sut.Count.Should().Be(10);
+	}
+
+	private class TestBindable : IBindable
+	{
+	}
+}

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableConfig.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableConfig.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive.Bindings;
+
+/// <summary>
+/// Advanced configuration flags for <see cref="Bindable{T}"/>.
+/// </summary>
+[Flags]
+internal enum BindableConfig
+{
+	/// <summary>
+	/// Automatically initialize the Bindable (Cf. remarks for details).
+	/// </summary>
+	/// <remarks>
+	/// During the initialization, the bindable subscribes to the given property in order to be notified when the value changed.
+	/// But the "updated callback" is also expected to be invoked synchronously in order to get the current value (if ready).
+	/// If so, the current value will be applied locally (`SetValueCore`) which drives to invoke the `UpdateSubProperties` which is a virtual method.
+	/// Inheritors can remove that flag to avoid this issue. Is so, it's their responsibility to invoke the `Initialize` method at the end of their constructor.
+	/// </remarks>
+	AutoInit = 1,
+
+	/// <summary>
+	/// Indicates that the inheritor has a property name `Value` which can be data bind directly instead of <see cref="Bindable{T}.GetValue"/> and <see cref="Bindable{T}.SetValue(T)"/>.
+	/// Is so, the <see cref="INotifyPropertyChanged.PropertyChanged"/> will be raise accordingly.
+	/// </summary>
+	RaiseValuePropertyChanged,
+
+	Default = AutoInit
+}

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableEnumerable.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableEnumerable.cs
@@ -40,13 +40,21 @@ public abstract class BindableEnumerable<TCollection, TItem, TBindableItem> : Bi
 	/// </summary>
 	/// <param name="property">Info of the property that is backed by this instance.</param>
 	/// <param name="bindableFactory">The factory to create an instance of <typeparamref name="TBindableItem"/>.</param>
+	/// <param name="config">Advanced configuration of the base bindable.</param>
 	private protected BindableEnumerable(
 		BindablePropertyInfo<TCollection> property,
-		Func<BindablePropertyInfo<TItem>, TBindableItem> bindableFactory)
-		: base(property)
+		Func<BindablePropertyInfo<TItem>, TBindableItem> bindableFactory,
+		BindableConfig config)
+		: base(property, config & ~BindableConfig.AutoInit)
 	{
 		_listProperty = property;
 		_bindableFactory = bindableFactory;
+
+		// As we disabled auto-init on parent, if sub-classes kept it enabled, we have to invoke it by our own.
+		if (config.HasFlag(BindableConfig.AutoInit))
+		{
+			Initialize();
+		}
 	}
 
 	private protected abstract CollectionChangeSet<TItem> GetChanges(TCollection previous, TCollection current);

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableImmutableList.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableImmutableList.cs
@@ -34,15 +34,19 @@ public class BindableImmutableList<TItem, TBindableItem> : BindableEnumerable<II
 		BindablePropertyInfo<IImmutableList<TItem>> property,
 		Func<BindablePropertyInfo<TItem>, TBindableItem> bindableFactory,
 		ItemComparer<TItem> comparer)
-		: base(property, bindableFactory)
+		: base(property, bindableFactory, BindableConfig.Default & ~BindableConfig.AutoInit)
 	{
 		_analyzer = new CollectionAnalyzer<TItem>(ListFeed<TItem>.GetComparer(comparer));
+
+		// As we disabled the `AutoInit`, we make sure to init by our own.
+		Initialize();
 	}
 
 	/// <inheritdoc />
 	private protected override CollectionChangeSet<TItem> GetChanges(IImmutableList<TItem> previous, IImmutableList<TItem> current)
 		// '_analyzer' might be null when the base.ctor subscribe to the 'property' and invokes the 'OnOwnerUpdated'
-		// We can safely fallback on ListFeed<TItem>.DefaultAnalyzer as in that case the 'previous' will be null/empty anyway.
+		// That's should not happen since the `AutoInit` has been disable, but for safety we fallback on ListFeed<TItem>.DefaultAnalyzer.
+		// This is valid as in that case the 'previous' will be null/empty anyway.
 		=> (_analyzer ?? ListFeed<TItem>.DefaultAnalyzer).GetChanges(previous ?? ImmutableList<TItem>.Empty, current);
 
 	private protected override IImmutableList<TItem> Replace(IImmutableList<TItem>? items, TItem oldItem, TItem newItem)

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindablePropertyInfo.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindablePropertyInfo.cs
@@ -48,7 +48,7 @@ public readonly struct BindablePropertyInfo<T>
 	/// Updates the property.
 	/// </summary>
 	/// <param name="updater">The method to update the current value.</param>
-	/// <param name="isLeafPropertyChanged">Indicates if the update is directly on this property (true) or it's dure to an update of a sub-property.</param>
+	/// <param name="isLeafPropertyChanged">Indicates if the update is directly on this property (true) or it's due to an update of a sub-property.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns></returns>
 	/// <remarks>This method has to be invoked on the UI thread.</remarks>


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno.extensions/issues/978

## Bugfix
Fix possible null ref in list feed init

## What is the current behavior?
We are invoking a `virtual` method while in the ctor

## What is the new behavior?
Sub-classes (internal) can now prevent this call and are responsible to it at the end of their own ctor.

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
