### PR TITLE
feat(reactive): Add support of multi-selection in feeds

### DIFF
--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/CommandFromMethod.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/CommandFromMethod.cs
@@ -179,7 +179,7 @@ internal partial record CommandFromMethod : IMappedMember
 				{
 					return args => parameters
 						.Select((p, i) => p.Symbol is { Type.IsValueType: false, NullableAnnotation: NullableAnnotation.NotAnnotated }
-							? $"{args}.Item{i} is not null"
+							? $"{args}.Item{i+1} is not null"
 							: null)
 						.Where(s => s is not null)
 						.JoinBy(" && ");

--- a/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableCollection_Selection.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableCollection_Selection.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.Devices.Input;
+using Windows.Foundation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Testing;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Extensions.Reactive.WinUI.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+public partial class Given_BindableCollection_Selection : FeedTests
+{
+	public partial class Given_BindableCollection_Selection_Model
+	{
+		public IListState<int> Items => ListState.Value(this, () => ImmutableList.Create(41, 42, 43));
+	}
+
+	[TestMethod]
+	[InjectedPointer(PointerDeviceType.Mouse)]
+#if !__SKIA__
+	[Ignore("Pointer injection not supported yet on this platform")]
+#endif
+	public async Task When_SelectSingleFromView_ListView()
+	{
+		var (vm, lv, items) = await SetupListView(ListViewSelectionMode.Single);
+
+		InputInjectorHelper.Current.Tap(items[1]);
+
+		await UIHelper.WaitFor(async ct => await vm.Items.GetSelectedItem(ct) == 42, CT);
+	}
+
+	[TestMethod]
+	[InjectedPointer(PointerDeviceType.Mouse)]
+#if !__SKIA__
+	[Ignore("Pointer injection not supported yet on this platform")]
+#endif
+	public async Task When_SelectMultipleFromView_ListView()
+	{
+		var (vm, lv, items) = await SetupListView(ListViewSelectionMode.Multiple);
+
+		InputInjectorHelper.Current.Tap(items[0]);
+		InputInjectorHelper.Current.Tap(items[1]);
+
+		await UIHelper.WaitFor(async ct =>
+		{
+			return (await vm.Items.GetSelectedItems(ct)).SequenceEqual(new[] { 41, 42 });
+		}, CT);
+	}
+
+	private async Task<(BindableGiven_BindableCollection_Selection_Model, ListView, ListViewItem[])> SetupListView(ListViewSelectionMode selectionMode)
+	{
+		var vm = new BindableGiven_BindableCollection_Selection_Model();
+		var lv = new ListView { ItemsSource = vm.Items, SelectionMode = selectionMode };
+
+		await UIHelper.Load(lv, CT);
+
+		var lvItems = Array.Empty<ListViewItem>();
+		await UIHelper.WaitFor(async ct =>
+		{
+			lvItems = UIHelper.FindChildren<ListViewItem>(lv).ToArray();
+			return lvItems.Length > 0;
+		}, CT);
+
+		return (vm, lv, lvItems);
+	}
+}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
@@ -100,11 +100,13 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 		var currentCount = 0;
 		var pageTokens = new TokenSetAwaiter<PageToken>();
 
+		var collection = default(BindableCollection);
 		var requests = new RequestSource();
 		var pagination = new PaginationService(LoadMore);
 		var selection = new SelectionService(SetSelected);
 		var services = new SingletonServiceProvider(pagination, selection);
-		var collection = BindableCollection.Create(
+		
+		collection = BindableCollection.Create(
 			services: services,
 			itemComparer: ListFeed<T>.DefaultComparer);
 

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/ISelectionService.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/ISelectionService.cs
@@ -1,29 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Uno.Extensions.Reactive.Bindings.Collections.Services;
 
-internal interface ISelectionService
+internal interface ISelectionService : ISelectionInfo
 {
 	/// <summary>
 	/// Event raise when any properties of the service has changed
 	/// </summary>
 	event EventHandler StateChanged;
-
-	/// <summary>
-	/// Get the index of the primary selected item.
-	/// </summary>
-	uint? SelectedIndex { get; }
-
-	/// <summary>
-	/// Sets the **single** selected item.
-	/// </summary>
-	/// <param name="index">The index of the selected item or null to clear selection.</param>
-	void SelectFromModel(uint? index);
-
-	/// <summary>
-	/// Sets the **single** selected item.
-	/// </summary>
-	/// <param name="index">The index of the selected item or -1 to clear selection.</param>
-	void SelectFromView(int index);
 }

--- a/src/Uno.Extensions.Reactive/Core/Axes/SelectionIndexRange.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/SelectionIndexRange.cs
@@ -13,9 +13,9 @@ public sealed record SelectionIndexRange(uint FirstIndex, uint Length)
 	/// <summary>
 	/// Gets the index of the last selected item.
 	/// </summary>
-	public uint LastIndex { get; } = FirstIndex + Length - 1;
+	public uint LastIndex { get; } = Length is 0 ? FirstIndex : FirstIndex + Length - 1;
 
 	/// <inheritdoc />
 	public override string ToString()
-		=> $"[{FirstIndex}, {LastIndex}[";
+		=> $"[{FirstIndex}, {LastIndex}]";
 };

--- a/src/Uno.Extensions.Reactive/Core/Axes/SelectionInfo.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/SelectionInfo.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Uno.Extensions.Reactive.Utils;
 
 namespace Uno.Extensions.Reactive;
 
@@ -193,6 +194,42 @@ public sealed record SelectionInfo
 
 		return selectedItems.ToImmutable();
 	}
+
+	/// <summary>
+	/// Determines if an index is contained by any of the ranges of this selection info
+	/// </summary>
+	/// <param name="index">The index to validate.</param>
+	/// <returns>True is the index is present, false otherwise.</returns>
+	public bool Contains(int index)
+		=> Ranges.Any(range => range.FirstIndex >= index && range.LastIndex <= index);
+
+	/// <summary>
+	/// Create a new SelectionInfo which contains ranges of this instance among the provided <paramref name="range"/>.
+	/// </summary>
+	/// <remarks>The provided range will be coerced with current ranges to avoid duplicate and reduce the number of ranges.</remarks>
+	/// <param name="range">The range to add.</param>
+	/// <returns>A new SelectionInfo which contains all selected ranges.</returns>
+	public SelectionInfo Add(SelectionIndexRange range)
+		=> new(SelectionHelper.Add(Ranges, range));
+
+	/// <summary>
+	/// Create a new SelectionInfo which contains ranges of this instance except the provided <paramref name="range"/>.
+	/// </summary>
+	/// <remarks>
+	/// The provided range is not required to be an instance of the <see cref="Ranges"/>, it can be a subset of any current range
+	/// and even be out of current ranges (i.e. this method won't have any impact).
+	/// </remarks>
+	/// <param name="range">The range to remove.</param>
+	/// <returns>A new SelectionInfo which contains current ranges except <paramref name="range"/>.</returns>
+	public SelectionInfo Remove(SelectionIndexRange range)
+		=> new(SelectionHelper.Remove(Ranges, range));
+
+	/// <summary>
+	/// Returns the <see cref="Empty"/> instance.
+	/// </summary>
+	/// <returns>Returns the <see cref="Empty"/> instance.</returns>
+	public SelectionInfo Clear()
+		=> Empty;
 
 	/// <inheritdoc />
 	public override string ToString()

--- a/src/Uno.Extensions.Reactive/Utils/SelectionHelper.cs
+++ b/src/Uno.Extensions.Reactive/Utils/SelectionHelper.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive.Utils;
+
+internal static class SelectionHelper
+{
+	public static IReadOnlyList<SelectionIndexRange> Coerce(IReadOnlyList<SelectionIndexRange> ranges)
+	{
+		if (ranges.Count <= 1)
+		{
+			return ranges;
+		}
+
+		using var enumerator = ranges.OrderBy(range => range.Length).GetEnumerator();
+		if (!enumerator.MoveNext())
+		{
+			return Array.Empty<SelectionIndexRange>();
+		}
+
+		var result = new List<SelectionIndexRange>(ranges.Count);
+		var previous = enumerator.Current;
+		while (enumerator.MoveNext())
+		{
+			var current = enumerator.Current;
+			var intersect = previous.LastIndex - current.FirstIndex;
+			if (intersect >= 0)
+			{
+				previous = previous with { Length = previous.Length + current.Length - intersect };
+			}
+			else
+			{
+				result.Add(previous);
+				previous = current;
+			}
+		}
+		result.Add(previous);
+
+		return result;
+	}
+
+	public static IReadOnlyList<SelectionIndexRange> Add(IReadOnlyList<SelectionIndexRange> ranges, SelectionIndexRange added)
+	{
+		if (ranges.Count is 0 || added.Length is 0)
+		{
+			return new[] { added };
+		}
+
+		var rangesList = ranges.ToList();
+		rangesList.Add(added);
+
+		return Coerce(rangesList);
+	}
+
+	public static IReadOnlyList<SelectionIndexRange> Remove(IReadOnlyList<SelectionIndexRange> ranges, SelectionIndexRange removed)
+	{
+		if (ranges.Count is 0 || removed.Length is 0)
+		{
+			return ranges;
+		}
+
+		var result = new List<SelectionIndexRange>(ranges.Count);
+		foreach (var range in ranges)
+		{
+			if (range == removed)
+			{
+				continue;
+			}
+
+			//var firstIndex = range.FirstIndex;
+			//var length = (int)range.Length;
+
+			if (range.FirstIndex < removed.FirstIndex)
+			{
+				var lastIndex = Math.Min(range.LastIndex, removed.FirstIndex);
+				var length = range.FirstIndex - lastIndex + 1;
+
+				if (length == range.Length)
+				{
+					// The whole range is before the exclusion, keep instance and continue!
+					result.Add(range);
+					continue;
+				}
+
+				result.Add(new(range.FirstIndex, length));
+			}
+
+			if (range.LastIndex >= removed.LastIndex)
+			{
+				var firstIndex = Math.Max(range.FirstIndex, removed.LastIndex);
+				var length = range.Length - (firstIndex - range.FirstIndex);
+
+				if (length == range.Length)
+				{
+					// The whole range is before the exclusion, keep instance and continue!
+					result.Add(range);
+					continue;
+				}
+
+				result.Add(new(firstIndex, length));
+			}
+		}
+
+		return result;
+	}
+
+	//public static SelectionIndexRange? Except(SelectionIndexRange range, SelectionIndexRange exclusion)
+	//{
+	//	if (range == exclusion)
+	//	{
+	//		return null;
+	//	}
+
+	//	var firstIndex = range.FirstIndex;
+	//	var length = (int)range.Length;
+	//	if (range.FirstIndex >= exclusion.FirstIndex)
+	//	{
+	//		var intersectAtRangeHead = range.FirstIndex - (int)exclusion.LastIndex + 1;
+	//		if (intersectAtRangeHead > 0)
+	//		{
+	//			firstIndex = exclusion.LastIndex + 1;
+	//			length -= (int)intersectAtRangeHead;
+	//		}
+	//	}
+
+
+	//	if (range.LastIndex <= exclusion.LastIndex)
+	//	{
+	//		var intersectAtRangeTail = range.LastIndex - (int)exclusion.FirstIndex + 1;
+	//		if (intersectAtRangeTail > 0)
+	//		{
+	//			length -= (int)intersectAtRangeTail;
+	//		}
+	//	}
+
+	//	return length == range.Length
+	//		? range
+	//		: new(firstIndex, (uint)length);
+	//}
+
+}

--- a/src/Uno.Extensions.Reactive/Utils/SelectionHelper.cs
+++ b/src/Uno.Extensions.Reactive/Utils/SelectionHelper.cs
@@ -104,39 +104,4 @@ internal static class SelectionHelper
 
 		return result;
 	}
-
-	//public static SelectionIndexRange? Except(SelectionIndexRange range, SelectionIndexRange exclusion)
-	//{
-	//	if (range == exclusion)
-	//	{
-	//		return null;
-	//	}
-
-	//	var firstIndex = range.FirstIndex;
-	//	var length = (int)range.Length;
-	//	if (range.FirstIndex >= exclusion.FirstIndex)
-	//	{
-	//		var intersectAtRangeHead = range.FirstIndex - (int)exclusion.LastIndex + 1;
-	//		if (intersectAtRangeHead > 0)
-	//		{
-	//			firstIndex = exclusion.LastIndex + 1;
-	//			length -= (int)intersectAtRangeHead;
-	//		}
-	//	}
-
-
-	//	if (range.LastIndex <= exclusion.LastIndex)
-	//	{
-	//		var intersectAtRangeTail = range.LastIndex - (int)exclusion.FirstIndex + 1;
-	//		if (intersectAtRangeTail > 0)
-	//		{
-	//			length -= (int)intersectAtRangeTail;
-	//		}
-	//	}
-
-	//	return length == range.Length
-	//		? range
-	//		: new(firstIndex, (uint)length);
-	//}
-
 }

--- a/src/Uno.Extensions.RuntimeTests.Core/UIHelper.cs
+++ b/src/Uno.Extensions.RuntimeTests.Core/UIHelper.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
 
 namespace Uno.UI.RuntimeTests;
 
@@ -21,6 +23,22 @@ public static class UIHelper
 	{
 		Content = element;
 		await WaitForLoaded(element, ct);
+	}
+
+	public static IEnumerable<T> FindChildren<T>(DependencyObject element)
+	{
+		if (element is T t)
+		{
+			yield return t;
+		}
+
+		for (var i = 0; i < VisualTreeHelper.GetChildrenCount(element); i++)
+		{
+			foreach (var child in FindChildren<T>(VisualTreeHelper.GetChild(element, i)))
+			{
+				yield return child;
+			}
+		}
 	}
 
 	public static async Task WaitForLoaded(FrameworkElement element, CancellationToken ct)

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
@@ -30,11 +30,11 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.417" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.417" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.417" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.626" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.626" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.417" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.626" />
 	</ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net6.0-android'">

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
@@ -19,10 +19,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.6.19" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.6.19" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.19" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.6.19" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.626" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.626" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
@@ -26,10 +26,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.6.19" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.6.19" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.19" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.6.19" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.626" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.626" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
@@ -48,12 +48,12 @@
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.6.19" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.6.19" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.19" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.626" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.626" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.3" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.3" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.6.19" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.626" />
 	</ItemGroup>
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems')" />
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\common.props" />


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/902

## Feature
Add support of multi selection


## What is the current behavior?
`BindableCollection` supports only single-select

## What is the new behavior?
`BindableCollection` now also implements `ISelectionInfo`

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
