### PR TITLE
feat(reactive): Add support for collection edition

### DIFF
--- a/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableCollection_Edition.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableCollection_Edition.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.Devices.Input;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Testing;
+using Uno.UI.RuntimeTests;
+using Microsoft.UI.Xaml.Data;
+
+namespace Uno.Extensions.Reactive.WinUI.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+public partial class Given_BindableCollection_Edition : FeedTests
+{
+	public partial class Given_BindableCollection_Edition_Model
+	{
+		public IListState<int> Items => ListState.Value(this, () => ImmutableList.Create(41, 42, 43));
+	}
+
+	[TestMethod]
+	[InjectedPointer(PointerDeviceType.Touch)]
+	public async Task When_EditFromView()
+	{
+		var vm = new BindableGiven_BindableCollection_Edition_Model();
+		var collectionView = (await (vm.Items as ISignal<IMessage>).GetSource(Context, CT).FirstAsync()).Current.Data.SomeOrDefault() as ICollectionView;
+
+		Assert.IsNotNull(collectionView);
+
+		collectionView.RemoveAt(1);
+		collectionView.Insert(0, 42);
+
+		await UIHelper.WaitFor(async ct =>
+		{
+			var items = await vm.Items;
+			var isRightOrder = items.SequenceEqual(new[] { 42, 41, 43 });
+
+			return isRightOrder;
+		}, CT);
+	}
+
+	private async Task<(BindableGiven_BindableCollection_Edition_Model, ListView, ListViewItem[])> SetupListView()
+	{
+		var vm = new BindableGiven_BindableCollection_Edition_Model();
+		var lv = new ListView { ItemsSource = vm.Items, CanDragItems = true, AllowDrop = true, CanReorderItems = true };
+
+		await UIHelper.Load(lv, CT);
+
+		var lvItems = Array.Empty<ListViewItem>();
+		await UIHelper.WaitFor(async ct =>
+		{
+			lvItems = UIHelper.FindChildren<ListViewItem>(lv).ToArray();
+			return lvItems.Length > 0;
+		}, CT);
+
+		return (vm, lv, lvItems);
+	}
+}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataLayer.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataLayer.cs
@@ -195,6 +195,9 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 		/// <inheritdoc />
 		public object? GetService(Type serviceType)
 			=> _services?.GetService(serviceType);
+
+		public void Update(RichNotifyCollectionChangedEventArgs args)
+			=> _currentChangesBuffer?.Add(args); // Note: _currentChangesBuffer should never be 'null' here.
 		#endregion
 
 		public void Schedule(Action action)
@@ -203,9 +206,9 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 			{
 				_parent.Schedule(action);
 			}
-			else if (_context is not null and {HasThreadAccess: false})
+			else if (_context is not null and { HasThreadAccess: false })
 			{
-				_context.TryEnqueue(() => action());
+				_context.TryEnqueue(action);
 			}
 			else
 			{

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataLayerUpdate.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataLayerUpdate.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Uno.Extensions.Collections;
+using Uno.Extensions.Collections.Facades.Differential;
 using Uno.Extensions.Collections.Tracking;
 using Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data;
 using Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets;
@@ -82,7 +83,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 				else if (_context.HasReachedLimit)
 				{
 					// We should reach this code only for a root holder, for children we should have been invoked with 'silently = true'
-					_target.UpdateTo(_changes.ToReset(_target.ToImmutable(), Result), Result);
+					_target.UpdateTo(_changes.ToReset(_target.Head.AsList(), Result), Result);
 				}
 				else
 				{

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/LeafStrategy.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/LeafStrategy.cs
@@ -36,8 +36,9 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 			{
 				var paginationFacet = new PaginationFacet(source, extendedPropertiesFacet);
 				var selectionFacet = new SelectionFacet(source, () => view ?? throw new InvalidOperationException("The owner provider must be resolved lazily!"));
+				var editionFacet = new EditionFacet(source, collectionFacet);
 
-				view = new BasicView(collectionFacet, collectionChangedFacet, extendedPropertiesFacet, selectionFacet, paginationFacet);
+				view = new BasicView(collectionFacet, collectionChangedFacet, extendedPropertiesFacet, selectionFacet, paginationFacet, editionFacet);
 
 				return (collectionFacet, view, new object[] { collectionFacet, collectionChangedFacet, paginationFacet, selectionFacet, extendedPropertiesFacet });
 			}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/EditionFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/EditionFacet.cs
@@ -22,7 +22,7 @@ internal class EditionFacet
 		_service = source.GetService(typeof(IEditionService)) as IEditionService;
 	}
 
-	public bool IsReadOnly => _service is not null;
+	public bool IsReadOnly => _service is null;
 
 	public void SetItem(int index, object? value)
 	{

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/EditionFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/EditionFacet.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Windows.Foundation.Collections;
+using Uno.Extensions.Collections;
+using Uno.Extensions.Collections.Facades.Differential;
+using Uno.Extensions.Reactive.Bindings.Collections.Services;
+
+namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets;
+
+internal class EditionFacet
+{
+	private readonly IBindableCollectionViewSource _source;
+	private readonly CollectionFacet _collection;
+	private readonly IEditionService? _service;
+
+	public EditionFacet(IBindableCollectionViewSource source, CollectionFacet collection)
+	{
+		_source = source;
+		_collection = collection;
+		_service = source.GetService(typeof(IEditionService)) as IEditionService;
+	}
+
+	public bool IsReadOnly => _service is not null;
+
+	public void SetItem(int index, object? value)
+	{
+		if (_service is { } svc)
+		{
+			var oldItem = _collection[index];
+			var newItem = value;
+
+			svc.Update(srcNode =>
+			{
+				// The source collection might have been updated and not yet pushed to the current thread.
+				// So to avoid out-of-range exception, we have to make sure to get the effective index from the source.
+				// However, we are not validating the instances of the oldItem and newItem as they should be either same instance either Equals.
+				var srcIndex = srcNode.IndexOf(oldItem, 0);
+				return new ReplaceNode(srcNode, oldItem, newItem, srcIndex);
+			});
+			_source.Update(RichNotifyCollectionChangedEventArgs.Replace(oldItem, newItem, index));
+		}
+	}
+
+	public void Add(object? value)
+	{
+		if (_service is { } svc)
+		{
+			var index = _collection.Count;
+			var newItem = value;
+
+			svc.Update(srcNode =>
+			{
+				// The source collection might have been updated and not yet pushed to the current thread.
+				// So to avoid out-of-range exception, we have to make sure to get the effective index from the source.
+				var srcIndex = Math.Min(index, srcNode.Count);
+				return new AddNode(srcNode, newItem!, srcIndex);
+			});
+			_source.Update(RichNotifyCollectionChangedEventArgs.Add(newItem, index));
+		}
+	}
+
+	public void Insert(int index, object? value)
+	{
+		if (_service is { } svc)
+		{
+			var newItem = value;
+
+			svc.Update(srcNode =>
+			{
+				// The source collection might have been updated and not yet pushed to the current thread.
+				// So to avoid out-of-range exception, we have to make sure to get the effective index from the source.
+				var srcIndex = Math.Min(index, srcNode.Count);
+				return new AddNode(srcNode, newItem!, srcIndex);
+			});
+			_source.Update(RichNotifyCollectionChangedEventArgs.Add(newItem, index));
+		}
+	}
+
+	public void RemoveAt(int index)
+	{
+		if (_service is { } svc)
+		{
+			var oldItem = _collection[index];
+
+			svc.Update(srcNode =>
+			{
+				// The source collection might have been updated and not yet pushed to the current thread.
+				// So to avoid out-of-range exception, we have to make sure to get the effective index from the source.
+				// However, we are not validating the instances of the oldItem and newItem as they should be either same instance either Equals.
+				var srcIndex = srcNode.IndexOf(oldItem, 0);
+				return srcIndex < 0 ? srcNode : new RemoveNode(srcNode, oldItem, srcIndex);
+			});
+			_source.Update(RichNotifyCollectionChangedEventArgs.Remove(oldItem, index));
+		}
+	}
+
+	public bool Remove(object? value)
+	{
+		if (_service is { } svc)
+		{
+			var index = _collection.IndexOf(value!);
+			if (index < 0)
+			{
+				return false;
+			}
+
+			var oldItem = value;
+
+			svc.Update(srcNode =>
+			{
+				// The source collection might have been updated and not yet pushed to the current thread.
+				// So to avoid out-of-range exception, we have to make sure to get the effective index from the source.
+				// However, we are not validating the instances of the oldItem and newItem as they should be either same instance either Equals.
+				var srcIndex = srcNode.IndexOf(oldItem, 0);
+				return srcIndex < 0 ? srcNode : new RemoveNode(srcNode, oldItem, srcIndex);
+			});
+			_source.Update(RichNotifyCollectionChangedEventArgs.Remove(oldItem, index));
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public void Clear()
+	{
+		if (_service is { } svc)
+		{
+			var oldItems = _collection.Head.AsList();
+			var newItems = Array.Empty<object?>();
+
+			svc.Update(_ => new EmptyNode());
+			_source.Update(RichNotifyCollectionChangedEventArgs.Reset(oldItems, newItems));
+		}
+	}
+}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/IBindableCollectionViewSource.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/IBindableCollectionViewSource.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Uno.Extensions.Collections;
 using Uno.Extensions.Reactive.Dispatching;
 
 namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection;
@@ -28,4 +29,10 @@ internal interface IBindableCollectionViewSource : IServiceProvider
 	/// <returns>The requested facet.</returns>
 	/// <exception cref="InvalidOperationException">If the requested facet is not available on this collection.</exception>
 	TFacet GetFacet<TFacet>();
+
+	/// <summary>
+	/// Update the source from the View
+	/// </summary>
+	/// <param name="args">The change args to apply.</param>
+	void Update(RichNotifyCollectionChangedEventArgs args);
 }

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/EditionService.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/EditionService.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions.Collections.Facades.Differential;
+using Uno.Extensions.Threading;
+
+namespace Uno.Extensions.Reactive.Bindings.Collections.Services;
+
+internal class EditionService : IEditionService, IDisposable
+{
+	private readonly FastAsyncLock _gate = new();
+	private readonly CancellationTokenSource _ct = new();
+	private readonly AsyncAction<Func<IDifferentialCollectionNode, IDifferentialCollectionNode>> _editFromView;
+
+	private ImmutableQueue<Func<IDifferentialCollectionNode, IDifferentialCollectionNode>> _editions = ImmutableQueue<Func<IDifferentialCollectionNode, IDifferentialCollectionNode>>.Empty;
+
+	public EditionService(AsyncAction<Func<IDifferentialCollectionNode, IDifferentialCollectionNode>> editFromView)
+	{
+		_editFromView = editFromView;
+	}
+
+	/// <inheritdoc />
+	public void Update(Func<IDifferentialCollectionNode, IDifferentialCollectionNode> edition)
+	{
+		ImmutableInterlocked.Enqueue(ref _editions, edition);
+		Task.Run(Dequeue, _ct.Token);
+	}
+
+	private async Task Dequeue()
+	{
+		// Make sure we are not running multiple dequeue in //
+		using var _ = await _gate.LockAsync(_ct.Token);
+
+		var editions = Interlocked.Exchange(ref _editions, ImmutableQueue<Func<IDifferentialCollectionNode, IDifferentialCollectionNode>>.Empty);
+		foreach (var edition in editions)
+		{
+			await _editFromView(edition, _ct.Token);
+		}
+	}
+
+	/// <inheritdoc />
+	public void Dispose()
+		=> _ct.Cancel();
+}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/IEditionService.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/IEditionService.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Linq;
+using Uno.Extensions.Collections;
+using Uno.Extensions.Collections.Facades.Differential;
+
+namespace Uno.Extensions.Reactive.Bindings.Collections.Services;
+
+internal interface IEditionService
+{
+	/// <summary>
+	/// Apply a collection changed issued by the view
+	/// </summary>
+	/// <param name="args">The change args.</param>
+	void Update(Func<IDifferentialCollectionNode, IDifferentialCollectionNode> args);
+}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets;
@@ -18,19 +19,22 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 		private readonly CollectionChangedFacet _collectionChanged;
 		private readonly SelectionFacet? _selection;
 		private readonly PaginationFacet? _pagination;
+		private readonly EditionFacet? _edition;
 
 		public BasicView(
 			CollectionFacet collectionFacet,
 			CollectionChangedFacet collectionChangedFacet,
 			BindableCollectionExtendedProperties extendedProperties,
 			SelectionFacet? selectionFacet = null,
-			PaginationFacet? paginationFacet = null)
+			PaginationFacet? paginationFacet = null,
+			EditionFacet? editionFacet = null)
 		{
 			_collection = collectionFacet;
 			_collectionChanged = collectionChangedFacet;
 			ExtendedProperties = extendedProperties;
 			_selection = selectionFacet;
 			_pagination = paginationFacet;
+			_edition = editionFacet;
 		}
 
 		#region ICollection
@@ -46,33 +50,36 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 		}
 
 		public int Count => _collection.Count;
-		public bool IsReadOnly => _collection.IsReadOnly;
+		public bool IsReadOnly => _edition?.IsReadOnly ?? false;
 
 		public object? this[int index]
 		{
 			get => _collection[index];
-			set => _collection[index] = value;
+			set => (_edition ?? throw EditionNotSupported()).SetItem(index, value);
 		}
-
-		public void Add(object item) => _collection.Add(item);
-
-		public void Insert(int index, object item) => _collection.Insert(index, item);
 
 		public int IndexOf(object item) => _collection.IndexOf(item);
 
 		public bool Contains(object item) => _collection.Contains(item);
 
-		public bool Remove(object item) => _collection.Remove(item);
+		public void Add(object item) => (_edition ?? throw EditionNotSupported()).Add(item);
 
-		public void RemoveAt(int index) => _collection.RemoveAt(index);
+		public void Insert(int index, object item) => (_edition ?? throw EditionNotSupported()).Insert(index, item);
 
-		public void Clear() => _collection.Clear();
+		public bool Remove(object item) => (_edition ?? throw EditionNotSupported()).Remove(item);
+
+		public void RemoveAt(int index) => (_edition ?? throw EditionNotSupported()).RemoveAt(index);
+
+		public void Clear() => (_edition ?? throw EditionNotSupported()).Clear();
 
 		IEnumerator<object?> IEnumerable<object?>.GetEnumerator() => _collection.GetEnumerator();
 		IEnumerator IEnumerable.GetEnumerator() => _collection.GetEnumerator();
 
 		public void CopyTo(object[] array, int arrayIndex) => _collection.CopyTo(array, arrayIndex);
-#endregion
+
+		private NotSupportedException EditionNotSupported([CallerMemberName] string? method = null)
+			=> new($"{method} is not supported on a read-only collection.");
+		#endregion
 
 		#region Selection (Single)
 		/// <inheritdoc />

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/FlatView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/FlatView.cs
@@ -8,6 +8,7 @@ using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Uno.Extensions.Collections;
 using Uno.Extensions.Collections.Facades.Composite;
+using Uno.Extensions.Collections.Facades.Differential;
 using Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets;
 
 namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
@@ -115,7 +116,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 
 			return -1;
 		}
-		public IEnumerator<object?> GetEnumerator() => new CompositeEnumerator<object?>(_source.Where(group => group is not null).Cast<IEnumerable<object?>>());
+		public IEnumerator<object?> GetEnumerator() => new CompositeEnumerator<object?>(_source.Head.AsList<object?>().Where(group => group is not null).Cast<IEnumerable<object?>>());
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 		public void CopyTo(object[] array, int arrayIndex)
 		{

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/MapView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/MapView.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Windows.Foundation.Collections;
 using Uno.Extensions.Collections;
+using Uno.Extensions.Collections.Facades.Differential;
 using Uno.Extensions.Collections.Facades.Map;
 using Uno.Extensions.Conversion;
 using Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets;
@@ -141,7 +142,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 		/// <inheritdoc />
 		public IEnumerator<object?> GetEnumerator() => new MapEnumerator<object?, object?>(_converter, _source.GetEnumerator());
 		/// <inheritdoc />
-		public void CopyTo(object?[] array, int arrayIndex) => _converter.ArrayCopy(_source, array, arrayIndex);
+		public void CopyTo(object?[] array, int arrayIndex) => _converter.ArrayCopy(_source.Head.AsList(), array, arrayIndex);
 
 		private NotSupportedException NotSupported([CallerMemberName] string? methodName = null)
 			=> new NotSupportedException(methodName + " is not supported on this collection.");


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/370

## Feature
Add support for collection edition

## What is the current behavior?
Collection send to teh are read-only

## What is the new behavior?
You can now edit them, changes will be reflected in the `ListState`

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
