### PR TITLE
fix(feeds): Fix multi selection support by forwarding ISelectionInfo impl on wrapping types

### DIFF
--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.CollectionView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.CollectionView.cs
@@ -8,7 +8,7 @@ using Windows.Foundation.Collections;
 
 namespace Uno.Extensions.Reactive.Bindings;
 
-partial class BindableListFeed<T> : ICollectionView, INotifyCollectionChanged
+partial class BindableListFeed<T> : ICollectionView, INotifyCollectionChanged, ISelectionInfo
 {
 	/// <inheritdoc />
 	public IEnumerator<object> GetEnumerator()
@@ -136,4 +136,20 @@ partial class BindableListFeed<T> : ICollectionView, INotifyCollectionChanged
 		add => _items.CollectionChanged += value;
 		remove => _items.CollectionChanged -= value;
 	}
+
+	/// <inheritdoc />
+	public void SelectRange(ItemIndexRange itemIndexRange)
+		=> _items.SelectRange(itemIndexRange);
+
+	/// <inheritdoc />
+	public void DeselectRange(ItemIndexRange itemIndexRange)
+		=> _items.DeselectRange(itemIndexRange);
+
+	/// <inheritdoc />
+	public bool IsSelected(int index)
+		=> _items.IsSelected(index);
+
+	/// <inheritdoc />
+	public IReadOnlyList<ItemIndexRange> GetSelectedRanges()
+		=> _items.GetSelectedRanges();
 }

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
@@ -22,7 +22,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 	/// <summary>
 	/// A collection which is responsible to manage the items tracking.
 	/// </summary>
-	internal sealed partial class BindableCollection : ICollectionView, INotifyCollectionChanged
+	internal sealed partial class BindableCollection : ICollectionView, INotifyCollectionChanged, ISelectionInfo
 	{
 		private readonly IBindableCollectionDataStructure _dataStructure;
 		private readonly DispatcherLocal<DataLayer> _holder;
@@ -293,6 +293,29 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 			add => AddCurrentChangingHandler(value);
 			remove => RemoveCurrentChangingHandler(value);
 		}
+		#endregion
+
+		#region ISelectionInfo
+		#pragma warning disable Uno0001 // ISelectionInfo is just an interface
+		public ISelectionInfo? GetSelectionForCurrentThread()
+			=> _holder.Value.View as ISelectionInfo;
+
+		/// <inheritdoc />
+		public void SelectRange(ItemIndexRange itemIndexRange)
+			=> GetSelectionForCurrentThread()?.SelectRange(itemIndexRange);
+
+		/// <inheritdoc />
+		public void DeselectRange(ItemIndexRange itemIndexRange)
+			=> GetSelectionForCurrentThread()?.DeselectRange(itemIndexRange);
+
+		/// <inheritdoc />
+		public bool IsSelected(int index)
+			=> GetSelectionForCurrentThread()?.IsSelected(index) ?? false;
+
+		/// <inheritdoc />
+		public IReadOnlyList<ItemIndexRange> GetSelectedRanges()
+			=> GetSelectionForCurrentThread()?.GetSelectedRanges() ?? Array.Empty<ItemIndexRange>();
+		#pragma warning restore Uno0001
 		#endregion
 
 		internal EventRegistrationToken AddVectorChangedHandler(VectorChangedEventHandler<object?>? handler)

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/SelectionService.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/SelectionService.cs
@@ -50,7 +50,7 @@ internal sealed class SelectionService : ISelectionService, IDisposable, ISelect
 	/// <inheritdoc />
 	public void SelectRange(ItemIndexRange itemIndexRange)
 	{
-		if (Update((info, removed) => info.Add(removed), new SelectionIndexRange((uint)itemIndexRange.FirstIndex, (uint)itemIndexRange.LastIndex)))
+		if (Update((info, added) => info.Add(added), new SelectionIndexRange((uint)itemIndexRange.FirstIndex, itemIndexRange.Length)))
 		{
 			PushToSource();
 		}
@@ -59,7 +59,7 @@ internal sealed class SelectionService : ISelectionService, IDisposable, ISelect
 	/// <inheritdoc />
 	public void DeselectRange(ItemIndexRange itemIndexRange)
 	{
-		if (Update((info, removed) => info.Remove(removed), new SelectionIndexRange((uint)itemIndexRange.FirstIndex, (uint)itemIndexRange.LastIndex)))
+		if (Update((info, removed) => info.Remove(removed), new SelectionIndexRange((uint)itemIndexRange.FirstIndex, itemIndexRange.Length)))
 		{
 			PushToSource();
 		}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
@@ -12,7 +12,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 	/// <summary>
 	/// A basic view on a <see cref="IBindableCollectionViewSource"/>.
 	/// </summary>
-	internal partial class BasicView : INotifyCollectionChanged, ICollectionView, ISupportIncrementalLoading, IDisposable
+	internal partial class BasicView : INotifyCollectionChanged, ICollectionView, ISupportIncrementalLoading, IDisposable, ISelectionInfo
 	{
 		private readonly CollectionFacet _collection;
 		private readonly CollectionChangedFacet _collectionChanged;
@@ -74,7 +74,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 		public void CopyTo(object[] array, int arrayIndex) => _collection.CopyTo(array, arrayIndex);
 #endregion
 
-		#region Selection (Single)
+		#region Selection (Single - ICollectionView.Current)
 		/// <inheritdoc />
 		public event CurrentChangingEventHandler CurrentChanging
 		{
@@ -126,6 +126,24 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 
 		/// <inheritdoc />
 		public bool MoveCurrentToPrevious() => _selection?.MoveCurrentToPrevious() ?? false;
+		#endregion
+
+		#region Selection (Multiple - ISelectionInfo)
+		/// <inheritdoc />
+		public void SelectRange(ItemIndexRange itemIndexRange)
+			=> _selection?.SelectRange(itemIndexRange);
+
+		/// <inheritdoc />
+		public void DeselectRange(ItemIndexRange itemIndexRange)
+			=> _selection?.DeselectRange(itemIndexRange);
+
+		/// <inheritdoc />
+		public bool IsSelected(int index)
+			=> _selection?.IsSelected(index) ?? false;
+
+		/// <inheritdoc />
+		public IReadOnlyList<ItemIndexRange> GetSelectedRanges()
+			=> _selection?.GetSelectedRanges() ?? Array.Empty<ItemIndexRange>();
 		#endregion
 
 		#region Pagination

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/FlatView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/FlatView.cs
@@ -16,7 +16,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 	/// A view which flatten the items of a <see cref="IBindableCollectionViewSource"/>
 	/// <remarks>This view assume that the items of the source <see cref="IBindableCollectionViewSource"/> are of type <see cref="IObservableGroup"/>.</remarks>
 	/// </summary>
-	internal partial class FlatView : ICollectionView, INotifyCollectionChanged, ISupportIncrementalLoading, IDisposable
+	internal partial class FlatView : ICollectionView, INotifyCollectionChanged, ISupportIncrementalLoading, IDisposable, ISelectionInfo
 	{
 		private readonly CollectionFacet _source;
 		private readonly SelectionFacet _selection;
@@ -131,7 +131,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 			}
 		}
 
-		#region Selection (Single)
+		#region Selection (Single - ICollectionView.Current)
 		/// <inheritdoc />
 		public event CurrentChangingEventHandler CurrentChanging
 		{
@@ -175,7 +175,25 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 
 		/// <inheritdoc />
 		public bool MoveCurrentToPrevious() => _selection.MoveCurrentToPrevious();
-#endregion
+		#endregion
+
+		#region Selection (Multiple - ISelectionInfo)
+		/// <inheritdoc />
+		public void SelectRange(ItemIndexRange itemIndexRange)
+			=> _selection.SelectRange(itemIndexRange);
+
+		/// <inheritdoc />
+		public void DeselectRange(ItemIndexRange itemIndexRange)
+			=> _selection.DeselectRange(itemIndexRange);
+
+		/// <inheritdoc />
+		public bool IsSelected(int index)
+			=> _selection.IsSelected(index);
+
+		/// <inheritdoc />
+		public IReadOnlyList<ItemIndexRange> GetSelectedRanges()
+			=> _selection.GetSelectedRanges();
+		#endregion
 
 		#region Pagination
 		/// <inheritdoc />

--- a/src/Uno.Extensions.Reactive/Core/Axes/SelectionIndexRange.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/SelectionIndexRange.cs
@@ -13,9 +13,9 @@ public sealed record SelectionIndexRange(uint FirstIndex, uint Length)
 	/// <summary>
 	/// Gets the index of the last selected item.
 	/// </summary>
-	public uint LastIndex { get; } = Length is 0 ? FirstIndex : FirstIndex + Length - 1;
+	public uint LastIndex => Length is 0 ? FirstIndex : FirstIndex + Length - 1;
 
 	/// <inheritdoc />
 	public override string ToString()
 		=> $"[{FirstIndex}, {LastIndex}]";
-};
+}

--- a/src/Uno.Extensions.Reactive/Core/Axes/SelectionInfo.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/SelectionInfo.cs
@@ -236,4 +236,45 @@ public sealed record SelectionInfo
 		=> IsEmpty
 			? "--Empty--"
 			: string.Join(" & ", Ranges);
+
+	/// <inheritdoc />
+	public bool Equals(SelectionInfo? other)
+		=> Equals(Ranges, other?.Ranges);
+
+	/// <inheritdoc />
+	public override int GetHashCode()
+		=> (int)Count;
+
+	private static bool Equals(IReadOnlyList<SelectionIndexRange>? leftRanges, IReadOnlyList<SelectionIndexRange>? rightRanges)
+	{
+		if (object.ReferenceEquals(leftRanges, rightRanges))
+		{
+			return true;
+		}
+
+		if (leftRanges is null || rightRanges is null)
+		{
+			return false;
+		}
+
+		var count = leftRanges.Count;
+		if (count is 0)
+		{
+			return rightRanges.Count == 0;
+		}
+		else if (count != rightRanges.Count)
+		{
+			return false;
+		}
+
+		for (var i = 0; i < leftRanges.Count; i++)
+		{
+			if (!leftRanges[i].Equals(rightRanges[i]))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
 }

--- a/src/Uno.Extensions.Reactive/Utils/SelectionHelper.cs
+++ b/src/Uno.Extensions.Reactive/Utils/SelectionHelper.cs
@@ -24,10 +24,10 @@ internal static class SelectionHelper
 		while (enumerator.MoveNext())
 		{
 			var current = enumerator.Current;
-			var intersect = previous.LastIndex - current.FirstIndex;
+			var intersect = (long)previous.LastIndex + 1 - current.FirstIndex;
 			if (intersect >= 0)
 			{
-				previous = previous with { Length = previous.Length + current.Length - intersect };
+				previous = previous with { Length = previous.Length + current.Length - (uint)intersect };
 			}
 			else
 			{


### PR DESCRIPTION
Linked to https://github.com/unoplatform/uno/issues/10742

## Bugfix
Fix multi selection support by forwarding ISelectionInfo impl on wrapping types

## What is the current behavior?
Multi select is not working properly depending of how the collection is used

## What is the new behavior?
🙃

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
