### PR TITLE
feat: Adding support for navigation when menuitems are data bound

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigators/NavigationViewNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/NavigationViewNavigator.cs
@@ -56,7 +56,7 @@ public class NavigationViewNavigator : SelectorNavigator<Microsoft.UI.Xaml.Contr
 		{
 			if (Control is null)
 			{
-				return new object[] { };
+				return Array.Empty<object>();
 			}
 
 
@@ -75,7 +75,7 @@ public class NavigationViewNavigator : SelectorNavigator<Microsoft.UI.Xaml.Contr
 		{
 			if (Control is null)
 			{
-				return new FrameworkElement[] { };
+				return Array.Empty<FrameworkElement>();
 			}
 
 			var elements = (from mi in NavigationMenuItems

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundPage.xaml
@@ -1,0 +1,92 @@
+﻿<Page x:Class="TestHarness.Ext.Navigation.NavigationView.NavigationViewDataBoundPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.NavigationView"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  xmlns:models="using:TestHarness.Models"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  Background="LightBlue">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<utu:NavigationBar Content="NavigationView DataBound"
+						   AutomationProperties.AutomationId="NavigationViewDataBoundNavigationBar" />
+		<TextBlock Text="..."
+				   Grid.Row="1"
+				   x:Name="CurrentNavigationViewItemText"
+				   AutomationProperties.AutomationId="CurrentNavigationViewItemTextBlock" />
+		<muxc:NavigationView uen:Region.Attached="true"
+							 Grid.Row="2"
+							 SelectionChanged="NavigationViewItemChanged"
+							 ItemInvoked="NavigationItemInvoked"
+							 MenuItemsSource="{Binding NavigationItems}"
+							 IsSettingsVisible="True">
+			<muxc:NavigationView.MenuItemTemplate>
+				<DataTemplate x:Key="NavigationViewMenuItemDataTemplate">
+
+					<muxc:NavigationViewItem uen:Region.Name="{Binding}"
+											 Content="{Binding}"
+											 FontSize="14"
+											 Tag="{Binding}"
+											 ToolTipService.ToolTip="{Binding}" />
+				</DataTemplate>
+			</muxc:NavigationView.MenuItemTemplate>
+
+			<!--<muxc:NavigationView.MenuItems>
+				<muxc:NavigationViewItem  AutomationProperties.AutomationId="ProductsNavigationViewItem"
+										  Content="Products"
+										  uen:Region.Name="Products" />
+				<muxc:NavigationViewItem AutomationProperties.AutomationId="DealsNavigationViewItem"
+										 Content="Deals"
+										 uen:Region.Name="Deals" />
+				<muxc:NavigationViewItem AutomationProperties.AutomationId="ProfileNavigationViewItem"
+										 Content="Profile"
+										 uen:Region.Name="Profile" />
+			</muxc:NavigationView.MenuItems>-->
+			<Grid uen:Region.Attached="True"
+				  uen:Region.Navigator="Visibility">
+				<StackPanel uen:Region.Name="Products"
+							AutomationProperties.AutomationId="ProductsStackPanel"
+							Visibility="Collapsed">
+					<TextBlock Text="Products" />
+					<Button AutomationProperties.AutomationId="ProductsDealsButton"
+							Content="Deals"
+							uen:Navigation.Request="Deals" />
+					<Button AutomationProperties.AutomationId="ProductsProfileButton"
+							Content="Profile"
+							uen:Navigation.Request="Profile" />
+				</StackPanel>
+				<StackPanel uen:Region.Name="Deals"
+							AutomationProperties.AutomationId="DealsStackPanel"
+							Visibility="Collapsed">
+					<TextBlock Text="Deals" />
+					<Button AutomationProperties.AutomationId="DealsProductsButton"
+							Content="Products"
+							uen:Navigation.Request="Products" />
+					<Button AutomationProperties.AutomationId="DealsProfileButton"
+							Content="Profile"
+							uen:Navigation.Request="Profile" />
+				</StackPanel>
+				<StackPanel AutomationProperties.AutomationId="ProfileStackPanel"
+							uen:Region.Name="Profile"
+							Visibility="Collapsed">
+					<TextBlock Text="Profile" />
+					<Button AutomationProperties.AutomationId="ProfileProductsButton"
+							Content="Products"
+							uen:Navigation.Request="Products" />
+					<Button AutomationProperties.AutomationId="ProfileDealsButton"
+							Content="Deals"
+							uen:Navigation.Request="Deals" />
+				</StackPanel>
+			</Grid>
+		</muxc:NavigationView>
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundPage.xaml.cs
@@ -1,0 +1,23 @@
+﻿
+namespace TestHarness.Ext.Navigation.NavigationView;
+
+public sealed partial class NavigationViewDataBoundPage : Page
+{
+	public NavigationViewDataBoundPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public void NavigationItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs e)
+	{
+		if(e.InvokedItemContainer == sender.SettingsItem as Microsoft.UI.Xaml.Controls.NavigationViewItem)
+		{
+			this.Navigator()!.NavigateViewModelAsync<NavigationViewSettingsViewModel>(this);
+		}
+	}
+
+	private void NavigationViewItemChanged(Microsoft.UI.Xaml.Controls.NavigationView sender, NavigationViewSelectionChangedEventArgs args)
+	{
+		CurrentNavigationViewItemText.Text = (args.SelectedItem as NavigationViewItem)?.Content + string.Empty;
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace TestHarness.Ext.Navigation.NavigationView;
+
+public record NavigationViewDataBoundViewModel(INavigator Navigator)
+{
+	public string[] NavigationItems { get; } = new string[] { "Products", "Deals", "Profile" };
+
+}
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewHostInit.cs
@@ -7,6 +7,7 @@ public class NavigationViewHostInit : BaseHostInitialization
 
 		views.Register(
 			new ViewMap<NavigationViewHomePage, NavigationViewHomeViewModel>(),
+			new ViewMap<NavigationViewDataBoundPage, NavigationViewDataBoundViewModel>(),
 			new ViewMap<NavigationViewSettingsPage, NavigationViewSettingsViewModel>()
 			);
 
@@ -17,6 +18,7 @@ public class NavigationViewHostInit : BaseHostInitialization
 				Nested: new[]
 				{
 						new RouteMap("Home", View: views.FindByViewModel<NavigationViewHomeViewModel>()),
+						new RouteMap("DataBound", View: views.FindByViewModel<NavigationViewDataBoundViewModel>()),
 						new RouteMap("Settings", View: views.FindByViewModel<NavigationViewSettingsViewModel>()),
 				}));
 	}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewMainPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewMainPage.xaml
@@ -31,6 +31,9 @@
 			<Button AutomationProperties.AutomationId="ShowNavigationViewHomeButton"
 					Content="NavigationView Home"
 					Click="NavigationViewHomeClick" />
+			<Button AutomationProperties.AutomationId="ShowNavigationViewDataBoundButton"
+					Content="NavigationView DataBound"
+					Click="NavigationViewDataBoundClick" />
 		</StackPanel>
 	</Grid>
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewMainPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewMainPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿namespace TestHarness.Ext.Navigation.NavigationView;
 
-[TestSectionRoot("NavigationView",TestSections.Navigation_NavigationView, typeof(NavigationViewHostInit))]
+[TestSectionRoot("NavigationView", TestSections.Navigation_NavigationView, typeof(NavigationViewHostInit))]
 public sealed partial class NavigationViewMainPage : BaseTestSectionPage
 {
 	public NavigationViewMainPage()
@@ -12,5 +12,8 @@ public sealed partial class NavigationViewMainPage : BaseTestSectionPage
 	{
 		await Navigator.NavigateViewModelAsync<NavigationViewHomeViewModel>(this);
 	}
-
+	public async void NavigationViewDataBoundClick(object sender, RoutedEventArgs e)
+	{
+		await Navigator.NavigateViewModelAsync<NavigationViewDataBoundViewModel>(this);
+	}
 }

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -254,6 +254,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\ListToDetails\ListToDetailsMainPage.xaml.cs">
       <DependentUpon>ListToDetailsMainPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\NavigationView\NavigationViewDataBoundPage.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\NavigationView\NavigationViewDataBoundViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\NavigationView\NavigationViewHomePage.xaml.cs">
       <DependentUpon>NavigationViewHomePage.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
GitHub Issue (If applicable): #1033 

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

MenuItems can be data bound by setting MenuItemsSource
Region.Name has to be set in the item template to define the regions that can be navigated to


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
