### PR TITLE
fix: Using StorageHelpers to determine if file exists in uno app package

### DIFF
--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -29,16 +29,16 @@
 		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.2" />
-		<PackageVersion Include="Uno.UI" Version="4.7.0-dev.918" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
-		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.0-dev.918" />
-		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.0-dev.918" />
-		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.0-dev.918" />
-		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.0-dev.918" />
-		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.UI" Version="4.7.0-dev.972" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
+		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.0-dev.972" />
+		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.0-dev.972" />
+		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.0-dev.972" />
+		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.0-dev.972" />
+		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.0-dev.972" />
 		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-		<PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.972" />
 	</ItemGroup>
 </Project>

--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -29,16 +29,16 @@
 		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.2" />
-		<PackageVersion Include="Uno.UI" Version="4.7.0-dev.853" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
-		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.0-dev.853" />
-		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.0-dev.853" />
-		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.0-dev.853" />
-		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.0-dev.853" />
-		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.UI" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.0-dev.918" />
 		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-		<PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.918" />
 	</ItemGroup>
 </Project>

--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -29,16 +29,16 @@
 		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.2" />
-		<PackageVersion Include="Uno.UI" Version="4.6.19" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.19" />
-		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.19" />
-		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.6.19" />
-		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.6.19" />
-		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.6.19" />
-		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.6.19" />
+		<PackageVersion Include="Uno.UI" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.0-dev.853" />
 		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-		<PackageVersion Include="Uno.WinUI" Version="4.6.19" />
+		<PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.853" />
 	</ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -47,15 +47,15 @@
 		<PackageVersion Include="Uno.Toolkit" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
-		<PackageVersion Include="Uno.UI" Version="4.6.19" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.19"/>
-		<PackageVersion Include="Uno.UI.MSAL"  Version="4.6.19" />
-		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.6.19" />
+		<PackageVersion Include="Uno.UI" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853"/>
+		<PackageVersion Include="Uno.UI.MSAL"  Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.7.0-dev.853" />
 		<PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageVersion Include="Uno.WinUI" Version="4.6.19" />
-		<PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
-		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.6.19" />
-		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.6.19" />
+		<PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.12" />
+		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.7.0-dev.853" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />
 		<PackageVersion Include="xunit" Version="2.4.1" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -47,15 +47,15 @@
 		<PackageVersion Include="Uno.Toolkit" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
-		<PackageVersion Include="Uno.UI" Version="4.7.0-dev.853" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853"/>
-		<PackageVersion Include="Uno.UI.MSAL"  Version="4.7.0-dev.853" />
-		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.UI" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918"/>
+		<PackageVersion Include="Uno.UI.MSAL"  Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.7.0-dev.918" />
 		<PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.918" />
 		<PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.12" />
-		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.0-dev.853" />
-		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.7.0-dev.853" />
+		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.7.0-dev.918" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />
 		<PackageVersion Include="xunit" Version="2.4.1" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -53,7 +53,7 @@
 		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.7.0-dev.972" />
 		<PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
 		<PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.972" />
-		<PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.12" />
+		<PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.0-dev.972" />
 		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.7.0-dev.972" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -47,15 +47,15 @@
 		<PackageVersion Include="Uno.Toolkit" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
-		<PackageVersion Include="Uno.UI" Version="4.7.0-dev.918" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918"/>
-		<PackageVersion Include="Uno.UI.MSAL"  Version="4.7.0-dev.918" />
-		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.UI" Version="4.7.0-dev.972" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972"/>
+		<PackageVersion Include="Uno.UI.MSAL"  Version="4.7.0-dev.972" />
+		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.7.0-dev.972" />
 		<PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.972" />
 		<PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.12" />
-		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.0-dev.918" />
-		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.7.0-dev.918" />
+		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.0-dev.972" />
+		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.7.0-dev.972" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />
 		<PackageVersion Include="xunit" Version="2.4.1" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
@@ -30,11 +30,11 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.972" />
 	</ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net6.0-android'">

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
@@ -30,11 +30,11 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.626" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.626" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.853" />
 	</ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net6.0-android'">

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
@@ -30,11 +30,11 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.918" />
 	</ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net6.0-android'">

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
@@ -19,10 +19,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.918" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
@@ -19,10 +19,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.972" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
@@ -19,10 +19,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.626" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.626" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.626" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.853" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
@@ -26,10 +26,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.918" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
@@ -26,10 +26,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.972" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
@@ -26,10 +26,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.626" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.626" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.626" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.853" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
@@ -48,12 +48,12 @@
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.3" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.3" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.972" />
 	</ItemGroup>
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems')" />
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\common.props" />

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
@@ -48,12 +48,12 @@
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.3" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.3" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.918" />
 	</ItemGroup>
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems')" />
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\common.props" />

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
@@ -48,12 +48,12 @@
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.626" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.626" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.3" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.3" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.626" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.0-dev.853" />
 	</ItemGroup>
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems')" />
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\common.props" />

--- a/src/Uno.Extensions.Storage.UI/FileStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/FileStorage.cs
@@ -1,46 +1,8 @@
-﻿
-using System.Reflection;
-#if __IOS__ || MACCATALYST || MACOS
-using Foundation;
-#endif
-
-namespace Uno.Extensions.Storage;
+﻿namespace Uno.Extensions.Storage;
 
 public class FileStorage : IStorage
 {
-	private async Task<bool> FileExistsInPackage(string filename)
-	{
-#if __ANDROID__
-		var assets = global::Android.App.Application.Context.Assets;
-		var files = assets?.List("");
-		filename = Path.GetFileNameWithoutExtension(filename).Replace('.', '_') + Path.GetExtension(filename);
-		return files?.Contains(filename)??false;
-#elif __IOS__ || MACCATALYST || MACOS
-		var directoryName = global::System.IO.Path.GetDirectoryName(filename) + string.Empty;
-		var fileName = global::System.IO.Path.GetFileNameWithoutExtension(filename);
-		var fileExtension = global::System.IO.Path.GetExtension(filename);
-
-		var resourcePathname = NSBundle.MainBundle.PathForResource(global::System.IO.Path.Combine(directoryName, fileName), fileExtension.Substring(1));
-
-		return resourcePathname != null;
-#elif WINDOWS
-		var executingPath = Assembly.GetExecutingAssembly().Location;
-		if (!string.IsNullOrWhiteSpace(executingPath))
-		{
-			var path = Path.GetDirectoryName(executingPath);
-			if (path is not null &&
-				!string.IsNullOrWhiteSpace(path))
-			{
-				var fullPath = Path.Combine(path, filename);
-				return File.Exists(fullPath);
-			}
-		}
-		return true;
-#else
-		return true;
-#endif
-
-	}
+	private Task<bool> FileExistsInPackage(string fileName) => Uno.UI.Toolkit.StorageFileHelper.ExistsInPackage(fileName);
 
 	public async Task<string> CreateFolderAsync(string foldername)
 	{
@@ -57,6 +19,7 @@ public class FileStorage : IStorage
 			{
 				return default;
 			}
+
 			var storageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri($"ms-appx:///{filename}"));
 			if (File.Exists(storageFile.Path))
 			{
@@ -75,14 +38,21 @@ public class FileStorage : IStorage
 
 	public async Task<Stream?> OpenPackageFileAsync(string filename)
 	{
-		if (!await FileExistsInPackage(filename))
+		try
+		{
+			if (!await FileExistsInPackage(filename))
+			{
+				return default;
+			}
+
+			var storageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri($"ms-appx:///{filename}"));
+			var stream = await storageFile.OpenStreamForReadAsync();
+			return stream;
+		}
+		catch
 		{
 			return default;
 		}
-
-		var storageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri($"ms-appx:///{filename}"));
-		var stream = await storageFile.OpenStreamForReadAsync();
-		return stream;
 	}
 
 	public async Task WriteFileAsync(string filename, string text, bool overwrite)

--- a/src/Uno.Extensions.Storage.UI/Uno.Extensions.Storage.WinUI.csproj
+++ b/src/Uno.Extensions.Storage.UI/Uno.Extensions.Storage.WinUI.csproj
@@ -16,7 +16,7 @@
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(_IsWinUI)'=='false'">
+	<ItemGroup>
 		<PackageReference Include="Uno.WinUI" />
 	</ItemGroup>
 

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
@@ -60,13 +60,13 @@
     <!--#if (useMaterial)-->
     <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version=" 2.5.0-dev.8" />
     <!--#endif-->
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
     <PackageVersion Include="Uno.UITest.Helpers" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.11" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.11" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.Server" Version="7.0.11" />
-    <PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.918" />
     <!--#if (useCsharpMarkup)-->
     <PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
     <PackageVersion Include="Uno.Toolkit.WinUI.Markup" Version="2.5.0-dev.8" />
@@ -79,11 +79,11 @@
     <!--#endif-->
     <PackageVersion Include="Uno.Themes.WinUI.Markup" Version="2.5.0-dev.6" />
     <!--#endif-->
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.918" />
     <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.7.0.1" />
     <PackageVersion Include="Xamarin.UITest" Version="4.0.1" />
   </ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
@@ -60,13 +60,13 @@
     <!--#if (useMaterial)-->
     <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version=" 2.5.0-dev.8" />
     <!--#endif-->
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
     <PackageVersion Include="Uno.UITest.Helpers" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.11" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.11" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.Server" Version="7.0.11" />
-    <PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.730" />
+    <PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.853" />
     <!--#if (useCsharpMarkup)-->
     <PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
     <PackageVersion Include="Uno.Toolkit.WinUI.Markup" Version="2.5.0-dev.8" />
@@ -79,11 +79,11 @@
     <!--#endif-->
     <PackageVersion Include="Uno.Themes.WinUI.Markup" Version="2.5.0-dev.6" />
     <!--#endif-->
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.730" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.730" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.730" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.730" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.730" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.853" />
     <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.7.0.1" />
     <PackageVersion Include="Xamarin.UITest" Version="4.0.1" />
   </ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
@@ -60,13 +60,13 @@
     <!--#if (useMaterial)-->
     <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version=" 2.5.0-dev.8" />
     <!--#endif-->
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
     <PackageVersion Include="Uno.UITest.Helpers" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.11" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.11" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.Server" Version="7.0.11" />
-    <PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.972" />
     <!--#if (useCsharpMarkup)-->
     <PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
     <PackageVersion Include="Uno.Toolkit.WinUI.Markup" Version="2.5.0-dev.8" />
@@ -79,11 +79,11 @@
     <!--#endif-->
     <PackageVersion Include="Uno.Themes.WinUI.Markup" Version="2.5.0-dev.6" />
     <!--#endif-->
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.972" />
     <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.7.0.1" />
     <PackageVersion Include="Xamarin.UITest" Version="4.0.1" />
   </ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
@@ -59,9 +59,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.730" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.730" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useDefaultAppTemplate)-->
@@ -73,9 +73,9 @@
 		<!--#endif-->
 		<PackageReference Include="Uno.Themes.WinUI.Markup" Version="2.5.0-dev.6" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.730" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.730" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
@@ -59,9 +59,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useDefaultAppTemplate)-->
@@ -73,9 +73,9 @@
 		<!--#endif-->
 		<PackageReference Include="Uno.Themes.WinUI.Markup" Version="2.5.0-dev.6" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
@@ -59,9 +59,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useDefaultAppTemplate)-->
@@ -73,9 +73,9 @@
 		<!--#endif-->
 		<PackageReference Include="Uno.Themes.WinUI.Markup" Version="2.5.0-dev.6" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
@@ -20,9 +20,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.730" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.730" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -38,9 +38,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.730" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.730" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
@@ -20,9 +20,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -38,9 +38,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
@@ -20,9 +20,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -38,9 +38,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
@@ -22,9 +22,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useDefaultAppTemplate)-->
@@ -38,9 +38,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
@@ -22,9 +22,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useDefaultAppTemplate)-->
@@ -38,9 +38,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
@@ -22,9 +22,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.730" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.730" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useDefaultAppTemplate)-->
@@ -38,9 +38,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.730" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.730" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
@@ -21,9 +21,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -39,9 +39,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
@@ -21,9 +21,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.730" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.730" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -39,9 +39,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.730" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.730" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
@@ -21,9 +21,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -39,9 +39,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
@@ -54,9 +54,9 @@
 		<!--#endif-->
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.11" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.11" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 	</ItemGroup>
 	<!--#endif-->
@@ -65,9 +65,9 @@
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.11" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.11" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.853" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
@@ -54,9 +54,9 @@
 		<!--#endif-->
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.11" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.11" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 	</ItemGroup>
 	<!--#endif-->
@@ -65,9 +65,9 @@
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.11" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.11" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.918" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.972" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
@@ -54,9 +54,9 @@
 		<!--#endif-->
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.11" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.11" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.730" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.730" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 	</ItemGroup>
 	<!--#endif-->
@@ -65,9 +65,9 @@
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.11" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.11" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.730" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.730" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.6" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.8" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
@@ -32,7 +32,7 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useDefaultAppTemplate)-->
@@ -41,7 +41,7 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#if (useMaterial)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
@@ -32,7 +32,7 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useDefaultAppTemplate)-->
@@ -41,7 +41,7 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#if (useMaterial)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
@@ -32,7 +32,7 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useDefaultAppTemplate)-->
@@ -41,7 +41,7 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<!--#if (useMaterial)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
@@ -116,7 +116,7 @@
 		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.853" />
+				<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.918" />
 			</ItemGroup>
 
 			<ItemGroup>
@@ -131,7 +131,7 @@
 	</Choose>
 	<!--#else-->
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.853" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.918" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
@@ -116,7 +116,7 @@
 		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.730" />
+				<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.853" />
 			</ItemGroup>
 
 			<ItemGroup>
@@ -131,7 +131,7 @@
 	</Choose>
 	<!--#else-->
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.730" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.853" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
@@ -116,7 +116,7 @@
 		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.918" />
+				<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.972" />
 			</ItemGroup>
 
 			<ItemGroup>
@@ -131,7 +131,7 @@
 	</Choose>
 	<!--#else-->
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.918" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.972" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -35,8 +35,8 @@
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageVersion Include="Uno.Extensions.Logging.OSLog " Version="1.4.0" />
     <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
-    <PackageVersion Include="Uno.Material" Version="2.3.0" />
-    <PackageVersion Include="Uno.Material.WinUI" Version="2.3.0" />
+    <PackageVersion Include="Uno.Material" Version="2.4.1" />
+    <PackageVersion Include="Uno.Material.WinUI" Version="2.4.1" />
     <PackageVersion Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="7.1.11" />
     <PackageVersion Include="Uno.Toolkit.UI" Version="2.4.2" />
     <PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.2" />

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -42,15 +42,15 @@
     <PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.0-dev.114" />
     <PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
     <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.0-dev.114" />
-    <PackageVersion Include="Uno.UI" Version="4.6.19" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.6.19" />
-    <PackageVersion Include="Uno.UI.MSAL" Version="4.6.19" />
-    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.6.19" />
-    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.6.19" />
-    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.6.19" />
-    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.6.19" />
-    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.6.19" />
-    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.6.19" />
+    <PackageVersion Include="Uno.UI" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.UI.MSAL" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.0-dev.853" />
     <PackageVersion Include="Uno.UITest" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.32" />
@@ -58,13 +58,13 @@
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-    <PackageVersion Include="Uno.WinUI" Version="4.6.19" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.6.19" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.6.19" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.6.19" />
-    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.6.19" />
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.6.19" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.6.19" />
+    <PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.853" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Text.Json" Version="6.0.3" />
-    <PackageVersion Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100-dev.15.g12261e2626" />
+    <PackageVersion Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageVersion Include="Uno.Extensions.Logging.OSLog " Version="1.4.0" />
     <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
@@ -39,18 +39,18 @@
     <PackageVersion Include="Uno.Material.WinUI" Version="2.3.0" />
     <PackageVersion Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="7.1.11" />
     <PackageVersion Include="Uno.Toolkit.UI" Version="2.4.2" />
-    <PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.0-dev.114" />
+    <PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.2" />
     <PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
-    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.0-dev.114" />
-    <PackageVersion Include="Uno.UI" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.UI.MSAL" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.2" />
+    <PackageVersion Include="Uno.UI" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.UI.MSAL" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.0-dev.972" />
     <PackageVersion Include="Uno.UITest" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.32" />
@@ -58,13 +58,13 @@
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-    <PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.972" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.972" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -42,15 +42,15 @@
     <PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.0-dev.114" />
     <PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
     <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.0-dev.114" />
-    <PackageVersion Include="Uno.UI" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.UI.MSAL" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.UI" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.UI.MSAL" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.0-dev.918" />
     <PackageVersion Include="Uno.UITest" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.32" />
@@ -58,13 +58,13 @@
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
-    <PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.853" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.853" />
+    <PackageVersion Include="Uno.WinUI" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.918" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.918" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />

--- a/testing/TestHarness/TestHarness.Shared/App.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/App.xaml.cs
@@ -8,6 +8,9 @@ public sealed partial class App : Application
 	public App()
 	{
 		this.InitializeComponent();
+
+		// TODO: Remove once https://github.com/unoplatform/uno/issues/10990 is resolved
+		var type = typeof(Uno.UI.FluentTheme.GlobalStaticResources);
 	}
 
 	protected override void OnLaunched(LaunchActivatedEventArgs args)

--- a/testing/TestHarness/TestHarness.Wasm/LinkerConfig.xml
+++ b/testing/TestHarness/TestHarness.Wasm/LinkerConfig.xml
@@ -5,6 +5,10 @@
   <assembly fullname="Microsoft.Extensions.Options" />
 	<assembly fullname="Refit" />
 	<assembly fullname="System.IdentityModel.Tokens.Jwt" />
+	<!-- TODO: Remove once https://github.com/unoplatform/uno/issues/10990 is resolved -->
+	<assembly fullname="Uno.UI.FluentTheme.v1" />
+	<assembly fullname="Uno.UI.FluentTheme.v2" />
+	<assembly fullname="Uno.UI.FluentTheme" />
 
 	<assembly fullname="System.Core">
 	<!-- This is required by JSon.NET and any expression.Compile caller -->


### PR DESCRIPTION
GitHub Issue (If applicable): #927

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Nested files packages with the application can't be accessed using IStorage

## What is the new behavior?

Nested files are accessible using IStorage

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
