### PR TITLE
fix(reactive): Fix Count property not updated in Bindable<Collection|LisFeed>

### DIFF
--- a/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableListFeed.cs
@@ -40,4 +40,21 @@ public partial class Given_BindableListFeed : FeedUITests
 		async Task<object?> GetBindableCollection(SourceContext context)
 			=> (await ((ISignal<IMessage>)sut!).GetSource(context).FirstAsync(CT)).Current.Data.SomeOrDefault();
 	}
+
+	[TestMethod]
+	public async Task When_CollectionChanged_Then_CountPropertyChangedRaised()
+	{
+		var vm = new BindableGiven_BindableListFeed_Model();
+		var sut = vm.Items as BindableListFeed<int>;
+
+		sut.Should().NotBeNull();
+
+		var countHasChanged = false;
+		sut!.PropertyChanged += (snd, e) => countHasChanged |= e.PropertyName is null or { Length: 0 } or "Count";
+
+		await Task.Run(async () => await vm.Model.Items.AddAsync(44, CT), CT);
+
+		await UIHelper.WaitFor(() => countHasChanged, CT);
+		countHasChanged.Should().BeTrue();
+	}
 }

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.CollectionView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.CollectionView.cs
@@ -2,13 +2,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 
 namespace Uno.Extensions.Reactive.Bindings;
 
-partial class BindableListFeed<T> : ICollectionView, INotifyCollectionChanged, ISelectionInfo
+partial class BindableListFeed<T> : ICollectionView, INotifyCollectionChanged, INotifyPropertyChanged, ISelectionInfo
 {
 	/// <inheritdoc />
 	public IEnumerator<object> GetEnumerator()
@@ -135,6 +136,13 @@ partial class BindableListFeed<T> : ICollectionView, INotifyCollectionChanged, I
 	{
 		add => _items.CollectionChanged += value;
 		remove => _items.CollectionChanged -= value;
+	}
+
+	/// <inheritdoc />
+	public event PropertyChangedEventHandler? PropertyChanged
+	{
+		add => _items.PropertyChanged += value;
+		remove => _items.PropertyChanged -= value;
 	}
 
 	/// <inheritdoc />

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Threading;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
@@ -22,7 +23,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 	/// <summary>
 	/// A collection which is responsible to manage the items tracking.
 	/// </summary>
-	internal sealed partial class BindableCollection : ICollectionView, INotifyCollectionChanged, ISelectionInfo
+	internal sealed partial class BindableCollection : ICollectionView, INotifyCollectionChanged, INotifyPropertyChanged, ISelectionInfo
 	{
 		private readonly IBindableCollectionDataStructure _dataStructure;
 		private readonly DispatcherLocal<DataLayer> _holder;
@@ -242,6 +243,12 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 		{
 			add => _holder.Value.GetFacet<CollectionChangedFacet>().AddCollectionChangedHandler(value!);
 			remove => _holder.Value.GetFacet<CollectionChangedFacet>().RemoveCollectionChangedHandler(value!);
+		}
+
+		public event PropertyChangedEventHandler? PropertyChanged
+		{
+			add => _holder.Value.GetFacet<CollectionChangedFacet>().AddPropertyChangedHandler(value!);
+			remove => _holder.Value.GetFacet<CollectionChangedFacet>().RemovePropertyChangedHandler(value!);
 		}
 
 		/// <inheritdoc />

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/BranchStrategy.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/BranchStrategy.cs
@@ -85,7 +85,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 			// Init the flat tracking view (ie. the flatten view of the groups that can be consumed directly by the ICollectionView properties)
 			var flatCollectionChanged = new FlatCollectionChangedFacet(() => view ?? throw new InvalidOperationException("The owner provider must be resolved lazily!"));
 			var flatSelectionFacet = new SelectionFacet(source, () => view ?? throw new InvalidOperationException("The owner provider must be resolved lazily!"));
-			var flatPaginationFacet = new PaginationFacet(source, extendedPropertiesFacet);
+			var flatPaginationFacet = new PaginationFacet(source, flatCollectionChanged, extendedPropertiesFacet);
 
 			// Init the groups tracking
 			var groupsChanged = new CollectionChangedFacet(() => view?.CollectionGroups ?? throw new InvalidOperationException("The owner provider must be resolved lazily!"));

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/LeafStrategy.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/LeafStrategy.cs
@@ -34,7 +34,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 
 			if (_isRoot) // I.e. Collection is not grouped
 			{
-				var paginationFacet = new PaginationFacet(source, extendedPropertiesFacet);
+				var paginationFacet = new PaginationFacet(source, collectionChangedFacet, extendedPropertiesFacet);
 				var selectionFacet = new SelectionFacet(source, () => view ?? throw new InvalidOperationException("The owner provider must be resolved lazily!"));
 				var editionFacet = new EditionFacet(source, collectionFacet);
 

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionChangedFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionChangedFacet.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using Windows.Foundation.Collections;
@@ -148,5 +149,23 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 				}
 			}
 		}
+
+		#region INotifyPropertyChanged
+		private static readonly PropertyChangedEventArgs _allPropertiesChanged = new(null);
+
+		private event PropertyChangedEventHandler? _propertyChanged;
+
+		public void PropertyChanged()
+			=> _propertyChanged?.Invoke(Sender, _allPropertiesChanged);
+
+		public void PropertyChanged(string propertyName)
+			=> _propertyChanged?.Invoke(Sender, new PropertyChangedEventArgs(propertyName));
+
+		public void AddPropertyChangedHandler(PropertyChangedEventHandler value)
+			=> _propertyChanged += value;
+
+		public void RemovePropertyChangedHandler(PropertyChangedEventHandler value)
+			=> _propertyChanged -= value;
+		#endregion
 	}
 }

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionFacet.cs
@@ -235,6 +235,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 			{
 				// We don't have any event to raise, just update the _head
 				UpdateHead(arg);
+				_collectionChanged.PropertyChanged();
 			}
 #if XAMARIN // the ListView on windows does not supports event for multiple items at once (except insert at the end of the list).
 			else if (_collectionChanged.VectorChanged == null)
@@ -373,6 +374,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 
 			_collectionChanged.CollectionChanged?.Invoke(arg);
 			_collectionChanged.VectorChanged?.Invoke(new VectorChangedEventArgs(CollectionChange.ItemInserted, (uint)arg.NewStartingIndex));
+			_collectionChanged.PropertyChanged();
 		}
 
 		private void RaiseMove(NotifyCollectionChangedEventArgs arg, string? logMeta = null, (int number, int of)? item = null)
@@ -399,6 +401,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 
 				_collectionChanged.VectorChanged?.Invoke(new VectorChangedEventArgs(CollectionChange.ItemInserted, (uint)toIndex));
 			}
+			_collectionChanged.PropertyChanged();
 		}
 
 		private void RaiseReplace(NotifyCollectionChangedEventArgs arg, string? logMeta = null, (int number, int of)? item = null)
@@ -412,6 +415,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 
 			_collectionChanged.CollectionChanged?.Invoke(arg);
 			_collectionChanged.VectorChanged?.Invoke(new VectorChangedEventArgs(CollectionChange.ItemChanged, (uint)arg.NewStartingIndex));
+			_collectionChanged.PropertyChanged();
 		}
 
 		private void RaiseRemove(NotifyCollectionChangedEventArgs arg, string? logMeta = null, (int number, int of)? item = null)
@@ -425,6 +429,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 
 			_collectionChanged.CollectionChanged?.Invoke(arg);
 			_collectionChanged.VectorChanged?.Invoke(new VectorChangedEventArgs(CollectionChange.ItemRemoved, (uint)arg.OldStartingIndex));
+			_collectionChanged.PropertyChanged();
 		}
 		private void RaiseReset(NotifyCollectionChangedEventArgs poor)
 		{
@@ -490,6 +495,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 			}
 
 			_onReseted?.Invoke();
+			_collectionChanged.PropertyChanged();
 		}
 
 		private void UpdateHead(NotifyCollectionChangedEventArgs change)

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/FlatCollectionChangedFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/FlatCollectionChangedFacet.cs
@@ -46,6 +46,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 						VectorChanged?.Invoke(new VectorChangedEventArgs(CollectionChange.ItemInserted, (uint)i));
 					}
 				}
+				PropertyChanged();
 			}
 		}
 
@@ -73,6 +74,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 						VectorChanged?.Invoke(new VectorChangedEventArgs(CollectionChange.ItemRemoved, (uint)i));
 					}
 				}
+				PropertyChanged();
 			}
 		}
 
@@ -83,6 +85,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 		{
 			CollectionChanged?.Invoke(Uno.Extensions.Collections.CollectionChanged.Reset());
 			VectorChanged?.Invoke(new VectorChangedEventArgs(CollectionChange.Reset, 0));
+			PropertyChanged();
 		}
 
 		private void OnVectorChanged(IObservableVector<object?> sender, IVectorChangedEventArgs args)

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/PaginationFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/PaginationFacet.cs
@@ -16,11 +16,13 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 
 		private readonly CancellationTokenSource _ct = new();
 		private readonly IPaginationService? _service;
+		private readonly CollectionChangedFacet _changed;
 		private readonly BindableCollectionExtendedProperties _properties;
 
-		public PaginationFacet(IBindableCollectionViewSource source, BindableCollectionExtendedProperties properties)
+		public PaginationFacet(IBindableCollectionViewSource source, CollectionChangedFacet changed, BindableCollectionExtendedProperties properties)
 		{
 			_service = source.GetService(typeof(IPaginationService)) as IPaginationService;
+			_changed = changed;
 			_properties = properties;
 
 			if (_service is not null)
@@ -57,6 +59,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 			{
 				_properties.HasMoreItems = HasMoreItems = svc.HasMoreItems;
 				_properties.IsLoadingMoreItems = svc.IsLoadingMoreItems;
+				_changed.PropertyChanged(nameof(HasMoreItems));
 			}
 			else
 			{

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Windows.Foundation;
@@ -13,7 +14,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 	/// <summary>
 	/// A basic view on a <see cref="IBindableCollectionViewSource"/>.
 	/// </summary>
-	internal partial class BasicView : INotifyCollectionChanged, ICollectionView, ISupportIncrementalLoading, IDisposable, ISelectionInfo
+	internal partial class BasicView : INotifyCollectionChanged, INotifyPropertyChanged, ICollectionView, ISupportIncrementalLoading, IDisposable, ISelectionInfo
 	{
 		private readonly CollectionFacet _collection;
 		private readonly CollectionChangedFacet _collectionChanged;
@@ -79,6 +80,14 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 
 		private NotSupportedException EditionNotSupported([CallerMemberName] string? method = null)
 			=> new($"{method} is not supported on a read-only collection.");
+		#endregion
+
+		#region INotifyPropertyChanged
+		public event PropertyChangedEventHandler? PropertyChanged
+		{
+			add => _collectionChanged.AddPropertyChangedHandler(value!);
+			remove => _collectionChanged.RemovePropertyChangedHandler(value!);
+		}
 		#endregion
 
 		#region Selection (Single - ICollectionView.Current)

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableConfig.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableConfig.cs
@@ -23,7 +23,7 @@ internal enum BindableConfig
 
 	/// <summary>
 	/// Indicates that the inheritor has a property name `Value` which can be data bind directly instead of <see cref="Bindable{T}.GetValue"/> and <see cref="Bindable{T}.SetValue(T)"/>.
-	/// Is so, the <see cref="INotifyPropertyChanged.PropertyChanged"/> will be raise accordingly.
+	/// If so, the <see cref="INotifyPropertyChanged.PropertyChanged"/> will be raise accordingly.
 	/// </summary>
 	RaiseValuePropertyChanged,
 


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno.chefs/issues/102

## Bugfix
Fix Count property (and other properties) not updated in Bindable<Collection|LisFeed>

## What is the current behavior?
The `BindableCollection` does not implement `INotifyPropertyChanged`

## What is the new behavior?
🙃

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
