### PR TITLE
feat: Removes test projects and data contract project from blank template

### DIFF
--- a/src/Uno.Extensions.Templates/Uno.Extensions.Templates.csproj
+++ b/src/Uno.Extensions.Templates/Uno.Extensions.Templates.csproj
@@ -34,6 +34,10 @@
 			DestinationFiles="$(IntermediateOutputPath)/content/%(RecursiveDir)%(Filename)%(Extension)"
 			SkipUnchangedFiles="false" />
 		<Copy
+			SourceFiles="content/unoapp-extensions/MyExtensionsApp.DataContracts/WeatherForecast.cs"
+			DestinationFiles="$(IntermediateOutputPath)/content/unoapp-extensions/MyExtensionsApp.Server/WeatherForecast.cs"
+			SkipUnchangedFiles="false" />
+		<Copy
 			SourceFiles="content/unoapp-extensions/MyExtensionsApp.Windows/app.manifest"
 			DestinationFiles="$(IntermediateOutputPath)/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/app.manifest"
 			SkipUnchangedFiles="false" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -377,7 +377,7 @@
     "useSerilog": {
       "type": "computed",
       "datatype": "bool",
-      "value": "(logging && serilog)"
+      "value": "(logging && serilog && templateType == 'default')"
     },
     "useMvux": {
       "type": "computed",
@@ -461,7 +461,7 @@
       "path": "MyExtensionsApp.Server\\MyExtensionsApp.Server.csproj"
     },
     {
-      "condition": "server || http",
+      "condition": "server || (http && useDefaultAppTemplate)",
       "path": "MyExtensionsApp.DataContracts\\MyExtensionsApp.DataContracts.csproj"
     },
     {
@@ -597,7 +597,13 @@
           ]
         },
         {
-          "condition": "(!http && !server)",
+          "condition": "(useDefaultAppTemplate)",
+          "exclude": [
+            "MyExtensionsApp.Server/WeatherForecast.cs"
+          ]
+        },
+        {
+          "condition": "(useBlankAppTemplate || ((!http && useDefaultAppTemplate) && !server))",
           "exclude": [
             "MyExtensionsApp.DataContracts/**/*"
           ]

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -465,11 +465,11 @@
       "path": "MyExtensionsApp.DataContracts\\MyExtensionsApp.DataContracts.csproj"
     },
     {
-      "condition": "unitTest",
+      "condition": "unitTest && useDefaultAppTemplate",
       "path": "MyExtensionsApp.Tests\\MyExtensionsApp.Tests.csproj"
     },
     {
-      "condition": "tests",
+      "condition": "tests && useDefaultAppTemplate",
       "path": "MyExtensionsApp.UITests\\MyExtensionsApp.UITests.csproj"
     },
     {
@@ -625,13 +625,13 @@
           ]
         },
         {
-          "condition": "(!unitTest)",
+          "condition": "(!unitTest || useBlankAppTemplate)",
           "exclude": [
             "MyExtensionsApp.Tests/**/*"
           ]
         },
         {
-          "condition": "(!tests)",
+          "condition": "(!tests || useBlankAppTemplate)",
           "exclude": [
             "MyExtensionsApp.UITests/**/*"
           ]

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.csproj
@@ -180,7 +180,7 @@
 	</Choose>
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
@@ -178,7 +178,7 @@
 	</Choose>
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/MyExtensionsApp.Server.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/MyExtensionsApp.Server.csproj
@@ -10,7 +10,9 @@
 		<!--#if (wasm)-->
 		<ProjectReference Include="..\MyExtensionsApp.Wasm\MyExtensionsApp.Wasm.csproj" />
 		<!--#endif -->
+		<!--#if (useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
+		<!--#endif -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/MyExtensionsApp.Server.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/MyExtensionsApp.Server.nocpm.csproj
@@ -10,7 +10,9 @@
 		<!--#if (wasm)-->
 		<ProjectReference Include="..\MyExtensionsApp.Wasm\MyExtensionsApp.Wasm.csproj" />
 		<!--#endif -->
+		<!--#if (useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
+		<!--#endif -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.csproj
@@ -88,7 +88,7 @@
 	<!--#endif-->
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
@@ -87,7 +87,7 @@
 	<!--#endif-->
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.csproj
@@ -87,7 +87,7 @@
 	<!--#endif-->
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
@@ -87,7 +87,7 @@
 	<!--#endif-->
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.csproj
@@ -93,7 +93,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
@@ -91,7 +91,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.csproj
@@ -115,7 +115,7 @@
 	<!--#endif-->
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
@@ -115,7 +115,7 @@
 	<!--#endif-->
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
@@ -97,7 +97,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
@@ -97,7 +97,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp\MyExtensionsApp.csproj" />
-		<!--#if (http)-->
+		<!--#if (http && useDefaultAppTemplate)-->
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />
 		<!--#endif-->
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.sln
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.sln
@@ -46,7 +46,7 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyExtensionsApp.Server", "MyExtensionsApp.Server\MyExtensionsApp.Server.csproj", "{1ADD4B1D-2758-4ED5-963A-FE3F4206BF20}"
 EndProject
 #//#endif
-#//#if (server || http)
+#//#if (useDefaultAppTemplate && (server || http))
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyExtensionsApp.DataContracts", "MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj", "{5ED31500-DF01-462D-9436-EC2EDCAA1965}"
 EndProject
 #//#endif
@@ -262,7 +262,7 @@ Global
 		{1ADD4B1D-2758-4ED5-963A-FE3F4206BF20}.Release|x86.ActiveCfg = Release|Any CPU
 		{1ADD4B1D-2758-4ED5-963A-FE3F4206BF20}.Release|x86.Build.0 = Release|Any CPU
 #//#endif
-#//#if (server || http)
+#//#if (useDefaultAppTemplate && (server || http))
 		{5ED31500-DF01-462D-9436-EC2EDCAA1965}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5ED31500-DF01-462D-9436-EC2EDCAA1965}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5ED31500-DF01-462D-9436-EC2EDCAA1965}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -452,7 +452,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{BACDD33A-304C-46C4-9B00-AC166978D7E0} = {FAA2C1DE-F859-4053-9573-6245F7E832EF}
-//#if (server || http)
+//#if (useDefaultAppTemplate && (server || http))
 		{5ED31500-DF01-462D-9436-EC2EDCAA1965} = {FAA2C1DE-F859-4053-9573-6245F7E832EF}
 //#endif
 		{339C569C-EE23-445E-B908-743673EE5BC9} = {FAA2C1DE-F859-4053-9573-6245F7E832EF}

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.sln
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.sln
@@ -11,7 +11,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Backend", "Backend", "{BA1ACE40-623E-4F42-94BB-11CF4D52C445}"
 EndProject
 //#endif
-#//#if (tests || unitTest)
+#//#if (useDefaultAppTemplate && (tests || unitTest))
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{7EF70027-9874-4112-A14F-33F02169CF8A}"
 EndProject
 #//#endif
@@ -50,11 +50,11 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyExtensionsApp.DataContracts", "MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj", "{5ED31500-DF01-462D-9436-EC2EDCAA1965}"
 EndProject
 #//#endif
-#//#if (unitTest)
+#//#if (unitTest && useDefaultAppTemplate)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyExtensionsApp.Tests", "MyExtensionsApp.Tests\MyExtensionsApp.Tests.csproj", "{EB3EB846-D5CB-4140-834F-1CC40A0FD6D0}"
 EndProject
 #//#endif
-#//#if (tests)
+#//#if (tests && useDefaultAppTemplate)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyExtensionsApp.UITests", "MyExtensionsApp.UITests\MyExtensionsApp.UITests.csproj", "{7229D034-7DBE-4FD7-B0E4-38D617571F93}"
 EndProject
 #//#endif
@@ -320,7 +320,7 @@ Global
 		{BACDD33A-304C-46C4-9B00-AC166978D7E0}.Release|x64.Build.0 = Release|Any CPU
 		{BACDD33A-304C-46C4-9B00-AC166978D7E0}.Release|x86.ActiveCfg = Release|Any CPU
 		{BACDD33A-304C-46C4-9B00-AC166978D7E0}.Release|x86.Build.0 = Release|Any CPU
-#//#if (unitTest)
+#//#if (unitTest && useDefaultAppTemplate)
 		{EB3EB846-D5CB-4140-834F-1CC40A0FD6D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EB3EB846-D5CB-4140-834F-1CC40A0FD6D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB3EB846-D5CB-4140-834F-1CC40A0FD6D0}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -350,7 +350,7 @@ Global
 		{EB3EB846-D5CB-4140-834F-1CC40A0FD6D0}.Release|x86.ActiveCfg = Release|Any CPU
 		{EB3EB846-D5CB-4140-834F-1CC40A0FD6D0}.Release|x86.Build.0 = Release|Any CPU
 #//#endif
-#//#if (tests)
+#//#if (tests && useDefaultAppTemplate)
 		{7229D034-7DBE-4FD7-B0E4-38D617571F93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7229D034-7DBE-4FD7-B0E4-38D617571F93}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7229D034-7DBE-4FD7-B0E4-38D617571F93}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -480,10 +480,10 @@ Global
 #//#if (server)
 		{1ADD4B1D-2758-4ED5-963A-FE3F4206BF20} = {BA1ACE40-623E-4F42-94BB-11CF4D52C445}
 #//#endif
-#//#if (unitTest)
+#//#if (unitTest && useDefaultAppTemplate)
 		{EB3EB846-D5CB-4140-834F-1CC40A0FD6D0} = {7EF70027-9874-4112-A14F-33F02169CF8A}
 #//#endif
-#//#if (tests)
+#//#if (tests && useDefaultAppTemplate)
 		{7229D034-7DBE-4FD7-B0E4-38D617571F93} = {7EF70027-9874-4112-A14F-33F02169CF8A}
 #//#endif
 	EndGlobalSection

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.csproj
@@ -115,7 +115,7 @@
 			</ItemGroup>
 		</Otherwise>
 	</Choose>
-	<!--#if (http)-->
+	<!--#if (http && useDefaultAppTemplate)-->
 
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
@@ -148,7 +148,7 @@
 		</Compile>
 	</ItemGroup>
 	<!--#endif-->
-	<!--#if (http)-->
+	<!--#if (http && useDefaultAppTemplate)-->
 
 	<ItemGroup>
 		<ProjectReference Include="..\MyExtensionsApp.DataContracts\MyExtensionsApp.DataContracts.csproj" />


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #1036

## PR Type

What kind of change does this PR introduce?

- Refactoring

## What is the current behavior?

DataContracts, Unit Test and UI Tests get included with blank template

## What is the new behavior?

- DataContracts project is excluded from the solution
- WeatherForecast model is part of the Server project when using Blank Template Type
- Serilog is disabled on the server when using a Blank Template Type
- Unit Tests project is excluded from the solution
- UI Tests project is excluded from the solution