### PR TITLE
fix: Fix missing some global:: prefixes

### DIFF
--- a/src/Uno.Extensions.Core.Generators/Common/BuildingBlocks/Property.cs
+++ b/src/Uno.Extensions.Core.Generators/Common/BuildingBlocks/Property.cs
@@ -16,12 +16,12 @@ internal record Property(Accessibility Accessibility, string Type, string Name)
 		};
 
 	public Property(Accessibility accessibility, ITypeSymbol type, string name)
-		: this(accessibility, type.ToString(), name)
+		: this(accessibility, type.ToFullString(), name)
 	{
 	}
 
 	public Property(ITypeSymbol type, string name)
-		: this(type.DeclaredAccessibility, type.ToString(), name)
+		: this(type.DeclaredAccessibility, type.ToFullString(), name)
 	{
 	}
 

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/BindableGenerator.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/BindableGenerator.cs
@@ -78,7 +78,7 @@ internal class BindableGenerator : ICodeGenTool
 						? GetPropertyInfo(_ctx.IImmutableList.Construct(itemType), (prop.Type, v => $"global::System.Collections.Immutable.ImmutableList.ToImmutableList({v})"))
 						: GetPropertyInfo(prop.Type);
 
-					bindable = $"{NS.Bindings}.BindableImmutableList<{itemType}, {itemBindableType}>";
+					bindable = $"{NS.Bindings}.BindableImmutableList<{itemType.ToFullString()}, {itemBindableType}>";
 					initializer = $@"_{camelName} = new {bindable}(
 						{propertyInfo.Align(6)},
 						p => new {itemBindableType}(p));";
@@ -109,7 +109,7 @@ internal class BindableGenerator : ICodeGenTool
 				}
 				else
 				{
-					bindable = $"{NS.Bindings}.Bindable<{prop.Type}>";
+					bindable = $"{NS.Bindings}.Bindable<{prop.Type.ToFullString()}>";
 					initializer = $@"_{camelName} = new {bindable}({GetPropertyInfo(prop.Type)});";
 					property = Property.FromProperty(prop, allowInitOnlySetter: true) with
 					{
@@ -132,9 +132,9 @@ internal class BindableGenerator : ICodeGenTool
 				);
 
 				string GetPropertyInfo(ITypeSymbol type, (ITypeSymbol type, Func<string, string> cast)? concrete = null)
-					=> $@"base.Property<{type}>(
+					=> $@"base.Property<{type.ToFullString()}>(
 							nameof({prop.Name}),
-							{record.GetCamelCaseName()} => {(canRead ? $"{record.GetCamelCaseName()}?.{prop.Name} ?? default({concrete?.type ?? type})" : $"default({concrete?.type ?? type})")},
+							{record.GetCamelCaseName()} => {(canRead ? $"{record.GetCamelCaseName()}?.{prop.Name} ?? default({(concrete?.type ?? type).ToFullString()})" : $"default({(concrete?.type ?? type).ToFullString()})")},
 							({record.GetCamelCaseName()}, {camelName}) => {(canWrite ? $"({record.GetCamelCaseName()} ?? CreateDefault()) with {{{prop.Name} = {concrete?.cast(camelName) ?? camelName}}}" : record.GetCamelCaseName())})";
 			})
 			.ToList();
@@ -168,7 +168,7 @@ namespace {record.ContainingNamespace}
 		}}
 
 		private static {record} CreateDefault()
-			=> new({_ctx.GetDefaultCtor(record)!.Parameters.Select(p => $"default({p.Type})!").JoinBy(", ")});
+			=> new({_ctx.GetDefaultCtor(record)!.Parameters.Select(p => $"default({p.Type.ToFullString()})!").JoinBy(", ")});
 
 		{valueProperty}
 

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableFromFeedField.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableFromFeedField.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Uno.Extensions.Generators;
 
 namespace Uno.Extensions.Reactive.Generator;
 
@@ -23,5 +24,5 @@ internal record BindableFromFeedField(IFieldSymbol _field, ITypeSymbol _valueTyp
 
 	/// <inheritdoc />
 	public string? GetInitialization()
-		=> $"{_field.Name} = new {_bindableValueType}(base.Property<{_valueType}>(nameof({_field.Name}), {N.Ctor.Model}.{_field.Name} ?? throw new NullReferenceException(\"The feed field '{_field.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
+		=> $"{_field.Name} = new {_bindableValueType}(base.Property<{_valueType.ToFullString()}>(nameof({_field.Name}), {N.Ctor.Model}.{_field.Name} ?? throw new NullReferenceException(\"The feed field '{_field.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
 }

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableFromFeedProperty.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableFromFeedProperty.cs
@@ -9,7 +9,7 @@ internal record BindableFromFeedProperty(IPropertySymbol _property, ITypeSymbol 
 {
 	private readonly IPropertySymbol _property = _property;
 	private readonly ITypeSymbol _valueType = _valueType;
-	private readonly string _bindableValueType = _bindableValueType ?? $"{NS.Bindings}.Bindable<{_valueType}>";
+	private readonly string _bindableValueType = _bindableValueType ?? $"{NS.Bindings}.Bindable<{_valueType.ToFullString()}>";
 
 	/// <inheritdoc />
 	public string Name => _property.Name;
@@ -24,5 +24,5 @@ internal record BindableFromFeedProperty(IPropertySymbol _property, ITypeSymbol 
 
 	/// <inheritdoc />
 	public string? GetInitialization()
-		=> $"{_property.Name} = new {_bindableValueType}(base.Property<{_valueType}>(nameof({_property.Name}), {N.Ctor.Model}.{_property.Name} ?? throw new NullReferenceException(\"The feed field '{_property.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
+		=> $"{_property.Name} = new {_bindableValueType}(base.Property<{_valueType.ToFullString()}>(nameof({_property.Name}), {N.Ctor.Model}.{_property.Name} ?? throw new NullReferenceException(\"The feed field '{_property.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
 }

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListField.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListField.cs
@@ -16,13 +16,13 @@ internal record BindableListFromFeedOfListField(IFieldSymbol Field, ITypeSymbol 
 
 	/// <inheritdoc />
 	public string GetDeclaration()
-		=> $"{Field.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{ItemType}> {Field.Name};"; // Note: This should be a State
+		=> $"{Field.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{ItemType.ToFullString()}> {Field.Name};"; // Note: This should be a State
 
 	/// <inheritdoc />
 	public string? GetInitialization()
 		=> @$"
 			var {Field.GetCamelCaseName()}Source = {N.Ctor.Model}.{Field.Name} ?? throw new NullReferenceException(""The list feed field '{Field.Name}' is null. Public feeds properties must be initialized in the constructor."");
-			var {Field.GetCamelCaseName()}SourceListFeed = {N.ListFeed.Extensions.ToListFeed}<{CollectionType}, {ItemType}>({Field.GetCamelCaseName()}Source);
+			var {Field.GetCamelCaseName()}SourceListFeed = {N.ListFeed.Extensions.ToListFeed}<{CollectionType.ToFullString()}, {ItemType.ToFullString()}>({Field.GetCamelCaseName()}Source);
 			var {Field.GetCamelCaseName()}SourceListState = {N.Ctor.Ctx}.GetOrCreateListState({Field.GetCamelCaseName()}SourceListFeed);
 			{Field.Name} = {NS.Bindings}.BindableHelper.CreateBindableList(nameof({Field.Name}), {Field.GetCamelCaseName()}SourceListState);";
 }

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListProperty.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListProperty.cs
@@ -16,13 +16,13 @@ internal record BindableListFromFeedOfListProperty(IPropertySymbol Property, ITy
 
 	/// <inheritdoc />
 	public string GetDeclaration()
-		=> $"{Property.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{ItemType}> {Property.Name} {{ get; }}"; // Note: This should be a State
+		=> $"{Property.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{ItemType.ToFullString()}> {Property.Name} {{ get; }}"; // Note: This should be a State
 
 	/// <inheritdoc />
 	public string GetInitialization()
 		=> @$"
 			var {Property.GetCamelCaseName()}Source = {N.Ctor.Model}.{Property.Name} ?? throw new NullReferenceException(""The list feed property '{Property.Name}' is null. Public feeds properties must be initialized in the constructor."");
-			var {Property.GetCamelCaseName()}SourceListFeed = {N.ListFeed.Extensions.ToListFeed}<{CollectionType}, {ItemType}>({Property.GetCamelCaseName()}Source);
+			var {Property.GetCamelCaseName()}SourceListFeed = {N.ListFeed.Extensions.ToListFeed}<{CollectionType.ToFullString()}, {ItemType.ToFullString()}>({Property.GetCamelCaseName()}Source);
 			var {Property.GetCamelCaseName()}SourceListState = {N.Ctor.Ctx}.GetOrCreateListState({Property.GetCamelCaseName()}SourceListFeed);
 			{Property.Name} = {NS.Bindings}.BindableHelper.CreateBindableList(nameof({Property.Name}), {Property.GetCamelCaseName()}SourceListState);";
 }

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedField.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedField.cs
@@ -19,7 +19,7 @@ internal record BindableListFromListFeedField(IFieldSymbol _field, ITypeSymbol _
 
 	/// <inheritdoc />
 	public string GetDeclaration()
-		=> $"{_field.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{_valueType}> {_field.Name};"; // Note: This should be a State
+		=> $"{_field.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{_valueType.ToFullString()}> {_field.Name};"; // Note: This should be a State
 
 	/// <inheritdoc />
 	public string? GetInitialization()

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedProperty.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedProperty.cs
@@ -19,7 +19,7 @@ internal record BindableListFromListFeedProperty(IPropertySymbol _property, ITyp
 
 	/// <inheritdoc />
 	public string GetDeclaration()
-		=> $"{_property.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{_valueType}> {_property.Name} {{ get; }}"; // Note: This should be a State
+		=> $"{_property.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{_valueType.ToFullString()}> {_property.Name} {{ get; }}"; // Note: This should be a State
 
 	/// <inheritdoc />
 	public string GetInitialization()

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/CommandFromMethod.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/CommandFromMethod.cs
@@ -118,8 +118,8 @@ internal partial record CommandFromMethod : IMappedMember
 				configs.Add(new CommandConfigGenerator(this)
 				{
 					ExternalParameter = $"ctx => ctx.GetOrCreateSource({sourceFeed})",
-					ParametersCoercer = $"{NS.Commands}.CommandParametersCoercingStrategy.UseBoth((viewParameter, feedParameter) => (viewParameter is {viewParameter.Symbol.Type} vp ? vp : default, feedParameter is {GetTypeOrTuple(feedParameters)} fp ? fp : default))",
-					ParameterType = $"global::System.ValueTuple<{viewParameter.Symbol.Type}, {GetTypeOrTuple(feedParameters)}>",
+					ParametersCoercer = $"{NS.Commands}.CommandParametersCoercingStrategy.UseBoth((viewParameter, feedParameter) => (viewParameter is {viewParameter.Symbol.Type.ToFullString()} vp ? vp : default, feedParameter is {GetTypeOrTuple(feedParameters)} fp ? fp : default))",
+					ParameterType = $"global::System.ValueTuple<{viewParameter.Symbol.Type.ToFullString()}, {GetTypeOrTuple(feedParameters)}>",
 					DeconstructParameters = (args, ct) => GetDeconstruct($"{args}.Item2", ct, viewArg: $"{args}.Item1"),
 					CanExecute = CheckForNulls(new[] { viewParameter }) is { } check ? args => check($"{args}.Item1") : null,
 				});
@@ -161,8 +161,8 @@ internal partial record CommandFromMethod : IMappedMember
 
 		string GetTypeOrTuple(IEnumerable<CommandParameter> parameters)
 			=> parameters.Count() is 1
-				? parameters.First().Symbol.Type.ToString()
-				: $"global::System.ValueTuple<{parameters.Select(p => p.Symbol.Type.ToString()).JoinBy(", ")}>";
+				? parameters.First().Symbol.Type.ToFullString()
+				: $"global::System.ValueTuple<{parameters.Select(p => p.Symbol.Type.ToFullString()).JoinBy(", ")}>";
 
 		Func<string, string>? CheckForNulls(IEnumerable<CommandParameter> parameters)
 		{

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/MappedField.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/MappedField.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Uno.Extensions.Generators;
 
 namespace Uno.Extensions.Reactive.Generator;
 
@@ -17,7 +18,7 @@ internal record MappedField(IFieldSymbol _field) : IMappedMember
 
 	/// <inheritdoc />
 	public string GetDeclaration()
-		=> $@"{_field.GetAccessibilityAsCSharpCodeString()} {_field.Type} {_field.Name}
+		=> $@"{_field.GetAccessibilityAsCSharpCodeString()} {_field.Type.ToFullString()} {_field.Name}
 			{{
 				get => {N.Model}.{_field.Name};
 				set => {N.Model}.{_field.Name} = value;

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/MappedMethod.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/MappedMethod.cs
@@ -21,7 +21,7 @@ internal record MappedMethod(IMethodSymbol _method) : IMappedMember
 	{
 		var parametersDeclaration = _method
 			.Parameters
-			.Select(p => $"{p.Type} {p.Name} {(p.IsOptional ? "= " + (p.ExplicitDefaultValue ?? "default") : "")}")
+			.Select(p => $"{p.Type.ToFullString()} {p.Name} {(p.IsOptional ? "= " + (p.ExplicitDefaultValue ?? "default") : "")}")
 			.JoinBy(", ");
 
 		var parametersUsage = _method
@@ -30,7 +30,7 @@ internal record MappedMethod(IMethodSymbol _method) : IMappedMember
 			.JoinBy(", ");
 
 		return $@"
-			{_method.GetAccessibilityAsCSharpCodeString()} {_method.ReturnType} {_method.Name}({parametersDeclaration})
+			{_method.GetAccessibilityAsCSharpCodeString()} {_method.ReturnType.ToFullString()} {_method.Name}({parametersDeclaration})
 				=> {N.Model}.{_method.Name}({parametersUsage});";
 	}
 

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/PropertyFromFeedField.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/PropertyFromFeedField.cs
@@ -16,7 +16,7 @@ internal record PropertyFromFeedField(IFieldSymbol _field, ITypeSymbol _valueTyp
 
 	/// <inheritdoc />
 	public string GetBackingField()
-		=> $"private {NS.Bindings}.Bindable<{_valueType}> _{_field.Name};";
+		=> $"private {NS.Bindings}.Bindable<{_valueType.ToFullString()}> _{_field.Name};";
 
 	/// <inheritdoc />
 	public string GetDeclaration()
@@ -28,5 +28,5 @@ internal record PropertyFromFeedField(IFieldSymbol _field, ITypeSymbol _valueTyp
 
 	/// <inheritdoc />
 	public string GetInitialization()
-		=> $"_{_field.Name} = new {NS.Bindings}.Bindable<{ _valueType}>(base.Property<{_valueType}>(nameof({_field.Name}), {N.Ctor.Model}.{_field.Name} ?? throw new NullReferenceException(\"The feed field '{_field.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
+		=> $"_{_field.Name} = new {NS.Bindings}.Bindable<{_valueType.ToFullString()}>(base.Property<{_valueType.ToFullString()}>(nameof({_field.Name}), {N.Ctor.Model}.{_field.Name} ?? throw new NullReferenceException(\"The feed field '{_field.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
 }

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/PropertyFromFeedProperty.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/PropertyFromFeedProperty.cs
@@ -16,7 +16,7 @@ internal record PropertyFromFeedProperty(IPropertySymbol _property, ITypeSymbol 
 
 	/// <inheritdoc />
 	public string GetBackingField()
-		=> $"private {NS.Bindings}.Bindable<{_valueType}> _{_property.GetCamelCaseName()};";
+		=> $"private {NS.Bindings}.Bindable<{_valueType.ToFullString()}> _{_property.GetCamelCaseName()};";
 
 	/// <inheritdoc />
 	public string GetDeclaration()
@@ -28,5 +28,5 @@ internal record PropertyFromFeedProperty(IPropertySymbol _property, ITypeSymbol 
 
 	/// <inheritdoc />
 	public string? GetInitialization()
-		=> $"_{_property.GetCamelCaseName()} = new {NS.Bindings}.Bindable<{ _valueType}>(base.Property<{_valueType}>(nameof({_property.Name}), {N.Ctor.Model}.{_property.Name} ?? throw new NullReferenceException(\"The feed property '{_property.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
+		=> $"_{_property.GetCamelCaseName()} = new {NS.Bindings}.Bindable<{_valueType.ToFullString()}>(base.Property<{_valueType.ToFullString()}>(nameof({_property.Name}), {N.Ctor.Model}.{_property.Name} ?? throw new NullReferenceException(\"The feed property '{_property.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
 }

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_2.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_2.cs
@@ -106,12 +106,12 @@ internal class ViewModelGenTool_2 : ICodeGenTool
 						.Where(_ctx.IsGenerationNotDisable)
 						.Select(ctor => $@"
 							{GetCtorAccessibility(ctor)} {vmName}({ctor.Parameters.Select(p => p.ToFullString()).JoinBy(", ")})
-								: this(new {model}({ctor.Parameters.Select(p => p.Name).JoinBy(", ")}))
+								: this(new {model.ToFullString()}({ctor.Parameters.Select(p => p.Name).JoinBy(", ")}))
 							{{
 							}}")
 						.Align(5)}
 
-					protected {vmName}({model} {N.Ctor.Model}){(hasBaseType ? $" : base({N.Ctor.Model})" : "")}
+					protected {vmName}({model.ToFullString()} {N.Ctor.Model}){(hasBaseType ? $" : base({N.Ctor.Model})" : "")}
 					{{
 						var {N.Ctor.Ctx} = {NS.Core}.SourceContext.GetOrCreate({N.Ctor.Model});
 
@@ -125,7 +125,7 @@ internal class ViewModelGenTool_2 : ICodeGenTool
 						{members.Select(member => member.GetInitialization()).Align(6)}
 					}}
 
-					public {(hasBaseType ? $"new {model} {N.Model} => ({model}) base.{N.Model};" : $"{model} {N.Model} {{ get; }}")}
+					public {(hasBaseType ? $"new {model.ToFullString()} {N.Model} => ({model.ToFullString()}) base.{N.Model};" : $"{model} {N.Model} {{ get; }}")}
 
 					{members.Select(member => member.GetDeclaration()).Align(5)}
 				}}");

--- a/src/Uno.Extensions.Reactive.Testing/FeedUITests.cs
+++ b/src/Uno.Extensions.Reactive.Testing/FeedUITests.cs
@@ -38,7 +38,7 @@ public class FeedUITests : FeedTests, ISourceContextOwner
 		if (DispatcherHelper.GetForCurrentThread == DispatcherHelper.NotConfigured)
 		{
 			_testDispatcher = new();
-			DispatcherHelper.GetForCurrentThread  = () => Dispatcher.HasThreadAccess ? Dispatcher : null;
+			DispatcherHelper.GetForCurrentThread  = () => _testDispatcher.HasThreadAccess ? _testDispatcher : null;
 		}
 		else
 		{

--- a/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.Utils.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.Utils.cs
@@ -81,7 +81,7 @@ internal abstract class CollectionTrackerTester<TCollection, T>
 
 			var node = updater
 				.GetType()
-				.GetField("_head", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+				.GetField("_head", global::System.Reflection.BindingFlags.Instance | global::System.Reflection.BindingFlags.NonPublic)
 				?.GetValue(updater) as CollectionUpdater.Update;
 
 			while(node != null)

--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_Methods_Then_GenerateCommands.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_Methods_Then_GenerateCommands.cs
@@ -819,6 +819,22 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 		GetSubCommands(vm.WithExplicitAttributeWithName).Any(HasExternalParameter).Should().BeTrue();
 	}
 
+	public partial class When_UsingConflictingTypesParameter_ViewModel
+	{
+		public void ConflictWhenNotPrefixedByGlobal1(Uno.System.DateTime parameter) { }
+
+		public void ConflictWhenNotPrefixedByGlobal2(global::System.DateTime parameter) { }
+	}
+
+	[TestMethod]
+	public async Task When_When_UsingConflictingTypesParameter_Then_Compiles()
+	{
+		await using var vm = new BindableWhen_UsingConflictingTypesParameter_ViewModel();
+
+		vm.ConflictWhenNotPrefixedByGlobal1.CanExecute(new Uno.System.DateTime()).Should().BeTrue();
+		vm.ConflictWhenNotPrefixedByGlobal1.CanExecute(new global::System.DateTime()).Should().BeFalse();
+	}
+
 	private async ValueTask WaitFor(Func<bool> predicate)
 	{
 		await Task.Yield();

--- a/src/Uno.Extensions.Reactive.Tests/Generator/_ConflictingNsAndTypes.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/_ConflictingNsAndTypes.cs
@@ -1,0 +1,7 @@
+using System;
+using System.Linq;
+
+namespace Uno.System // Namespace that will conflicts with any system types that are fully qualified but not prefixed by 'global'
+{
+	public class DateTime { } // Type that conflicts the System.DateTime type when not prefixed with 'global'
+}


### PR DESCRIPTION
## Bugfix
Fix missing some global:: prefixes in generated code

## What is the current behavior?
Missing some global:: prefixes in generated code

## What is the new behavior?
🙃

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
