### PR TITLE
fix: Allowing SelectedItem to be data bound

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigators/NavigationViewNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/NavigationViewNavigator.cs
@@ -14,6 +14,18 @@ public class NavigationViewNavigator : SelectorNavigator<Microsoft.UI.Xaml.Contr
 	{
 	}
 
+	public override void ControlInitialize()
+	{
+		// Make sure selectionchanged event handlers are wired up
+		base.ControlInitialize();
+
+		if(Control?.SelectedItem is not null)
+		{
+			_ = SelectionChanged(Control, MenuItemToFrameworkElement(Control.SelectedItem));
+		}
+
+	}
+
 	protected override FrameworkElement? SelectedItem
 	{
 		get => Control is null ? null : MenuItemToFrameworkElement(Control.SelectedItem);

--- a/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
@@ -9,7 +9,7 @@ public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
 	{
 		if (Control is not null)
 		{
-			_detachSelectionChanged = AttachSelectionChanged(SelectionChanged);
+			_detachSelectionChanged = AttachSelectionChanged((sender, selected) => _ = SelectionChanged(sender, selected));
 		}
 	}
 
@@ -23,7 +23,7 @@ public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
 
 	protected override async Task<bool> RegionCanNavigate(Route route, RouteInfo? routeMap)
 	{
-		if(!await base.RegionCanNavigate(route, routeMap))
+		if (!await base.RegionCanNavigate(route, routeMap))
 		{
 			return false;
 		}
@@ -73,11 +73,11 @@ public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
 		}
 		finally
 		{
-			_detachSelectionChanged = AttachSelectionChanged(SelectionChanged);
+			_detachSelectionChanged = AttachSelectionChanged((sender, selected) => _ = SelectionChanged(sender, selected));
 		}
 	}
 
-	private async void SelectionChanged(FrameworkElement sender, FrameworkElement? selectedItem)
+	protected async Task SelectionChanged(FrameworkElement sender, FrameworkElement? selectedItem)
 	{
 		if (selectedItem is null)
 		{

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundPage.xaml
@@ -15,6 +15,7 @@
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
 			<RowDefinition />
 		</Grid.RowDefinitions>
 		<utu:NavigationBar Content="NavigationView DataBound"
@@ -23,9 +24,18 @@
 				   Grid.Row="1"
 				   x:Name="CurrentNavigationViewItemText"
 				   AutomationProperties.AutomationId="CurrentNavigationViewItemTextBlock" />
+		<StackPanel Orientation="Horizontal">
+			<Button Content="Profile"
+					Click="{x:Bind ViewModel.SelectProfile}" />
+			<Button Content="Deals"
+					Click="{x:Bind ViewModel.SelectDeals}" />
+			<Button Content="Products"
+					Click="{x:Bind ViewModel.SelectProducts}" />
+		</StackPanel>
 		<muxc:NavigationView uen:Region.Attached="true"
-							 Grid.Row="2"
+							 Grid.Row="3"
 							 SelectionChanged="NavigationViewItemChanged"
+							 SelectedItem="{Binding SelectedNavigationItem, Mode=TwoWay}"
 							 ItemInvoked="NavigationItemInvoked"
 							 MenuItemsSource="{Binding NavigationItems}"
 							 IsSettingsVisible="True">

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundPage.xaml.cs
@@ -3,6 +3,7 @@ namespace TestHarness.Ext.Navigation.NavigationView;
 
 public sealed partial class NavigationViewDataBoundPage : Page
 {
+	public NavigationViewDataBoundViewModel? ViewModel => DataContext as NavigationViewDataBoundViewModel;
 	public NavigationViewDataBoundPage()
 	{
 		this.InitializeComponent();

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewDataBoundViewModel.cs
@@ -1,8 +1,25 @@
 ﻿namespace TestHarness.Ext.Navigation.NavigationView;
 
-public record NavigationViewDataBoundViewModel(INavigator Navigator)
+public partial class NavigationViewDataBoundViewModel : ObservableObject
 {
+	[ObservableProperty]
+	private string selectedNavigationItem = "Deals";
+
 	public string[] NavigationItems { get; } = new string[] { "Products", "Deals", "Profile" };
 
+	public void SelectProfile()
+	{
+		SelectedNavigationItem = "Profile";
+	}
+
+	public void SelectProducts()
+	{
+		SelectedNavigationItem = "Products";
+	}
+
+	public void SelectDeals()
+	{
+		SelectedNavigationItem = "Deals";
+	}
 }
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/NavigationView/NavigationViewHostInit.cs
@@ -18,7 +18,13 @@ public class NavigationViewHostInit : BaseHostInitialization
 				Nested: new[]
 				{
 						new RouteMap("Home", View: views.FindByViewModel<NavigationViewHomeViewModel>()),
-						new RouteMap("DataBound", View: views.FindByViewModel<NavigationViewDataBoundViewModel>()),
+						new RouteMap("DataBound", View: views.FindByViewModel<NavigationViewDataBoundViewModel>(),
+						Nested: new[]
+						{
+							new RouteMap("Profile"),
+							new RouteMap("Deals"),
+							new RouteMap("Products")
+						}),
 						new RouteMap("Settings", View: views.FindByViewModel<NavigationViewSettingsViewModel>()),
 				}));
 	}


### PR DESCRIPTION
closes: #1033

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

NavigationView menu items could be data bound but you couldn't data bind the SelectedItem property

## What is the new behavior?

SelectedItem can be data bound to set the initial value and twoway bound so the underlying viewmodel can be updated when selection changes

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
