### PR TITLE
feat: Remove use of activator to create ui elements

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/MessageDialogViewMap.cs
+++ b/src/Uno.Extensions.Navigation.UI/MessageDialogViewMap.cs
@@ -23,11 +23,12 @@ public record MessageDialogViewMap(
 	Type? ViewModel = default,
 	DataMap? Data = default,
 	Type? ResultData = default
-) : ViewMap<MessageDialog>(
-		ViewModel,
-		Data,
-		ResultData,
-		new MessageDialogAttributes(
+) : ViewMap(
+		View: typeof(MessageDialog),
+		ViewModel: ViewModel,
+		Data: Data,
+		ResultData: ResultData,
+		ViewAttributes: new MessageDialogAttributes(
 			ContentProvider: _ => Content,
 			TitleProvider: _ => Title,
 			DelayUserInput,
@@ -48,11 +49,12 @@ public record LocalizableMessageDialogViewMap(
 	Type? ViewModel = default,
 	DataMap? Data = default,
 	Type? ResultData = default
-) : ViewMap<MessageDialog>(
-		ViewModel,
-		Data,
-		ResultData,
-		new MessageDialogAttributes(
+) : ViewMap(
+		View: typeof(MessageDialog),
+		ViewModel: ViewModel,
+		Data: Data,
+		ResultData: ResultData,
+		ViewAttributes: new MessageDialogAttributes(
 			ContentProvider: Content,
 			TitleProvider: Title,
 			DelayUserInput,

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ContentControlNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ContentControlNavigator.cs
@@ -4,7 +4,6 @@ public class ContentControlNavigator : ControlNavigator<ContentControl>
 {
 	protected override FrameworkElement? CurrentView => _content;
 	private FrameworkElement? _content;
-
 	public ContentControlNavigator(
 		ILogger<ContentControlNavigator> logger,
 		IDispatcher dispatcher,
@@ -53,7 +52,7 @@ public class ContentControlNavigator : ControlNavigator<ContentControl>
 			Region.Children.Clear();
 
 			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Creating instance of type '{viewType.Name}'");
-			var content = Activator.CreateInstance(viewType);
+			var content = CreateControlFromType(viewType); 
 			if (path is not null &&
 					content is UI.Controls.FrameView fe)
 			{

--- a/src/Uno.Extensions.Navigation.UI/Navigators/PanelVisiblityNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/PanelVisiblityNavigator.cs
@@ -59,7 +59,7 @@ public class PanelVisiblityNavigator : ControlNavigator<Panel>
 				}
 
 				if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Creating instance of type '{viewType.Name}'");
-				controlToShow = Activator.CreateInstance(viewType) as FrameworkElement;
+				controlToShow = CreateControlFromType(viewType) as FrameworkElement;
 				if (controlToShow is not null)
 				{
 					if (!string.IsNullOrWhiteSpace(regionName) &&

--- a/src/Uno.Extensions.Navigation/MappedViewMap.cs
+++ b/src/Uno.Extensions.Navigation/MappedViewMap.cs
@@ -1,6 +1,6 @@
 ﻿namespace Uno.Extensions.Navigation;
 
-public record MappedViewMap(
+internal record MappedViewMap(
 		Type? View = null,
 		Func<Type?>? ViewSelector = null,
 		Type? ViewModel = null,

--- a/src/Uno.Extensions.Navigation/ViewMap.cs
+++ b/src/Uno.Extensions.Navigation/ViewMap.cs
@@ -38,14 +38,21 @@ public record ViewMap<TView>(
 	Type? ResultData = null,
 	object? ViewAttributes = null
 ) : ViewMap(View: typeof(TView), ViewModel: ViewModel, Data: Data, ResultData: ResultData, ViewAttributes: ViewAttributes)
+	where TView: class, new()
 {
+	public override void RegisterTypes(IServiceCollection services)
+	{
+		services.AddTransient<TView>(sp => new TView());
+		base.RegisterTypes(services);
+	}
 }
 
 public record ViewMap<TView, TViewModel>(
 	DataMap? Data = null,
 	Type? ResultData = null,
 	object? ViewAttributes = null
-) : ViewMap(View: typeof(TView), ViewModel: typeof(TViewModel), Data: Data, ResultData: ResultData, ViewAttributes: ViewAttributes)
+) : ViewMap<TView>(ViewModel: typeof(TViewModel), Data: Data, ResultData: ResultData, ViewAttributes: ViewAttributes)
+	where TView : class, new()
 {
 }
 
@@ -54,7 +61,8 @@ public record DataViewMap<TView, TViewModel, TData>(
 	Func<IServiceProvider, IDictionary<string, object>, Task<TData?>>? FromQuery = null,
 	Type? ResultData = null,
 	object? ViewAttributes = null
-) : ViewMap(View: typeof(TView), ViewModel: typeof(TViewModel), Data: new DataMap<TData>(ToQuery, FromQuery), ResultData: ResultData, ViewAttributes: ViewAttributes)
+) : ViewMap<TView,TViewModel>(Data: new DataMap<TData>(ToQuery, FromQuery), ResultData: ResultData, ViewAttributes: ViewAttributes)
+	where TView : class, new()
 	where TData : class
 {
 }
@@ -62,8 +70,9 @@ public record DataViewMap<TView, TViewModel, TData>(
 public record ResultDataViewMap<TView, TViewModel, TResultData>(
 	DataMap? Data = null,
 	object? ViewAttributes = null
-) : ViewMap(View: typeof(TView), ViewModel: typeof(TViewModel), Data: Data, ResultData: typeof(TResultData), ViewAttributes: ViewAttributes)
-		where TResultData : class
+) : ViewMap<TView,TViewModel>(Data: Data, ResultData: typeof(TResultData), ViewAttributes: ViewAttributes)
+	where TView : class, new()
+	where TResultData : class
 {
 	internal override void RegisterResultDataType(IServiceCollection services)
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): #1081 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Uses Activator to create instances of FrameView and other view types

## What is the new behavior?

Views specified in mapping are registered with DI using empty constructor, eliminating need to use Activator

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
