### PR TITLE
Update Markup References

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -42,7 +42,7 @@
 		<PackageVersion Include="Uno.Core" Version="4.0.1" />
 		<PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.3.0" />
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
-		<PackageVersion Include="Uno.Extensions.Markup.Generators" Version="1.0.0-dev.125" />
+		<PackageVersion Include="Uno.Extensions.Markup.Generators" Version="1.0.0-dev.166" />
 		<PackageVersion Include="Uno.Roslyn" Version="1.3.0-dev.12" />
 		<PackageVersion Include="Uno.Toolkit" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.2" />
@@ -53,7 +53,7 @@
 		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.6.19" />
 		<PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
 		<PackageVersion Include="Uno.WinUI" Version="4.6.19" />
-		<PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.12" />
+		<PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
 		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.6.19" />
 		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.6.19" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />

--- a/src/Uno.Extensions.Navigation.UI.Markup/AssemblyInfo.cs
+++ b/src/Uno.Extensions.Navigation.UI.Markup/AssemblyInfo.cs
@@ -1,3 +1,3 @@
-﻿using Microsoft.UI.Xaml.Generator;
+﻿using Uno.Extensions.Markup.Generator;
 
 [assembly: GenerateMarkupForAssembly(typeof(Uno.Extensions.Navigation.UI.Navigation))]

--- a/src/Uno.Extensions.Reactive.UI.Markup/AssemblyInfo.cs
+++ b/src/Uno.Extensions.Reactive.UI.Markup/AssemblyInfo.cs
@@ -1,3 +1,3 @@
-﻿using Microsoft.UI.Xaml.Generator;
+﻿using Uno.Extensions.Markup.Generator;
 
 [assembly: GenerateMarkupForAssembly(typeof(Uno.Extensions.Reactive.UI.FeedView))]

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
@@ -70,6 +70,10 @@
     <!--#if (useCsharpMarkup)-->
     <PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
     <PackageVersion Include="Uno.Toolkit.WinUI.Markup" Version="2.5.0-dev.8" />
+    <PackageVersion Include="Uno.Extensions.Navigation.WinUI.Markup" Version="255.255.255.255" />
+    <!--#if (reactive)-->
+    <PackageVersion Include="Uno.Extensions.Reactive.WinUI.Markup" Version="255.255.255.255" />
+    <!--#endif-->
     <!--#if (useMaterial)-->
     <PackageVersion Include="Uno.Material.WinUI.Markup" Version="2.5.0-dev.6" />
     <!--#endif-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.csproj
@@ -88,8 +88,14 @@
 		<!--#endif-->
 		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" />
 		<PackageReference Include="Uno.Extensions.Navigation.WinUI" />
+		<!--#if (useCsharpMarkup)-->
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" />
+		<!--#endif-->
 		<!--#if (useMvux)-->
 		<PackageReference Include="Uno.Extensions.Reactive.WinUI" />
+		<!--#if (useCsharpMarkup)-->
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" />
+		<!--#endif-->
 		<!--#endif-->
 	</ItemGroup>
 	<!--#endif-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
@@ -79,8 +79,14 @@
 		<!--#endif-->
 		<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="255.255.255.255" />
 		<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="255.255.255.255" />
+		<!--#if (useCsharpMarkup)-->
+		<PackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" Version="255.255.255.255" />
+		<!--#endif-->
 		<!--#if (useMvux)-->
 		<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="255.255.255.255" />
+		<!--#if (useCsharpMarkup)-->
+		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="255.255.255.255" />
+		<!--#endif-->
 		<!--#endif-->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 	</ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #

n/a

## PR Type

What kind of change does this PR introduce?

- Dependency Update

## What is the current behavior?

- Markup packages reference older build of C# Markup which is not binary compatible with the current version
- Template is missing the pre-generated Extensions packages

## What is the new behavior?

- Updates to the latest Markup package
- Adds references to the Extensions pre-generated packages in the template