### PR TITLE
fix: Preventing tapped event for when event is on an enabled button

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
@@ -70,15 +70,15 @@ public class ItemsRepeaterRequestHandler : ControlRequestHandlerBase<ItemsRepeat
 			if (isCaptured)
 			{
 				pointerElement ??= sender;
-				var _pointerPosition = actionArgs.GetCurrentPoint(pointerElement).Position;
+				var pointerPosition = actionArgs.GetCurrentPoint(pointerElement).Position;
 
 				// Tolerance is consistent with use in ButtonBase
 				// https://github.com/unoplatform/uno/blob/4bc829e4ef01f2b89733b74c61a3161780818a8b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.mux.cs#LL490C4-L494C88
 				const double tolerance = 0.05;
 				var layoutRect = LayoutInformation.GetLayoutSlot(pointerElement);
 				var pointerInControl =
-					-tolerance <= _pointerPosition.X && _pointerPosition.X <= layoutRect.Width + tolerance &&
-					-tolerance <= _pointerPosition.Y && _pointerPosition.Y <= layoutRect.Height + tolerance;
+					-tolerance <= pointerPosition.X && pointerPosition.X <= layoutRect.Width + tolerance &&
+					-tolerance <= pointerPosition.Y && pointerPosition.Y <= layoutRect.Height + tolerance;
 				if (pointerInControl)
 				{
 					actionArgs.Handled = true;

--- a/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
@@ -84,6 +84,10 @@ public class ItemsRepeaterRequestHandler : ControlRequestHandlerBase<ItemsRepeat
 					actionArgs.Handled = true;
 					await action(sender, dataContext);
 				}
+				
+				isCaptured = false;
+				dataContext = null;
+				pointerElement = null;
 			}
 
 		};

--- a/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
@@ -39,6 +39,13 @@ public class ItemsRepeaterRequestHandler : ControlRequestHandlerBase<ItemsRepeat
 			var elt = actionArgs.OriginalSource as DependencyObject;
 			while (elt is not null)
 			{
+				if(elt is ButtonBase button &&
+					button.IsEnabled)
+				{
+					// Assume that Button captures all tapped events
+					return;
+				}
+
 				var parent = VisualTreeHelper.GetParent(elt);
 				if (parent == sender)
 				{

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
@@ -19,7 +19,8 @@
 		<utu:NavigationBar Content="Page Navigation - One"
 						   AutomationProperties.AutomationId="PageNavigationOne" />
 		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center" Grid.Row="1">
+					VerticalAlignment="Center"
+					Grid.Row="1">
 			<TextBlock>
 				<Run Text="Created on UI Thread: " /><Run Text="{Binding CreatedOnUIThread}" />
 			</TextBlock>
@@ -28,33 +29,33 @@
 					uen:Navigation.Request="PageNavigationTwo" />
 			<Button AutomationProperties.AutomationId="OnePageToTwoPageCodebehindButton"
 					Content="Two (Codebehind)"
-					Click="OnePageToTwoPageCodebehindClick"
-					/>
+					Click="OnePageToTwoPageCodebehindClick" />
 			<Button AutomationProperties.AutomationId="OnePageToTwoPageViewModelButton"
 					Content="Two (ViewModel)"
-					Click="{x:Bind ViewModel.GoToTwo}"/>
+					Click="{x:Bind ViewModel.GoToTwo}" />
 			<Button AutomationProperties.AutomationId="RapidSettingsWriteTestButton"
 					Content="Settings Write Test"
 					Click="{x:Bind ViewModel.SettingsWriteTest}" />
 		</StackPanel>
 		<ScrollViewer Grid.Row="2">
-			<muxc:ItemsRepeater ItemsSource="{Binding Items}"
-								uen:Navigation.Request="PageNavigationTwo">
-				<muxc:ItemsRepeater.ItemTemplate>
-					<DataTemplate>
-						<Grid Height="200"
-								Width="200"
-								Background="Red">
-							<TextBlock Text="{Binding}"
-									   VerticalAlignment="Center"
-									   HorizontalAlignment="Center" />
-							<Button VerticalAlignment="Bottom"
-									Content="Go to Three"
-									uen:Navigation.Request="PageNavigationThree" />
-						</Grid>
-					</DataTemplate>
-				</muxc:ItemsRepeater.ItemTemplate>
-			</muxc:ItemsRepeater>
+		<muxc:ItemsRepeater ItemsSource="{Binding Items}"
+							uen:Navigation.Request="PageNavigationTwo">
+			<muxc:ItemsRepeater.ItemTemplate>
+				<DataTemplate>
+					<Grid Height="200"
+						  Background="Red">
+						<Border Background="Pink"
+								VerticalAlignment="Top"
+								HorizontalAlignment="Center">
+							<TextBlock Text="{Binding}"/>
+						</Border>
+						<Button VerticalAlignment="Bottom"
+								Content="Go to Three"
+								uen:Navigation.Request="PageNavigationThree" />
+					</Grid>
+				</DataTemplate>
+			</muxc:ItemsRepeater.ItemTemplate>
+		</muxc:ItemsRepeater>
 		</ScrollViewer>
 	</Grid>
 </Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
@@ -42,13 +42,16 @@
 								uen:Navigation.Request="PageNavigationTwo">
 				<muxc:ItemsRepeater.ItemTemplate>
 					<DataTemplate>
-						<Border Height="200"
+						<Grid Height="200"
 								Width="200"
 								Background="Red">
 							<TextBlock Text="{Binding}"
 									   VerticalAlignment="Center"
 									   HorizontalAlignment="Center" />
-						</Border>
+							<Button VerticalAlignment="Bottom"
+									Content="Go to Three"
+									uen:Navigation.Request="PageNavigationThree" />
+						</Grid>
 					</DataTemplate>
 				</muxc:ItemsRepeater.ItemTemplate>
 			</muxc:ItemsRepeater>


### PR DESCRIPTION
GitHub Issue (If applicable): #1065

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Button click also triggers Tapped on ItemsRepeater, which means that navigation will pick up both Navigation.REquest on Button and on ItemsRepeater

## What is the new behavior?

Navigation only picks up on the Request set on the Button

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
