### PR TITLE
fix: Making RuntimeIdentifier conditional

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Build.nocpm.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Build.nocpm.props
@@ -25,10 +25,13 @@
 		<IsWinAppSdk Condition="$(TargetFramework.Contains('windows10'))">true</IsWinAppSdk>
 	</PropertyGroup>
 
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(RuntimeIdentifier)'==''">
 		<RuntimeIdentifier Condition="$(IsIOS)">iossimulator-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="$(IsMacCatalyst)">maccatalyst-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="$(IsMac)">osx-x64</RuntimeIdentifier>
+	</PropertyGroup>
+
+	<PropertyGroup>
 		<SupportedOSPlatformVersion Condition="$(IsIOS)">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(IsMacCatalyst)">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(IsAndroid)">21.0</SupportedOSPlatformVersion>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Build.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Build.props
@@ -27,10 +27,13 @@
 		<IsWinAppSdk Condition="$(TargetFramework.Contains('windows10'))">true</IsWinAppSdk>
 	</PropertyGroup>
 
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(RuntimeIdentifier)'==''">
 		<RuntimeIdentifier Condition="$(IsIOS)">iossimulator-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="$(IsMacCatalyst)">maccatalyst-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="$(IsMac)">osx-x64</RuntimeIdentifier>
+	</PropertyGroup>
+	
+	<PropertyGroup>
 		<SupportedOSPlatformVersion Condition="$(IsIOS)">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(IsMacCatalyst)">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$(IsAndroid)">21.0</SupportedOSPlatformVersion>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

RuntimeIdentifier should only be set if not passed in as part of build

## What is the new behavior?

RuntimeIdentifier property group is conditional
(same as https://github.com/unoplatform/uno/blob/510d75bd0ead90399208905f28d7c6dbfa13ab23/src/SolutionTemplate/UnoSolutionTemplate.WinUI.netcore/Mobile/UnoQuickStart.Mobile.csproj#L44)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
