### PR TITLE
fix: Correct handling of threads and initialization

### DIFF
--- a/samples/Playground/Playground.Shared/ViewModels/ThemeSwitchViewModel.cs
+++ b/samples/Playground/Playground.Shared/ViewModels/ThemeSwitchViewModel.cs
@@ -30,17 +30,26 @@ public partial class ThemeSwitchViewModel:ObservableObject
 
 	public async Task ChangeToSystem()
 	{
-		await _ts.SetThemeAsync(AppTheme.System);
+		await Task.Run(async () =>
+		{
+			await _ts.SetThemeAsync(AppTheme.System);
+		});
 	}
 
 	public async Task ChangeToLight()
 	{
-		await _ts.SetThemeAsync(AppTheme.Light);
+		await Task.Run(async () =>
+		{
+			await _ts.SetThemeAsync(AppTheme.Light);
+		});
 	}
 
 	public async Task ChangeToDark()
 	{
-		await _ts.SetThemeAsync(AppTheme.Dark);
+		await Task.Run(async () =>
+		{
+			await _ts.SetThemeAsync(AppTheme.Dark);
+		});
 	}
 }
 


### PR DESCRIPTION
GitHub Issue (If applicable): #1107

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

IsDark being accessed from background thread 

## What is the new behavior?

IsDark is accessed from UI thread in SetThemeAsync. 
Also added check to make sure initializeasync has completed before setthemeasync proceeds

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
