### PR TITLE
fix: Using HostBuilder properties to capture istregistered flag instead of static field

### DIFF
--- a/samples/Playground/Playground.Shared/AppHost.cs
+++ b/samples/Playground/Playground.Shared/AppHost.cs
@@ -44,9 +44,9 @@ internal static class AppHost
 				services
 					.AddSingleton<IAuthenticationTokenProvider>(new SimpleAuthenticationToken { AccessToken = "My access token" })
 					.AddScoped<NeedsADispatcherService>()
-					.AddNativeHandler()
+					.AddNativeHandler(context)
 					.AddTransient<DebugHttpHandler>()
-					.AddContentSerializer()
+					.AddContentSerializer(context)
 
 					.AddRefitClient<IToDoTaskListEndpoint>(context,
 							// Leaving this commented code here as an example of using the settingsBuilder callback

--- a/src/Uno.Extensions.Authentication/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication/HostBuilderExtensions.cs
@@ -80,8 +80,13 @@ public static class HostBuilderExtensions
 		build?.Invoke(authBuilder);
 
 		return builder
-			.ConfigureServices(services =>
+			.ConfigureServices((ctx,services) =>
 			{
+				if (ctx.IsRegistered(nameof(UseAuthentication)))
+				{
+					return;
+				}
+
 				services
 					.AddSingleton<ITokenCache>(sp =>
 							new TokenCache(

--- a/src/Uno.Extensions.Configuration/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/HostBuilderExtensions.cs
@@ -20,6 +20,13 @@ public static class HostBuilderExtensions
 
 		hostBuilder = hostBuilder.ConfigureServices((ctx, s) =>
 				{
+					// We're doing the IsRegistered check here so that the
+					// other configure delegates still run if required
+					if (ctx.IsRegistered(nameof(UseConfiguration)))
+					{
+						return;
+					}
+
 					s.TryAddSingleton(a => ctx.Configuration);
 					s.TryAddSingleton(a => (IConfigurationRoot)ctx.Configuration);
 					s.TryAddSingleton<Reloader>();

--- a/src/Uno.Extensions.Core/DependencyInjection/HostBuilderContextExtensions.cs
+++ b/src/Uno.Extensions.Core/DependencyInjection/HostBuilderContextExtensions.cs
@@ -1,0 +1,9 @@
+﻿namespace Uno.Extensions;
+
+public static class HostBuilderContextExtensions
+{
+	public static bool IsRegistered(this HostBuilderContext context, string registeredKey, bool  newIsRegistered = true)
+	{
+		return context.Properties.IsRegistered(registeredKey, newIsRegistered);
+	}
+}

--- a/src/Uno.Extensions.Core/DependencyInjection/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Core/DependencyInjection/HostBuilderExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace Uno.Extensions;
+
+public static class HostBuilderExtensions
+{
+	public static bool IsRegistered(this IHostBuilder builder, string registeredKey, bool newIsRegistered = true)
+	{
+		return builder.Properties.IsRegistered(registeredKey, newIsRegistered);
+	}
+
+	internal static bool IsRegistered(this IDictionary<object,object> properties, string registeredKey, bool newIsRegistered = true)
+	{
+		if (properties.TryGetValue(registeredKey, out var value) &&
+			value is bool registeredValue &&
+			registeredValue)
+		{
+			return true;
+		}
+		properties[registeredKey] = newIsRegistered;
+		return false;
+	}
+
+}

--- a/src/Uno.Extensions.Core/GlobalUsings.cs
+++ b/src/Uno.Extensions.Core/GlobalUsings.cs
@@ -10,4 +10,5 @@ global using System.Threading.Tasks;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.DependencyInjection.Extensions;
 global using Microsoft.Extensions.Logging;
+global using Microsoft.Extensions.Hosting;
 global using Uno.Extensions.DependencyInjection;

--- a/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
+++ b/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
@@ -9,6 +9,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
 		<PackageReference Include="System.Collections.Immutable" /><!--Lower version breaks build of reactive.<UI|WinUI>-->
 		<PackageReference Include="System.Threading.Tasks.Extensions" />
 	</ItemGroup>

--- a/src/Uno.Extensions.Http/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Http/HostBuilderExtensions.cs
@@ -16,9 +16,12 @@ public static class HostBuilderExtensions
 		return builder
 			.ConfigureServices((ctx, services) =>
 		{
-			_ = services
-				.AddNativeHandler()
-				.AddTransient<DelegatingHandler, DiagnosticHandler>();
+			if (!ctx.IsRegistered(nameof(UseHttp)))
+			{
+				_ = services
+					.AddNativeHandler(ctx)
+					.AddTransient<DelegatingHandler, DiagnosticHandler>();
+			}
 
 			configure?.Invoke(ctx, services);
 		});

--- a/src/Uno.Extensions.Http/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Http/ServiceCollectionExtensions.cs
@@ -46,7 +46,7 @@ public static class ServiceCollectionExtensions
 	  )
 		  where TInterface : class
 	{
-		var optionsName = name??( typeof(TInterface).IsInterface ? typeof(TInterface).Name.TrimStart(InterfaceNamePrefix) : typeof(TInterface).Name);
+		var optionsName = name ?? (typeof(TInterface).IsInterface ? typeof(TInterface).Name.TrimStart(InterfaceNamePrefix) : typeof(TInterface).Name);
 		options ??= ConfigurationBinder.Get<EndpointOptions>(context.Configuration.GetSection(optionsName));
 
 		httpClientFactory ??=
@@ -146,8 +146,13 @@ public static class ServiceCollectionExtensions
 			.AddTypedClient(factory);
 	}
 
-	public static IServiceCollection AddNativeHandler(this IServiceCollection services)
+	public static IServiceCollection AddNativeHandler(this IServiceCollection services, HostBuilderContext context)
 	{
+		if (context.IsRegistered(nameof(AddNativeHandler)))
+		{
+			return services;
+		}
+
 		return services
 			.AddSingleton<ICookieManager, CookieManager>()
 			.AddTransient<HttpMessageHandler>(s =>
@@ -157,13 +162,13 @@ public static class ServiceCollectionExtensions
 #if NET6_0_OR_GREATER
 				new Xamarin.Android.Net.AndroidMessageHandler()
 #else
-                new Xamarin.Android.Net.AndroidClientHandler()
+			new Xamarin.Android.Net.AndroidClientHandler()
 #endif
 #elif WINDOWS || WINDOWS_UWP
 				new WinHttpHandler()
 #else
 			new HttpClientHandler()
 #endif
-		);
+	);
 	}
 }

--- a/src/Uno.Extensions.Localization.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Localization.UI/HostBuilderExtensions.cs
@@ -15,6 +15,11 @@ public static class HostBuilderExtensions
 		this IHostBuilder hostBuilder,
 		Action<HostBuilderContext, IServiceCollection>? configure = default)
 	{
+		if (hostBuilder.IsRegistered(nameof(UseLocalization)))
+		{
+			return hostBuilder;
+		}
+
 		return hostBuilder
 			.UseConfiguration(
 				configure: configBuilder =>

--- a/src/Uno.Extensions.Logging/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Logging/HostBuilderExtensions.cs
@@ -18,6 +18,8 @@ public static class HostBuilderExtensions
 		return hostBuilder
 				.ConfigureLogging((context, builder) =>
 				{
+					if (!context.IsRegistered(nameof(UseLogging)))
+					{
 #if !__WASM__
 #if __IOS__
 #pragma warning disable CA1416 // Validate platform compatibility: The net6.0 version is not used on older versions of OS
@@ -26,16 +28,25 @@ public static class HostBuilderExtensions
 #elif NET6_0_OR_GREATER // Console isn't supported on all Xamarin targets, so only adding for net6.0 and above
 					builder.AddConsole();
 #endif
-					builder.AddDebug();
+						builder.AddDebug();
 #elif __WASM__
 					builder.AddProvider(new global::Uno.Extensions.Logging.WebAssembly.WebAssemblyConsoleLoggerProvider());
 #endif
+					}
+
 					configure?.Invoke(context, builder);
 				})
-				.ConfigureServices(services =>
+				.ConfigureServices((ctx, services) =>
 				{
+					if (ctx.IsRegistered(nameof(HostExtensions.ConnectUnoLogging)))
+					{
+						return;
+					}
+
 					if (enableUnoLogging)
+					{
 						services.AddSingleton<IServiceInitialize, LoggingInitializer>();
+					}
 				});
 	}
 

--- a/src/Uno.Extensions.Navigation.Toolkit/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/HostBuilderExtensions.cs
@@ -7,9 +7,9 @@ public static class HostBuilderExtensions
 	{
 		return builder
 			.UseToolkit()
-			.ConfigureServices(sp =>
+			.ConfigureServices((ctx,sp) =>
 			{
-				_ = sp.AddToolkitNavigation();
+				_ = sp.AddToolkitNavigation(ctx);
 			});
 	}
 }

--- a/src/Uno.Extensions.Navigation.Toolkit/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/ServiceCollectionExtensions.cs
@@ -5,21 +5,21 @@
 /// </summary>
 public static class ServiceCollectionExtensions
 {
-	private static bool _didRegisterServices;
 	/// <summary>
 	/// Adds navigation support for toolkit controls such as TabBar and DrawControl
 	/// </summary>
 	/// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+	/// <param name="context">The <see cref="HostBuilderContext"/> to use when adding services</param>
 	/// <returns>A reference to this instance after the operation has completed.</returns>
 	public static IServiceCollection AddToolkitNavigation(
-		this IServiceCollection services)
+		this IServiceCollection services,
+		HostBuilderContext context)
 	{
-		if (_didRegisterServices)
+		if(context.IsRegistered(nameof(AddToolkitNavigation)))
 		{
 			return services;
 		}
 
-		_didRegisterServices = true;
 		return services
 					.AddTransient<Flyout, ModalFlyout>()
 

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
@@ -33,7 +33,7 @@
 		<PackageReference Include="Uno.WinUI" Version="4.7.30" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.30" />
 	</ItemGroup>
 	<Choose>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
@@ -18,7 +18,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.30" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
@@ -25,7 +25,7 @@
 
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.30" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Windows/Uno.Extensions.RuntimeTests.Windows.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Windows/Uno.Extensions.RuntimeTests.Windows.csproj
@@ -28,7 +28,7 @@
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.3" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.197" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
 
 		<Manifest Include="$(ApplicationManifest)" />

--- a/src/Uno.Extensions.Serialization.Http/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Serialization.Http/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions;
+﻿using Microsoft.Extensions.Hosting;
+
+namespace Uno.Extensions;
 
 /// <summary>
 /// This class is used for serialization configuration.
@@ -6,14 +8,19 @@
 /// </summary>
 public static class ServiceCollectionExtensions
 {
-    /// <summary>
-    /// Adds the serialization services to the <see cref="IServiceCollection"/>.
-    /// </summary>
-    /// <param name="services">Service collection.</param>
-    /// <returns><see cref="IServiceCollection"/>.</returns>
-    public static IServiceCollection AddResponseContentDeserializer(this IServiceCollection services)
+	/// <summary>
+	/// Adds the serialization services to the <see cref="IServiceCollection"/>.
+	/// </summary>
+	/// <param name="services">Service collection.</param>
+	/// <param name="context">The <see cref="HostBuilderContext"/> to use when adding services</param>
+	/// <returns><see cref="IServiceCollection"/>.</returns>
+	public static IServiceCollection AddResponseContentDeserializer(this IServiceCollection services, HostBuilderContext context)
     {
-        return services
+		if (context.IsRegistered(nameof(AddResponseContentDeserializer)))
+		{
+			return services;
+		}
+		return services
             .AddSingleton<IResponseContentDeserializer, SerializerToResponseContentDeserializer>();
     }
 }

--- a/src/Uno.Extensions.Serialization.Refit/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Serialization.Refit/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions
+﻿using Microsoft.Extensions.Hosting;
+
+namespace Uno.Extensions
 {
 	/// <summary>
 	/// This class is used for serialization configuration.
@@ -6,14 +8,19 @@
 	/// </summary>
 	public static class ServiceCollectionExtensions
     {
-        /// <summary>
-        /// Adds the serialization services to the <see cref="IServiceCollection"/>.
-        /// </summary>
-        /// <param name="services">Service collection.</param>
-        /// <returns><see cref="IServiceCollection"/>.</returns>
-        public static IServiceCollection AddContentSerializer(this IServiceCollection services)
-        {
-            return services
+		/// <summary>
+		/// Adds the serialization services to the <see cref="IServiceCollection"/>.
+		/// </summary>
+		/// <param name="services">Service collection.</param>
+		/// <param name="context">The <see cref="HostBuilderContext"/> to use when adding services</param>
+		/// <returns><see cref="IServiceCollection"/>.</returns>
+		public static IServiceCollection AddContentSerializer(this IServiceCollection services, HostBuilderContext context)
+		{
+			if (context.IsRegistered(nameof(AddContentSerializer)))
+			{
+				return services;
+			}
+			return services
                 .AddSingleton<IHttpContentSerializer, SerializerToContentSerializerAdapter>();
         }
     }

--- a/src/Uno.Extensions.Serialization.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/Uno.Extensions.Serialization.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Uno.Extensions.Serialization.Tests;
@@ -18,8 +20,9 @@ public class ServiceCollectionExtensionsTests
 	[TestMethod]
 	public void AddSystemTextJsonSerializationTest()
 	{
+		var context = new HostBuilderContext(new Dictionary<object,object>());
 		var services = new ServiceCollection();
-		services.AddSystemTextJsonSerialization();
+		services.AddSystemTextJsonSerialization(context);
 		_services = services.BuildServiceProvider();
 
 		var serializer = _services.GetService<ISerializer>();

--- a/src/Uno.Extensions.Serialization/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Serialization/HostBuilderExtensions.cs
@@ -8,12 +8,12 @@ public static class HostBuilderExtensions
 	}
 
 	public static IHostBuilder UseSerialization(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection>? configure = default)
-    {
-        return hostBuilder
-                .ConfigureServices((ctx, s) =>
+	{
+		return hostBuilder
+				.ConfigureServices((ctx, s) =>
 				{
-					_=s.AddSystemTextJsonSerialization();
-					configure?.Invoke(ctx,s);
+					_ = s.AddSystemTextJsonSerialization(ctx);
+					configure?.Invoke(ctx, s);
 				});
-    }
+	}
 }

--- a/src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs
@@ -10,10 +10,17 @@ public static class ServiceCollectionExtensions
 	/// Adds the serialization services to the <see cref="IServiceCollection"/>.
 	/// </summary>
 	/// <param name="services">Service collection.</param>
+	/// <param name="context">The <see cref="HostBuilderContext"/> to use when adding services</param>
 	/// <returns><see cref="IServiceCollection"/>.</returns>
 	public static IServiceCollection AddSystemTextJsonSerialization(
-		this IServiceCollection services)
+		this IServiceCollection services,
+		HostBuilderContext context)
 	{
+		if (context.IsRegistered(nameof(AddSystemTextJsonSerialization)))
+		{
+			return services;
+		}
+
 		return services
 			.AddSingleton(sp => new JsonSerializerOptions
 			{

--- a/src/Uno.Extensions.Storage.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Storage.UI/HostBuilderExtensions.cs
@@ -1,5 +1,7 @@
 ﻿
 
+using Uno.Extensions.Configuration;
+
 namespace Uno.Extensions;
 
 public static class HostBuilderExtensions
@@ -18,16 +20,24 @@ public static class HostBuilderExtensions
 		return builder
 			.UseConfiguration(
 				configure: configBuilder =>
-				configBuilder
-						.Section<KeyValueStorageConfiguration>(nameof(KeyValueStorageConfiguration))
-					)
-			.ConfigureServices((ctx, services) =>
-		{
-			_ = services
-				.AddFileStorage()
-				.AddKeyedStorage();
+				{
+					if (configBuilder.IsRegistered(nameof(KeyValueStorageConfiguration)))
+					{
+						return configBuilder;
+					}
 
-			configure?.Invoke(ctx, services);
-		});
+					return configBuilder
+							.Section<KeyValueStorageConfiguration>(nameof(KeyValueStorageConfiguration));
+				})
+			.ConfigureServices((ctx, services) =>
+			{
+				if (!ctx.IsRegistered(nameof(UseStorage)))
+				{
+					_ = services
+						.AddFileStorage()
+						.AddKeyedStorage();
+				}
+				configure?.Invoke(ctx, services);
+			});
 	}
 }

--- a/src/Uno.Extensions.Toolkit.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Toolkit.UI/HostBuilderExtensions.cs
@@ -8,17 +8,13 @@ public static class HostBuilderExtensions
 		return hostBuilder.UseThemeSwitching();
 	}
 
-	private static bool _didRegisterThemeSwitching;
-
 	public static IHostBuilder UseThemeSwitching(
 		this IHostBuilder hostBuilder)
 	{
-		if (_didRegisterThemeSwitching)
+		if (hostBuilder.IsRegistered(nameof(UseThemeSwitching)))
 		{
 			return hostBuilder;
 		}
-
-		_didRegisterThemeSwitching = true;
 
 		return hostBuilder
 			.ConfigureServices((ctx, services) =>

--- a/src/Uno.Extensions.Toolkit.UI/common.props
+++ b/src/Uno.Extensions.Toolkit.UI/common.props
@@ -12,5 +12,6 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Extensions.Configuration\Uno.Extensions.Configuration.csproj" />
 		<ProjectReference Include="..\Uno.Extensions.Toolkit\Uno.Extensions.Toolkit.csproj" />
+		<ProjectReference Include="..\Uno.Extensions.Core\Uno.Extensions.Core.csproj" />
 	</ItemGroup>
 </Project>

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.7.1" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.230118.102" />
     <PackageVersion Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.197" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
     <PackageVersion Include="Refit" Version="6.3.2" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="6.3.2" />
     <PackageVersion Include="SkiaSharp.HarfBuzz" Version="2.88.3" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationHostInit.cs
@@ -72,7 +72,7 @@ public class CustomAuthenticationHostInit : BaseHostInitialization
 				.ConfigureServices((context, services) =>
 				{
 					services
-							.AddNativeHandler()
+							.AddNativeHandler(context)
 
 							.AddRefitClient<ICustomAuthenticationDummyJsonEndpoint>(context);
 				});

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationServiceHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationServiceHostInit.cs
@@ -77,7 +77,7 @@ public class CustomAuthenticationServiceHostInit : BaseHostInitialization
 				.ConfigureServices((context, services) =>
 				{
 					services
-							.AddNativeHandler()
+							.AddNativeHandler(context)
 							.AddTransient<DelegatingHandler, DynamicUrlHandler>()
 							.AddRefitClient<ICustomAuthenticationDummyJsonEndpoint>(context);
 				});

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationTestBackendHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Custom/CustomAuthenticationTestBackendHostInit.cs
@@ -61,7 +61,7 @@ public class CustomAuthenticationTestBackendHostInit : BaseHostInitialization
 				.ConfigureServices((context, services) =>
 				{
 					services
-							.AddNativeHandler()
+							.AddNativeHandler(context)
 
 							.AddRefitClient<ICustomAuthenticationTestBackendEndpoint>(context);
 				});

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Msal/HostBuilderExtensions.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Msal/HostBuilderExtensions.cs
@@ -16,7 +16,7 @@ public abstract class BaseMsalHostInitialization : BaseHostInitialization
 				.ConfigureServices((context, services) =>
 				{
 					services
-							.AddNativeHandler()
+							.AddNativeHandler(context)
 							.AddRefitClient<IMsalAuthenticationTaskListEndpoint>(context);
 				});
 	}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Oidc/OidcAuthenticationHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Oidc/OidcAuthenticationHostInit.cs
@@ -30,8 +30,8 @@ public class OidcAuthenticationHostInit : BaseHostInitialization
 				.ConfigureServices((context, services) =>
 				{
 					services
-							.AddNativeHandler()
-							.AddContentSerializer()
+							.AddNativeHandler(context)
+							.AddContentSerializer(context)
 
 							.AddRefitClient<IOidcAuthenticationTestEndpoint>(context);
 				});

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/WebAuthenticationHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/WebAuthenticationHostInit.cs
@@ -33,8 +33,8 @@ public class WebAuthenticationHostInit : BaseHostInitialization
 				.ConfigureServices((context, services) =>
 				{
 					services
-							.AddNativeHandler()
-							.AddContentSerializer()
+							.AddNativeHandler(context)
+							.AddContentSerializer(context)
 
 							.AddRefitClient<IWebAuthenticationTestEndpoint>(context);
 				});

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/WebAuthenticationSettingsHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/WebAuthenticationSettingsHostInit.cs
@@ -24,8 +24,8 @@ public class WebAuthenticationSettingsHostInit : BaseHostInitialization
 				.ConfigureServices((context, services) =>
 				{
 					services
-							.AddNativeHandler()
-							.AddContentSerializer()
+							.AddNativeHandler(context)
+							.AddContentSerializer(context)
 
 							.AddRefitClient<IWebAuthenticationTestEndpoint>(context);
 				});


### PR DESCRIPTION
GitHub Issue (If applicable): #1116 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Currently a static field is used to track whether types have been registered

## What is the new behavior?

HostBuilder and HostBuilderContext have a Properties dictionary that can be used to track registration of types

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
