### PR TITLE
fix: Eliminate noticeable delay during navigation due to thread switching

### DIFF
--- a/samples/Playground/Playground.Shared/ViewModels/ThemeSwitchViewModel.cs
+++ b/samples/Playground/Playground.Shared/ViewModels/ThemeSwitchViewModel.cs
@@ -14,14 +14,14 @@ public partial class ThemeSwitchViewModel:ObservableObject
 	public ThemeSwitchViewModel(IThemeService themeService,IDispatcher dispatcher)
 	{
 		_ts = themeService;
-		_ts.DesiredThemeChanged += ts_DesiredThemeChanged;
+		_ts.ThemeChanged += ts_ThemeChanged;
 		_ = dispatcher.ExecuteAsync(() =>
 		{
 			IsDarkTheme = themeService.IsDark.ToString();
 		});
 	}
 
-	private void ts_DesiredThemeChanged(object? sender, AppTheme e)
+	private void ts_ThemeChanged(object? sender, AppTheme e)
 	{
 		IsDarkTheme = _ts.IsDark.ToString();
 		Console.WriteLine($"Theme was changed to:{e.ToString()}");

--- a/src/Uno.Extensions.Core.UI/Dispatcher.cs
+++ b/src/Uno.Extensions.Core.UI/Dispatcher.cs
@@ -1,5 +1,7 @@
 ﻿
 
+using System.Diagnostics;
+
 namespace Uno.Extensions;
 
 public class Dispatcher : IDispatcher
@@ -50,6 +52,8 @@ public class Dispatcher : IDispatcher
 		{
 			return await func(cancellation);
 		}
+
+		Debug.WriteLine(">>>>>>>>>>>> Hop, Hop, Hop <<<<<<<<<<<<");
 		return await _dispatcher.ExecuteAsync(func, cancellation);
 	}
 

--- a/src/Uno.Extensions.Core.UI/Dispatcher.cs
+++ b/src/Uno.Extensions.Core.UI/Dispatcher.cs
@@ -1,7 +1,5 @@
 ﻿
 
-using System.Diagnostics;
-
 namespace Uno.Extensions;
 
 public class Dispatcher : IDispatcher
@@ -52,8 +50,6 @@ public class Dispatcher : IDispatcher
 		{
 			return await func(cancellation);
 		}
-
-		Debug.WriteLine(">>>>>>>>>>>> Hop, Hop, Hop <<<<<<<<<<<<");
 		return await _dispatcher.ExecuteAsync(func, cancellation);
 	}
 

--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -52,10 +52,11 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 		try
 		{
 			// Uncomment this to prevent thread jumping
-			// request = request with { InProgress = true };
+			 request = request with { InProgress = true };
 			if (Dispatcher.HasThreadAccess &&
 				!request.InProgress)
 			{
+				Debug.WriteLine("*********** Jump, Jump, Jump ************");
 				request = request with { InProgress = true }; // Prevent multiple re-entrance where HasThreadAccess always returns true eg WASM
 				if (Logger.IsEnabled(LogLevel.Information)) Logger.LogInformationMessage($"Navigation started on UI thread, so moving to background thread");
 				return await Task.Run(() => NavigateAsync(request));

--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -51,7 +51,8 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 		RouteUpdater.StartNavigation(this, Region, request);
 		try
 		{
-
+			// Uncomment this to prevent thread jumping
+			// request = request with { InProgress = true };
 			if (Dispatcher.HasThreadAccess &&
 				!request.InProgress)
 			{

--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -51,17 +51,6 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 		RouteUpdater.StartNavigation(this, Region, request);
 		try
 		{
-			// Uncomment this to prevent thread jumping
-			 request = request with { InProgress = true };
-			if (Dispatcher.HasThreadAccess &&
-				!request.InProgress)
-			{
-				Debug.WriteLine("*********** Jump, Jump, Jump ************");
-				request = request with { InProgress = true }; // Prevent multiple re-entrance where HasThreadAccess always returns true eg WASM
-				if (Logger.IsEnabled(LogLevel.Information)) Logger.LogInformationMessage($"Navigation started on UI thread, so moving to background thread");
-				return await Task.Run(() => NavigateAsync(request));
-			}
-
 			if (request.Source is null)
 			{
 				if (Logger.IsEnabled(LogLevel.Information)) Logger.LogInformationMessage($"Starting Navigation - Navigator: {this.GetType().Name} Request: {request.Route}");

--- a/src/Uno.Extensions.Navigation.UI/RouteResolverDefault.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteResolverDefault.cs
@@ -41,6 +41,13 @@ public class RouteResolverDefault : RouteResolver
 
 	private RouteInfo[] DefaultMapping(string? path = null, Type? view = null, Type? viewModel = null)
 	{
+		if(path is null &&
+			view is null &&
+			viewModel is null)
+		{
+			return Array.Empty<RouteInfo>();
+		}
+
 		if (!ReturnImplicitMapping)
 		{
 			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage("Implicit mapping disabled");

--- a/src/Uno.Extensions.Navigation/NavigationRequest.cs
+++ b/src/Uno.Extensions.Navigation/NavigationRequest.cs
@@ -6,8 +6,6 @@ public record NavigationRequest(object Sender, Route Route, CancellationToken? C
 {
 	internal Guid Id { get; } = Guid.NewGuid();
 
-	internal bool InProgress { get; init; }
-
 	public override string ToString() => $"Request [Sender: {Sender.GetType().Name}, Route:{Route}, Result: {Result?.Name ?? "N/A"}]";
 
 	internal virtual IResponseNavigator? GetResponseNavigator(IResponseNavigatorFactory responseFactory, INavigator navigator) => default;

--- a/src/Uno.Extensions.Toolkit.UI/ThemeService.cs
+++ b/src/Uno.Extensions.Toolkit.UI/ThemeService.cs
@@ -11,7 +11,7 @@ internal class ThemeService : IThemeService
 	private readonly TaskCompletionSource<bool> _initialization = new TaskCompletionSource<bool>();
 
 	/// <inheritdoc/>
-	public event EventHandler<AppTheme>? DesiredThemeChanged;
+	public event EventHandler<AppTheme>? ThemeChanged;
 
 	internal ThemeService(
 		Window window,
@@ -78,7 +78,7 @@ internal class ThemeService : IThemeService
 
 				if (existingIsDark != IsDark)
 				{
-					DesiredThemeChanged?.Invoke(this, theme);
+					ThemeChanged?.Invoke(this, theme);
 				}
 				return true;
 			}

--- a/src/Uno.Extensions.Toolkit/IThemeService.cs
+++ b/src/Uno.Extensions.Toolkit/IThemeService.cs
@@ -21,5 +21,5 @@ public interface IThemeService
 	/// <summary>
 	/// Event that fires up whenever SetThemeAsync() is called.
 	/// </summary>
-	event EventHandler<AppTheme> DesiredThemeChanged;
+	event EventHandler<AppTheme> ThemeChanged;
 }

--- a/testing/TestHarness/TestHarness.Mobile/TestHarness.Mobile.csproj
+++ b/testing/TestHarness/TestHarness.Mobile/TestHarness.Mobile.csproj
@@ -17,7 +17,7 @@
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)'=='net6.0-macos'">10.14</SupportedOSPlatformVersion>
-		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
+		<DefineConstants>$(DefineConstants);WINUI;UNO_EXT_TIMERS</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" />

--- a/testing/TestHarness/TestHarness.Shared/App.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/App.xaml.cs
@@ -10,6 +10,7 @@ public sealed partial class App : Application
 	public App()
 	{
 		PerformanceTimer.InitializeTimers();
+		this.InitializeComponent();
 
 		// TODO: Remove once https://github.com/unoplatform/uno/issues/10990 is resolved
 		var type = typeof(Uno.UI.FluentTheme.GlobalStaticResources);

--- a/testing/TestHarness/TestHarness.Shared/App.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/App.xaml.cs
@@ -1,3 +1,5 @@
+using Uno.Extensions.Diagnostics;
+
 namespace TestHarness;
 
 public sealed partial class App : Application
@@ -7,7 +9,7 @@ public sealed partial class App : Application
 
 	public App()
 	{
-		this.InitializeComponent();
+		PerformanceTimer.InitializeTimers();
 
 		// TODO: Remove once https://github.com/unoplatform/uno/issues/10990 is resolved
 		var type = typeof(Uno.UI.FluentTheme.GlobalStaticResources);

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank1Page.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank1Page.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl x:Class="TestHarness.Ext.Navigation.TabBar.Blank1Page"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:SectionNavPerf.Views"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 xmlns:utu="using:Uno.Toolkit.UI"
+			 Background="Green">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<utu:NavigationBar Content="Section 1" />
+
+		<ListView ItemsSource="{Binding Data}"
+				  Grid.Row="1" />
+	</Grid>
+</UserControl>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank1Page.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank1Page.xaml.cs
@@ -1,0 +1,11 @@
+﻿namespace TestHarness.Ext.Navigation.TabBar;
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class Blank1Page : UserControl
+{
+	public Blank1Page()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank1ViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank1ViewModel.cs
@@ -1,0 +1,11 @@
+﻿namespace TestHarness.Ext.Navigation.TabBar;
+public class Blank1ViewModel
+{
+	public Blank1ViewModel()
+	{
+		Data = Enumerable.Range(1, 10).Select(x => $"item {x}");
+	}
+
+	public IEnumerable<string> Data { get; }
+}
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank2Page.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank2Page.xaml
@@ -1,0 +1,14 @@
+﻿<Page x:Class="TestHarness.Ext.Navigation.TabBar.Blank2Page"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:SectionNavPerf.Views"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="Blue">
+
+	<Grid>
+		<TextBlock Text="Section 2"
+				   Foreground="White" />
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank2Page.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank2Page.xaml.cs
@@ -1,0 +1,12 @@
+﻿namespace TestHarness.Ext.Navigation.TabBar;
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class Blank2Page : Page
+{
+	public Blank2Page()
+	{
+		this.InitializeComponent();
+	}
+}
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank2ViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank2ViewModel.cs
@@ -1,0 +1,5 @@
+﻿namespace TestHarness.Ext.Navigation.TabBar;
+public class Blank2ViewModel
+{
+}
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank3Page.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank3Page.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="TestHarness.Ext.Navigation.TabBar.Blank3Page"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:SectionNavPerf.Views"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="Red">
+
+	<Grid>
+		<TextBlock Text="Section 3" />
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank3Page.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/Blank3Page.xaml.cs
@@ -1,0 +1,12 @@
+﻿namespace TestHarness.Ext.Navigation.TabBar;
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class Blank3Page : Page
+{
+	public Blank3Page()
+	{
+		this.InitializeComponent();
+	}
+}
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/BlankViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/Sections/BlankViewModel.cs
@@ -1,0 +1,5 @@
+﻿namespace TestHarness.Ext.Navigation.TabBar;
+public class Blank3ViewModel
+{
+}
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarHostInit.cs
@@ -7,7 +7,11 @@ public class TabBarHostInit : BaseHostInitialization
 
 		views.Register(
 			new ViewMap<TabBarHomePage, TabBarHomeViewModel>(),
-			new ViewMap<TabBarSettingsPage, TabBarSettingsViewModel>()
+			new ViewMap<TabBarListPage, TabBarListViewModel>(),
+			new ViewMap<TabBarSettingsPage, TabBarSettingsViewModel>(),
+			new ViewMap<Blank1Page, Blank1ViewModel>(),
+			new ViewMap<Blank2Page, Blank2ViewModel>(),
+			new ViewMap<Blank3Page, Blank3ViewModel>()
 			);
 
 
@@ -17,6 +21,14 @@ public class TabBarHostInit : BaseHostInitialization
 				Nested: new[]
 				{
 						new RouteMap("Home", View: views.FindByViewModel<TabBarHomeViewModel>()),
+						new RouteMap("List", View: views.FindByViewModel<TabBarListViewModel>(), Nested:
+						new RouteMap[]
+						{
+							new RouteMap("Section1", View: views.FindByViewModel<Blank1ViewModel>(), IsDefault:true),
+							new RouteMap("Section2", View: views.FindByViewModel<Blank2ViewModel>()),
+							new RouteMap("Section3", View: views.FindByViewModel<Blank3ViewModel>()),
+
+						}),
 						new RouteMap("Settings", View: views.FindByViewModel<TabBarSettingsViewModel>()),
 				}));
 	}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarListPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarListPage.xaml
@@ -1,0 +1,48 @@
+﻿<Page x:Class="TestHarness.Ext.Navigation.TabBar.TabBarListPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.TabBar"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  xmlns:models="using:TestHarness.Models"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  Background="LightBlue">
+
+	<Grid uen:Region.Attached="True">
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<Grid Grid.Row="0"
+			  uen:Region.Attached="True"
+			  uen:Region.Navigator="Visibility">
+		</Grid>
+
+		<utu:TabBar x:Name="Tabs"
+					Grid.Row="1"
+					uen:Region.Attached="True">
+
+			<utu:TabBarItem Content="Section1"
+							uen:Region.Name="Section1"
+							HorizontalAlignment="Stretch"
+							HorizontalContentAlignment="Center"
+							IsSelectable="True" />
+
+			<utu:TabBarItem Content="Section2"
+							uen:Region.Name="Section2"
+							HorizontalAlignment="Stretch"
+							HorizontalContentAlignment="Center"
+							IsSelectable="True" />
+
+			<utu:TabBarItem Content="Section3"
+							uen:Region.Name="Section3"
+							HorizontalAlignment="Stretch"
+							HorizontalContentAlignment="Center"
+							IsSelectable="True" />
+		</utu:TabBar>
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarListPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarListPage.xaml.cs
@@ -1,0 +1,14 @@
+﻿
+using Uno.Toolkit.UI;
+
+namespace TestHarness.Ext.Navigation.TabBar;
+
+public sealed partial class TabBarListPage : Page
+{
+	public TabBarListPage()
+	{
+		this.InitializeComponent();
+	}
+
+
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarListViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarListViewModel.cs
@@ -1,0 +1,6 @@
+﻿namespace TestHarness.Ext.Navigation.TabBar;
+
+public record TabBarListViewModel(INavigator Navigator)
+{
+}
+

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarMainPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarMainPage.xaml
@@ -31,6 +31,9 @@
 			<Button AutomationProperties.AutomationId="ShowTabBarHomeButton"
 					Content="TabBar Home"
 					Click="TabBarHomeClick" />
+			<Button AutomationProperties.AutomationId="ShowTabBarListButton"
+					Content="TabBar List"
+					Click="TabBarListClick" />
 		</StackPanel>
 	</Grid>
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarMainPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarMainPage.xaml.cs
@@ -13,4 +13,8 @@ public sealed partial class TabBarMainPage : BaseTestSectionPage
 		await Navigator.NavigateViewModelAsync<TabBarHomeViewModel>(this);
 	}
 
+	public async void TabBarListClick(object sender, RoutedEventArgs e)
+	{
+		await Navigator.NavigateViewModelAsync<TabBarListViewModel>(this);
+	}
 }

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -353,11 +353,19 @@
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Responsive\ResponsiveMainPage.xaml.cs">
       <DependentUpon>ResponsiveMainPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\Sections\Blank1Page.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\Sections\Blank1ViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\Sections\Blank2Page.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\Sections\Blank2ViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\Sections\Blank3Page.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\Sections\BlankViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\TabBarHomePage.xaml.cs">
       <DependentUpon>TabBarHomePage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\TabBarHomeViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\TabBarHostInit.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\TabBarListPage.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\TabBarListViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\TabBar\TabBarMainPage.xaml.cs">
       <DependentUpon>TabBarMainPage.xaml</DependentUpon>
     </Compile>

--- a/testing/TestHarness/TestHarness.Skia.WPF/TestHarness.Skia.WPF.csproj
+++ b/testing/TestHarness/TestHarness.Skia.WPF/TestHarness.Skia.WPF.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
+		<DefineConstants>$(DefineConstants);WINUI;UNO_EXT_TIMERS</DefineConstants>
 		<AssemblyName>TestHarnessApp</AssemblyName>
 		<UnoExtensionsGeneration_DisableNotNullIfNotNullAttribute>true</UnoExtensionsGeneration_DisableNotNullIfNotNullAttribute>
 	</PropertyGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #976 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Navigation switches to background thread - this causes thread switching delays

## What is the new behavior?

Navigation continues on whatever thread it's started - it will still switch to UI thread as required

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
