### PR TITLE
[Template] Refactor logging option to choice

### DIFF
--- a/build/ci/.azure-pipelines.TemplateValidation.yml
+++ b/build/ci/.azure-pipelines.TemplateValidation.yml
@@ -33,7 +33,7 @@ jobs:
         templateArgs: '-di false'
       HostingOnly:
         createdProjectName: UnoAppHostingOnly01
-        templateArgs: '-config false -loc false -http false -log false --navigation frame'
+        templateArgs: '-config false -loc false -http false -log none --navigation frame'
       NoConfiguration:
         createdProjectName: UnoAppNoConfiguration01
         templateArgs: '-config false'
@@ -45,7 +45,7 @@ jobs:
         templateArgs: '-http false'
       NoSerilog:
         createdProjectName: UnoAppNoSerilog01
-        templateArgs: '--logging-serilog false'
+        templateArgs: '-log default'
       NoServer:
         createdProjectName: UnoAppNoServer01
         templateArgs: '-server false'

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/dotnetcli.host.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/dotnetcli.host.json
@@ -98,10 +98,6 @@
       "longName": "logging",
       "shortName": "log"
     },
-    "serilog": {
-      "longName": "logging-serilog",
-      "shortName": "serilog"
-    },
     "navigation": {
       "longName": "navigation",
       "shortName": "nav"

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/ide.host.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/ide.host.json
@@ -103,17 +103,6 @@
       "isVisible": true
     },
     {
-      "id": "serilog",
-      "name": {
-        "text": "Extensions - Logging Serilog"
-      },
-      "description":
-      {
-        "text": "Enables app logging with Serilog"
-      },
-      "defaultValue": "true"
-    },
-    {
       "id": "navigation",
       "isVisible": true
     },

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/ide.host.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/ide.host.json
@@ -104,7 +104,14 @@
     },
     {
       "id": "serilog",
-      "isVisible": true
+      "name": {
+        "text": "Extensions - Logging Serilog"
+      },
+      "description":
+      {
+        "text": "Enables app logging with Serilog"
+      },
+      "defaultValue": "true"
     },
     {
       "id": "navigation",

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -289,23 +289,28 @@
       "displayName": "Extensions - Logging",
       "description": "Includes Uno.Extensions.Logging",
       "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true",
+      "datatype": "choice",
+      "defaultValue": "serilog",
+      "choices": [
+        {
+          "choice": "none",
+          "description": "Disables logging",
+          "displayName": "None"
+        },
+        {
+          "choice": "default",
+          "description": "Enables basic logging to the console",
+          "displayName": "Default"
+        },
+        {
+          "choice": "serilog",
+          "description": "Enables logging to the console and Serilog",
+          "displayName": "Serilog"
+        }
+      ],
       "onlyIf": {
         "preset": "recommended",
         "dependencyInjection": "true"
-      }
-    },
-    "serilog": {
-      "displayName": "Extensions - Serilog",
-      "description": "Includes Uno.Extensions.Logging.Serilog when logging is enabled",
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "true",
-      "onlyIf": {
-        "preset": "recommended",
-        "dependencyInjection": "true",
-        "logging": "true"
       }
     },
     "navigation": {
@@ -381,6 +386,11 @@
       "datatype": "bool",
       "value": "preset == 'recommended'"
     },
+    "useTestSolutionFolder": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "preset == 'recommended' && (tests || unitTest)"
+    },
     "useCsharpMarkup": {
       "type": "computed",
       "datatype": "bool",
@@ -409,12 +419,22 @@
     "useLogging": {
       "type": "computed",
       "datatype": "bool",
-      "value": "(useDependencyInjection && logging)"
+      "value": "(useDependencyInjection && logging != 'none')"
     },
     "useSerilog": {
       "type": "computed",
       "datatype": "bool",
-      "value": "(serilog && useLogging)"
+      "value": "(useDependencyInjection && logging == 'serilog')"
+    },
+    "useOSLoggingPackage": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "(useBlankAppTemplate || useLogging)"
+    },
+    "useAspNetCoreSerilogPackage": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "(server && useSerilog)"
     },
     "useMvux": {
       "type": "computed",

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
@@ -35,12 +35,14 @@
     <PackageVersion Include="Uno.Extensions.Localization" Version="255.255.255.255" />
     <PackageVersion Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255" />
     <!--#endif-->
-    <!--#if (useLogging)-->
+    <!--#if (useOSLoggingPackage)-->
     <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
+    <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
+    <!--#endif-->
     <!--#if (useSerilog)-->
     <PackageVersion Include="Uno.Extensions.Logging.Serilog" Version="255.255.255.255" />
     <!--#endif-->
-    <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
+    <!--#if (useLogging)-->
     <PackageVersion Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255" />
     <!--#endif-->
     <PackageVersion Include="Uno.Extensions.Navigation" Version="255.255.255.255" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.3.1" />
-    <!--#if (server && useSerilog)-->
+    <!--#if (useAspNetCoreSerilogPackage)-->
     <PackageVersion Include="Serilog.AspNetCore" Version="6.1.0" />
     <!--#endif-->
     <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.3" />
@@ -35,7 +35,7 @@
     <PackageVersion Include="Uno.Extensions.Localization" Version="255.255.255.255" />
     <PackageVersion Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255" />
     <!--#endif-->
-    <!--#if (logging)-->
+    <!--#if (useLogging)-->
     <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
     <!--#if (useSerilog)-->
     <PackageVersion Include="Uno.Extensions.Logging.Serilog" Version="255.255.255.255" />
@@ -75,7 +75,7 @@
     <PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
     <PackageVersion Include="Uno.Toolkit.WinUI.Markup" Version="2.5.0-dev.17" />
     <PackageVersion Include="Uno.Extensions.Navigation.WinUI.Markup" Version="255.255.255.255" />
-    <!--#if (reactive)-->
+    <!--#if (useMvux)-->
     <PackageVersion Include="Uno.Extensions.Reactive.WinUI.Markup" Version="255.255.255.255" />
     <!--#endif-->
     <!--#if (useMaterial)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.csproj
@@ -67,7 +67,7 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->
@@ -111,7 +111,7 @@
 				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
 				<MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
 			</PropertyGroup>
-			<!--#if (logging)-->
+			<!--#if (useOSLoggingPackage)-->
 			<ItemGroup>
 				<PackageReference Include="Uno.Extensions.Logging.OSLog" />
 			</ItemGroup>
@@ -130,7 +130,7 @@
 				<!-- Full globalization is required for Uno -->
 				<InvariantGlobalization>false</InvariantGlobalization>
 			</PropertyGroup>
-			<!--#if (logging)-->
+			<!--#if (useOSLoggingPackage)-->
 			<ItemGroup>
 				<PackageReference Include="Uno.Extensions.Logging.OSLog" />
 			</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
@@ -61,7 +61,7 @@
 		<PackageReference Include="Uno.Extensions.Localization" Version="255.255.255.255" />
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->
@@ -110,7 +110,7 @@
 				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
 				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
 			</PropertyGroup>
-			<!--#if (logging || useBlankAppTemplate)-->
+			<!--#if (useOSLoggingPackage)-->
 			<ItemGroup>
 				<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
 			</ItemGroup>
@@ -129,7 +129,7 @@
 				<!-- Full globalization is required for Uno -->
 				<InvariantGlobalization>false</InvariantGlobalization>
 			</PropertyGroup>
-			<!--#if (logging || useBlankAppTemplate)-->
+			<!--#if (useOSLoggingPackage)-->
 			<ItemGroup>
 				<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
 			</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.csproj
@@ -62,7 +62,7 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
@@ -57,7 +57,7 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.csproj
@@ -61,7 +61,7 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
@@ -57,7 +57,7 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.csproj
@@ -62,7 +62,7 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
@@ -58,7 +58,7 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.csproj
@@ -84,7 +84,7 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" />
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" />
 		<!--#endif-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
@@ -84,7 +84,7 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255" />
 		<!--#endif-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
@@ -66,7 +66,7 @@
 		<PackageReference Include="Uno.Extensions.Localization" />
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
@@ -66,7 +66,7 @@
 		<PackageReference Include="Uno.Extensions.Localization" Version="255.255.255.255" />
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
-		<!--#if (logging)-->
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.sln
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.sln
@@ -11,7 +11,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Backend", "Backend", "{BA1ACE40-623E-4F42-94BB-11CF4D52C445}"
 EndProject
 //#endif
-#//#if (useRecommendedAppTemplate && (tests || unitTest))
+#//#if (useTestSolutionFolder)
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{7EF70027-9874-4112-A14F-33F02169CF8A}"
 EndProject
 #//#endif

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/AppStart.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/AppStart.cs
@@ -36,9 +36,9 @@ public class AppStart
 							LogLevel.Information :
 							LogLevel.Warning);
 				}, enableUnoLogging: true)
+#endif
 #if useSerilog
 				.UseSerilog(consoleLoggingEnabled: true, fileLoggingEnabled: true)
-#endif
 #endif
 #if useConfiguration
 				.UseConfiguration(configure: configBuilder =>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Infrastructure/DebugHandler.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Infrastructure/DebugHandler.cs
@@ -3,7 +3,7 @@ namespace MyExtensionsApp.Infrastructure;
 
 internal class DebugHttpHandler : DelegatingHandler
 {
-#if logging
+#if (useLogging)
 	private readonly ILogger _logger;
 	public DebugHttpHandler(ILogger<DebugHttpHandler> logger, HttpMessageHandler? innerHandler = null)
 		: base(innerHandler ?? new HttpClientHandler())
@@ -27,7 +27,7 @@ internal class DebugHttpHandler : DelegatingHandler
 //+:cnd:noEmit
 		if(!response.IsSuccessStatusCode)
 		{
-#if logging
+#if (useLogging)
 			_logger.LogDebugMessage("Unsuccessful API Call");
 			if(request.RequestUri is not null)
 				_logger.LogDebugMessage($"{request.RequestUri} ({request.Method})");


### PR DESCRIPTION
GitHub Issue (If applicable): #

- ongoing changes for #1113 

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Refactor

## What is the current behavior?

Logging and Serilog are two independent boolean flags on the template

## What is the new behavior?

The Serilog option has been dropped, and the Logging option refactored to a choic `None`, `Default`, & `Serilog`.
Previously unchanged template conditions `#if (logging)` have been refactored to use `#if (useLogging)` .