### PR TITLE
chore(deps): Updating uno version to handle changes to app.xaml in templates

### DIFF
--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -29,16 +29,16 @@
 		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.2" />
-		<PackageVersion Include="Uno.UI" Version="4.7.30" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
-		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.30" />
-		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.30" />
-		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.30" />
-		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.30" />
-		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.30" />
+		<PackageVersion Include="Uno.UI" Version="4.7.37" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
+		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.37" />
+		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.37" />
+		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.37" />
+		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.37" />
+		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.37" />
 		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.12" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.12" />
-		<PackageVersion Include="Uno.WinUI" Version="4.7.30" />
+		<PackageVersion Include="Uno.WinUI" Version="4.7.37" />
 	</ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -47,15 +47,15 @@
 		<PackageVersion Include="Uno.Toolkit" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.UI" Version="2.4.2" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
-		<PackageVersion Include="Uno.UI" Version="4.7.30" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30"/>
-		<PackageVersion Include="Uno.UI.MSAL"  Version="4.7.30" />
-		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.7.30" />
+		<PackageVersion Include="Uno.UI" Version="4.7.37" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37"/>
+		<PackageVersion Include="Uno.UI.MSAL"  Version="4.7.37" />
+		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.7.37" />
 		<PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageVersion Include="Uno.WinUI" Version="4.7.30" />
+		<PackageVersion Include="Uno.WinUI" Version="4.7.37" />
 		<PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
-		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.30" />
-		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.7.30" />
+		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.37" />
+		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.7.37" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />
 		<PackageVersion Include="xunit" Version="2.4.1" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
@@ -30,11 +30,11 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageReference Include="Uno.WinUI" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.37" />
 	</ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net6.0-android'">

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
@@ -19,10 +19,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.37" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
@@ -26,10 +26,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.37" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
@@ -48,12 +48,12 @@
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.12" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.12" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.7.37" />
 	</ItemGroup>
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems')" />
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\common.props" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
@@ -66,13 +66,13 @@
     <!--#if (useMaterial)-->
     <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version=" 2.5.0-dev.18" />
     <!--#endif-->
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
     <PackageVersion Include="Uno.UITest.Helpers" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.13" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.13" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.Server" Version="7.0.13" />
-    <PackageVersion Include="Uno.WinUI" Version="4.7.30" />
+    <PackageVersion Include="Uno.WinUI" Version="4.7.37" />
     <!--#if (useCsharpMarkup)-->
     <PackageVersion Include="Uno.WinUI.Markup" Version="4.7.0-dev.17" />
     <PackageVersion Include="Uno.Toolkit.WinUI.Markup" Version="2.5.0-dev.18" />
@@ -85,11 +85,11 @@
     <!--#endif-->
     <PackageVersion Include="Uno.Themes.WinUI.Markup" Version="2.5.0-dev.15" />
     <!--#endif-->
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.30" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.30" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.30" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.30" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.30" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.37" />
     <PackageVersion Include="Xamarin.Google.Android.Material" Version="1.7.0.2" />
     <PackageVersion Include="Xamarin.UITest" Version="4.1.0" />
   </ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
@@ -27,9 +27,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.7.0-dev.17" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useRecommendedAppTemplate)-->
@@ -41,9 +41,9 @@
 		<!--#endif-->
 		<PackageReference Include="Uno.Themes.WinUI.Markup" Version="2.5.0-dev.15" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.15" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.18" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.nocpm.csproj
@@ -20,9 +20,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.7.0-dev.17" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -38,9 +38,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.15" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.18" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.nocpm.csproj
@@ -22,9 +22,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useRecommendedAppTemplate)-->
@@ -38,9 +38,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.15" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.18" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.nocpm.csproj
@@ -21,9 +21,9 @@
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.7.0-dev.17" />
 		<!--#endif-->
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -39,9 +39,9 @@
 		<!--#endif-->
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.15" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.18" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
@@ -54,9 +54,9 @@
 		<!--#endif-->
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.13" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.13" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 	</ItemGroup>
 	<!--#endif-->
@@ -65,9 +65,9 @@
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.13" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.13" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.30" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.30" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<!--#if (useMaterial)-->
 		<PackageReference Include="Uno.Material.WinUI" Version="2.5.0-dev.15" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.18" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
@@ -32,7 +32,7 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useRecommendedAppTemplate)-->
@@ -41,7 +41,7 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<!--#if (useCsharpMarkup)-->
 		<PackageReference Include="Uno.WinUI.Markup" Version="4.7.0-dev.17" />
 		<!--#if (useMaterial)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.nocpm.csproj
@@ -116,7 +116,7 @@
 		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="Uno.WinUI" Version="4.7.30" />
+				<PackageReference Include="Uno.WinUI" Version="4.7.37" />
 			</ItemGroup>
 
 			<ItemGroup>
@@ -130,7 +130,7 @@
 	</Choose>
 	<!--#else-->
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI" Version="4.7.30" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.37" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -42,15 +42,15 @@
     <PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.4.2" />
     <PackageVersion Include="Uno.Toolkit.WinUI" Version="2.4.2" />
     <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.4.2" />
-    <PackageVersion Include="Uno.UI" Version="4.7.30" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.30" />
-    <PackageVersion Include="Uno.UI.MSAL" Version="4.7.30" />
-    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.30" />
-    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.30" />
-    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.7.30" />
-    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.30" />
-    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.30" />
-    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.30" />
+    <PackageVersion Include="Uno.UI" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.MSAL" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.7.37" />
+    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.7.37" />
     <PackageVersion Include="Uno.UITest" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.32" />
@@ -58,13 +58,13 @@
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.12" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.12" />
-    <PackageVersion Include="Uno.WinUI" Version="4.7.30" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.30" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.30" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.30" />
-    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.30" />
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.30" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.30" />
+    <PackageVersion Include="Uno.WinUI" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.7.37" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.7.37" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
GitHub Issue (If applicable): #1136 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Uno 4.7.30 doesn't handle renaming app.xaml

## What is the new behavior?

App.xaml can be renamed

