### PR TITLE
fix: Wasm VSCode launch config

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.vscode/launch.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.vscode/launch.json
@@ -9,7 +9,7 @@
       // Use hover for the description of the existing attributes
       // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
       "name": "Debug (Chrome, WebAssembly)",
-      "type": "pwa-chrome",
+      "type": "chrome",
       "request": "launch",
       "url": "http://localhost:5000",
       "webRoot": "${workspaceFolder}/MyExtensionsApp.Wasm",


### PR DESCRIPTION
GitHub Issue (If applicable): #

- backport from Uno template unoplatform/uno/pull/11200

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

VSCode Launch config uses pwa-chrome

## What is the new behavior?

VSCode Launch config uses chrome