### PR TITLE
Add fallback logging on recommended preset

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -391,6 +391,11 @@
       "datatype": "bool",
       "value": "(appTheme == 'cupertino' && preset == 'recommended')"
     },
+    "useLoggingFallback": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "(logging == 'none' || preset == 'blank')"
+    },
     "useLogging": {
       "type": "computed",
       "datatype": "bool",
@@ -400,11 +405,6 @@
       "type": "computed",
       "datatype": "bool",
       "value": "(useDependencyInjection && logging == 'serilog')"
-    },
-    "useOSLoggingPackage": {
-      "type": "computed",
-      "datatype": "bool",
-      "value": "(useBlankAppTemplate || useLogging)"
     },
     "useAspNetCoreSerilogPackage": {
       "type": "computed",

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
@@ -35,10 +35,8 @@
     <PackageVersion Include="Uno.Extensions.Localization" Version="255.255.255.255" />
     <PackageVersion Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255" />
     <!--#endif-->
-    <!--#if (useOSLoggingPackage)-->
     <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
     <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-    <!--#endif-->
     <!--#if (useSerilog)-->
     <PackageVersion Include="Uno.Extensions.Logging.Serilog" Version="255.255.255.255" />
     <!--#endif-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Base/AppHead.xaml.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Base/AppHead.xaml.cs
@@ -1,5 +1,5 @@
 //+:cnd:noEmit
-#if (useBlankAppTemplate)
+#if (useLoggingFallback)
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
@@ -12,7 +12,7 @@ namespace MyExtensionsApp;
 
 public sealed partial class AppHead : App
 {
-#if (useBlankAppTemplate)
+#if (useLoggingFallback)
 	static AppHead() =>
 		InitializeLogging();
 
@@ -40,7 +40,7 @@ public sealed partial class AppHead : App
 		base.OnLaunched(args);
 	}
 #endif
-#if (useBlankAppTemplate)
+#if (useLoggingFallback)
 
 	/// <summary>
 	/// Configures global Uno Platform logging
@@ -60,7 +60,7 @@ public sealed partial class AppHead : App
 		{
 #if __WASM__
 			builder.AddProvider(new global::Uno.Extensions.Logging.WebAssembly.WebAssemblyConsoleLoggerProvider());
-#elif __IOS__ && !__MACCATALYST__
+#elif __IOS__ || __MACCATALYST__
 			builder.AddProvider(new global::Uno.Extensions.Logging.OSLogLoggerProvider());
 #elif NETFX_CORE
 			builder.AddDebug();

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.csproj
@@ -34,6 +34,7 @@
 		<PackageReference Include="Uno.WinUI" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
+		<PackageReference Include="Uno.Extensions.Logging.OSLog" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useRecommendedAppTemplate)-->
@@ -68,6 +69,7 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" />
 		<!--#endif-->
+		<PackageReference Include="Uno.Extensions.Logging.OSLog" />
 		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" />
 		<!--#endif-->
@@ -112,11 +114,6 @@
 				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
 				<MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
 			</PropertyGroup>
-			<!--#if (useOSLoggingPackage)-->
-			<ItemGroup>
-				<PackageReference Include="Uno.Extensions.Logging.OSLog" />
-			</ItemGroup>
-			<!--#endif-->
 		</When>
 		<!--#endif-->
 		<!--#if (useMacCatalyst)-->
@@ -131,11 +128,6 @@
 				<!-- Full globalization is required for Uno -->
 				<InvariantGlobalization>false</InvariantGlobalization>
 			</PropertyGroup>
-			<!--#if (useOSLoggingPackage)-->
-			<ItemGroup>
-				<PackageReference Include="Uno.Extensions.Logging.OSLog" />
-			</ItemGroup>
-			<!--#endif-->
 		</When>
 		<!--#endif-->
 		<!--#if (useMacOS)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.nocpm.csproj
@@ -31,6 +31,7 @@
 		<PackageReference Include="Uno.WinUI" Version="4.7.37" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
+		<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useRecommendedAppTemplate)-->
@@ -62,6 +63,7 @@
 		<PackageReference Include="Uno.Extensions.Localization" Version="255.255.255.255" />
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
+		<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
 		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
@@ -111,11 +113,6 @@
 				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
 				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
 			</PropertyGroup>
-			<!--#if (useOSLoggingPackage)-->
-			<ItemGroup>
-				<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
-			</ItemGroup>
-			<!--#endif-->
 		</When>
 		<!--#endif-->
 		<!--#if (useMacCatalyst)-->
@@ -130,11 +127,6 @@
 				<!-- Full globalization is required for Uno -->
 				<InvariantGlobalization>false</InvariantGlobalization>
 			</PropertyGroup>
-			<!--#if (useOSLoggingPackage)-->
-			<ItemGroup>
-				<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
-			</ItemGroup>
-			<!--#endif-->
 		</When>
 		<!--#endif-->
 		<!--#if (useMacOS)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.csproj
@@ -84,8 +84,8 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" />
 		<!--#endif-->
-		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" />
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.nocpm.csproj
@@ -84,8 +84,8 @@
 		<!--#if (useLocalization)-->
 		<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
-		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
+		<!--#if (useLogging)-->
 		<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#if (useSerilog)-->


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #1105

## PR Type

What kind of change does this PR introduce?

- Refactor

## What is the current behavior?

When Logging is set to none on the recommended preset there is no native logging hook.

## What is the new behavior?

When Logging is set to none on the recommended preset the default platform level logging from the blank preset is included.
- Fixes condition with OS Log so that MacCatalyst is properly wired up
- Removes unnecessary condition for including the OSLog package as it is installable for the entire Mobile project but only has binaries for iOS & MacCatalyst.
