### PR TITLE
[Template] Add localization resources

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/dotnetcli.host.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/dotnetcli.host.json
@@ -57,6 +57,10 @@
       "longName": "localization",
       "shortName": "loc"
     },
+    "cultures": {
+      "longName": "cultures",
+      "shortName": "cultures"
+    },
     "logging": {
       "longName": "logging",
       "shortName": "log"

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/ide.host.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/ide.host.json
@@ -63,6 +63,10 @@
       "isVisible": true
     },
     {
+      "id": "cultures",
+      "isVisible": true
+    },
+    {
       "id": "logging",
       "isVisible": true
     },

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -269,6 +269,106 @@
       "datatype": "bool",
       "defaultValue": "true"
     },
+    "cultures": {
+      "displayName": "Additional Languages",
+      "description": "Adds additional language resource files",
+      "type": "parameter",
+      "datatype": "choice",
+      "allowMultipleValues": true,
+      "defaultValue": "es|fr|pt-BR",
+      "choices": [
+        {
+          "choice": "ar",
+          "description": "Arabic",
+          "displayName": "Arabic"
+        },
+        {
+          "choice": "cs",
+          "description": "Czech",
+          "displayName": "Czech"
+        },
+        {
+          "choice": "da",
+          "description": "Danish",
+          "displayName": "Danish"
+        },
+        {
+          "choice": "nl",
+          "description": "Dutch",
+          "displayName": "Dutch"
+        },
+        {
+          "choice": "fr",
+          "description": "French",
+          "displayName": "French"
+        },
+        {
+          "choice": "de",
+          "description": "German",
+          "displayName": "German"
+        },
+        {
+          "choice": "es",
+          "description": "Spanish",
+          "displayName": "Spanish"
+        },
+        {
+          "choice": "it",
+          "description": "Italian",
+          "displayName": "Italian"
+        },
+        {
+          "choice": "ja",
+          "description": "Japanese",
+          "displayName": "Japanese"
+        },
+        {
+          "choice": "ko",
+          "description": "Korean",
+          "displayName": "Korean"
+        },
+        {
+          "choice": "pt-BR",
+          "description": "Portuguese (Brazil)",
+          "displayName": "Portuguese (Brazil)"
+        },
+        {
+          "choice": "ru",
+          "description": "Russian",
+          "displayName": "Russian"
+        },
+        {
+          "choice": "sv",
+          "description": "Swedish",
+          "displayName": "Swedish"
+        },
+        {
+          "choice": "tr",
+          "description": "Turkish",
+          "displayName": "Turkish"
+        },
+        {
+          "choice": "uk",
+          "description": "Ukrainian",
+          "displayName": "Ukrainian"
+        },
+        {
+          "choice": "vi",
+          "description": "Vietnamese",
+          "displayName": "Vietnamese"
+        },
+        {
+          "choice": "zh-Hans",
+          "description": "Chinese (Simplified)",
+          "displayName": "Chinese (Simplified)"
+        },
+        {
+          "choice": "zh-Hant",
+          "description": "Chinese (Traditional)",
+          "displayName": "Chinese (Traditional)"
+        }
+      ]
+    },
     "logging": {
       "displayName": "Extensions - Logging",
       "description": "Includes Uno.Extensions.Logging",
@@ -505,6 +605,96 @@
       "type": "computed",
       "dataType": "bool",
       "value": "(localization && useConfiguration)"
+    },
+    "useArabic": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'ar'"
+    },
+    "useCzech": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'cs'"
+    },
+    "useDanish": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'da'"
+    },
+    "useDutch": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'nl'"
+    },
+    "useFrench": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'fr'"
+    },
+    "useGerman": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'de'"
+    },
+    "useSpanish": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'es'"
+    },
+    "useItalian": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'it'"
+    },
+    "useJapanese": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'ja'"
+    },
+    "useKorean": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'ko'"
+    },
+    "usePortuguese": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'pt-BR'"
+    },
+    "useRussian": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'ru'"
+    },
+    "useSwedish": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'sv'"
+    },
+    "useTurkish": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'tr'"
+    },
+    "useUkrainian": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'uk'"
+    },
+    "useVietnamese": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'vi'"
+    },
+    "useChineseSimplified": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'zh-Hans'"
+    },
+    "useChineseTraditional": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "cultures == 'zh-Hant'"
     },
     "useNetSix": {
       "type": "computed",
@@ -903,6 +1093,137 @@
             "MyExtensionsApp/Presentation/MainViewModel.cs",
             "MyExtensionsApp/Presentation/SecondViewModel.cs",
             "MyExtensionsApp/Presentation/ShellViewModel.cs"
+          ]
+        },
+        {
+          "condition": "(!useLocalization)",
+          "exclude": [
+            "MyExtensionsApp/Strings/ar/*",
+            "MyExtensionsApp/Strings/cs/*",
+            "MyExtensionsApp/Strings/da/*",
+            "MyExtensionsApp/Strings/de/*",
+            "MyExtensionsApp/Strings/es/*",
+            "MyExtensionsApp/Strings/fr/*",
+            "MyExtensionsApp/Strings/it/*",
+            "MyExtensionsApp/Strings/ja/*",
+            "MyExtensionsApp/Strings/ko/*",
+            "MyExtensionsApp/Strings/nl/*",
+            "MyExtensionsApp/Strings/pt-BR/*",
+            "MyExtensionsApp/Strings/ru/*",
+            "MyExtensionsApp/Strings/sv/*",
+            "MyExtensionsApp/Strings/tr/*",
+            "MyExtensionsApp/Strings/uk/*",
+            "MyExtensionsApp/Strings/vi/*",
+            "MyExtensionsApp/Strings/zh-Hans/*",
+            "MyExtensionsApp/Strings/zh-Hant/*"
+          ]
+        },
+        {
+          "condition": "(useArabic)",
+          "exclude": [
+            "MyExtensionsApp/Strings/ar/*"
+          ]
+        },
+        {
+          "condition": "(useCzech)",
+          "exclude": [
+            "MyExtensionsApp/Strings/cs/*"
+          ]
+        },
+        {
+          "condition": "(useDanish)",
+          "exclude": [
+            "MyExtensionsApp/Strings/da/*"
+          ]
+        },
+        {
+          "condition": "(useGerman)",
+          "exclude": [
+            "MyExtensionsApp/Strings/de/*"
+          ]
+        },
+        {
+          "condition": "(useSpanish)",
+          "exclude": [
+            "MyExtensionsApp/Strings/es/*"
+          ]
+        },
+        {
+          "condition": "(useFrench)",
+          "exclude": [
+            "MyExtensionsApp/Strings/fr/*"
+          ]
+        },
+        {
+          "condition": "(useItalian)",
+          "exclude": [
+            "MyExtensionsApp/Strings/it/*"
+          ]
+        },
+        {
+          "condition": "(useJapanese)",
+          "exclude": [
+            "MyExtensionsApp/Strings/ja/*"
+          ]
+        },
+        {
+          "condition": "(useKorean)",
+          "exclude": [
+            "MyExtensionsApp/Strings/ko/*"
+          ]
+        },
+        {
+          "condition": "(useDutch)",
+          "exclude": [
+            "MyExtensionsApp/Strings/nl/*"
+          ]
+        },
+        {
+          "condition": "(usePortuguese)",
+          "exclude": [
+            "MyExtensionsApp/Strings/pt-BR/*"
+          ]
+        },
+        {
+          "condition": "(useRussian)",
+          "exclude": [
+            "MyExtensionsApp/Strings/ru/*"
+          ]
+        },
+        {
+          "condition": "(useSwedish)",
+          "exclude": [
+            "MyExtensionsApp/Strings/sv/*"
+          ]
+        },
+        {
+          "condition": "(useTurkish)",
+          "exclude": [
+            "MyExtensionsApp/Strings/tr/*"
+          ]
+        },
+        {
+          "condition": "(useUkrainian)",
+          "exclude": [
+            "MyExtensionsApp/Strings/uk/*"
+          ]
+        },
+        {
+          "condition": "(useVietnamese)",
+          "exclude": [
+            "MyExtensionsApp/Strings/vi/*"
+          ]
+        },
+        {
+          "condition": "(useChineseSimplified)",
+          "exclude": [
+            "MyExtensionsApp/Strings/zh-Hans/*"
+          ]
+        },
+        {
+          "condition": "(useChineseTraditional)",
+          "exclude": [
+            "MyExtensionsApp/Strings/zh-Hant/*"
           ]
         },
         {

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
@@ -15,7 +15,6 @@
 		<!-- <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained> -->
 		<!-- This bundles the .NET Core libraries (Uncomment for packaged builds)  -->
 		<SelfContained>true</SelfContained>
-		<DefaultLanguage>en</DefaultLanguage>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.nocpm.csproj
@@ -15,7 +15,6 @@
 		<!-- <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained> -->
 		<!-- This bundles the .NET Core libraries (Uncomment for packaged builds)  -->
 		<SelfContained>true</SelfContained>
-		<DefaultLanguage>en</DefaultLanguage>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/GlobalUsings.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/GlobalUsings.cs
@@ -10,6 +10,9 @@ global using Microsoft.Extensions.DependencyInjection;
 #if (useDependencyInjection)
 global using Microsoft.Extensions.Hosting;
 #endif
+#if (useLocalization)
+global using Microsoft.Extensions.Localization;
+#endif
 global using Microsoft.Extensions.Logging;
 global using Microsoft.UI.Xaml;
 #if (useCsharpMarkup)

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Presentation/MainModel.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Presentation/MainModel.cs
@@ -10,7 +10,14 @@ public partial record MainModel
 	public IState<string> Name { get; }
 
 //+:cnd:noEmit
-#if useConfiguration
+#if useLocalization
+	public MainModel(
+		INavigator navigator,
+		IStringLocalizer localizer)
+	{
+		_navigator = navigator;
+		Title = $"Main - {localizer["ApplicationName"]}";
+#elif useConfiguration
 	public MainModel(
 		INavigator navigator,
 		IOptions<AppConfig> appInfo)

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Presentation/MainViewModel.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Presentation/MainViewModel.cs
@@ -14,7 +14,14 @@ public partial class MainViewModel : ObservableObject
 	public ICommand GoToSecond { get; }
 
 //+:cnd:noEmit
-#if useConfiguration
+#if useLocalization
+	public MainViewModel(
+		INavigator navigator,
+		IStringLocalizer localizer)
+	{
+		_navigator = navigator;
+		Title = $"Main - {localizer["ApplicationName"]}";
+#elif useConfiguration
 	public MainViewModel(
 		INavigator navigator,
 		IOptions<AppConfig> appInfo)

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/ar/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/ar/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-ar</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/cs/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/cs/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-cs</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/da/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/da/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-da</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/de/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/de/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-de</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/es/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/es/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-es</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/fr/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/fr/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-fr</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/it/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/it/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-it</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/ja/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/ja/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-ja</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/ko/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/ko/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-ko</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/nl/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/nl/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-nl</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/pt-BR/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/pt-BR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-pt-BR</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/ru/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/ru/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-ru</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/sv/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/sv/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-sv</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/tr/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/tr/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-tr</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/uk/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/uk/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-uk</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/vi/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/vi/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-vi</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/zh-Hans/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/zh-Hans/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-zh-Hans</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/zh-Hant/Resources.resw
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/Strings/zh-Hant/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>MyExtensionsApp-en</value>
+    <value>MyExtensionsApp-zh-Hant</value>
   </data>
 </root>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/appsettings.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/appsettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "AppConfig": {
     "Title": "MyExtensionsApp"
 //#if (useHttp)
@@ -9,7 +9,63 @@
 //#if (useLocalization)
   },
   "LocalizationConfiguration": {
-    "Cultures": [ "en" ]
+    "Cultures": [
+//#if (useArabic)
+      "ar",
+//#endif
+//#if (useCzech)
+      "cs",
+//#endif
+//#if (useDanish)
+      "da",
+  //#endif
+//#if (useGerman)
+      "de",
+//#endif
+//#if (useSpanish)
+      "es",
+//#endif
+//#if (useFrench)
+      "fr",
+//#endif
+//#if (useItalian)
+      "it",
+//#endif
+//#if (useJapanese)
+      "ja",
+//#endif
+//#if (useKorean)
+      "ko",
+//#endif
+//#if (useDutch)
+      "nl",
+//#endif
+//#if (usePortuguese)
+      "pt-BR",
+//#endif
+//#if (useRussian)
+      "ru",
+//#endif
+//#if (useSwedish)
+      "sv",
+//#endif
+//#if (useTurkish)
+      "tr",
+//#endif
+//#if (useUkrainian)
+      "uk",
+//#endif
+//#if (useVietnamese)
+      "vi",
+//#endif
+//#if (useChineseSimplified)
+      "zh-Hans",
+//#endif
+//#if (useChineseTraditional)
+      "zh-Hant",
+//#endif
+      "en"
+    ]
 //#endif
   }
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #1041

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

The Template only has localization resources for English

## What is the new behavior?

By default the template will provide additional localization files for Spanish, French and Portuguese, with the option to customize the additional localization languages based on the most commonly localized languages. This is not an exhaustive list and we can add support for additional languages down the road if required.

Also the MainModel/MainViewModel have been updated so that when Localization is enabled we will use the IStringLocalizer to retrieve the resource and set the localized title