### PR TITLE
fix: Return correct data item when itemrepeater tapped

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
@@ -51,7 +51,7 @@ public class ItemsRepeaterRequestHandler : ControlRequestHandlerBase<ItemsRepeat
 					if (parent == sender)
 					{
 						pointerElement = elt as FrameworkElement;
-						dataContext = (elt as ContentControl)?.Content ?? (elt as FrameworkElement)?.DataContext;
+						dataContext = (elt as FrameworkElement)?.DataContext;
 					}
 					elt = parent;
 				}

--- a/testing/TestHarness/TestHarness.Shared/App.xaml
+++ b/testing/TestHarness/TestHarness.Shared/App.xaml
@@ -13,10 +13,10 @@
 				<ToolkitResources xmlns="using:Uno.Toolkit.UI" />
 
 				<!--<MaterialColors xmlns="using:Uno.Material"  />
-				<MaterialFonts xmlns="using:Uno.Material"  />
+				<MaterialFonts xmlns="using:Uno.Material"  />-->
 				<MaterialResources xmlns="using:Uno.Material" />
 
-				<MaterialToolkitResources xmlns="using:Uno.Toolkit.UI.Material" />-->
+				<MaterialToolkitResources xmlns="using:Uno.Toolkit.UI.Material" />
 
 			</ResourceDictionary.MergedDictionaries>
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
@@ -38,24 +38,42 @@
 					Click="{x:Bind ViewModel.SettingsWriteTest}" />
 		</StackPanel>
 		<ScrollViewer Grid.Row="2">
-		<muxc:ItemsRepeater ItemsSource="{Binding Items}"
-							uen:Navigation.Request="PageNavigationTwo">
-			<muxc:ItemsRepeater.ItemTemplate>
-				<DataTemplate>
-					<Grid Height="200"
-						  Background="Red">
-						<Border Background="Pink"
-								VerticalAlignment="Top"
-								HorizontalAlignment="Center">
-							<TextBlock Text="{Binding}"/>
-						</Border>
-						<Button VerticalAlignment="Bottom"
-								Content="Go to Three"
-								uen:Navigation.Request="PageNavigationThree" />
-					</Grid>
-				</DataTemplate>
-			</muxc:ItemsRepeater.ItemTemplate>
-		</muxc:ItemsRepeater>
+			<muxc:ItemsRepeater ItemsSource="{Binding Items}"
+								uen:Navigation.Request="PageNavigationTwo">
+				<muxc:ItemsRepeater.ItemTemplate>
+					<DataTemplate>
+						<!--<UserControl>-->
+							<Grid Height="200"
+								  Background="Red">
+								<Border Background="Pink"
+										VerticalAlignment="Top"
+										HorizontalAlignment="Center">
+									<TextBlock Text="{Binding}" />
+								</Border>
+								<utu:CardContentControl Height="50"
+														Width="200"
+														Style="{StaticResource FilledCardContentControlStyle}"
+														HorizontalAlignment="Stretch"
+														HorizontalContentAlignment="Stretch"
+														VerticalContentAlignment="Stretch">
+									<utu:CardContentControl.ContentTemplate>
+										<DataTemplate>
+											<Border Background="Green"
+													Height="50"
+													Width="200">
+												<TextBlock Text="Inner card" />
+											</Border>
+										</DataTemplate>
+									</utu:CardContentControl.ContentTemplate>
+								</utu:CardContentControl>
+								<Button VerticalAlignment="Bottom"
+										Content="Go to Three"
+										uen:Navigation.Request="PageNavigationThree" />
+							</Grid>
+						<!--</UserControl>-->
+					</DataTemplate>
+				</muxc:ItemsRepeater.ItemTemplate>
+			</muxc:ItemsRepeater>
 		</ScrollViewer>
 	</Grid>
 </Page>

--- a/testing/TestHarness/TestHarness.UITest/Constants.cs
+++ b/testing/TestHarness/TestHarness.UITest/Constants.cs
@@ -4,7 +4,7 @@ namespace TestHarness.UITest;
 
 public class Constants
 {
-	public readonly static string WebAssemblyDefaultUri = "https://localhost:64364";
+	public readonly static string WebAssemblyDefaultUri = "https://localhost:49198";
 	public readonly static string iOSAppName = "uno.platform.extensions.demo";
 	public readonly static string AndroidAppName = "uno.platform.extensions.demo";
 	public readonly static string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";


### PR DESCRIPTION
GitHub Issue (If applicable): #Internal

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

If a UserControl is placed at the root of the DataTemplate for ItemsRepeater, navigation fails to pick up the correct data item to send with navigation

## What is the new behavior?

Correct data item is selected

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [N/A] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [N/A] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [Internal] Associated with an issue (GitHub or internal)
