### PR TITLE
feat: Adding UI for testing more complex dialogs

### DIFF
--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexDialog.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexDialog.xaml
@@ -1,19 +1,17 @@
-﻿<ContentDialog
-    x:Class="TestHarness.Ext.Navigation.Dialogs.DialogsComplexDialog"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Title="TITLE"
+﻿<ContentDialog x:Class="TestHarness.Ext.Navigation.Dialogs.DialogsComplexDialog"
+			   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			   mc:Ignorable="d"
+			   Title="TITLE"
 			   xmlns:ui="using:Uno.Toolkit.UI"
 			   xmlns:uen="using:Uno.Extensions.Navigation.UI"
 			   PrimaryButtonText="Button1"
-    SecondaryButtonText="Button2"
-    PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
-    SecondaryButtonClick="ContentDialog_SecondaryButtonClick">
-
-    <Grid>
+			   SecondaryButtonText="Button2"
+			   PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
+			   SecondaryButtonClick="ContentDialog_SecondaryButtonClick">
+	<Grid>
 		<Frame uen:Region.Attached="True" />
 	</Grid>
 </ContentDialog>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyout.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyout.xaml
@@ -1,0 +1,21 @@
+﻿<Flyout x:Class="TestHarness.Ext.Navigation.Dialogs.DialogsComplexFlyout"
+		xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		xmlns:local="using:TestHarness.Ext.Navigation.Dialogs"
+		xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+		xmlns:ui="using:Uno.Toolkit.UI"
+		xmlns:uen="using:Uno.Extensions.Navigation.UI"
+		mc:Ignorable="d"
+		Placement="Full"
+		FlyoutPresenterStyle="{StaticResource MaterialFlyoutPresenterStyle}">
+
+	<Grid Height="500"
+		  Width="500">
+		<Frame uen:Region.Attached="True"
+			   HorizontalAlignment="Stretch"
+			   VerticalAlignment="Stretch"
+			   HorizontalContentAlignment="Stretch"
+			   VerticalContentAlignment="Stretch" />
+	</Grid>
+</Flyout>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyout.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyout.xaml.cs
@@ -1,0 +1,10 @@
+﻿
+namespace TestHarness.Ext.Navigation.Dialogs;
+
+public sealed partial class DialogsComplexFlyout : Flyout
+{
+	public DialogsComplexFlyout()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOnePage.xaml
@@ -1,0 +1,28 @@
+﻿<Page x:Class="TestHarness.Ext.Navigation.Dialogs.DialogsComplexFlyoutOnePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.Dialogs"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:ui="using:Uno.Toolkit.UI"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<ui:NavigationBar Content="Complex Flyout First Page"
+						  AutomationProperties.AutomationId="ComplexFlyoutFirstPageNavigationBar" />
+
+		<StackPanel Grid.Row="1">
+			<Button AutomationProperties.AutomationId="ComplexFlyoutFirstPageSecondButton"
+					uen:Navigation.Request="DialogsComplexFlyoutSecond"
+					Content="Second page" />
+			<Button AutomationProperties.AutomationId="ComplexFlyoutFirstPageCloseButton"
+					Content="Close dialog"
+					Command="{Binding CloseCommand}" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOnePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOnePage.xaml.cs
@@ -1,0 +1,10 @@
+﻿
+namespace TestHarness.Ext.Navigation.Dialogs;
+
+public sealed partial class DialogsComplexFlyoutOnePage : Page
+{
+	public DialogsComplexFlyoutOnePage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOneViewModel.cs
@@ -1,0 +1,24 @@
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
+
+public class DialogsComplexFlyoutOneViewModel
+{
+	private INavigator Navigator { get; }
+
+	public ICommand CloseCommand { get; }
+
+	public string? Name { get; set; }
+
+	public DialogsComplexFlyoutOneViewModel(
+		INavigator navigator)
+	{
+
+		Navigator = navigator;
+
+		CloseCommand = new AsyncRelayCommand(Close);
+	}
+
+	public async Task Close()
+	{
+		await Navigator.NavigateBackAsync(this, qualifier: Qualifiers.Root);
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutTwoPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutTwoPage.xaml
@@ -1,0 +1,34 @@
+﻿<Page x:Class="TestHarness.Ext.Navigation.Dialogs.DialogsComplexFlyoutTwoPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.Dialogs"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:ui="using:Uno.Toolkit.UI"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<ui:NavigationBar Content="Complex Flyout Second Page"
+						  AutomationProperties.AutomationId="ComplexFlyoutSecondPageNavigationBar">
+			<ui:NavigationBar.MainCommand>
+				<AppBarButton>
+					<AppBarButton.Icon>
+						<BitmapIcon UriSource="ms-appx:///Assets/Icons/back.png" />
+					</AppBarButton.Icon>
+				</AppBarButton>
+			</ui:NavigationBar.MainCommand>
+		</ui:NavigationBar>
+
+		<StackPanel Grid.Row="1">
+			<Button AutomationProperties.AutomationId="ComplexFlyoutSecondPageCloseButton"
+					Content="Close dialog"
+					Command="{Binding CloseCommand}" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutTwoPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutTwoPage.xaml.cs
@@ -1,0 +1,10 @@
+﻿
+namespace TestHarness.Ext.Navigation.Dialogs;
+
+public sealed partial class DialogsComplexFlyoutTwoPage : Page
+{
+	public DialogsComplexFlyoutTwoPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutTwoViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutTwoViewModel.cs
@@ -1,0 +1,24 @@
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
+
+public class DialogsComplexFlyoutTwoViewModel
+{
+	private INavigator Navigator { get; }
+
+	public ICommand CloseCommand { get; }
+
+	public string? Name { get; set; }
+
+	public DialogsComplexFlyoutTwoViewModel(
+		INavigator navigator)
+	{
+
+		Navigator = navigator;
+
+		CloseCommand = new AsyncRelayCommand(Close);
+	}
+
+	public async Task Close()
+	{
+		await Navigator.NavigateBackAsync(this, qualifier: Qualifiers.Root);
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml
@@ -26,6 +26,8 @@
 				<Button Content="Flyout from Background Thread requesting data"
 						Click="FlyoutFromBackgroundRequestingDataClick" />
 
+				<Button uen:Navigation.Request="!DialogsComplexFlyout"
+						Content="Complex Flyout from Xaml" />
 			</StackPanel>
 		</ScrollViewer>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml.cs
@@ -1,15 +1,12 @@
 ﻿
 namespace TestHarness.Ext.Navigation.Dialogs;
 
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
-    public sealed partial class DialogsFlyoutsPage : Page
-    {
-        public DialogsFlyoutsPage()
-        {
-            this.InitializeComponent();
-        }
+public sealed partial class DialogsFlyoutsPage : Page
+{
+	public DialogsFlyoutsPage()
+	{
+		this.InitializeComponent();
+	}
 
 	private async void FlyoutFromBackgroundClick(object sender, RoutedEventArgs e)
 	{

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsHostInit.cs
@@ -35,6 +35,9 @@ public class DialogsHostInit : BaseHostInitialization
 			new ViewMap<DialogsComplexDialog>(),
 			new ViewMap<DialogsComplexDialogFirstPage, DialogsComplexDialogFirstViewModel>(),
 			new ViewMap<DialogsComplexDialogSecondPage, DialogsComplexDialogSecondViewModel>(),
+			new ViewMap<DialogsComplexFlyout>(),
+			new ViewMap<DialogsComplexFlyoutOnePage, DialogsComplexFlyoutOneViewModel>(),
+			new ViewMap<DialogsComplexFlyoutTwoPage, DialogsComplexFlyoutTwoViewModel>(),
 			confirmDialog,
 			localizedDialog
 			);
@@ -49,6 +52,11 @@ public class DialogsHostInit : BaseHostInitialization
 				{
 					new RouteMap("DialogsComplexDialogFirst", View: views.FindByViewModel<DialogsComplexDialogFirstViewModel>(), IsDefault:true),
 					new RouteMap("DialogsComplexDialogSecond", View: views.FindByViewModel<DialogsComplexDialogSecondViewModel>())
+				}),
+				new RouteMap("DialogsComplexFlyout", View: views.FindByView<DialogsComplexFlyout>(), Nested: new[]
+				{
+					new RouteMap("DialogsComplexFlyoutFirst", View: views.FindByViewModel<DialogsComplexFlyoutOneViewModel>(), IsDefault:true),
+					new RouteMap("DialogsComplexFlyoutSecond", View: views.FindByViewModel<DialogsComplexFlyoutTwoViewModel>(), DependsOn: "DialogsComplexFlyoutFirst")
 				}),
 				new RouteMap("Confirm", View: confirmDialog),
 				new RouteMap("LocalizedConfirm", View: localizedDialog)

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -221,6 +221,11 @@
       <DependentUpon>DialogsComplexDialogSecondPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsComplexDialogSecondViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsComplexFlyout.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsComplexFlyoutOnePage.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsComplexFlyoutOneViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsComplexFlyoutTwoPage.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsComplexFlyoutTwoViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsFlyoutsPage.xaml.cs">
       <DependentUpon>DialogsFlyoutsPage.xaml</DependentUpon>
     </Compile>
@@ -532,6 +537,18 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsComplexDialogSecondPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsComplexFlyout.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsComplexFlyoutOnePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsComplexFlyoutTwoPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.shproj
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.shproj
@@ -10,4 +10,14 @@
   <PropertyGroup />
   <Import Project="TestHarness.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+  <ItemGroup>
+    <_Globbed_Compile Remove="Ext\Navigation\Dialogs\DialogsComplexFlyout.xaml.cs" />
+    <_Globbed_Compile Remove="Ext\Navigation\Dialogs\DialogsComplexFlyoutOnePage.xaml.cs" />
+    <_Globbed_Compile Remove="Ext\Navigation\Dialogs\DialogsComplexFlyoutTwoPage.xaml.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <_Globbled_Page Remove="Ext\Navigation\Dialogs\DialogsComplexFlyout.xaml" />
+    <_Globbled_Page Remove="Ext\Navigation\Dialogs\DialogsComplexFlyoutOnePage.xaml" />
+    <_Globbled_Page Remove="Ext\Navigation\Dialogs\DialogsComplexFlyoutTwoPage.xaml" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): #N/A

# PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Nothing in TestHarness that shows how to do a complex flyout (ie with multiple pages)

## What is the new behavior?

Dialogs -> Flyouts -> ComplexFlyout shows how to load a flyout that supports navigating between two pages

