### PR TITLE
feat: included mvvm support to current validation sample

### DIFF
--- a/src/Uno.Extensions.Validation/Validator.cs
+++ b/src/Uno.Extensions.Validation/Validator.cs
@@ -27,9 +27,9 @@ internal class Validator : IValidator
 			try
 			{
 				context ??= new ValidationContext(instance);
-				System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, context, results, true);
+				bool validates = System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, context, results, true);
 
-				if (!results.Any() && instance is INotifyDataErrorInfo _instance)
+				if (!results.Any() && !validates && instance is INotifyDataErrorInfo _instance)
 				{
 					return _instance?.GetErrors(null).OfType<ValidationResult>()?.ToList()
 						?? new List<ValidationResult>();

--- a/testing/TestHarness/TestHarness.Shared/Converters/StringToBoolConverter.cs
+++ b/testing/TestHarness/TestHarness.Shared/Converters/StringToBoolConverter.cs
@@ -1,0 +1,14 @@
+﻿namespace TestHarness.Converters;
+
+public class StringToBoolConverter : IValueConverter
+{
+	public object Convert(object value, Type targetType, object parameter, string language)
+	{
+		return !string.IsNullOrEmpty(value as string);
+	}
+
+	public object ConvertBack(object value, Type targetType, object parameter, string language)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Validation/ValidationOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Validation/ValidationOnePage.xaml
@@ -5,9 +5,12 @@
 	xmlns:local="using:TestHarness.Ext.Navigation.Validation"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:app="using:TestHarness.Converters"
 	mc:Ignorable="d"
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-
+	<Page.Resources>
+		<app:StringToBoolConverter x:Key="stringToBoolConverter"/>
+	</Page.Resources>
 	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition/>
@@ -18,23 +21,35 @@
 			<StackPanel
 				Orientation="Vertical">
 				<TextBlock
-					Text="ValidatableObject Validation Results:"
+					Text="SimpleValidator Demo:"
 					HorizontalAlignment="Left"
 					FontSize="25" />
-				<ListView
-					AutomationProperties.AutomationId="ValidatableObjectErrorsList"
-					HorizontalAlignment="Left"
-					ItemsSource="{Binding ValidatableObjectErrors}">
-					<ListView.ItemTemplate>
-						<DataTemplate>
+				<StackPanel
+					Orientation="Horizontal"
+					Spacing="10">
+					<TextBlock
+						Text="Name: "
+						HorizontalAlignment="Left"
+						VerticalAlignment="Center"
+						FontSize="15" />
+					<TextBox
+						Width="100"
+						Height="20"
+						VerticalAlignment="Center"
+						Text="{Binding SimpleEntity.Title, Mode=TwoWay}" />
+					<SymbolIcon
+						Symbol="ReportHacked"
+						Foreground="Red"
+						Visibility="{Binding SimpleEntity.TitleErrors, Mode=OneWay, Converter={StaticResource stringToBoolConverter}}"
+						HorizontalAlignment="Right"
+						Margin="0 8">
+						<ToolTipService.ToolTip>
 							<TextBlock
-								HorizontalAlignment="Left"
-								Text="{Binding ErrorMessage}"
-								FontSize="14" />
-						</DataTemplate>
-					</ListView.ItemTemplate>
-
-				</ListView>
+								Text="{Binding SimpleEntity.TitleErrors, Mode=OneWay}"
+								Foreground="Red" />
+						</ToolTipService.ToolTip>
+					</SymbolIcon>
+				</StackPanel>
 			</StackPanel>
 		</Grid>
 
@@ -43,23 +58,60 @@
 			<StackPanel
 				Orientation="Vertical">
 				<TextBlock
-					Text="ObservableValidator Validation Results:"
+					Text="ObservableValidator Demo:"
 					HorizontalAlignment="Left"
 					FontSize="25" />
-				<ListView
-					AutomationProperties.AutomationId="ObservableValidatorErrorsList"
-					HorizontalAlignment="Left"
-					ItemsSource="{Binding ObservableValidatorErrors}">
-					<ListView.ItemTemplate>
-						<DataTemplate>
+				<StackPanel
+					Orientation="Horizontal" Spacing="10">
+					<TextBlock
+						Text="First Name: "
+						HorizontalAlignment="Left"
+						VerticalAlignment="Center"
+						FontSize="15" />
+					<TextBox
+						Width="100"
+						Height="20"
+						VerticalAlignment="Center"
+						Text="{Binding ObservableUser.FirstName, Mode=TwoWay}" />
+					<SymbolIcon
+						Symbol="ReportHacked"
+						Foreground="Red"
+						Visibility="{Binding ObservableUser.FirstNameErrors, Mode=OneWay, Converter={StaticResource stringToBoolConverter}}"
+						HorizontalAlignment="Right"
+						Margin="0 8">
+						<ToolTipService.ToolTip>
 							<TextBlock
-								HorizontalAlignment="Left"
-								Text="{Binding ErrorMessage}"
-								FontSize="14" />
-						</DataTemplate>
-					</ListView.ItemTemplate>
-
-				</ListView>
+								Text="{Binding ObservableUser.FirstNameErrors, Mode=OneWay}"
+								Foreground="Red" />
+						</ToolTipService.ToolTip>
+					</SymbolIcon>
+				</StackPanel>
+				<StackPanel
+					Orientation="Horizontal"
+					Spacing="10">
+					<TextBlock
+						Text="Last Name: "
+						HorizontalAlignment="Left"
+						VerticalAlignment="Center"
+						FontSize="15" />
+					<TextBox
+						Width="100"
+						Height="20"
+						VerticalAlignment="Center"
+						Text="{Binding ObservableUser.LastName, Mode=TwoWay}" />
+					<SymbolIcon
+						Symbol="ReportHacked"
+						Foreground="Red"
+						Visibility="{Binding ObservableUser.LastNameErrors, Mode=OneWay, Converter={StaticResource stringToBoolConverter}}"
+						HorizontalAlignment="Right"
+						Margin="0 8">
+						<ToolTipService.ToolTip>
+							<TextBlock
+								Text="{Binding ObservableUser.LastNameErrors, Mode=OneWay}"
+								Foreground="Red" />
+						</ToolTipService.ToolTip>
+					</SymbolIcon>
+				</StackPanel>
 			</StackPanel>
 		</Grid>
 
@@ -68,23 +120,35 @@
 			<StackPanel
 				Orientation="Vertical">
 				<TextBlock
-					Text="FluentValidator Validation Results:"
+					Text="FluentValidator Demo:"
 					HorizontalAlignment="Left"
 					FontSize="25" />
-				<ListView
-					AutomationProperties.AutomationId="FluentValidatorErrorsList"
-					HorizontalAlignment="Left"
-					ItemsSource="{Binding FluentValidatorErrors}">
-					<ListView.ItemTemplate>
-						<DataTemplate>
+				<StackPanel
+					Orientation="Horizontal"
+					Spacing="10">
+					<TextBlock
+						Text="Name: "
+						HorizontalAlignment="Left"
+						VerticalAlignment="Center"
+						FontSize="15" />
+					<TextBox
+						Width="100"
+						Height="20"
+						VerticalAlignment="Center"
+						Text="{Binding FluentUser.Name, Mode=TwoWay}" />
+					<SymbolIcon
+						Symbol="ReportHacked"
+						Foreground="Red"
+						Visibility="{Binding FluentUser.NameErrors, Mode=OneWay, Converter={StaticResource stringToBoolConverter}}"
+						HorizontalAlignment="Right"
+						Margin="0 8">
+						<ToolTipService.ToolTip>
 							<TextBlock
-								HorizontalAlignment="Left"
-								Text="{Binding ErrorMessage}"
-								FontSize="14" />
-						</DataTemplate>
-					</ListView.ItemTemplate>
-
-				</ListView>
+								Text="{Binding FluentUser.NameErrors, Mode=OneWay}"
+								Foreground="Red" />
+						</ToolTipService.ToolTip>
+					</SymbolIcon>
+				</StackPanel>
 			</StackPanel>
 		</Grid>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Models/Validation/FluentValidatorUser.cs
+++ b/testing/TestHarness/TestHarness.Shared/Models/Validation/FluentValidatorUser.cs
@@ -1,0 +1,74 @@
+﻿using System.ComponentModel;
+using FluentValidation;
+
+namespace TestHarness.Models;
+
+public class ValidationUser : INotifyPropertyChanged
+{
+	private string _name;
+	private string _nameErrors;
+
+	public string Name
+	{
+		get { return _name; }
+		set
+		{
+			_name = value;
+			OnPropertyChanged(nameof(Name));
+		}
+	}
+
+	public string NameErrors
+	{
+		get { return _nameErrors; }
+		set
+		{
+			_nameErrors = value;
+			OnPropertyChanged(nameof(NameErrors));
+		}
+	}
+
+	#region PropertyChanged
+	public event PropertyChangedEventHandler PropertyChanged;
+	protected void OnPropertyChanged(string name)
+	{
+		PropertyChangedEventHandler handler = PropertyChanged;
+
+		if (handler != null)
+		{
+			handler(this, new PropertyChangedEventArgs(name));
+		}
+	}
+	#endregion
+}
+public class ValidationUserValidator : AbstractValidator<ValidationUser>
+{
+	public ValidationUserValidator()
+	{
+		RuleFor(x => x.Name).Custom((value, context) =>
+		{
+			var error = "";
+
+			if (value?.Length < 3)
+			{
+				error = "'Name' field minimum length is 3 characters.";
+				context.AddFailure(error);
+			}
+
+			if (value?.Length > 6)
+			{
+				error = "'Name' field maximum length is 6 characters.";
+				context.AddFailure(error);
+			}
+
+			if (string.IsNullOrEmpty(value))
+			{
+				error = "'Name' field is required.";
+				context.AddFailure(error);
+			}
+
+			context.InstanceToValidate.NameErrors = error;
+		});
+	}
+}
+

--- a/testing/TestHarness/TestHarness.Shared/Models/Validation/SimpleEntity.cs
+++ b/testing/TestHarness/TestHarness.Shared/Models/Validation/SimpleEntity.cs
@@ -1,0 +1,52 @@
+﻿using System.ComponentModel;
+
+namespace TestHarness.Models;
+public class SimpleEntity : IValidatableObject, INotifyPropertyChanged
+{
+	private string _title;
+	private string _titleErrors;
+
+	public string Title
+	{
+		get { return _title; }
+		set
+		{
+			_title = value;
+			OnPropertyChanged(nameof(Title));
+		}
+	}
+
+	public string TitleErrors
+	{
+		get { return _titleErrors; }
+		set
+		{
+			_titleErrors = value;
+			OnPropertyChanged(nameof(TitleErrors));
+		}
+	}
+	public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+	{
+		return string.IsNullOrWhiteSpace(Title) ?
+			new ValidationResult[] {
+					new ValidationResult(
+						errorMessage: "Title should not be null",
+						memberNames: new[] {nameof(Title) }
+						)
+			} :
+			default;
+	}
+
+	#region PropertyChanged
+	public event PropertyChangedEventHandler PropertyChanged;
+	protected void OnPropertyChanged(string name)
+	{
+		PropertyChangedEventHandler handler = PropertyChanged;
+
+		if (handler != null)
+		{
+			handler(this, new PropertyChangedEventArgs(name));
+		}
+	}
+	#endregion
+}

--- a/testing/TestHarness/TestHarness.Shared/Models/Validation/SimpleObservableUser.cs
+++ b/testing/TestHarness/TestHarness.Shared/Models/Validation/SimpleObservableUser.cs
@@ -1,0 +1,21 @@
+﻿namespace TestHarness.Models;
+public class SimpleObservableUser : ObservableValidator
+{
+	private string firstName;
+	private string firstNameErrors;
+	private string lastName;
+	private string lastNameErrors;
+
+	public string FirstNameErrors { get => firstNameErrors; set => SetProperty(ref firstNameErrors, value); }
+	public string LastNameErrors { get => lastNameErrors; set => SetProperty(ref lastNameErrors, value); }
+
+	[Required]
+	[MinLength(3)]
+	[MaxLength(100)]
+	public string FirstName { get => firstName; set => SetProperty(ref firstName, value, true); }
+
+	[Required]
+	[MinLength(3)]
+	[MaxLength(100)]
+	public string LastName { get => lastName; set => SetProperty(ref lastName, value, true); }
+}

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)BaseHostInitialization.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BaseTestSectionPage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ControlSizeTrigger.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Converters\StringToBoolConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\AdHoc\AdHocHostInit.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\AdHoc\AdHocMainPage.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\AdHoc\AdHocOnePage.xaml.cs" />
@@ -389,6 +390,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Models\Validation\FluentValidatorUser.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\Validation\SimpleEntity.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\Validation\SimpleObservableUser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Widget.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PageExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestFrameHost.xaml.cs">

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.shproj
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.shproj
@@ -10,4 +10,10 @@
   <PropertyGroup />
   <Import Project="TestHarness.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+  <ItemGroup>
+    <_Globbed_Compile Remove="Converters\StringToBoolConverter.cs" />
+    <_Globbed_Compile Remove="Models\Validation\FluentValidatorUser.cs" />
+    <_Globbed_Compile Remove="Models\Validation\SimpleEntity.cs" />
+    <_Globbed_Compile Remove="Models\Validation\SimpleObservableUser.cs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Current sample for Validator does not use Mvvm or provide any kind of UX when a string is validated. Simple validator is also missing a validation for when the object is not able to validate, not errors was found and it is of type INotifyDataErrorInfo.

## What is the new behavior?

Current sample for Validator does support real-time validation and Mvvm. Also  when simple validator fails to validate, no errors was found and type of the validating object is INotifyDataErrorInfo it falls in MVVMToolkit validator.

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)