### PR TITLE
Fix issues with bindable collection

### DIFF
--- a/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableCollection_Events.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableCollection_Events.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Reflection;
+using System.Threading.Tasks;
+using Windows.Foundation.Collections;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Bindings;
+using Uno.Extensions.Reactive.Dispatching;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Extensions.Reactive.WinUI.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_BindableCollection_Events
+{
+	[TestMethod]
+	public async Task When_UpdateWithoutCollHandler_Then_RaisePropertyChanged()
+	{
+		var sut = Create<int>();
+
+		// And subscribe to the PropertyChanged (Count)
+		var propChanged = false;
+		((INotifyPropertyChanged)sut).PropertyChanged += (snd, e) => propChanged = true;
+
+		// ACT - Cause a collection changed
+		Switch(sut, 0, 1, 2, 3);
+
+		// ASSERT - Validate that we get the property changed
+		Assert.IsTrue(propChanged);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateWithCollChangedHandlerOnly_Then_RaisePropertyChanged()
+	{
+		var sut = Create<int>();
+
+		// Create a subscription to the collection changed, but not the VectorChanged
+		((INotifyCollectionChanged)sut).CollectionChanged += (snd, e) => { };
+
+		// And subscribe to the PropertyChanged (Count)
+		var propChanged = false;
+		((INotifyPropertyChanged)sut).PropertyChanged += (snd, e) => propChanged = true;
+
+		// ACT - Cause a collection changed
+		Switch(sut, 0, 1, 2, 3);
+
+		// ASSERT - Validate that we get the property changed
+		Assert.IsTrue(propChanged);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateWithVectorChangedHandlerOnly_Then_RaisePropertyChanged()
+	{
+		var sut = Create<int>();
+
+		// Create a subscription to the vector changed, but not the CollectionChanged
+		((IObservableVector<object>)sut).VectorChanged += (snd, e) => { };
+
+		// And subscribe to the PropertyChanged (Count)
+		var propChanged = false;
+		((INotifyPropertyChanged)sut).PropertyChanged += (snd, e) => propChanged = true;
+
+		// ACT - Cause a collection changed
+		Switch(sut, 0, 1, 2, 3);
+
+		// ASSERT - Validate that we get the property changed
+		Assert.IsTrue(propChanged);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateWithCollAndVectorChangedHandlers_Then_RaisePropertyChanged()
+	{
+		var sut = Create<int>();
+
+		// Create a subscription to the vector and collection changed
+		((INotifyCollectionChanged)sut).CollectionChanged += (snd, e) => { };
+		((IObservableVector<object>)sut).VectorChanged += (snd, e) => { };
+
+		// And subscribe to the PropertyChanged (Count)
+		var propChanged = false;
+		((INotifyPropertyChanged)sut).PropertyChanged += (snd, e) => propChanged = true;
+
+		// ACT - Cause a collection changed
+		Switch(sut, 0, 1, 2, 3);
+
+		// ASSERT - Validate that we get the property changed
+		Assert.IsTrue(propChanged);
+	}
+
+	private static object Create<T>()
+	{
+		var uiAssembly = typeof(BindableListFeed<>).Assembly;
+		var type = uiAssembly.GetType("Uno.Extensions.Reactive.Bindings.Collections.BindableCollection", throwOnError: true, ignoreCase: true) ?? throw new InvalidOperationException("Cannot get BindableCollection type.");
+		var create = type.GetMethod("Create", BindingFlags.Static | BindingFlags.NonPublic) ?? throw new InvalidOperationException("Cannot get Create method.");
+		var genericCreate = create.MakeGenericMethod(typeof(T));
+		var instance = genericCreate.Invoke(null, new object[5]) ?? throw new InvalidOperationException("Failed to create instance of BindableCollection.");
+
+		return instance;
+	}
+
+	private static void Switch<T>(object sut, params T[] items)
+	{
+		var uiAssembly = typeof(BindableListFeed<>).Assembly;
+		var observableCollectionType = uiAssembly.GetType("Uno.Extensions.Reactive.Bindings.Collections.ImmutableObservableCollection`1") ?? throw new InvalidOperationException("Cannot ImmutableObservableCollection type.");
+		var observableCollectionOfT = observableCollectionType.MakeGenericType(typeof(T));
+		var observableCollectionCtor = observableCollectionOfT.GetConstructor(new[] { typeof(IImmutableList<T>) }) ?? throw new InvalidOperationException("Cannot get constructor.");
+		var observableCollection = observableCollectionCtor.Invoke(new object[] { items.ToImmutableList() });
+
+		sut
+			.GetType()
+			.GetMethod("Switch", BindingFlags.Instance | BindingFlags.NonPublic)
+			!.Invoke(sut, new[] { observableCollection, null, null });
+	}
+}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataLayerUpdate.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataLayerUpdate.cs
@@ -60,7 +60,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 
 			// If this update has been created from a background thread (init),
 			// it might happen that we already have some event handlers, 
-			// so we must make sure to raise event properly (i.e. silently: false)
+			// so we must make sure to raise the event properly (i.e. silently: false)
 			Invoke(CallbackPhase.All, silently: false);
 
 			_buffer.Start();

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataLayerUpdate.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/DataLayerUpdate.cs
@@ -68,7 +68,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 
 		// This will be invoked only when this data layer is a child layer
 		void ICompositeCallback.Invoke(CallbackPhase phases, bool silently)
-			=> Invoke(phases, false, silently);
+			=> Invoke(phases, silently);
 
 		private void Invoke(CallbackPhase phases, bool silently)
 		{

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/CollectionFacet.cs
@@ -252,6 +252,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 				{
 					UpdateHead(arg);
 					_collectionChanged.CollectionChanged?.Invoke(arg);
+					_collectionChanged.PropertyChanged();
 				}
 			}
 #endif


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno.extensions/issues/1161
fixes https://github.com/unoplatform/uno.chefs/issues/292
fixes https://github.com/unoplatform/uno.chefs/issues/311

## Bugfix
Misc issues with `BindableCollection`:
1. Collection changed events was not raised on initial load when created from a BG thread
2. Property changed event was not raised under certain circonstances

## What is the current behavior?
1. For perf consideration, we assume those events was useless and was ignored. While valid when init from the UI thread, this is invalid when the collection is initialized from a BG thread.
2. We missed a case when we added support the `PropertyChanged` event!

## What is the new behavior?
1. We always raise events
2. 🙃

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
