### PR TITLE
fix: Ensure flyout navigationresponse completes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,6 +35,9 @@
 
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
+		<!-- This is required to prevent XamlParseException when using Debug packages for local
+			debugging (see https://github.com/microsoft/microsoft-ui-xaml/issues/6452) -->
+		<DisableEmbeddedXbf>false</DisableEmbeddedXbf>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
@@ -66,11 +66,14 @@ public class FlyoutNavigator : ControlNavigator
 
 	private void CloseFlyout()
 	{
-		if (_flyout is not null)
+		if (_flyout is { } fly)
 		{
-			_flyout.Closed -= Flyout_Closed;
-			_flyout.Hide();
+			CleanupFlyout();
+
+			fly.Hide();
+
 		}
+
 	}
 
 	private async Task<Flyout?> DisplayFlyout(NavigationRequest request, Type? viewType, object? viewModel, bool injectedFlyout)
@@ -157,7 +160,7 @@ public class FlyoutNavigator : ControlNavigator
 			return;
 		}
 
-		_flyout.Closed -= Flyout_Closed;
+		CleanupFlyout();
 
 		var navigation = Region.Navigator();
 		if (navigation is null)
@@ -168,6 +171,19 @@ public class FlyoutNavigator : ControlNavigator
 		await navigation.NavigateBackAsync(this);
 	}
 
-	protected override Task CheckLoadedAsync() => _content is not null ? _content.EnsureLoaded() : Task.CompletedTask;
+	private void CleanupFlyout()
+	{
+		if (_flyout is null)
+		{
+			return;
+		}
+
+		_flyout.Closed -= Flyout_Closed;
+		_flyout = null;
+		_content = null;
+
+	}
+
+	protected override Task CheckLoadedAsync() => _flyout is not null && _content is not null ? _content.EnsureLoaded() : Task.CompletedTask;
 
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyout.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyout.xaml
@@ -10,7 +10,7 @@
 		Placement="Full"
 		FlyoutPresenterStyle="{StaticResource MaterialFlyoutPresenterStyle}">
 
-	<Grid Height="500"
+	<Grid Height="1000"
 		  Width="500">
 		<Frame uen:Region.Attached="True"
 			   HorizontalAlignment="Stretch"

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOnePage.xaml
@@ -7,8 +7,9 @@
 	  xmlns:ui="using:Uno.Toolkit.UI"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	  mc:Ignorable="d"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-	<Grid>
+	<Grid Background="Pink">
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition />
@@ -16,13 +17,26 @@
 		<ui:NavigationBar Content="Complex Flyout First Page"
 						  AutomationProperties.AutomationId="ComplexFlyoutFirstPageNavigationBar" />
 
-		<StackPanel Grid.Row="1">
+		<StackPanel Grid.Row="1" Background="Blue">
 			<Button AutomationProperties.AutomationId="ComplexFlyoutFirstPageSecondButton"
 					uen:Navigation.Request="DialogsComplexFlyoutSecond"
 					Content="Second page" />
 			<Button AutomationProperties.AutomationId="ComplexFlyoutFirstPageCloseButton"
 					Content="Close dialog"
 					Command="{Binding CloseCommand}" />
+
+			<Border Background="Green">
+			<muxc:ItemsRepeater ItemsSource="{Binding Items}"
+								uen:Navigation.Request="-">
+				<muxc:ItemsRepeater.ItemTemplate>
+					<DataTemplate>
+						<Grid>
+							<TextBlock Text="{Binding Id}" />
+						</Grid>
+					</DataTemplate>
+				</muxc:ItemsRepeater.ItemTemplate>
+			</muxc:ItemsRepeater>
+			</Border>
 		</StackPanel>
 	</Grid>
 </Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOneViewModel.cs
@@ -1,12 +1,20 @@
 ﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
-public class DialogsComplexFlyoutOneViewModel
+public partial class DialogsComplexFlyoutOneViewModel
 {
 	private INavigator Navigator { get; }
 
 	public ICommand CloseCommand { get; }
 
 	public string? Name { get; set; }
+
+	public DialogsFlyoutsData[] Items => new[]
+	{
+		new DialogsFlyoutsData(),
+		new DialogsFlyoutsData(),
+		new DialogsFlyoutsData(),
+		new DialogsFlyoutsData()
+	};
 
 	public DialogsComplexFlyoutOneViewModel(
 		INavigator navigator)
@@ -16,6 +24,8 @@ public class DialogsComplexFlyoutOneViewModel
 
 		CloseCommand = new AsyncRelayCommand(Close);
 	}
+
+
 
 	public async Task Close()
 	{

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml
@@ -6,6 +6,7 @@
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  mc:Ignorable="d"
 	  xmlns:utu="using:Uno.Toolkit.UI"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -25,9 +26,12 @@
 						Click="FlyoutFromBackgroundClick" />
 				<Button Content="Flyout from Background Thread requesting data"
 						Click="FlyoutFromBackgroundRequestingDataClick" />
-
+				<TextBlock Text="{Binding FlyoutData.Id}" />
 				<Button uen:Navigation.Request="!DialogsComplexFlyout"
+						uen:Navigation.Data="{Binding FlyoutData, Mode=TwoWay}"
 						Content="Complex Flyout from Xaml" />
+
+				
 			</StackPanel>
 		</ScrollViewer>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsViewModel.cs
@@ -1,0 +1,35 @@
+﻿
+namespace TestHarness.Ext.Navigation.Dialogs;
+
+public partial class DialogsFlyoutsViewModel
+{
+	private INavigator Navigator { get; }
+
+	public DialogsFlyoutsViewModel(
+		INavigator navigator)
+	{
+
+		//BindableDialogsFlyoutsViewModel
+		Navigator = navigator;
+
+		FlyoutData = State< DialogsFlyoutsData>.Empty(this);
+		FlyoutData.ForEachAsync(async (obj, ct) =>
+		{
+			if (obj is not null &&
+			obj.GetType() != typeof(object))
+			{
+				await Navigator.NavigateDataAsync(this, obj);
+			}
+		});
+	}
+
+	public IState<DialogsFlyoutsData> FlyoutData { get; }
+
+
+}
+
+
+public class DialogsFlyoutsData
+{
+	public Guid Id { get; } = Guid.NewGuid();
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsHostInit.cs
@@ -4,6 +4,11 @@ namespace TestHarness.Ext.Navigation.Dialogs;
 
 public class DialogsHostInit : BaseHostInitialization
 {
+	protected override IHostBuilder Navigation(IHostBuilder builder)
+	{
+		return builder.UseNavigation(ReactiveViewModelMappings.ViewModelMappings, RegisterRoutes);
+	}
+
 	protected override void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
 	{
 
@@ -32,10 +37,11 @@ public class DialogsHostInit : BaseHostInitialization
 			);
 
 		views.Register(
+			new ViewMap<DialogsFlyoutsPage, DialogsFlyoutsViewModel>(),
 			new ViewMap<DialogsComplexDialog>(),
 			new ViewMap<DialogsComplexDialogFirstPage, DialogsComplexDialogFirstViewModel>(),
 			new ViewMap<DialogsComplexDialogSecondPage, DialogsComplexDialogSecondViewModel>(),
-			new ViewMap<DialogsComplexFlyout>(),
+			new ViewMap<DialogsComplexFlyout>( ResultData: typeof(DialogsFlyoutsData)),
 			new ViewMap<DialogsComplexFlyoutOnePage, DialogsComplexFlyoutOneViewModel>(),
 			new ViewMap<DialogsComplexFlyoutTwoPage, DialogsComplexFlyoutTwoViewModel>(),
 			confirmDialog,
@@ -48,6 +54,7 @@ public class DialogsHostInit : BaseHostInitialization
 			new RouteMap("",
 			Nested: new[]
 			{
+				new RouteMap("DialogsFlyouts", View: views.FindByViewModel<DialogsFlyoutsViewModel>()),
 				new RouteMap("DialogsComplex", View: views.FindByView<DialogsComplexDialog>(), Nested: new[]
 				{
 					new RouteMap("DialogsComplexDialogFirst", View: views.FindByViewModel<DialogsComplexDialogFirstViewModel>(), IsDefault:true),

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -236,6 +236,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsSimpleDialog.xaml.cs">
       <DependentUpon>DialogsSimpleDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsFlyoutsViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsSimpleViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\LocalizedDialogsPage.xaml.cs">
       <DependentUpon>LocalizedDialogsPage.xaml</DependentUpon>


### PR DESCRIPTION
GitHub Issue (If applicable): #1188 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

NavigationResponse never completes because flyout waits for content to be loaded (which won't happen since flyout is closed)

## What is the new behavior?

Flyout only waits for content to load if it's not already closed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
