### PR TITLE
Add .NET 8 preview as a template option

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -93,6 +93,11 @@
           "choice": "net7.0",
           "displayName": ".NET 7.0 (Standard Term Support)",
           "description": "Target .NET 7.0 (Standard Term Support)"
+        },
+        {
+          "choice": "net8.0",
+          "displayName": ".NET 8.0 (Preview)",
+          "description": "Target .NET 8.0 (Preview)"
         }
       ]
     },
@@ -696,15 +701,10 @@
       "datatype": "bool",
       "value": "cultures == 'zh-Hant'"
     },
-    "useNetSix": {
+    "includeIsExternalInit": {
       "type": "computed",
       "dataType": "bool",
       "value": "(tfm == 'net6.0')"
-    },
-    "useNetSeven": {
-      "type": "computed",
-      "dataType": "bool",
-      "value": "(tfm == 'net7.0')"
     },
     "langVersion": {
       "type": "generated",
@@ -721,6 +721,10 @@
           {
             "condition": "(tfm == 'net7.0')",
             "value": "11"
+          },
+          {
+            "condition": "(tfm == 'net8.0')",
+            "value": "12"
           }
         ]
       }
@@ -740,6 +744,10 @@
           {
             "condition": "(tfm == 'net7.0')",
             "value": "net7.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0')",
+            "value": "net8.0"
           }
         ]
       }
@@ -761,12 +769,20 @@
             "value": "net7.0-ios;net7.0-android;net7.0-maccatalyst"
           },
           {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms == maccatalyst)",
+            "value": "net8.0-ios;net8.0-android;net8.0-maccatalyst"
+          },
+          {
             "condition": "(tfm == 'net6.0' && platforms == android && platforms == ios && platforms != maccatalyst)",
             "value": "net6.0-ios;net6.0-android"
           },
           {
             "condition": "(tfm == 'net7.0' && platforms == android && platforms == ios && platforms != maccatalyst)",
             "value": "net7.0-ios;net7.0-android"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms == ios && platforms != maccatalyst)",
+            "value": "net8.0-ios;net8.0-android"
           },
           {
             "condition": "(tfm == 'net6.0' && platforms != android && platforms == ios && platforms == maccatalyst)",
@@ -777,12 +793,20 @@
             "value": "net7.0-ios;net7.0-maccatalyst"
           },
           {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms == maccatalyst)",
+            "value": "net8.0-ios;net8.0-maccatalyst"
+          },
+          {
             "condition": "(tfm == 'net6.0' && platforms == android && platforms != ios && platforms == maccatalyst)",
-            "value": "net6.0-android;net7.0-maccatalyst"
+            "value": "net6.0-android;net6.0-maccatalyst"
           },
           {
             "condition": "(tfm == 'net7.0' && platforms == android && platforms != ios && platforms == maccatalyst)",
             "value": "net7.0-android;net7.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms == maccatalyst)",
+            "value": "net8.0-android;net8.0-maccatalyst"
           },
           {
             "condition": "(tfm == 'net6.0' && platforms == android && platforms != ios && platforms != maccatalyst)",
@@ -793,6 +817,10 @@
             "value": "net7.0-android"
           },
           {
+            "condition": "(tfm == 'net8.0' && platforms == android && platforms != ios && platforms != maccatalyst)",
+            "value": "net8.0-android"
+          },
+          {
             "condition": "(tfm == 'net6.0' && platforms != android && platforms == ios && platforms != maccatalyst)",
             "value": "net6.0-ios"
           },
@@ -801,12 +829,20 @@
             "value": "net7.0-ios"
           },
           {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms == ios && platforms != maccatalyst)",
+            "value": "net8.0-ios"
+          },
+          {
             "condition": "(tfm == 'net6.0' && platforms != android && platforms != ios && platforms == maccatalyst)",
             "value": "net6.0-maccatalyst"
           },
           {
             "condition": "(tfm == 'net7.0' && platforms != android && platforms != ios && platforms == maccatalyst)",
             "value": "net7.0-maccatalyst"
+          },
+          {
+            "condition": "(tfm == 'net8.0' && platforms != android && platforms != ios && platforms == maccatalyst)",
+            "value": "net8.0-maccatalyst"
           },
           {
             "condition": "(platforms != android && platforms != ios && platforms != maccatalyst)",
@@ -963,7 +999,7 @@
           ]
         },
         {
-          "condition": "(useNetSeven)",
+          "condition": "(!includeIsExternalInit)",
           "exclude": [
             "**/IsExternalInit.cs"
           ]

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.DataContracts/MyExtensionsApp.DataContracts.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.DataContracts/MyExtensionsApp.DataContracts.csproj
@@ -5,7 +5,7 @@
 		<!-- Suppress Compiler warnings for elements without XML Docs -->
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
-	<!--#if (useNetSix)-->
+	<!--#if (includeIsExternalInit)-->
 
 	<ItemGroup>
 		<Compile Include="..\MyExtensionsApp.Base\IsExternalInit.cs"

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.csproj
@@ -165,7 +165,7 @@
 	</ItemGroup>
 	<!--#endif-->
 	<!--#endif-->
-	<!--#if (useNetSix)-->
+	<!--#if (includeIsExternalInit)-->
 
 	<ItemGroup>
 		<Compile Include="..\MyExtensionsApp.Base\IsExternalInit.cs"
@@ -190,7 +190,8 @@
 				<!--
 				If you encounter this error message:
 
-					error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.
+					error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll.
+					Please update to a newer .NET SDK in order to reference this assembly.
 
 				This means that the two packages below must be aligned with the "build" version number of
 				the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number


### PR DESCRIPTION
GitHub Issue (If applicable): #

n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Maintenance

## What is the current behavior?

Support targets for .NET 6 & .NET 7

## What is the new behavior?

Adds support for .NET 8 preview
Fixes typo where we create `net6.0-android;net7.0-maccatalyst` with `net6.0` selected as the target framework

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
