### PR TITLE
docs(message-dialog): added title argument

### DIFF
--- a/doc/Learn/Tutorials/Navigation/HowTo-DisplayMessageDialog.md
+++ b/doc/Learn/Tutorials/Navigation/HowTo-DisplayMessageDialog.md
@@ -27,7 +27,7 @@ This topic walks through using Navigation to display a prompt using a `MessageDi
     ```csharp
     public async Task ShowSimpleDialog()
     {
-        _ = _navigator.ShowMessageDialogAsync(this, content: "Hello Uno Extensions!");
+        _ = _navigator.ShowMessageDialogAsync(this, title: "This is Uno", content: "Hello Uno Extensions!");
     }
     ```
 
@@ -42,7 +42,7 @@ This topic walks through using Navigation to display a prompt using a `MessageDi
     ```csharp
     public async Task ShowSimpleDialog()
     {
-        var result = await _navigator.ShowMessageDialogAsync<string>(this, content: "Hello Uno Extensions!");
+        var result = await _navigator.ShowMessageDialogAsync<string>(this, title: "This is Uno", content: "Hello Uno Extensions!");
     }
     ```
 
@@ -51,7 +51,8 @@ This topic walks through using Navigation to display a prompt using a `MessageDi
     ```csharp
     public async Task ShowSimpleDialog()
     {
-     var result = await _navigator.ShowMessageDialogAsync<string>(this, 
+     var result = await _navigator.ShowMessageDialogAsync<string>(this,
+      title: "This is Uno",
       content: "Hello Uno Extensions!",
       buttons: new[]
             {
@@ -75,7 +76,7 @@ If you want to use the same `MessageDialog` in different places in your applicat
     private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
     {
         var messageDialog = new MessageDialogViewMap(
-    
+            title: "This is Uno",
             Content: "Hello Uno Extensions",
             Buttons: new[]
             {


### PR DESCRIPTION
The title argument needs to be set, otherwise the WASM implementation throws an ArgumentNullException

GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

With the provided example, in WASM an ArgumentNullException is thrown due to the title being null.

## What is the new behavior?
The example works also in WASM

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
