### PR TITLE
fix: Limiting access to keys in shared storage

### DIFF
--- a/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageExtensions.cs
+++ b/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageExtensions.cs
@@ -13,7 +13,7 @@ public static class KeyValueStorageExtensions
 		string key,
 		CancellationToken ct)
 	{
-		if(await storage.ContainsKey(key,ct))
+		if (await storage.ContainsKey(key, ct))
 		{
 			return await storage.GetAsync<string>(key, ct);
 		}
@@ -21,17 +21,23 @@ public static class KeyValueStorageExtensions
 		return default;
 	}
 
-
-		public static async ValueTask<IDictionary<string,string>> GetAllValuesAsync(
+	public static ValueTask<IDictionary<string, string>> GetAllValuesAsync(
 		this IKeyValueStorage storage,
 		CancellationToken ct)
 	{
-		var dict=  new Dictionary<string, string>();
+		return GetAllValuesAsync(storage, _ => true, ct);
+	}
+	public static async ValueTask<IDictionary<string, string>> GetAllValuesAsync(
+	this IKeyValueStorage storage,
+	Func<string, bool> predicate,
+	CancellationToken ct)
+	{
+		var dict = new Dictionary<string, string>();
 		var keys = await storage.GetKeysAsync(ct);
-		foreach (var key in keys)
+		foreach (var key in keys.Where(predicate))
 		{
 			var value = await storage.GetAsync<string>(key, ct);
-			if(value is not null)
+			if (value is not null)
 			{
 				dict[key] = value;
 			}
@@ -39,12 +45,20 @@ public static class KeyValueStorageExtensions
 		return dict;
 	}
 
+	public static ValueTask ClearAllAsync(
+	this IKeyValueStorage storage,
+	CancellationToken ct)
+	{
+		return ClearAllAsync(storage, _ => true, ct);	
+	}
+
 	public static async ValueTask ClearAllAsync(
 		this IKeyValueStorage storage,
+		Func<string, bool> predicate,
 		CancellationToken ct)
 	{
 		var keys = await storage.GetKeysAsync(ct);
-		foreach (var key in keys)
+		foreach (var key in keys.Where(predicate))
 		{
 			await storage.ClearAsync(key, ct);
 		}

--- a/testing/TestHarness/TestHarness.Shared/BaseHostInitialization.cs
+++ b/testing/TestHarness/TestHarness.Shared/BaseHostInitialization.cs
@@ -84,7 +84,7 @@ public abstract class BaseHostInitialization : IHostInitialization
 				{
 					var host = context.HostingEnvironment;
 					// Configure log levels for different categories of logging
-					logBuilder.SetMinimumLevel(host.IsDevelopment() ? LogLevel.Trace : LogLevel.Warning);
+					logBuilder.SetMinimumLevel(host.IsDevelopment() ? LogLevel.Information : LogLevel.Warning);
 				});
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #1221 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

All key-values are returned (and set) in the authentication  

## What is the new behavior?

Only tokens that relate to auth are stored/retrieved

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
