### PR TITLE
fix: ensure analyzers are packed correctly

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -85,6 +85,7 @@
 		<WriteLinesToFile File="$(_AndroidResourceDesignerFile)" Lines="// Empty Content from uno.ui Directory.Build.targets." />
 	</Target>
 
+	<!-- NOTE: This is due to a Race Condition with MSBuild where the dll may not yet exist on a clean build -->
 	<Target Name="PackageGeneratorBuild"
 			AfterTargets="Build">
 		<PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -85,6 +85,22 @@
 		<WriteLinesToFile File="$(_AndroidResourceDesignerFile)" Lines="// Empty Content from uno.ui Directory.Build.targets." />
 	</Target>
 
+	<Target Name="PackageGeneratorBuild"
+			AfterTargets="Build">
+		<PropertyGroup>
+			<GeneratorOutputPath>$(MSBuildProjectDirectory)\$(IntermediateOutputPath)\PackGenerators\</GeneratorOutputPath>
+		</PropertyGroup>
+		<MSBuild Projects="@(GeneratorProjectReference)"
+				 Properties="Configuration=$(Configuration);OutputPath=$(GeneratorOutputPath)" />
+	</Target>
+
+	<Target Name="GeneratorPack"
+			AfterTargets="PackageGeneratorBuild">
+		<ItemGroup>
+			<None Include="$(GeneratorOutputPath)**\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+		</ItemGroup>
+	</Target>
+
 	<Import Project="winappsdk-workaround.targets" Condition="exists('winappsdk-workaround.targets')" />
 	<Import Project="xamarinmac-workaround.targets" Condition="exists('xamarinmac-workaround.targets') and $(TargetFramework.ToLower().StartsWith('xamarin')) and $(TargetFramework.ToLower().Contains('mac'))" />
 </Project>

--- a/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
+++ b/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
@@ -45,12 +45,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Uno.Extensions.Core.Generators\Uno.Extensions.Core.Generators.csproj" ReferenceOutputAssembly="false" />
+		<GeneratorProjectReference Include="..\Uno.Extensions.Core.Generators\Uno.Extensions.Core.Generators.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<None Include="..\Uno.Extensions.Core.Generators\buildTransitive\Uno.Extensions.Core.props" Pack="true" PackagePath="buildTransitive" />
-		<None Include="..\Uno.Extensions.Core.Generators\bin\Uno.Extensions.Core.Generators\$(Configuration)\netstandard2.0\**\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Reactive/Uno.Extensions.Reactive.csproj
+++ b/src/Uno.Extensions.Reactive/Uno.Extensions.Reactive.csproj
@@ -27,11 +27,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Uno.Extensions.Reactive.Generator\Uno.Extensions.Reactive.Generator.csproj" ReferenceOutputAssembly="false" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Include="..\Uno.Extensions.Reactive.Generator\bin\Uno.Extensions.Reactive.Generator\$(Configuration)\netstandard2.0\**\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+		<GeneratorProjectReference Include="..\Uno.Extensions.Reactive.Generator\Uno.Extensions.Reactive.Generator.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #

n/ae

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Generators have a ProjectReference and a None Include to pack as an analyzer

## What is the new behavior?

This is now handled by a build task that will process a GeneratorProjectReference. It ensures the generator is built with the output in the IntermediateOutputPath (obj) so that we can more easily ensure that the resources exist to reference / pack.