### PR TITLE
fix(reactive): Fix FeedView does not have a default style

### DIFF
--- a/src/Uno.Extensions.Reactive.UI/Themes/Generic.xaml
+++ b/src/Uno.Extensions.Reactive.UI/Themes/Generic.xaml
@@ -4,7 +4,7 @@
 	xmlns:toolkit="using:Uno.UI.Toolkit">
 
 	<ResourceDictionary.MergedDictionaries>
-		<ResourceDictionary Source="ms-appx:///Uno.Extensions.Reactive.UI/View/FeedView.xaml" />
+		<ResourceDictionary Source="View/FeedView.xaml" />
 	</ResourceDictionary.MergedDictionaries>
 
 </ResourceDictionary>

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.cs
@@ -217,6 +217,8 @@ public partial class FeedView : Control
 		{
 			ViewDebugger.SetIsEnabled(this, true);
 		}
+		
+		DefaultStyleKey = typeof(FeedView);
 
 		Refresh = new RefreshCommand(this);
 		State = new FeedViewState(this) { Parent = DataContext }; // Create a State instance specific for this FeedView


### PR DESCRIPTION
## Bugfix
FeedView does not have a default style

## What is the current behavior?
We need to copy the style in all apps

## What is the new behavior?
🙃

## PR Checklist

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
