### PR TITLE
Rename Frame Navigation Option -> Blank

### DIFF
--- a/build/ci/.azure-pipelines.TemplateValidation.yml
+++ b/build/ci/.azure-pipelines.TemplateValidation.yml
@@ -33,7 +33,7 @@ jobs:
         templateArgs: '-di false'
       HostingOnly:
         createdProjectName: UnoAppHostingOnly01
-        templateArgs: '-config false -loc false -http false -log none --navigation frame'
+        templateArgs: '-config false -loc false -http false -log none --navigation blank'
       NoConfiguration:
         createdProjectName: UnoAppNoConfiguration01
         templateArgs: '-config false'
@@ -54,7 +54,7 @@ jobs:
         templateArgs: '-server false -http false'
       FrameNavigation:
         createdProjectName: UnoAppFrameNavigation01
-        templateArgs: '--navigation frame'
+        templateArgs: '--navigation blank'
       Net6:
         createdProjectName: UnoAppNet6
         templateArgs: '-tfm net6.0'

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -396,9 +396,9 @@
           "description": "Uses Uno.Extensions.Navigation to navigate between pages"
         },
         {
-          "choice": "frame",
-          "displayName": "Frame",
-          "description": "Uses Frame to navigate between pages"
+          "choice": "blank",
+          "displayName": "Blank",
+          "description": "Provides Blank App experience with default WinUI Frame Navigation"
         }
       ],
       "defaultValue": "default"
@@ -1123,7 +1123,7 @@
           },
           {
             "condition": "(preset == 'blank')",
-            "value": "frame"
+            "value": "blank"
           }
         ]
       }
@@ -1139,7 +1139,7 @@
     "useExtensionsNavigation": {
       "type": "computed",
       "datatype": "bool",
-      "value": "useDependencyInjection && navigationEvaluator != 'frame'"
+      "value": "useDependencyInjection && navigationEvaluator != 'blank'"
     },
     "useReactiveExtensionsNavigation": {
       "type": "computed",
@@ -1154,7 +1154,7 @@
     "useFrameNav": {
       "type": "computed",
       "datatype": "bool",
-      "value": "preset  == 'blank' || !useDependencyInjection || navigationEvaluator == 'frame'"
+      "value": "!useDependencyInjection || navigationEvaluator == 'blank'"
     },
     "useInfrastructureNamespace": {
       "type": "computed",
@@ -1164,7 +1164,7 @@
     "useBusinessModelsNamespace": {
       "type": "computed",
       "datatype": "bool",
-      "value": "useDependencyInjection && (useConfiguration || navigationEvaluator != 'frame')"
+      "value": "useDependencyInjection && (useConfiguration || navigationEvaluator != 'blank')"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -391,17 +391,16 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "default",
-          "displayName": "Default",
-          "description": "Uses Uno.Extensions.Navigation to navigate between pages"
+          "choice": "regions",
+          "displayName": "Regions",
+          "description": "Uses Uno.Extensions.Navigation to navigate using regions"
         },
         {
           "choice": "blank",
           "displayName": "Blank",
           "description": "Provides Blank App experience with default WinUI Frame Navigation"
         }
-      ],
-      "defaultValue": "default"
+      ]
     },
     "cpm": {
       "displayName": "Central Package Management",
@@ -1146,10 +1145,10 @@
       "datatype": "bool",
       "value": "useExtensionsNavigation && useMvux"
     },
-    "useDefaultNav": {
+    "useRegionsNav": {
       "type": "computed",
       "datatype": "bool",
-      "value": "useExtensionsNavigation && navigationEvaluator == 'default'"
+      "value": "useExtensionsNavigation && navigationEvaluator == 'regions'"
     },
     "useFrameNav": {
       "type": "computed",
@@ -1565,9 +1564,9 @@
           }
         },
         {
-          "condition": "(!useDefaultNav)",
+          "condition": "(!useRegionsNav)",
           "exclude": [
-            "MyExtensionsApp/Business/Models/Entity.cs",
+            "MyExtensionsApp/Business/Models/Entity.cs"
           ]
         },
         {

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -1118,7 +1118,7 @@
         "cases": [
           {
             "condition": "(preset == 'recommended')",
-            "value": "default"
+            "value": "regions"
           },
           {
             "condition": "(preset == 'blank')",

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/App.recommended.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/App.recommended.cs
@@ -14,7 +14,7 @@ public class App : Application
 	{
 		var builder = this.CreateBuilder(args)
 
-#if (useDefaultNav)
+#if (useRegionsNav)
 			// Add navigation support for toolkit controls such as TabBar and NavigationView
 			.UseToolkitNavigation()
 #endif
@@ -110,7 +110,7 @@ public class App : Application
 
 	private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
 	{
-#if (useDefaultNav)
+#if (useRegionsNav)
 		views.Register(
 			new ViewMap(ViewModel: typeof($shellRouteViewModel$)),
 			new ViewMap<MainPage, $mainRouteViewModel$>(),

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/App.recommended.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/App.recommended.cs
@@ -14,7 +14,7 @@ public class App : Application
 	{
 		var builder = this.CreateBuilder(args)
 
-#if (useRegionsNav)
+#if (useExtensionsNavigation)
 			// Add navigation support for toolkit controls such as TabBar and NavigationView
 			.UseToolkitNavigation()
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): #

- #1113

## PR Type

What kind of change does this PR introduce?

- Refactoring

## What is the current behavior?

Navigation Options are:
- Default - This uses Uno.Extensions.Navigation for a simple navigation from one page to another page
- Frame - This uses Frame navigation the same as the Uno Blank app

## What is the new behavior?

Navigation Options
- Default - (Unchanged)
- Blank - This is Frame with a new name