### PR TITLE
fix: DataTemplates project included with Blank preset

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -662,7 +662,7 @@
     "useDataContracts": {
       "type": "computed",
       "dataType": "bool",
-      "value": "((useDependencyInjection && useHttp) || server)"
+      "value": "((useDependencyInjection && useHttp) || (server && useRecommendedAppTemplate))"
     },
     "useUnitTests": {
       "type": "computed",


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #1252 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

DataContracts project is created with the Blank preset

## What is the new behavior?

DataContracts is not created with the Blank preset unless you have enabled DependencyInjection and Http explicitly