### PR TITLE
add IDE host back to explicitly disable VS

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/ide.host.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/ide.host.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "unsupportedHosts": [
+    {
+      "id": "vs"
+    }
+  ]
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #1256 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The template shows up in VS now that it has the editorTreatAs tag

## What is the new behavior?

The template uses the ide.host.json to declare vs as an unsupported host