### PR TITLE
fix: resizetizer app icon size

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Base/base.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Base/base.props
@@ -20,6 +20,7 @@
 				Link="AppHead.xaml.cs" />
 		<UnoIcon Include="$(MSBuildThisFileDirectory)Icons\iconapp.svg"
 				ForegroundFile="$(MSBuildThisFileDirectory)Icons\appconfig.svg"
+				ForegroundScale="0.65"
 				Color="#00000000" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): #

n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The generated icon cuts off part of the Uno logo in the generated app icon

## What is the new behavior?

The generated icon shows the full Uno logo