### PR TITLE
fix: Add back isVsix symbol

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -430,6 +430,12 @@
       "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false"
     },
+    "isVsix": {
+      "displayName": "isVsix",
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
+    },
     "useCPM": {
       "type": "computed",
       "datatype": "bool",
@@ -1172,6 +1178,7 @@
   },
   "primaryOutputs": [
     {
+      "condition": "!isVsix",
       "path": "MyExtensionsApp.sln"
     },
     {
@@ -1235,6 +1242,13 @@
           ],
           "exclude": [
             "MyExtensionsApp.Debugging.sln"
+          ]
+        },
+        {
+          "condition": "(isVsix)",
+          "exclude": [
+            "MyExtensionsApp.sln",
+            "MyExtensionsApp-vsmac.slnf"
           ]
         },
         {
@@ -1595,7 +1609,7 @@
             "MyExtensionsApp/appsettings.*",
             "MyExtensionsApp.Tests/AppInfoTests.cs"
           ]
-        }
+        } 
       ]
     }
   ],


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno.studio/issues/143

## PR Type

What kind of change does this PR introduce?
- Bugfix
 
## What is the current behavior?

Creating solution in VS is causing issues with editorTreatAs not being respected when using wizard. 
There's also an exception raised when the slnf file exists

## What is the new behavior?

Both sln and slnf are not used when isVsix symbol is set to true

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
