### PR TITLE
[Template] Minimal API

### DIFF
--- a/build/ci/.azure-pipelines.TemplateValidation.yml
+++ b/build/ci/.azure-pipelines.TemplateValidation.yml
@@ -55,6 +55,12 @@ jobs:
       FrameNavigation:
         createdProjectName: UnoAppFrameNavigation01
         templateArgs: '--navigation blank'
+      ServerController:
+        createdProjectName: UnoAppServerController01
+        templateArgs: '-minimal false'
+      ServerControllerNet6:
+        createdProjectName: UnoAppServerController01
+        templateArgs: '-minimal false -tfm net6.0'
       Net6:
         createdProjectName: UnoAppNet6
         templateArgs: '-tfm net6.0'

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/dotnetcli.host.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/dotnetcli.host.json
@@ -41,6 +41,10 @@
       "longName": "tests",
       "shortName": "tests"
     },
+    "minimalApi": {
+      "longName": "minimal-api",
+      "shortName": "minimal"
+    },
     "dependencyInjection": {
       "longName": "dependency-injection",
       "shortName": "di"

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -237,6 +237,13 @@
       "defaultValue": "true",
       "description": "Includes a Server project for an API & host for the WebAssembly project"
     },
+    "minimalApi": {
+      "displayName": "Minimal Api",
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "true",
+      "description": "When enabled this provides a minimal API instead of a controller"
+    },
     "dependencyInjection": {
       "displayName": "Dependency Injection",
       "description": "Use dependency injection for registering and accessing services",
@@ -435,6 +442,11 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false"
+    },
+    "useMinimalApi": {
+      "type": "computed",
+      "datatype": "bool",
+      "value": "(minimalApi)"
     },
     "useCPM": {
       "type": "computed",
@@ -1655,7 +1667,19 @@
             "MyExtensionsApp/appsettings.*",
             "MyExtensionsApp.Tests/AppInfoTests.cs"
           ]
-        } 
+        },
+        {
+          "condition": "(useMinimalApi)",
+          "exclude": [
+            "MyExtensionsApp.Server/Controllers/*"
+          ]
+        },
+        {
+          "condition": "(!useMinimalApi)",
+          "exclude": [
+            "MyExtensionsApp.Server/Apis/*"
+          ]
+        }
       ]
     }
   ],

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -1171,6 +1171,52 @@
       "datatype": "bool",
       "value": "useDependencyInjection && (useConfiguration || navigationEvaluator != 'blank')"
     },
+    "MsftExtensionsLoggingConsoleVersion": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$MsftExtensionsLoggingConsoleVersion$",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(tfm == 'net6.0')",
+            "value": "6.0.0"
+          },
+          {
+            "condition": "(tfm == 'net7.0')",
+            "value": "7.0.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0')",
+            "value": "8.0.0-preview.1.23110.8"
+          }
+        ]
+      }
+    },
+    "MsftWindowsCompatibilityVersion": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$MsftWindowsCompatibilityVersion$",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(tfm == 'net6.0')",
+            "value": "6.0.3"
+          },
+          {
+            "condition": "(tfm == 'net7.0')",
+            "value": "7.0.0"
+          },
+          {
+            "condition": "(tfm == 'net8.0')",
+            "value": "8.0.0-preview.1.23110.8"
+          }
+        ]
+      }
+    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -1408,7 +1408,7 @@
           ]
         },
         {
-          "condition": "(useRecommendedAppTemplate)",
+          "condition": "(useDataContracts)",
           "exclude": [
             "MyExtensionsApp.Server/WeatherForecast.cs"
           ]

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/Directory.Packages.props
@@ -5,10 +5,10 @@
     <!--#endif-->
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="FluentAssertions" Version="6.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageVersion Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Windows.Compatibility" Version="$MsftWindowsCompatibilityVersion$" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.230217.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.DataContracts/Serialization/WeatherForecastContext.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.DataContracts/Serialization/WeatherForecastContext.cs
@@ -7,7 +7,10 @@ namespace MyExtensionsApp.DataContracts.Serialization;
  * When using the JsonSerializerContext you must add the JsonSerializableAttribute
  * for each type that you may need to serialize / deserialize including both the
  * concrete type and any interface that the concrete type implements.
+ * For more information on the JsonSerializerContext see:
+ * https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation?WT.mc_id=DT-MVP-5002924
  */
+[JsonSerializable(typeof(WeatherForecast))]
 [JsonSerializable(typeof(WeatherForecast[]))]
 [JsonSerializable(typeof(IEnumerable<WeatherForecast>))]
 [JsonSerializable(typeof(IImmutableList<WeatherForecast>))]

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.DataContracts/WeatherForecast.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.DataContracts/WeatherForecast.cs
@@ -34,7 +34,7 @@ public class WeatherForecast
 /// <param name="Date">Gets the Date of the Forecast.</param>
 /// <param name="TemperatureC">Gets the Forecast Temperature in Celsius.</param>
 /// <param name="Summary">Get a description of how the weather will feel.</param>
-public record WeatherForecast(DateTime Date, int TemperatureC, string? Summary)
+public record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {
 	/// <summary>
 	/// Gets the Forecast Temperature in Fahrenheit

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Mobile/MyExtensionsApp.Mobile.csproj
@@ -154,7 +154,7 @@
 		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#endif-->
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 		<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.44" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.44" Condition="'$(Configuration)'=='Debug'" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/Apis/WeatherForecastApi.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/Apis/WeatherForecastApi.cs
@@ -1,0 +1,58 @@
+namespace MyExtensionsApp.Server.Apis;
+
+public static class WeatherForecastApi
+{
+	private const string Tag = "Weather";
+	private static readonly string[] Summaries = new[]
+	{
+		"Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+	};
+
+	public static WebApplication MapWeatherApi(this WebApplication app)
+	{
+		app.MapGet("/api/weatherforecast", GetForecast)
+			.WithTags(Tag)
+			.WithName(nameof(GetForecast));
+		return app;
+	}
+
+	/// <summary>
+	/// Creates a make believe weather forecast for the next 5 days.
+	/// </summary>
+	/// <param name="loggerFactory"></param>
+	/// <returns>A fake 5 day forecast</returns>
+	/// <remarks>A 5 Day Forecast</remarks>
+	/// <response code="200">Weather Forecast returned</response>
+	[Produces("application/json")]
+	[ProducesResponseType(typeof(IEnumerable<WeatherForecast>), 200)]
+	private static IEnumerable<WeatherForecast> GetForecast(ILoggerFactory loggerFactory)
+	{
+		var logger = loggerFactory.CreateLogger(nameof(WeatherForecastApi));
+		logger.LogDebug("Getting Weather Forecast.");
+
+		return Enumerable.Range(1, 5).Select(index =>
+//+:cnd:noEmit
+		#if (includeNet6DataContractReferences)
+			new WeatherForecast
+			{
+				Date = DateTime.Now.AddDays(index),
+				TemperatureC = Random.Shared.Next(-20, 55),
+				Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+			}
+		#else
+			new WeatherForecast(
+				DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+				Random.Shared.Next(-20, 55),
+				Summaries[Random.Shared.Next(Summaries.Length)]
+			)
+		#endif
+//-:cnd:noEmit
+		)
+		.Select(x =>
+		{
+			logger.LogInformation("Weather forecast for {Date} is a {Summary} {TemperatureC}°C", x.Date, x.Summary, x.TemperatureC);
+			return x;
+		})
+		.ToArray();
+	}
+}

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/Controllers/WeatherForecastController.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/Controllers/WeatherForecastController.cs
@@ -37,7 +37,7 @@ public class WeatherForecastController : ControllerBase
 			}
 		#else
 			new WeatherForecast(
-				DateTime.Now.AddDays(index),
+				DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
 				Random.Shared.Next(-20, 55),
 				Summaries[Random.Shared.Next(Summaries.Length)]
 			)

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/GlobalUsings.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/GlobalUsings.cs
@@ -1,2 +1,6 @@
 global using Microsoft.AspNetCore.Mvc;
 global using MyExtensionsApp.DataContracts;
+//+:cnd:noEmit
+#if (useMinimalApi)
+global using MyExtensionsApp.Server.Apis;
+#endif

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/GlobalUsings.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Server/GlobalUsings.cs
@@ -4,3 +4,4 @@ global using MyExtensionsApp.DataContracts;
 #if (useMinimalApi)
 global using MyExtensionsApp.Server.Apis;
 #endif
+//-:cnd:noEmit

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.csproj
@@ -146,7 +146,7 @@
 		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#endif-->
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.44" Condition="'$(Configuration)'=='Debug'" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.csproj
@@ -146,7 +146,7 @@
 		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#endif-->
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.44" Condition="'$(Configuration)'=='Debug'" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.WPF/MyExtensionsApp.Skia.WPF.csproj
@@ -149,7 +149,7 @@
 		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#endif-->
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.44" Condition="'$(Configuration)'=='Debug'" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Wasm/MyExtensionsApp.Wasm.csproj
@@ -128,7 +128,7 @@
 	</ItemGroup>
 	<!--#else-->
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="$MsftWindowsCompatibilityVersion$" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.19" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.19" />
 		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.44" />
@@ -195,7 +195,7 @@
 		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#endif-->
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 	</ItemGroup>
 	<!--#endif-->
 	<ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Windows/MyExtensionsApp.Windows.csproj
@@ -156,7 +156,7 @@
 		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#endif-->
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.44" />
 	</ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp/MyExtensionsApp.csproj
@@ -147,7 +147,7 @@
 		<PackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" Version="255.255.255.255" />
 		<!--#endif-->
 		<!--#endif-->
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$MsftExtensionsLoggingConsoleVersion$" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (includeIsExternalInit)-->


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #1264

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

The server project provides a standard Controller for the WeatherForecast API

## What is the new behavior?

By default you now get a Minimal Api with the same Open Api support you get from the existing Controller. You can additionally disable minimal API's to get the existing controller. This also updates the WeatherForecast model to use DateOnly for .NET 7.0+. We cannot use DateOnly for .NET 6.0 due to the library having to use netstandard2.1 instead of being able to use net6.0.