### PR TITLE
Package.appxmanifest missing when Windows head is not present

### DIFF
--- a/build/ci/.azure-pipelines.TemplateValidation.yml
+++ b/build/ci/.azure-pipelines.TemplateValidation.yml
@@ -13,6 +13,12 @@ jobs:
       BlankApp:
         createdProjectName: UnoAppBlank01
         templateArgs: '-preset blank'
+      SkiaOnlyHeads:
+        createdProjectName: UnoAppSkiaOnlyHeads01
+        templateArgs: '-platforms gtk wpf linux-fb'
+      MobileOnlyHeads:
+        createdProjectName: UnoAppMobileOnlyHeads01
+        templateArgs: '-platforms android ios maccatalyst'
     #   BlankMarkupApp:
     #     createdProjectName: UnoAppBlank01
     #     templateArgs: '-preset blank -markup csharp'

--- a/src/Uno.Extensions.Templates/Uno.Extensions.Templates.csproj
+++ b/src/Uno.Extensions.Templates/Uno.Extensions.Templates.csproj
@@ -38,12 +38,12 @@
 			DestinationFiles="$(IntermediateOutputPath)/content/unoapp-extensions/MyExtensionsApp.Server/WeatherForecast.cs"
 			SkipUnchangedFiles="false" />
 		<Copy
-			SourceFiles="content/unoapp-extensions/MyExtensionsApp.Windows/app.manifest"
-			DestinationFiles="$(IntermediateOutputPath)/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/app.manifest"
+			SourceFiles="content/unoapp-extensions/MyExtensionsApp.Windows/Package.appxmanifest"
+			DestinationFiles="$(IntermediateOutputPath)/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/Package.appxmanifest"
 			SkipUnchangedFiles="false" />
 		<Copy
-			SourceFiles="content/unoapp-extensions/MyExtensionsApp.Windows/app.manifest"
-			DestinationFiles="$(IntermediateOutputPath)/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/app.manifest"
+			SourceFiles="content/unoapp-extensions/MyExtensionsApp.Windows/Package.appxmanifest"
+			DestinationFiles="$(IntermediateOutputPath)/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/Package.appxmanifest"
 			SkipUnchangedFiles="false" />
 		<ItemGroup>
 			<_PackageFiles Include="$(IntermediateOutputPath)/content/**/*"

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Gtk/MyExtensionsApp.Skia.Gtk.csproj
@@ -5,8 +5,8 @@
 		<TargetFramework>$baseTargetFramework$</TargetFramework>
 	</PropertyGroup>
 	<!--#if (useWinAppSdk)-->
-	<ItemGroup Condition="exists('Platforms\Windows')">
-		<EmbeddedResource Include="Platforms\Windows\Package.appxmanifest" LogicalName="Package.appxmanifest" />
+	<ItemGroup Condition="exists('..\MyExtensionsApp.Windows\Package.appxmanifest')">
+		<EmbeddedResource Include="..\MyExtensionsApp.Windows\Package.appxmanifest" LogicalName="Package.appxmanifest" />
 	</ItemGroup>
 	<!--#else-->
 	<ItemGroup>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.Skia.Linux.FrameBuffer/MyExtensionsApp.Skia.Linux.FrameBuffer.csproj
@@ -5,8 +5,8 @@
 		<TargetFramework>$baseTargetFramework$</TargetFramework>
 	</PropertyGroup>
 	<!--#if (useWinAppSdk)-->
-	<ItemGroup Condition="exists('Platforms\Windows')">
-		<EmbeddedResource Include="Platforms\Windows\Package.appxmanifest" LogicalName="Package.appxmanifest" />
+	<ItemGroup Condition="exists('..\MyExtensionsApp.Windows\Package.appxmanifest')">
+		<EmbeddedResource Include="..\MyExtensionsApp.Windows\Package.appxmanifest" LogicalName="Package.appxmanifest" />
 	</ItemGroup>
 	<!--#else-->
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #1268

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Template copies the app.manifest from the Windows project to the source for Gtk/Linux

## What is the new behavior?

Template correctly copies the Package.appxmanifest instead