### PR TITLE
fix: Correcting XAML referencing for material and toolkit to avoid build warnign

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1/AppResources.xaml
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1/AppResources.xaml
@@ -5,22 +5,22 @@
 		<!-- Load WinUI resources -->
 		<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
 <!--#if (useMaterial)-->
-		<MaterialTheme xmlns="using:Uno.Material"
+		<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material"
 			ColorOverrideSource="ms-appx:///MyExtensionsApp.1/Styles/ColorPaletteOverride.xaml"
 			FontOverrideSource="ms-appx:///MyExtensionsApp.1/Styles/MaterialFontsOverride.xaml" />
-<!--#elif (useCupertino)-->
+<!--#else-->
+<!--#if (useRecommendedAppTemplate)-->
+		<!-- Load Uno.UI.Toolkit resources -->
+		<ToolkitResources xmlns="using:Uno.Toolkit.UI" />
+<!--#endif-->
+
+<!--#if (useCupertino)-->
 		<CupertinoColors xmlns="using:Uno.Cupertino" />
 		<CupertinoFonts xmlns="using:Uno.Cupertino" />
 		<CupertinoResources xmlns="using:Uno.Cupertino" />
 <!--#endif-->
-<!--#if (useRecommendedAppTemplate)-->
+<!--#endif-->
 
-		<!-- Load Uno.UI.Toolkit resources -->
-		<ToolkitResources xmlns="using:Uno.Toolkit.UI" />
-<!--#endif-->
-<!--#if (useMaterial)-->
-		<MaterialToolkitResources xmlns="using:Uno.Toolkit.UI.Material" />
-<!--#endif-->
 	</ResourceDictionary.MergedDictionaries>
 	<!-- Add resources here -->
 


### PR DESCRIPTION
GitHub Issue (If applicable): #1276 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Build warning

## What is the new behavior?

No build warning

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
