### PR TITLE
fix: Correct csproj for Wasm to get UITests to work

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1.UITests/Given_MainPage.cs
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1.UITests/Given_MainPage.cs
@@ -10,6 +10,7 @@ public class Given_MainPage : TestBase
 		// the port that is being used and update the Constants.cs file
 		// in the UITests project with the correct port number.
 
+//+:cnd:noEmit
 #if (useExtensionsNavigation)
 		// Query for the SecondPageButton and then tap it
 		Query xamlButton = q => q.All().Marked("SecondPageButton");
@@ -26,5 +27,6 @@ public class Given_MainPage : TestBase
 		// Take a screenshot and add it to the test results
 		TakeScreenshot("After launch");
 #endif
+//-:cnd:noEmit
 	}
 }

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
@@ -29,10 +29,12 @@
 		<!-- Temporarily uncomment to generate an AOT profile https://aka.platform.uno/wasm-aot-profile -->
 		<!-- <WasmShellGenerateAOTProfile>true</WasmShellGenerateAOTProfile> -->
 	</PropertyGroup>
+	<!--#if (useUITests)-->
 	<PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(IsUiAutomationMappingEnabled)'=='True'">
 		<IsUiAutomationMappingEnabled>True</IsUiAutomationMappingEnabled>
 		<DefineConstants>$(DefineConstants);USE_UITESTS</DefineConstants>
 	</PropertyGroup>
+	<!--#endif-->
 	<ItemGroup>
 		<!--#if (wasmPwaManifest)-->
 		<Content Include="manifest.webmanifest" />

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1.Wasm/MyExtensionsApp.1.Wasm.csproj
@@ -29,6 +29,10 @@
 		<!-- Temporarily uncomment to generate an AOT profile https://aka.platform.uno/wasm-aot-profile -->
 		<!-- <WasmShellGenerateAOTProfile>true</WasmShellGenerateAOTProfile> -->
 	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(IsUiAutomationMappingEnabled)'=='True'">
+		<IsUiAutomationMappingEnabled>True</IsUiAutomationMappingEnabled>
+		<DefineConstants>$(DefineConstants);USE_UITESTS</DefineConstants>
+	</PropertyGroup>
 	<ItemGroup>
 		<!--#if (wasmPwaManifest)-->
 		<Content Include="manifest.webmanifest" />


### PR DESCRIPTION
GitHub Issue (If applicable): #1270 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Missing IsUiAutomationMappingEnabled property on wasm target which prevents IDs being assigned so that UITests can locate elements
Corrected Given_MainPage so that template conditions are invoked

## What is the new behavior?

UITests work

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
