### PR TITLE
fix: Add proper DefaultFeedViewStyle Key and use it as Implicit

### DIFF
--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.xaml
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.xaml
@@ -2,7 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:uer="using:Uno.Extensions.Reactive.UI">
 
-	<Style TargetType="uer:FeedView">
+	<Style x:Key="DefaultFeedViewStyle" TargetType="uer:FeedView">
 		<Setter Property="VerticalAlignment" Value="Stretch" />
 		<Setter Property="HorizontalAlignment" Value="Stretch" />
 		<Setter Property="VerticalContentAlignment" Value="Stretch" />
@@ -181,7 +181,7 @@
 		</Setter>
 	</Style>
 
-	<Style TargetType="uer:FeedView" x:Key="CompositeFeedViewStyle">
+	<Style x:Key="CompositeFeedViewStyle" TargetType="uer:FeedView">
 		<Setter Property="VerticalAlignment" Value="Stretch" />
 		<Setter Property="HorizontalAlignment" Value="Stretch" />
 		<Setter Property="VerticalContentAlignment" Value="Stretch" />
@@ -355,4 +355,7 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+	 
+	<!-- Default FeedView Style -->
+	<Style TargetType="uer:FeedView" BasedOn="{StaticResource DefaultFeedViewStyle}" />
 </ResourceDictionary>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description
Add proper DefaultFeedViewStyle Key to have both an explicit and implicit style. 
So in an app, you would be able to base a custom FeedView style on the default without having to repeat everything that's in the default template. 


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
