### PR TITLE
feat: Adjusting background brush for specified theme

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/.template.config/template.json
@@ -525,6 +525,28 @@
       "datatype": "bool",
       "value": "(appTheme == 'cupertino')"
     },
+    "themeBackgroundBrush":{
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "$themeBackgroundBrush$",
+      "parameters": {
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(appThemeEvaluator == 'material')",
+            "value": "BackgroundBrush"
+          },
+          {
+            "condition": "(appThemeEvaluator == 'fluent')",
+            "value": "ApplicationPageBackgroundThemeBrush"
+          },
+          {
+            "condition": "(appTheme == 'cupertino')",
+            "value": "CupertinoSystemBackgroundBrush"
+          }
+        ]
+      }
+    },
     "presetDependencyInjectionDefault": {
       "type": "generated",
       "generator": "switch",

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1/Presentation/MainPage.xaml
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1/Presentation/MainPage.xaml
@@ -9,7 +9,7 @@
 	  xmlns:utu="using:Uno.Toolkit.UI"
 	  xmlns:not_skia="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  NavigationCacheMode="Required"
-	  Background="{ThemeResource BackgroundBrush}">
+	  Background="{ThemeResource $themeBackgroundBrush$}">
 
 	<Grid>
 		<Grid.RowDefinitions>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1/Presentation/SecondPage.xaml
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1/Presentation/SecondPage.xaml
@@ -6,7 +6,7 @@
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	  xmlns:utu="using:Uno.Toolkit.UI"
-	  Background="{ThemeResource BackgroundBrush}">
+	  Background="{ThemeResource $themeBackgroundBrush$}">
 
 	<Grid>
 		<utu:NavigationBar Content="Second Page">


### PR DESCRIPTION
GitHub Issue (If applicable): #1303 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

BackgroundBrush is used for all themese

## What is the new behavior?

Appropriate theme brush used

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
