### PR TITLE
fix: localization for XAML elements

### DIFF
--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -198,6 +198,7 @@
 				<Compile Update="**\*.xaml.cs">
 					<DependentUpon>%(Filename)</DependentUpon>
 				</Compile>
+				<PRIResource Include ="**\*.resw" />
 			</ItemGroup>
 		</Otherwise>
 	</Choose>

--- a/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1/MyExtensionsApp.1.csproj
+++ b/src/Uno.Extensions.Templates/content/unoapp-extensions/MyExtensionsApp.1/MyExtensionsApp.1.csproj
@@ -208,6 +208,7 @@
 		<Compile Update="**\*.xaml.cs">
 			<DependentUpon>%(Filename)</DependentUpon>
 		</Compile>
+		<PRIResource Include ="**\*.resw" />
 	</ItemGroup>
 	<!--#endif-->
 	<!--#if (useHttp)-->


### PR DESCRIPTION
GitHub Issue (If applicable): #1050 #1307 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Resources for XAML elements aren't being loaded from resw (works on WinUI but not other platforms)

## What is the new behavior?

Resources for XAML elements are loaded from resw

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
