### PR TITLE
feat(mvux): Add ListFeed.SleectAsync

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -107,7 +107,12 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(_IsUWP)">
+		<DefineConstants>$(DefineConstants);__WINDOWS__</DefineConstants>
 		<TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
+	</PropertyGroup>
+	
+	<PropertyGroup Condition="$(_IsWinUI)">
+		<DefineConstants>$(DefineConstants);__WINDOWS__</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.Extensions.Reactive.Testing/ConstraintParts/Items.cs
+++ b/src/Uno.Extensions.Reactive.Testing/ConstraintParts/Items.cs
@@ -35,11 +35,11 @@ public static class Items
 	public static ItemsChanged Remove<T>(int at, IEnumerable<T> items)
 		=> ItemsChanged.Remove(at, items);
 
-	public static ItemsChanged Replace<T>(int at, IEnumerable<T> oldItems, IEnumerable<T> newItems)
-		=> ItemsChanged.Replace(at, oldItems, newItems);
+	public static ItemsChanged Replace<T>(int at, IEnumerable<T> oldItems, IEnumerable<T> newItems, bool isReplaceOfSameEntities = true)
+		=> ItemsChanged.Replace(at, oldItems, newItems, isReplaceOfSameEntities);
 
-	public static ItemsChanged Replace<T>(int at, T oldItem, T newItem)
-		=> ItemsChanged.Replace(at, oldItem, newItem);
+	public static ItemsChanged Replace<T>(int at, T oldItem, T newItem, bool isReplaceOfSameEntity = true)
+		=> ItemsChanged.Replace(at, oldItem, newItem, isReplaceOfSameEntity);
 
 	public static ItemsChanged Move<T>(int from, int to, params T[] items)
 		=> ItemsChanged.Move(from, to, items);

--- a/src/Uno.Extensions.Reactive.Testing/ConstraintParts/ItemsChanged.cs
+++ b/src/Uno.Extensions.Reactive.Testing/ConstraintParts/ItemsChanged.cs
@@ -27,11 +27,11 @@ public sealed class ItemsChanged : ChangesConstraint
 	public static ItemsChanged Remove<T>(int index, IEnumerable<T> items)
 		=> new(RichNotifyCollectionChangedEventArgs.RemoveSome<T>(items.ToList(), index));
 
-	public static ItemsChanged Replace<T>(int index, IEnumerable<T> oldItems, IEnumerable<T> newItems)
-		=> new(RichNotifyCollectionChangedEventArgs.ReplaceSome<T>(oldItems.ToList(), newItems.ToList(), index));
+	public static ItemsChanged Replace<T>(int index, IEnumerable<T> oldItems, IEnumerable<T> newItems, bool isReplaceOfSameEntities)
+		=> new(RichNotifyCollectionChangedEventArgs.ReplaceSome<T>(oldItems.ToList(), newItems.ToList(), index, isReplaceOfSameEntities));
 
-	public static ItemsChanged Replace<T>(int index, T oldItem, T newItem)
-		=> new(RichNotifyCollectionChangedEventArgs.Replace<T>(oldItem, newItem, index));
+	public static ItemsChanged Replace<T>(int index, T oldItem, T newItem, bool isReplaceOfSameEntity)
+		=> new(RichNotifyCollectionChangedEventArgs.Replace<T>(oldItem, newItem, index, isReplaceOfSameEntity));
 
 	public static ItemsChanged Move<T>(int oldIndex, int newIndex, params T[] items)
 		=> new(RichNotifyCollectionChangedEventArgs.MoveSome<T>(items.ToList(), oldIndex, newIndex));

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
@@ -182,23 +182,24 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 			=> await state.UpdateMessage(msg => msg.Selected(info).Set(BindableViewModelBase.BindingSource, collection), ct);
 
 		async ValueTask Edit(Func<IDifferentialCollectionNode, IDifferentialCollectionNode> change, CancellationToken ct)
-			=> await state.UpdateMessage(msg =>
-			{
-				// Note: The change might have been computed on an older version of the collection
-				// We are NOT validating this. It means that we cou;d get an out-of-range for remove for instance.
-
-				var currentItems = msg.CurrentData.SomeOrDefault();
-				var currentHead = currentItems switch
+			=> await state.UpdateMessage(
+				msg =>
 				{
-					IDifferentialCollection diffCollection => diffCollection.Head,
-					null => new EmptyNode(),
-					_ => new ResetNode<T>(currentItems)
-				};
-				var newHead = change(currentHead);
-				var newItems = new DifferentialImmutableList<T>(newHead) as IImmutableList<T>;
+					// Note: The change might have been computed on an older version of the collection
+					// We are NOT validating this. It means that we cou;d get an out-of-range for remove for instance.
 
-				msg.Data(newItems).Set(BindableViewModelBase.BindingSource, collection);
-			},
+					var currentItems = msg.CurrentData.SomeOrDefault();
+					var currentHead = currentItems switch
+					{
+						IDifferentialCollection diffCollection => diffCollection.Head,
+						null => new EmptyNode(),
+						_ => new ResetNode<T>(currentItems)
+					};
+					var newHead = change(currentHead);
+					var newItems = new DifferentialImmutableList<T>(newHead) as IImmutableList<T>;
+
+					msg.Data(newItems).Set(BindableViewModelBase.BindingSource, collection);
+				},
 				ct);
 
 		return collection;

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/BranchStrategy.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/BranchStrategy.cs
@@ -84,7 +84,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 
 			// Init the flat tracking view (ie. the flatten view of the groups that can be consumed directly by the ICollectionView properties)
 			var flatCollectionChanged = new FlatCollectionChangedFacet(() => view ?? throw new InvalidOperationException("The owner provider must be resolved lazily!"));
-			var flatSelectionFacet = new SelectionFacet(source, () => view ?? throw new InvalidOperationException("The owner provider must be resolved lazily!"));
+			var flatSelectionFacet = new SelectionFacet(source, flatCollectionChanged, () => view ?? throw new InvalidOperationException("The owner provider must be resolved lazily!"));
 			var flatPaginationFacet = new PaginationFacet(source, flatCollectionChanged, extendedPropertiesFacet);
 
 			// Init the groups tracking

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/LeafStrategy.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Data/LeafStrategy.cs
@@ -35,7 +35,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data
 			if (_isRoot) // I.e. Collection is not grouped
 			{
 				var paginationFacet = new PaginationFacet(source, collectionChangedFacet, extendedPropertiesFacet);
-				var selectionFacet = new SelectionFacet(source, () => view ?? throw new InvalidOperationException("The owner provider must be resolved lazily!"));
+				var selectionFacet = new SelectionFacet(source, collectionChangedFacet, () => view ?? throw new InvalidOperationException("The owner provider must be resolved lazily!"));
 				var editionFacet = new EditionFacet(source, collectionFacet);
 
 				view = new BasicView(collectionFacet, collectionChangedFacet, extendedPropertiesFacet, selectionFacet, paginationFacet, editionFacet);

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/SelectionFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/SelectionFacet.cs
@@ -2,72 +2,85 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Windows.Foundation.Collections;
+using Uno.Extensions.Collections;
 using Uno.Extensions.Reactive.Bindings.Collections.Services;
 using Uno.Extensions.Reactive.Dispatching;
 
-namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets
+namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facets;
+
+/// <summary>
+/// The selection facet of the ICollectionView
+/// </summary>
+internal class SelectionFacet : IDisposable, ISelectionInfo
 {
-	/// <summary>
-	/// The selection facet of the ICollectionView
-	/// </summary>
-	internal class SelectionFacet : IDisposable, ISelectionInfo
+	/* 
+	* Note: The selection is sync between the ListView and the CollectionView only when SelectionMode is 'Single'
+	*		 
+	*		 For modes 'Multiple' and 'Extended' the ListView notifies using the `ISelectionInfo` interface.
+	*		 
+	*		 When we cycle between the selection modes, only the selection made in 'Single' is kept 
+	*		 (ie. the selection made in other modes is flushed when mode change, and the 'None' doesn't alter the Current on the collection View)
+	*		 
+	*		 When we unselect the 'CurrentItem', list view calls 'MoveCurrentTo(null)'.
+	*/
+
+	private readonly EventRegistrationTokenTable<CurrentChangedEventHandler> _currentChanged = new();
+	private readonly EventRegistrationTokenTable<CurrentChangingEventHandler> _currentChanging = new();
+	private readonly ISelectionService? _service;
+	private readonly Lazy<IObservableVector<object>> _target;
+	private readonly IDispatcher? _dispatcher;
+	private readonly CollectionChangedFacet _collectionChangedFacet;
+
+	private bool _isInit;
+
+	public SelectionFacet(IBindableCollectionViewSource source, CollectionChangedFacet collectionChangedFacet, Func < IObservableVector<object>> target)
 	{
-		/* 
-		 * Note: The selection is sync beetween the ListView and the CollectionView only when SelectionMode is 'Single'
-		 *		 
-		 *		 For modes 'Multiple'and 'Extended' the ListView doesn't notify the CollectionView in any way.
-		 *		 
-		 *		 When we cycle between the selection modes, only the selection made in 'Single' is kept 
-		 *		 (ie. the selection made in other modes is flushed when mode change, and the 'None' doesn't alter the Current on the collection View)
-		 *		 
-		 *		 When we unselect the 'CurrentItem', list view calls 'MoveCurrentTo(null)'.
-		 * 
-		 */
+		_service = source.GetService(typeof(ISelectionService)) as ISelectionService;
+		_target = new Lazy<IObservableVector<object>>(target, LazyThreadSafetyMode.None);
+		_dispatcher = source.Dispatcher;
+		_collectionChangedFacet = collectionChangedFacet;
+	}
 
-		private readonly EventRegistrationTokenTable<CurrentChangedEventHandler> _currentChanged = new();
-		private readonly EventRegistrationTokenTable<CurrentChangingEventHandler> _currentChanging = new();
-		private readonly ISelectionService? _service;
-		private readonly Lazy<IObservableVector<object>> _target;
-		private readonly IDispatcher? _dispatcher;
+	private void Init()
+	{
+		// Note: As the OnServiceStateChanged might cause a SetCurrent, which will try to resolve the _target,
+		//		 we must keep this Init lazy.
 
-		private bool _isInit;
-
-		public SelectionFacet(IBindableCollectionViewSource source, Func<IObservableVector<object>> target)
+		if (_isInit)
 		{
-			_service = source.GetService(typeof(ISelectionService)) as ISelectionService;
-			_target = new Lazy<IObservableVector<object>>(target, LazyThreadSafetyMode.None);
-			_dispatcher = source.Dispatcher;
+			return;
+		}
+		_isInit = true;
+
+		if (_service is not null)
+		{
+			_service.StateChanged += OnServiceStateChanged;
+			OnServiceStateChanged(_service, EventArgs.Empty);
+		}
+		_collectionChangedFacet.AddCollectionChangedHandler(RestoreCurrentItemOnSourceChanged, lowPriority: true);
+	}
+
+	private void OnServiceStateChanged(object? snd, EventArgs args)
+	{
+		if (_service!.IsSelected(CurrentPosition))
+		{
+			return;
 		}
 
-		private void Init()
+		var ranges = _service.GetSelectedRanges();
+
+#if __WINDOWS__
+		UpdateLocalSelection(ranges);
+#endif
+
+		if (!_service.IsSelected(CurrentPosition))
 		{
-			// Note: As the OnServiceStateChanged might cause a SetCurrent, which will try to resolve the _target,
-			//		 we must keep this Init lazy.
-
-			if (_isInit)
-			{
-				return;
-			}
-			_isInit = true;
-
-			if (_service is not null)
-			{
-				_service.StateChanged += OnServiceStateChanged;
-				OnServiceStateChanged(_service, EventArgs.Empty);
-			}
-		}
-
-		private void OnServiceStateChanged(object? snd, EventArgs args)
-		{
-			if (_service!.IsSelected(CurrentPosition))
-			{
-				return;
-			}
-
-			var index = _service.GetSelectedRanges().FirstOrDefault()?.FirstIndex ?? -1;
+			var index = ranges.FirstOrDefault()?.FirstIndex ?? -1;
 			if (_dispatcher is null or { HasThreadAccess: true })
 			{
 				MoveCurrentToPosition(index);
@@ -77,161 +90,279 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Facet
 				_dispatcher.TryEnqueue(() => MoveCurrentToPosition(index));
 			}
 		}
+	}
 
-		#region ICollectionView.Current
-		public EventRegistrationToken AddCurrentChangedHandler(CurrentChangedEventHandler value)
+	private void RestoreCurrentItemOnSourceChanged(object? sender, NotifyCollectionChangedEventArgs args)
+	{
+		// Note about the usage of the CurrentPosition here:
+		//		The ListView won't sync the Current<Item|Position> is the source implements ISelectionRange
+		//		BUT it will still listen to CurrentChanged event.
+		//		We keep it in sync on our side (cf. SelectRange and DeselectRange), so if the SelectedItem is updated by the VM (Replace with IsReplaceOfSameEntities flag),
+		//		we are be able to properly restore it here.
+		// Note: This will work only for the first selected item, i.e. only for SelectionMode.Single which is the main case we are interested in (master-details).
+
+		// Other actions (like Remove and Reset) will be pushed by the ListView itself.
+
+		if (args is RichNotifyCollectionChangedEventArgs { Action: NotifyCollectionChangedAction.Replace, IsReplaceOfSameEntities: true }
+			&& CurrentPosition >= args.OldStartingIndex
+			&& CurrentPosition < args.OldStartingIndex + args.OldItems!.Count)
 		{
-			Init();
-			return _currentChanged.AddEventHandler(value);
+			MoveCurrentToPosition(CurrentPosition, isCancelable: false, isSelectionRangeUpdate: true);
 		}
+	}
+
+	#region ICollectionView.Current (Single selection mode)
+	public EventRegistrationToken AddCurrentChangedHandler(CurrentChangedEventHandler value)
+	{
+		Init();
+		return _currentChanged.AddEventHandler(value);
+	}
 
 #if USE_EVENT_TOKEN
-		public void RemoveCurrentChangedHandler(EventRegistrationToken value)
-		{
-			Init();
-			_currentChanged.RemoveEventHandler(value);
-		}
+	public void RemoveCurrentChangedHandler(EventRegistrationToken value)
+	{
+		Init();
+		_currentChanged.RemoveEventHandler(value);
+	}
 #endif
 
-		public void RemoveCurrentChangedHandler(CurrentChangedEventHandler value)
-		{
-			Init();
-			_currentChanged.RemoveEventHandler(value);
-		}
+	public void RemoveCurrentChangedHandler(CurrentChangedEventHandler value)
+	{
+		Init();
+		_currentChanged.RemoveEventHandler(value);
+	}
 
-		public EventRegistrationToken AddCurrentChangingHandler(CurrentChangingEventHandler value)
-		{
-			Init();
-			return _currentChanging.AddEventHandler(value);
-		}
+	public EventRegistrationToken AddCurrentChangingHandler(CurrentChangingEventHandler value)
+	{
+		Init();
+		return _currentChanging.AddEventHandler(value);
+	}
 
 #if USE_EVENT_TOKEN
-		public void RemoveCurrentChangingHandler(EventRegistrationToken value)
-		{
-			Init();
-			_currentChanging.RemoveEventHandler(value);
-		}
+	public void RemoveCurrentChangingHandler(EventRegistrationToken value)
+	{
+		Init();
+		_currentChanging.RemoveEventHandler(value);
+	}
 #endif
 
-		public void RemoveCurrentChangingHandler(CurrentChangingEventHandler value)
+	public void RemoveCurrentChangingHandler(CurrentChangingEventHandler value)
+	{
+		Init();
+		_currentChanging.RemoveEventHandler(value);
+	}
+
+	public object? CurrentItem { get; private set; }
+
+	public int CurrentPosition { get; private set; } = -1; // -1 means nothing is selected
+
+	public bool IsCurrentAfterLast => false;
+
+	public bool IsCurrentBeforeFirst
+	{
+		get
 		{
 			Init();
-			_currentChanging.RemoveEventHandler(value);
+			return CurrentPosition < 0;
 		}
+	}
 
-		public object? CurrentItem { get; private set; }
+	public bool MoveCurrentTo(object item)
+	{
+		Init();
 
-		public int CurrentPosition { get; private set; } = -1; // -1 means nothing is selected
-
-		public bool IsCurrentAfterLast => false;
-
-		public bool IsCurrentBeforeFirst
+		if (item == null)
 		{
-			get
-			{
-				Init();
-				return CurrentPosition < 0;
-			}
+			return SetCurrent(-1, null);
 		}
-
-		public bool MoveCurrentTo(object item)
+		else
 		{
-			Init();
+			var index = _target.Value.IndexOf(item);
 
-			if (item == null)
-			{
-				return SetCurrent(-1, null);
-			}
-			else
-			{
-				var index = _target.Value.IndexOf(item);
-
-				return index >= 0 && SetCurrent(index, item);
-			}
+			return index >= 0 && SetCurrent(index, item);
 		}
+	}
 
-		public bool MoveCurrentToPosition(int index)
+	public bool MoveCurrentToPosition(int index)
+		=> MoveCurrentToPosition(index, isCancelable: true, isSelectionRangeUpdate: false);
+
+	private bool MoveCurrentToPosition(int index, bool isCancelable, bool isSelectionRangeUpdate)
+	{
+		Init();
+
+		if (index < 0)
 		{
-			Init();
-
-			if (index < 0)
-			{
-				return SetCurrent(-1, null);
-			}
-			else
-			{
-				return index < _target.Value.Count && SetCurrent(index, _target.Value[index]);
-			}
+			return SetCurrent(-1, null, isCancelable, isSelectionRangeUpdate);
 		}
-
-		public bool MoveCurrentToFirst() => MoveCurrentToPosition(0); // No needs to Init: are not using any Current***
-
-		public bool MoveCurrentToLast() => MoveCurrentToPosition(_target.Value.Count - 1); // No needs to Init: are not using any Current***
-
-		public bool MoveCurrentToNext()
+		else
 		{
-			Init();
-			return CurrentPosition + 1 < _target.Value.Count && MoveCurrentToPosition(CurrentPosition + 1);
+			return index < _target.Value.Count && SetCurrent(index, _target.Value[index], isCancelable, isSelectionRangeUpdate);
 		}
+	}
 
-		public bool MoveCurrentToPrevious()
+	public bool MoveCurrentToFirst() => MoveCurrentToPosition(0); // No needs to Init: are not using any Current***
+
+	public bool MoveCurrentToLast() => MoveCurrentToPosition(_target.Value.Count - 1); // No needs to Init: are not using any Current***
+
+	public bool MoveCurrentToNext()
+	{
+		Init();
+		return CurrentPosition + 1 < _target.Value.Count && MoveCurrentToPosition(CurrentPosition + 1);
+	}
+
+	public bool MoveCurrentToPrevious()
+	{
+		Init();
+		return CurrentPosition > 0 && MoveCurrentToPosition(CurrentPosition - 1);
+	}
+
+	private bool SetCurrent(int index, object? value, bool isCancelable = true, bool isSelectionRangeUpdate = false)
+	{
+		if (CurrentPosition == index && EqualityComparer<object?>.Default.Equals(CurrentItem, value))
 		{
-			Init();
-			return CurrentPosition > 0 && MoveCurrentToPosition(CurrentPosition - 1);
-		}
-
-		private bool SetCurrent(int index, object? value, bool isCancelable = true)
-		{
-			if (CurrentPosition == index && EqualityComparer<object?>.Default.Equals(CurrentItem, value))
-			{
-				// Current is already up to date, do not raise events for nothing!
-				return true;
-			}
-
-			var changing = _currentChanging.InvocationList;
-			if (changing != null)
-			{
-				var args = new CurrentChangingEventArgs(isCancelable);
-				changing.Invoke(this, args);
-				if (isCancelable && args.Cancel)
-				{
-					return false;
-				}
-			}
-
-			CurrentPosition = index;
-			CurrentItem = value;
-
-			SelectRange(new ItemIndexRange(index, 1));
-
-			_currentChanged.InvocationList?.Invoke(this, CurrentItem);
-
+			// Current is already up to date, do not raise events for nothing!
 			return true;
-		} 
-		#endregion
+		}
 
-		/// <inheritdoc />
-		public void SelectRange(ItemIndexRange itemIndexRange)
-			=> _service?.SelectRange(itemIndexRange);
-
-		/// <inheritdoc />
-		public void DeselectRange(ItemIndexRange itemIndexRange)
-			=> _service?.DeselectRange(itemIndexRange);
-
-		/// <inheritdoc />
-		public bool IsSelected(int index)
-			=> _service?.IsSelected(index) ?? false;
-
-		/// <inheritdoc />
-		public IReadOnlyList<ItemIndexRange> GetSelectedRanges()
-			=> _service?.GetSelectedRanges() ?? Array.Empty<ItemIndexRange>();
-
-		public void Dispose()
+		var changing = _currentChanging.InvocationList;
+		if (changing != null)
 		{
-			if (_service is not null)
+			var args = new CurrentChangingEventArgs(isCancelable);
+			changing.Invoke(this, args);
+			if (isCancelable && args.Cancel)
 			{
-				_service.StateChanged -= OnServiceStateChanged;
+				return false;
 			}
 		}
+
+		var oldPosition = CurrentPosition;
+
+		CurrentPosition = index;
+		CurrentItem = value;
+
+		if (!isSelectionRangeUpdate)
+		{
+			if (index >= 0)
+			{
+				SelectRange(new ItemIndexRange(index, 1));
+			}
+			else if (oldPosition >= 0)
+			{
+				// Note: we unselect only if the new position is -1 (and old was not -1), otherwise we would prevent multi-selection!
+				DeselectRange(new ItemIndexRange(oldPosition, 1));
+			}
+		}
+
+		_currentChanged.InvocationList?.Invoke(this, CurrentItem);
+
+		return true;
+	}
+	#endregion
+
+	#region ISelectionInfo (Multi selection modes)
+	/// <inheritdoc />
+	public void SelectRange(ItemIndexRange itemIndexRange)
+	{
+		if (_service is null)
+		{
+			return;
+		}
+
+#if __WINDOWS__
+		Debug.Assert(itemIndexRange.Length is 1); // Required for local coercing
+		_localSelection.Add(itemIndexRange);
+#endif
+		_service.SelectRange(itemIndexRange);
+
+		if (_service.GetSelectedRanges() is { Count: 1 } selection)
+		{
+			MoveCurrentToPosition(selection.First().FirstIndex, isCancelable: false, isSelectionRangeUpdate: true);
+		}
+	}
+
+	/// <inheritdoc />
+	public void DeselectRange(ItemIndexRange itemIndexRange)
+	{
+		if (_service is null)
+		{
+			return;
+		}
+
+#if __WINDOWS__
+		_localSelection.Remove(itemIndexRange);
+#endif
+		_service.DeselectRange(itemIndexRange);
+
+		if (CurrentPosition >= itemIndexRange.FirstIndex
+			&& CurrentPosition <= itemIndexRange.LastIndex
+			&& _service.GetSelectedRanges() is { Count: >= 1 } selection)
+		{
+			MoveCurrentToPosition(selection.First().FirstIndex, isCancelable: false, isSelectionRangeUpdate: true);
+		}
+	}
+
+	/// <inheritdoc />
+	public bool IsSelected(int index)
+		=> _service?.IsSelected(index) ?? false;
+
+#if __WINDOWS__
+	// On Windows the ListView does not accept to coerce the ranges.
+	// Instead we try to keep the range instances provided by the ListView.
+	private readonly List<ItemIndexRange> _localSelection = new();
+
+	/// <inheritdoc />
+	public IReadOnlyList<ItemIndexRange> GetSelectedRanges()
+		=> _localSelection;
+
+	private void UpdateLocalSelection(IReadOnlyList<ItemIndexRange> svcRanges)
+	{
+		// Here we make sure that 'ranges' we are receiving from the _service are the same as _localSelection
+		// Note: We assume that the ListView on window creates only range of 1 item.
+
+		if (_localSelection is { Count: 0 })
+		{
+			_localSelection.AddRange(svcRanges);
+			return;
+		}
+
+		var localIndexes = _localSelection
+			.SelectMany(r => Enumerable.Range(r.FirstIndex, (int)r.Length))
+			.ToList();
+
+		var serviceIndexes = svcRanges
+			.SelectMany(r => Enumerable.Range(r.FirstIndex, (int)r.Length))
+			.ToList();
+
+		foreach (var index in serviceIndexes)
+		{
+			if (!localIndexes.Contains(index))
+			{
+				_localSelection.Add(new ItemIndexRange(index, 1));
+			}
+		}
+
+		foreach (var index in localIndexes)
+		{
+			if (!serviceIndexes.Contains(index))
+			{ 
+				_localSelection.RemoveAll(r => r.FirstIndex == index);
+			}
+		}
+	}
+#else
+	/// <inheritdoc />
+	public IReadOnlyList<ItemIndexRange> GetSelectedRanges()
+		=> _service?.GetSelectedRanges() ?? Array.Empty<ItemIndexRange>();
+#endif
+
+	#endregion
+
+	public void Dispose()
+	{
+		if (_service is not null)
+		{
+			_service.StateChanged -= OnServiceStateChanged;
+		}
+		_collectionChangedFacet.RemoveCollectionChangedHandler(RestoreCurrentItemOnSourceChanged, lowPriority: true);
 	}
 }

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/SelectionService.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/SelectionService.cs
@@ -27,7 +27,6 @@ internal sealed class SelectionService : ISelectionService, IDisposable, ISelect
 		_setSelectionFromView = setSelectionFromView;
 	}
 
-
 	#region Change selection from source
 	public void SetFromSource(SelectionInfo selection)
 	{

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Differential/DifferentialImmutableList.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Differential/DifferentialImmutableList.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -49,39 +50,39 @@ internal sealed class DifferentialImmutableList<T> : IImmutableList<T>, IDiffere
 	}
 
 	/// <inheritdoc />
-	public int IndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
+	[Pure] public int IndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
 		=> Head.IndexOf(item, index, equalityComparer?.ToEqualityComparer());
 
 	/// <inheritdoc />
-	public int LastIndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
+	[Pure] public int LastIndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
 		=> throw new NotSupportedException();
 
 	/// <inheritdoc cref="IImmutableList{T}" />
-	public DifferentialImmutableList<T> Add(T value) => new (new AddNode(Head, value!, Count));
-	IImmutableList<T> IImmutableList<T>.Add(T value) => Add(value);
+	[Pure] public DifferentialImmutableList<T> Add(T value) => new (new AddNode(Head, value!, Count));
+	[Pure] IImmutableList<T> IImmutableList<T>.Add(T value) => Add(value);
 
 	/// <inheritdoc cref="IImmutableList{T}" />
-	public DifferentialImmutableList<T> AddRange(IImmutableList<T> items) => new(new AddNode(Head, items.AsUntypedList(), Count));
-	IImmutableList<T> IImmutableList<T>.AddRange(IEnumerable<T> items) => AddRange(items.ToImmutableList());
+	[Pure] public DifferentialImmutableList<T> AddRange(IImmutableList<T> items) => new(new AddNode(Head, items.AsUntypedList(), Count));
+	[Pure] IImmutableList<T> IImmutableList<T>.AddRange(IEnumerable<T> items) => AddRange(items.ToImmutableList());
 
 	/// <inheritdoc cref="IImmutableList{T}" />
-	public DifferentialImmutableList<T> Insert(int index, T element) => new(new AddNode(Head, element!, index));
-	IImmutableList<T> IImmutableList<T>.Insert(int index, T element) => Insert(index, element);
+	[Pure] public DifferentialImmutableList<T> Insert(int index, T element) => new(new AddNode(Head, element!, index));
+	[Pure] IImmutableList<T> IImmutableList<T>.Insert(int index, T element) => Insert(index, element);
 
 	/// <inheritdoc cref="IImmutableList{T}" />
-	public DifferentialImmutableList<T> InsertRange(int index, IImmutableList<T> items) => new(new AddNode(Head, items.AsUntypedList(), index));
-	IImmutableList<T> IImmutableList<T>.InsertRange(int index, IEnumerable<T> items) => InsertRange(index, items.ToImmutableList());
+	[Pure] public DifferentialImmutableList<T> InsertRange(int index, IImmutableList<T> items) => new(new AddNode(Head, items.AsUntypedList(), index));
+	[Pure] IImmutableList<T> IImmutableList<T>.InsertRange(int index, IEnumerable<T> items) => InsertRange(index, items.ToImmutableList());
 
 	/// <inheritdoc cref="IImmutableList{T}" />
-	public DifferentialImmutableList<T> Remove(T value, IEqualityComparer<T> equalityComparer)
+	[Pure] public DifferentialImmutableList<T> Remove(T value, IEqualityComparer<T> equalityComparer)
 	{
 		var index = Head.IndexOf(value, 0, equalityComparer?.ToEqualityComparer());
 		return new(new RemoveNode(Head, value, index));
 	}
-	IImmutableList<T> IImmutableList<T>.Remove(T value, IEqualityComparer<T> equalityComparer) => Remove(value, equalityComparer);
+	[Pure] IImmutableList<T> IImmutableList<T>.Remove(T value, IEqualityComparer<T> equalityComparer) => Remove(value, equalityComparer);
 
 	/// <inheritdoc cref="IImmutableList{T}" />
-	public DifferentialImmutableList<T> RemoveAll(Predicate<T> match)
+	[Pure] public DifferentialImmutableList<T> RemoveAll(Predicate<T> match)
 	{
 		var head = Head;
 		for (var i = Count - 1; i >= 0; i--)
@@ -95,32 +96,49 @@ internal sealed class DifferentialImmutableList<T> : IImmutableList<T>, IDiffere
 
 		return new(head);
 	}
-	IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) => RemoveAll(match);
+	[Pure] IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) => RemoveAll(match);
 
 	/// <inheritdoc cref="IImmutableList{T}" />
 	//public DifferentialImmutableList<T> RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer)
-	IImmutableList<T> IImmutableList<T>.RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer) => throw new NotSupportedException();
+	[Pure] IImmutableList<T> IImmutableList<T>.RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer) => throw new NotSupportedException();
 
 	/// <inheritdoc cref="IImmutableList{T}" />
-	public DifferentialImmutableList<T> RemoveRange(int index, int count) => new(new RemoveNode(Head, index, count));
-	IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) => RemoveRange(index, count);
+	[Pure] public DifferentialImmutableList<T> RemoveRange(int index, int count) => new(new RemoveNode(Head, index, count));
+	[Pure] IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) => RemoveRange(index, count);
 
 
 	/// <inheritdoc cref="IImmutableList{T}" />
-	public DifferentialImmutableList<T> RemoveAt(int index) => new(new RemoveNode(Head, index, 1));
-	IImmutableList<T> IImmutableList<T>.RemoveAt(int index) => RemoveAt(index);
+	[Pure] public DifferentialImmutableList<T> RemoveAt(int index) => new(new RemoveNode(Head, index, 1));
+	[Pure] IImmutableList<T> IImmutableList<T>.RemoveAt(int index) => RemoveAt(index);
 
 	/// <inheritdoc cref="IImmutableList{T}" />
-	public DifferentialImmutableList<T> Clear() => new(new EmptyNode());
-	IImmutableList<T> IImmutableList<T>.Clear() => Clear();
+	[Pure] public DifferentialImmutableList<T> Clear() => new(new EmptyNode());
+	[Pure] IImmutableList<T> IImmutableList<T>.Clear() => Clear();
 
 	/// <inheritdoc cref="IImmutableList{T}" />
-	public DifferentialImmutableList<T> SetItem(int index, T value) => new(new ReplaceNode(Head, value, index));
-	IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) => SetItem(index, value);
+	[Pure] public DifferentialImmutableList<T> SetItem(int index, T value) => new(new ReplaceNode(Head, value, index));
+	[Pure] IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) => SetItem(index, value);
 
 	/// <inheritdoc cref="IImmutableList{T}" />
 	//public DifferentialImmutableList<T> Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer) => throw new NotSupportedException();
-	IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer) => throw new NotSupportedException();
+	[Pure] IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer) => throw new NotSupportedException();
+
+	/// <summary>
+	/// Moves a range of items within the collection
+	/// </summary>
+	/// <param name="fromIndex">The original index of moved items</param>
+	/// <param name="toIndex">The target index of moved items</param>
+	/// <param name="count">The count of moved items</param>
+	/// <returns>A new instance of immutable list where items has been moved.</returns>
+	[Pure] public DifferentialImmutableList<T> MoveRange(int fromIndex, int toIndex, int count) => new(new MoveNode(Head, fromIndex, toIndex, count));
+
+	/// <summary>
+	/// Moves a range of items within the collection
+	/// </summary>
+	/// <param name="index">Index of the element that is being replaced.</param>
+	/// <param name="newValue">The new value</param>
+	/// <returns>A new instance of immutable list where item has been replaced.</returns>
+	[Pure] public DifferentialImmutableList<T> ReplaceAt(int index, T newValue) => new(new ReplaceNode(Head, Head.ElementAt(index), newValue, index));
 
 	/// <inheritdoc />
 	bool IList.Contains(object value) => ((IList)this).IndexOf(value) >= 0;
@@ -144,10 +162,10 @@ internal sealed class DifferentialImmutableList<T> : IImmutableList<T>, IDiffere
 	void IList.Clear() => throw NotSupported();
 
 	/// <inheritdoc />
-	public IEnumerator<T> GetEnumerator() => new Enumerator<T>(Head);
+	[Pure] public IEnumerator<T> GetEnumerator() => new Enumerator<T>(Head);
 
 	/// <inheritdoc />
-	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	[Pure] IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 	/// <inheritdoc />
 	public void CopyTo(Array array, int index)

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Differential/MoveNode.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Differential/MoveNode.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Specialized;
 using System.Linq;
+using Uno.Extensions.Reactive.Utils;
 
 namespace Uno.Extensions.Collections.Facades.Differential;
 
@@ -25,6 +26,22 @@ internal sealed class MoveNode : IDifferentialCollectionNode
 		_oldFromIndex = arg.OldStartingIndex;
 		_oldToIndex = _oldFromIndex + _movedCount;
 		_newFromIndex = arg.NewStartingIndex;
+		_newToIndex = _newFromIndex + _movedCount;
+
+		_isBackward = _oldFromIndex > _newFromIndex;
+	}
+
+	public MoveNode(IDifferentialCollectionNode previous, int fromIndex, int toIndex, int count)
+	{
+		Previous = previous;
+		Count = previous.Count;
+
+		_moved = previous.AsList().Slice(fromIndex, count);
+		_movedCount = count;
+
+		_oldFromIndex = fromIndex;
+		_oldToIndex = _oldFromIndex + _movedCount;
+		_newFromIndex = toIndex;
 		_newToIndex = _newFromIndex + _movedCount;
 
 		_isBackward = _oldFromIndex > _newFromIndex;

--- a/src/Uno.Extensions.Reactive/Collections/RichNotifyCollectionChangedEventArgs.cs
+++ b/src/Uno.Extensions.Reactive/Collections/RichNotifyCollectionChangedEventArgs.cs
@@ -61,26 +61,40 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Replace"/> collection changed event args
 	/// </summary>
-	public static RichNotifyCollectionChangedEventArgs Replace(object? oldItem, object? newItem, int index)
+	public static RichNotifyCollectionChangedEventArgs Replace(object? oldItem, object? newItem, int index, bool isReplaceOfSameEntity = false)
 		=> new(NotifyCollectionChangedAction.Replace, new[] { newItem }, new[] { oldItem }, index);
 
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Replace"/> collection changed event args
 	/// </summary>
-	public static RichNotifyCollectionChangedEventArgs Replace<T>(T oldItem, T newItem, int index)
-		=> new(NotifyCollectionChangedAction.Replace, new[] { newItem }, new[] { oldItem }, index);
+	public static RichNotifyCollectionChangedEventArgs Replace<T>(T oldItem, T newItem, int index, bool isReplaceOfSameEntity = false)
+		=> new(NotifyCollectionChangedAction.Replace, new[] { newItem }, new[] { oldItem }, index) { IsReplaceOfSameEntities = isReplaceOfSameEntity};
 
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Replace"/> collection changed event args
 	/// </summary>
-	public static RichNotifyCollectionChangedEventArgs ReplaceSome(IList oldItems, IList newItems, int index)
-		=> new(NotifyCollectionChangedAction.Replace, newItems, oldItems, index);
+	public static RichNotifyCollectionChangedEventArgs ReplaceSome(IList oldItems, IList newItems, int index, bool isReplaceOfSameEntities = false)
+	{
+		if (isReplaceOfSameEntities && oldItems.Count != newItems.Count)
+		{
+			throw new InvalidOperationException("For a replace flagged with isReplaceOfSameEntities (a.k.a. update), the number of oldItems must be the same as newItems.");
+		}
+
+		return new(NotifyCollectionChangedAction.Replace, newItems, oldItems, index) { IsReplaceOfSameEntities = isReplaceOfSameEntities };
+	}
 
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Replace"/> collection changed event args
 	/// </summary>
-	public static RichNotifyCollectionChangedEventArgs ReplaceSome<T>(IList<T> oldItems, IList<T> newItems, int index)
-		=> new(NotifyCollectionChangedAction.Replace, newItems.AsUntypedList(), oldItems.AsUntypedList(), index);
+	public static RichNotifyCollectionChangedEventArgs ReplaceSome<T>(IList<T> oldItems, IList<T> newItems, int index, bool isReplaceOfSameEntities = false)
+	{
+		if (isReplaceOfSameEntities && oldItems.Count != newItems.Count)
+		{
+			throw new InvalidOperationException("For a replace flagged with isReplaceOfSameEntities (a.k.a. update), the number of oldItems must be the same as newItems.");
+		}
+
+		return new(NotifyCollectionChangedAction.Replace, newItems.AsUntypedList(), oldItems.AsUntypedList(), index) { IsReplaceOfSameEntities = isReplaceOfSameEntities };
+	}
 
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Move"/> collection changed event args
@@ -190,6 +204,13 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 		: base(action, changedItems, index, oldIndex)
 	{
 	}
+
+	/// <summary>
+	/// For a Replace change, indicates if entities are actually new versions of the same (same Id / Key, cf. KeyEquality) entities.
+	/// If true, this change should be considered as an "update" instead of a real "replace".
+	/// (I.e. entities have same IDs but have some fields that has been updated).
+	/// </summary>
+	public bool IsReplaceOfSameEntities { get; private set; }
 
 	/// <summary>
 	/// Gets the old items for a reset change

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.ChangesBuffer.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.ChangesBuffer.cs
@@ -95,19 +95,19 @@ partial class CollectionAnalyzer
 			}
 		}
 
-		public void Update(T oldItem, T newItem, int index)
+		public void Keep(T oldItem, T newItem, int index)
 		{
 			// As they don't impact the 'result' index, replace-instance are buffered separately and will be inserted at the top of the changes collection.
 			// Note: We use a single '_Same' node for all updates
 
-			UpdateOrReplace(ref _sameHead, oldItem, newItem, index, (i, o) => new _Same<T>(i, o)); ;
+			KeepOrReplace(ref _sameHead, oldItem, newItem, index, (i, o) => new _Same<T>(i, o)); ;
 		}
 
 		public void Replace(T oldItem, T newItem, int index)
 		{
 			// As they don't impact the 'result' index, replaces are buffered separately and will be inserted at the top of the changes collection.
 
-			UpdateOrReplace(ref _replaceHead, oldItem, newItem, index, (i, o) => new _Replace<T>(i, o));
+			KeepOrReplace(ref _replaceHead, oldItem, newItem, index, (i, o) => new _Replace<T>(i, o, isReplaceOfSameEntities: true));
 		}
 
 		public void Add(T item, int at, int max)
@@ -137,7 +137,7 @@ partial class CollectionAnalyzer
 			remove.Append(item);
 		}
 
-		private void UpdateOrReplace<TNode>(ref TNode? head, T oldItem, T newItem, int index, Func<int, int, TNode> factory)
+		private void KeepOrReplace<TNode>(ref TNode? head, T oldItem, T newItem, int index, Func<int, int, TNode> factory)
 			where TNode : EntityChange<T>
 		{
 			if (head is null)

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Core.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Core.cs
@@ -164,22 +164,23 @@ internal partial class CollectionAnalyzer
 		*  (we already determined that they have the same key using the 'itemComparer').
 		*
 		*	If the 'itemVersionComparer' is 'null' we assume that there is no
-		*	notion of version of an item and we rely only on the `itemComparer` to check equality.
+		*	notion of version of an item and we rely only on the `itemComparer` to check (true/full) equality.
 		*	Note: in this case we don't raise any 'Replace'.
 		*
-		*	If the 'itemVersionComparer' returns 'true' (or if it's 'null') that means that they are not only KeyEquals but also Equals.
+		*	If the 'itemVersionComparer' returns 'true' that means that they are not only KeyEquals but also Equals.
 		*	So as we are usually working with immutable objects, we can ignore that a new instance is available and
-		*  we don't raise any event ('changesBuffer.Update'). Note: We still have to notify the visitor!
+		*	we don't raise any event ('changesBuffer.Update'). Note: We still have to notify the visitor!
 		*
-		*  If the 'itemVersionComparer' returns 'false' that means items are only key equals, but not same version.
-		*  So we have to raise a 'Replace' event.
+		*	If the 'itemVersionComparer' returns 'false' that means items are only key equals, but not same version.
+		*	So we have to raise a 'Replace' event.
+		*	Note: The replace event is flagged as "SameEntity" so the view can raise some "INPC.Item[]" instead of real "INCC.Replace"
 		*/
 
 		void UpdateInstanceFromOld(T oldItem, int oldIndex, int newIndex)
 		{
 			if (versionComparer is null)
 			{
-				buffer.Update(oldItem, oldItem, oldIndex);
+				buffer.Keep(oldItem, oldItem, oldIndex);
 
 				return;
 			}
@@ -187,7 +188,7 @@ internal partial class CollectionAnalyzer
 			var newItem = newItems.ElementAt(newIndex);
 			if (versionComparer(oldItem, newItem))
 			{
-				buffer.Update(oldItem, newItem, oldIndex);
+				buffer.Keep(oldItem, newItem, oldIndex);
 			}
 			else
 			{
@@ -199,7 +200,7 @@ internal partial class CollectionAnalyzer
 		{
 			if (versionComparer is null)
 			{
-				buffer.Update(newItem, newItem, oldIndex);
+				buffer.Keep(newItem, newItem, oldIndex);
 
 				return;
 			}
@@ -207,7 +208,7 @@ internal partial class CollectionAnalyzer
 			var oldItem = oldItems.ElementAt(oldIndex);
 			if (versionComparer(oldItem, newItem))
 			{
-				buffer.Update(oldItem, newItem, oldIndex);
+				buffer.Keep(oldItem, newItem, oldIndex);
 			}
 			else
 			{

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Replace.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Replace.cs
@@ -11,14 +11,17 @@ partial class CollectionAnalyzer
 {
 	private sealed class _Replace<T> : EntityChange<T>
 	{
+		private readonly bool _isReplaceOfSameEntities;
+
 		/// <inheritdoc />
-		public _Replace(int at, int indexOffset)
+		public _Replace(int at, int indexOffset, bool isReplaceOfSameEntities = true)
 			: base(at, indexOffset)
 		{
+			_isReplaceOfSameEntities = isReplaceOfSameEntities;
 		}
 
 		public override RichNotifyCollectionChangedEventArgs ToEvent()
-			=> RichNotifyCollectionChangedEventArgs.ReplaceSome<T>(_oldItems, _newItems, Starts + _indexOffset);
+			=> RichNotifyCollectionChangedEventArgs.ReplaceSome<T>(_oldItems, _newItems, Starts + _indexOffset, _isReplaceOfSameEntities);
 
 		/// <inheritdoc />
 		protected internal override void Visit(ICollectionChangeSetVisitor<T> visitor)
@@ -87,7 +90,8 @@ partial class CollectionAnalyzer
 			=> RichNotifyCollectionChangedEventArgs.ReplaceSome(
 				_oldItems.Slice(from, count),
 				_newItems.Slice(from, count),
-				Starts + _indexOffset + from);
+				Starts + _indexOffset + from,
+				_isReplaceOfSameEntities);
 
 		/// <inheritdoc />
 		public override string ToString()

--- a/src/Uno.Extensions.Reactive/Core/Axes/SelectionInfo.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/SelectionInfo.cs
@@ -136,7 +136,7 @@ public sealed record SelectionInfo
 		}
 
 		selectedItem = default!;
-		return true;
+		return false;
 	}
 
 	internal bool TryGetSelectedIndex<T>(IImmutableList<T> items, [NotNullWhen(true)] out uint? selectedIndex, bool failIfOutOfRange = true, bool failIfMultiple = false)

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/CoercingRequestManager.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/CoercingRequestManager.cs
@@ -19,7 +19,7 @@ internal class CoercingRequestManager<TRequest, TToken> : IAsyncEnumerable<Token
 	where TRequest : IContextRequest<TToken>
 	where TToken : class, IToken<TToken>
 {
-	private readonly AsyncEnumerableSubject<TokenSet<TToken>> _tokens = new(ReplayMode.Disabled);
+	private readonly AsyncEnumerableSubject<TokenSet<TToken>> _tokens = new(AsyncEnumerableReplayMode.Disabled);
 	private readonly CancellationToken _ct;
 	private readonly bool _autoPublishInitial;
 

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/SequentialRequestManager.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/SequentialRequestManager.cs
@@ -18,7 +18,7 @@ internal class SequentialRequestManager<TRequest, TToken> : IAsyncEnumerable<Tok
 	where TRequest : IContextRequest<TToken>
 	where TToken : class, IToken<TToken>
 {
-	private readonly AsyncEnumerableSubject<TokenSet<TToken>> _tokens = new(ReplayMode.EnabledForFirstEnumeratorOnly);
+	private readonly AsyncEnumerableSubject<TokenSet<TToken>> _tokens = new(AsyncEnumerableReplayMode.EnabledForFirstEnumeratorOnly);
 	private readonly CancellationToken _ct;
 
 	private TToken _current;

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.T.Internal.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.T.Internal.cs
@@ -26,5 +26,5 @@ static partial class ListFeed<T>
 	internal static CollectionAnalyzer<T> DefaultAnalyzer { get; } = new(DefaultComparer);
 
 	internal static CollectionAnalyzer<T> GetAnalyzer(ItemComparer<T> comparer)
-		=> comparer is { IsNull: true } ? DefaultAnalyzer : new(comparer);
+		=> comparer is { IsNull: true } ? DefaultAnalyzer : new(GetComparer(comparer));
 }

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.cs
@@ -83,17 +83,49 @@ public static partial class ListFeed
 		Predicate<TSource> predicate)
 		=> AttachedProperty.GetOrCreate(source, predicate, static (src, p) => new WhereListFeed<TSource>(src, p));
 
-	//public static IListFeed<TResult> Select<TSource, TResult>(
-	//	this IListFeed<TSource> source,
-	//	Func<TSource?, TResult?> selector)
-	//	=> default!;
+	/// <summary>
+	/// Gets or create a feed that synchronously projects each item of a source list feed.
+	/// </summary>
+	/// <typeparam name="TSource">Type of the items of the list feed.</typeparam>
+	/// <typeparam name="TResult">Type of the items of the resulting feed.</typeparam>
+	/// <param name="source">The source feed to project.</param>
+	/// <param name="selector">The projection method.</param>
+	/// <returns>A feed that projects each item of the source list feed.</returns>
+	public static IListFeed<TResult> Select<TSource, TResult>(
+		this IListFeed<TSource> source,
+		Func<TSource, TResult> selector)
+		=> AttachedProperty.GetOrCreate(source, selector, static (src, s) => new SelectAsyncListFeed<TSource, TResult>(src, s, static async (_, r, _) => r));
 
-	/*
-	public static IFeed<TResult> SelectAsync<TSource, TResult>(
-		this IFeed<TSource> source,
-		AsyncFunc<TSource?, TResult?> selector)
-		=> default!);
-	*/
+	/// <summary>
+	/// Gets or create a feed that asynchronously projects each item of a source list feed.
+	/// </summary>
+	/// <typeparam name="TSource">Type of the items of the list feed.</typeparam>
+	/// <param name="source">The source feed to project.</param>
+	/// <param name="selector">The projection method.</param>
+	/// <returns>A feed that projects each item of the source list feed.</returns>
+	public static IListFeed<TSource> SelectAsync<TSource>(
+		this IListFeed<TSource> source,
+		AsyncFunc<TSource, TSource> selector)
+		=> AttachedProperty.GetOrCreate(source, selector, static (src, s) => new SelectAsyncListFeed<TSource, TSource>(src, static i => i, (_, i, ct) => s(i, ct)));
+
+	/// <summary>
+	/// Gets or create a feed that asynchronously projects each item of a source list feed in a 2 step process.
+	/// </summary>
+	/// <typeparam name="TSource">Type of the items of the list feed.</typeparam>
+	/// <typeparam name="TResult">Type of the items of the resulting feed.</typeparam>
+	/// <param name="source">The source feed to project.</param>
+	/// <param name="syncSelector">The synchronous projection method that will be executed first.</param>
+	/// <param name="asyncSelector">The asynchronous projection method that will be executed after.</param>
+	/// <returns>A feed that projects each item of the source list feed.</returns>
+	/// <remarks>
+	/// The projection is made in 2 steps: first <paramref name="syncSelector"/> will be executed to build a placeholder item,
+	/// then <paramref name="asyncSelector"/> will be invoked to complete the item.
+	/// </remarks>
+	public static IListFeed<TResult> SelectAsync<TSource, TResult>(
+		this IListFeed<TSource> source,
+		Func<TSource, TResult> syncSelector,
+		AsyncFunc<TSource, TResult, TResult> asyncSelector)
+		=> AttachedProperty.GetOrCreate(source, (syncSelector, asyncSelector), static (src, args) => new SelectAsyncListFeed<TSource, TResult>(src, args.syncSelector, args.asyncSelector));
 
 	/// <summary>
 	/// Creates a ListState from a ListFeed onto which the selected items is being synced with the provided external state.

--- a/src/Uno.Extensions.Reactive/Operators/SelectAsyncFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/SelectAsyncFeed.cs
@@ -23,7 +23,7 @@ internal sealed class SelectAsyncFeed<TArg, TResult> : IFeed<TResult>
 	/// <inheritdoc />
 	public IAsyncEnumerable<Message<TResult>> GetSource(SourceContext context, CancellationToken ct)
 	{
-		var subject = new AsyncEnumerableSubject<Message<TResult>>(ReplayMode.EnabledForFirstEnumeratorOnly);
+		var subject = new AsyncEnumerableSubject<Message<TResult>>(AsyncEnumerableReplayMode.EnabledForFirstEnumeratorOnly);
 		var message = new MessageManager<TArg, TResult>(subject.SetNext);
 		var projectionToken = default(CancellationTokenSource);
 		var projection = default(Task);

--- a/src/Uno.Extensions.Reactive/Operators/SelectAsyncListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/SelectAsyncListFeed.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Utils;
+
+namespace Uno.Extensions.Reactive.Operators;
+
+internal class SelectAsyncListFeed<TArg, TResult> : IListFeed<TResult>
+{
+	private readonly IListFeed<TArg> _parent;
+	private readonly Func<TArg, TResult> _syncProjection;
+	private readonly AsyncFunc<TArg, TResult, TResult> _asyncProjection;
+
+	public SelectAsyncListFeed(
+		IListFeed<TArg> parent,
+		Func<TArg, TResult> syncProjection,
+		AsyncFunc<TArg, TResult, TResult> asyncProjection)
+	{
+		_parent = parent;
+		_syncProjection = syncProjection;
+		_asyncProjection = asyncProjection;
+	}
+
+	/// <inheritdoc />
+	public IAsyncEnumerable<Message<IImmutableList<TResult>>> GetSource(SourceContext context, CancellationToken ct = default)
+	{
+		var subject = new AsyncEnumerableSubject<Message<IImmutableList<TResult>>>(AsyncEnumerableReplayMode.EnabledForFirstEnumeratorOnly);
+		var message = new MessageManager<IImmutableList<TArg>, IImmutableList<TResult>>(subject.SetNext);
+		var helper = new ListAsyncProjectionHelper<TArg, TResult>(_syncProjection, _asyncProjection);
+		var isEnumerationCompleted = false;
+
+		BeginEnumeration();
+
+		helper.Updated += OnProjectionUpdated;
+		ct.Register(() => helper.Updated -= OnProjectionUpdated);
+
+		return subject;
+
+		async void BeginEnumeration()
+		{
+			try
+			{
+				var parentEnumerator = context.GetOrCreateSource(_parent).GetAsyncEnumerator(ct);
+				while (await parentEnumerator.MoveNextAsync(ct).ConfigureAwait(false))
+				{
+					var parentMsg = parentEnumerator.Current;
+					if (parentMsg.Changes.Contains(MessageAxis.Data, out var changeSet))
+					{
+						try
+						{
+							var data = parentMsg.Current.Data;
+							switch (data.Type)
+							{
+								case OptionType.Undefined:
+									helper.Update(ImmutableList<TArg>.Empty);
+									message.Update((local, parent) => local.With(parent).Data(Option<IImmutableList<TResult>>.Undefined()).Error(null), parentMsg, ct);
+									break;
+
+								case OptionType.None:
+									helper.Update(ImmutableList<TArg>.Empty);
+									message.Update((local, parent) => local.With(parent).Data(Option<IImmutableList<TResult>>.None()).Error(null), parentMsg, ct);
+									break;
+
+								case OptionType.Some:
+									helper.Update(data.SomeOrDefault() ?? ImmutableList<TArg>.Empty, changeSet);
+									message.Update((local, parent) => local.With(parent).Data(helper.CurrentResult).Error(helper.CurrentError), parentMsg, ct);
+									break;
+
+								default:
+									throw new NotSupportedException($"Data type '{data.Type}' is not supported.");
+							}
+						}
+						catch (Exception error)
+						{
+							// Usually this is because the sync projection failed.
+							message.Update((local, parent) => local.With(parent).Data(Option<IImmutableList<TResult>>.Undefined()).Error(error), parentMsg, ct);
+						}
+					}
+					else
+					{
+						message.Update((local, parent) => local.With(parent), parentMsg, ct);
+					}
+				}
+
+				isEnumerationCompleted = true;
+				if (helper.CurrentPending is 0)
+				{
+					subject.TryComplete();
+				}
+			}
+			catch (Exception error)
+			{
+				subject.TryFail(error);
+			}
+		}
+
+		void OnProjectionUpdated(object? _, EventArgs __)
+		{
+			message.Update(local => local.With().Data(helper.CurrentResult).Error(helper.CurrentError), ct);
+
+			if (isEnumerationCompleted && helper.CurrentPending is 0)
+			{
+				subject.TryComplete();
+			}
+		}
+	}
+}

--- a/src/Uno.Extensions.Reactive/Operators/UpdateFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/UpdateFeed.cs
@@ -24,7 +24,7 @@ internal record FeedUpdate<T>(Func<bool, MessageBuilder<T, T>, bool> IsActive, A
 
 internal sealed class UpdateFeed<T> : IFeed<T>
 {
-	private readonly AsyncEnumerableSubject<(IFeedUpdate<T>[]? added, IFeedUpdate<T>[]? removed)> _updates = new(ReplayMode.Disabled);
+	private readonly AsyncEnumerableSubject<(IFeedUpdate<T>[]? added, IFeedUpdate<T>[]? removed)> _updates = new(AsyncEnumerableReplayMode.Disabled);
 	private readonly IFeed<T> _source;
 
 	public UpdateFeed(IFeed<T> source)
@@ -63,7 +63,7 @@ internal sealed class UpdateFeed<T> : IFeed<T>
 		public UpdateFeedSource(UpdateFeed<T> owner, SourceContext context, CancellationToken ct)
 		{
 			_ct = ct;
-			_subject = new AsyncEnumerableSubject<Message<T>>(ReplayMode.EnabledForFirstEnumeratorOnly);
+			_subject = new AsyncEnumerableSubject<Message<T>>(AsyncEnumerableReplayMode.EnabledForFirstEnumeratorOnly);
 			_message = new MessageManager<T, T>(_subject.SetNext);
 			_activeUpdates = ImmutableList<IFeedUpdate<T>>.Empty;
 

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableImmutableList.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableImmutableList.cs
@@ -47,7 +47,7 @@ public class BindableImmutableList<TItem, TBindableItem> : BindableEnumerable<II
 		// '_analyzer' might be null when the base.ctor subscribe to the 'property' and invokes the 'OnOwnerUpdated'
 		// That's should not happen since the `AutoInit` has been disable, but for safety we fallback on ListFeed<TItem>.DefaultAnalyzer.
 		// This is valid as in that case the 'previous' will be null/empty anyway.
-		=> (_analyzer ?? ListFeed<TItem>.DefaultAnalyzer).GetChanges(previous ?? ImmutableList<TItem>.Empty, current);
+		=> (_analyzer ?? ListFeed<TItem>.DefaultAnalyzer).GetChanges(previous ?? ImmutableList<TItem>.Empty, current ?? ImmutableList<TItem>.Empty);
 
 	private protected override IImmutableList<TItem> Replace(IImmutableList<TItem>? items, TItem oldItem, TItem newItem)
 	{

--- a/src/Uno.Extensions.Reactive/Sources/AsyncFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/AsyncFeed.cs
@@ -29,7 +29,7 @@ internal sealed class AsyncFeed<T> : IFeed<T>, IRefreshableSource
 	/// <inheritdoc />
 	public IAsyncEnumerable<Message<T>> GetSource(SourceContext context, CancellationToken ct = default)
 	{
-		var loadRequests = new AsyncEnumerableSubject<RefreshToken>(ReplayMode.EnabledForFirstEnumeratorOnly);
+		var loadRequests = new AsyncEnumerableSubject<RefreshToken>(AsyncEnumerableReplayMode.EnabledForFirstEnumeratorOnly);
 		var current = RefreshToken.Initial(this, context);
 
 		// Request initial load (without refresh)
@@ -73,7 +73,7 @@ internal sealed class AsyncFeed<T> : IFeed<T>, IRefreshableSource
 		// Note: We prefer to manually enumerate the version instead of using the ForEachAwaitWithCancellationAsync
 		//		 so we have a better control of when we do cancel the 'loadToken' (ak.a. 'previousLoad')
 
-		var subject = new AsyncEnumerableSubject<Message<T>>(ReplayMode.EnabledForFirstEnumeratorOnly);
+		var subject = new AsyncEnumerableSubject<Message<T>>(AsyncEnumerableReplayMode.EnabledForFirstEnumeratorOnly);
 		var message = new MessageManager<T>(subject.SetNext);
 		var loadToken = default(CancellationTokenSource);
 		var load = default(Task);

--- a/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
@@ -31,7 +31,7 @@ internal class PaginatedListFeed<TCursor, TItem> : IListFeed<TItem>, IRefreshabl
 	{
 		var refreshRequests = new CoercingRequestManager<RefreshRequest, RefreshToken>(context, RefreshToken.Initial(this, context), ct);
 		var pageRequests = new CoercingRequestManager<Core.PageRequest, PageToken>(context, PageToken.Initial(this, context), ct);
-		var subject = new AsyncEnumerableSubject<Message<IImmutableList<TItem>>>(ReplayMode.EnabledForFirstEnumeratorOnly);
+		var subject = new AsyncEnumerableSubject<Message<IImmutableList<TItem>>>(AsyncEnumerableReplayMode.EnabledForFirstEnumeratorOnly);
 		var messages = new MessageManager<IImmutableList<TItem>>(subject.SetNext);
 
 		_ = refreshRequests.ForEachAwaitWithCancellationAsync(Load, ConcurrencyMode.AbortPrevious, continueOnError: true, ct);

--- a/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/AsyncEnumerableReplayMode.cs
+++ b/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/AsyncEnumerableReplayMode.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Uno.Extensions.Reactive.Utils;
 
-internal enum ReplayMode
+/// <summary>
+/// Enumeration of the possible replay modes for an <see cref="IAsyncEnumerable{T}"/>
+/// </summary>
+public enum AsyncEnumerableReplayMode
 {
 	/// <summary>
 	/// Does not replay any value
@@ -13,6 +17,9 @@ internal enum ReplayMode
 	/// <summary>
 	/// Replays the whole collection from the first item (like an async List&lt;T&gt;)
 	/// </summary>
+	/// <remarks>
+	/// Use with caution as this will leak all value produced by the <see cref="AsyncEnumerableSubject{T}"/>.
+	/// </remarks>
 	Enabled,
 
 	/// <summary>

--- a/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/AsyncEnumerableSubject.cs
+++ b/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/AsyncEnumerableSubject.cs
@@ -7,53 +7,91 @@ using System.Threading.Tasks;
 
 namespace Uno.Extensions.Reactive.Utils;
 
-internal class AsyncEnumerableSubject<T> : IAsyncEnumerable<T>
+/// <summary>
+/// A push-pull adapter for <see cref="IAsyncEnumerable{T}"/>.
+/// </summary>
+/// <typeparam name="T">Type of the value produced.</typeparam>
+public class AsyncEnumerableSubject<T> : IAsyncEnumerable<T>
 {
-	private readonly ReplayMode _mode;
+	private readonly AsyncEnumerableReplayMode _mode;
 	private TaskCompletionSource<Node>? _head; // This is set only for replay
 	private TaskCompletionSource<Node>? _current = new();
 
-	public AsyncEnumerableSubject(bool replay = false)
+	internal AsyncEnumerableSubject(bool replay = false)
 	{
 		if (replay)
 		{
-			_mode = ReplayMode.Enabled;
+			_mode = AsyncEnumerableReplayMode.Enabled;
 			_head = _current;
 		}
 	}
 
-	internal AsyncEnumerableSubject(ReplayMode mode)
+	/// <summary>
+	/// Creates a new instance.
+	/// </summary>
+	/// <param name="mode">Specify the replay mode used for this push-pull adapter.</param>
+	public AsyncEnumerableSubject(AsyncEnumerableReplayMode mode)
 	{
 		_mode = mode;
-		if (mode != ReplayMode.Disabled)
+		if (mode != AsyncEnumerableReplayMode.Disabled)
 		{
 			_head = _current;
 		}
 	}
 
+	/// <summary>
+	/// Appends a new item into this async enumerable sequence.
+	/// </summary>
+	/// <param name="item">The next item.</param>
 	public void SetNext(T item)
 		=> MoveNext(true, item, error: null, mightHaveNext: true);
 
+	/// <summary>
+	/// Appends a new  value and completes this async enumerable sequence.
+	/// </summary>
+	/// <param name="lastItem">The last item to append to this sequence.</param>
 	public void Complete(T lastItem)
 		=> MoveNext(true, lastItem, error: null, mightHaveNext: false);
 
+	/// <summary>
+	/// Completes this async enumerable sequence.
+	/// </summary>
 	public void Complete()
 		=> MoveNext(false, default, error: null, mightHaveNext: false);
 
+	/// <summary>
+	/// Completes this async enumerable sequence by throwing an exception.
+	/// </summary>
+	/// <param name="error">The exception to throw.</param>
 	public void Fail(Exception error)
-		=> MoveNext(false, default, error: null, mightHaveNext: false);
+		=> MoveNext(false, default, error: error, mightHaveNext: false);
 
+	/// <summary>
+	/// Attempts to append a new item into this async enumerable sequence if not already completed.
+	/// </summary>
+	/// <param name="item">The next item.</param>
 	public void TrySetNext(T item)
 		=> MoveNext(true, item, error: null, mightHaveNext: true, throwOnError: false);
 
+	/// <summary>
+	/// Attempts to append a new  value and completes this async enumerable sequence if not already completed.
+	/// </summary>
+	/// <param name="lastItem">The last item to append to this sequence.</param>
 	public void TryComplete(T lastItem)
 		=> MoveNext(true, lastItem, error: null, mightHaveNext: false, throwOnError: false);
 
+	/// <summary>
+	/// Attempts to complete this async enumerable sequence if not already completed.
+	/// </summary>
 	public void TryComplete()
 		=> MoveNext(false, default, error: null, mightHaveNext: false, throwOnError: false);
 
+	/// <summary>
+	/// Attempts to complete this async enumerable sequence by throwing an exception.
+	/// </summary>
+	/// <param name="error">The exception to throw.</param>
 	public void TryFail(Exception error)
-		=> MoveNext(false, default, error: null, mightHaveNext: false, throwOnError: false);
+		=> MoveNext(false, default, error: error, mightHaveNext: false, throwOnError: false);
 
 
 	private void MoveNext(bool hasValue, T? value, Exception? error = null, bool mightHaveNext = true, bool throwOnError = true)
@@ -86,9 +124,9 @@ internal class AsyncEnumerableSubject<T> : IAsyncEnumerable<T>
 	{
 		var nextNode = _mode switch
 		{
-			ReplayMode.Disabled => _current,
-			ReplayMode.Enabled => _head,
-			ReplayMode.EnabledForFirstEnumeratorOnly => Interlocked.Exchange(ref _head, null) ?? _current,
+			AsyncEnumerableReplayMode.Disabled => _current,
+			AsyncEnumerableReplayMode.Enabled => _head,
+			AsyncEnumerableReplayMode.EnabledForFirstEnumeratorOnly => Interlocked.Exchange(ref _head, null) ?? _current,
 			_ => throw new NotSupportedException($"Unknown replay mode '{_mode}'"),
 		};
 

--- a/src/Uno.Extensions.Reactive/Utils/ListAsyncProjectionHelper.cs
+++ b/src/Uno.Extensions.Reactive/Utils/ListAsyncProjectionHelper.cs
@@ -1,0 +1,348 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions.Collections.Facades.Differential;
+using Uno.Extensions.Collections.Tracking;
+using Uno.Extensions.Reactive.Logging;
+
+namespace Uno.Extensions.Reactive.Utils;
+
+/// <summary>
+/// An helper class that asynchronously project each item of a source collection into another type.
+/// </summary>
+/// <typeparam name="TSource">The type of the source items.</typeparam>
+/// <typeparam name="TResult">The type of the target items.</typeparam>
+public sealed class ListAsyncProjectionHelper<TSource, TResult> : IDisposable
+{
+	private readonly object _stateGate = new();
+	private readonly object _updateGate = new(); // This is only for user which usually doesn't expect to be invoked in //
+	private readonly Func<TSource, TResult> _syncProjection;
+	private readonly AsyncFunc<TSource, TResult, TResult> _asyncProjection;
+	private readonly CollectionAnalyzer<TSource> _analyzer;
+
+	private ImmutableList<Value> _values = ImmutableList<Value>.Empty;
+	private IImmutableList<TSource> _currentSourceItems = ImmutableList<TSource>.Empty;
+	private DifferentialImmutableList<TResult> _result = DifferentialImmutableList<TResult>.Empty;
+	private IImmutableList<Exception> _exceptions = ImmutableList<Exception>.Empty;
+	private int _pending;
+	private bool _isDisposed;
+
+	/// <summary>
+	/// An event raised when either <see cref="CurrentResult"/> of <see cref="CurrentError"/> has been updated.
+	/// </summary>
+	public event EventHandler? Updated;
+
+	/// <summary>
+	/// Gets the number of pending async projection.
+	/// </summary>
+	public long CurrentPending { get; private set; }
+
+	/// <summary>
+	/// Gets the result items.
+	/// </summary>
+	public IImmutableList<TResult> CurrentResult { get; private set; } = DifferentialImmutableList<TResult>.Empty;
+
+	/// <summary>
+	/// Gets an aggregate exception of error raised while asynchronously loading result, if any.
+	/// </summary>
+	/// <remarks>This will **NOT** contains exception raised by the sync projection.</remarks>
+	public AggregateException? CurrentError { get; private set; }
+
+	/// <summary>
+	/// Creates a new instance
+	/// </summary>
+	/// <param name="syncProjection">A synchronous projection that will be applied when a new item is added in the source collection.</param>
+	/// <param name="asyncProjection">The asynchronous projection that will be performed after the item has been added in the <see cref="CurrentResult"/> collection.</param>
+	/// <remarks>
+	/// While exception thrown in <paramref name="asyncProjection"/> will be reported in the <see cref="CurrentError"/>,
+	/// exceptions thrown by the <paramref name="syncProjection"/> will be thrown synchronously while <see cref="Update"/>.
+	/// </remarks>
+	public ListAsyncProjectionHelper(Func<TSource, TResult> syncProjection, AsyncFunc<TSource, TResult, TResult> asyncProjection)
+	{
+		_syncProjection = syncProjection;
+		_asyncProjection = asyncProjection;
+		_analyzer = ListFeed<TSource>.DefaultAnalyzer;
+	}
+
+	/// <summary>
+	/// Updates teh source collection that is going to be asynchronously projected to a collection of <typeparamref name="TResult"/>.
+	/// </summary>
+	/// <param name="items">The source items</param>
+	/// <param name="changes">An optional change set that indicates what has been modified in the <paramref name="items"/> compared to the previous collection.</param>
+	public void Update(IImmutableList<TSource> items, IChangeSet? changes = default)
+	{
+		lock (_stateGate)
+		{
+			if (_isDisposed)
+			{
+				throw new ObjectDisposedException(nameof(ListAsyncProjectionHelper<TSource, TResult>));
+			}
+
+			if (changes is not CollectionChangeSet<TSource> collectionChanges)
+			{
+				collectionChanges = _analyzer.GetChanges(_currentSourceItems, items);
+			}
+
+			var visitor = new Visitor(this, _values, _result);
+
+			collectionChanges.Visit(visitor);
+
+			_currentSourceItems = items;
+			(_values, _result) = visitor.Complete();
+		}
+
+		lock (_updateGate)
+		{
+			CurrentPending = _pending;
+			CurrentResult = _result;
+
+			Updated?.Invoke(this, EventArgs.Empty);
+		}
+	}
+
+	private void ReportResult(Value value, TResult result)
+	{
+		lock (_stateGate)
+		{
+			if (_isDisposed)
+			{
+				return;
+			}
+
+			var index = _values.IndexOf(value);
+			if (index >= 0)
+			{
+				_result = _result.ReplaceAt(index, result);
+			}
+			else
+			{
+				this.Log().Warn("Got result for a missing value.");
+			}
+		}
+
+		lock (_updateGate)
+		{
+			CurrentPending = _pending;
+			CurrentResult = _result;
+
+			Updated?.Invoke(this, EventArgs.Empty);
+		}
+	}
+
+	private void ReportException(Exception error)
+	{
+		lock (_stateGate)
+		{
+			if (_isDisposed)
+			{
+				return;
+			}
+
+			_exceptions = _exceptions.Add(error);
+		}
+
+		lock(_updateGate)
+		{
+			CurrentPending = _pending;
+			CurrentError = new AggregateException(_exceptions);
+
+			Updated?.Invoke(this, EventArgs.Empty);
+		}
+	}
+
+	private void RemoveException(Exception error)
+	{
+		lock (_stateGate)
+		{
+			if (_isDisposed)
+			{
+				return;
+			}
+
+			_exceptions = _exceptions.Remove(error);
+		}
+
+		lock (_updateGate)
+		{
+			CurrentPending = _pending;
+			CurrentError = _exceptions is { Count: 0 } ? null : new AggregateException(_exceptions);
+
+			Updated?.Invoke(this, EventArgs.Empty);
+		}
+	}
+
+	private class Visitor : CollectionChangeSetVisitorBase<TSource>
+	{
+		private readonly ListAsyncProjectionHelper<TSource, TResult> _owner;
+		private readonly ImmutableList<Value>.Builder _values;
+		private DifferentialImmutableList<TResult> _result;
+
+		public Visitor(ListAsyncProjectionHelper<TSource, TResult> owner, ImmutableList<Value> values, DifferentialImmutableList<TResult> result)
+		{
+			_owner = owner;
+			_values = values.ToBuilder();
+			_result = result;
+		}
+
+		public (ImmutableList<Value> values, DifferentialImmutableList<TResult> result) Complete()
+			=> (_values.ToImmutable(), _result);
+
+		/// <inheritdoc />
+		public override void Add(IReadOnlyList<TSource> items, int index)
+		{
+			if (items.Count is 0)
+			{
+				return;
+			}
+
+			var values = new Value[items.Count];
+			for (var i = 0; i < items.Count; i++)
+			{
+				values[i] = new Value(_owner, items[i]);
+			}
+
+			_result = _result.InsertRange(index, values.Select(v => v.Result).ToImmutableList());
+			_values.InsertRange(index, values);
+		}
+
+		/// <inheritdoc />
+		public override void Same(IReadOnlyList<TSource> original, IReadOnlyList<TSource> updated, int index)
+		{
+			// Nothing to do
+		}
+
+		// /// <inheritdoc />
+		// public void Replace(IReadOnlyList<TSource> original, IReadOnlyList<TSource> updated, int index)
+		// => Use base implementation
+
+		/// <inheritdoc />
+		public override void Move(IReadOnlyList<TSource> items, int fromIndex, int toIndex)
+		{
+			if (items.Count is 0)
+			{
+				return;
+			}
+
+			_result = _result.MoveRange(fromIndex, toIndex, items.Count);
+			var values = new Value[items.Count];
+			for (var i = 0; i < items.Count; i++)
+			{
+				values[i] = _values[fromIndex];
+				_values.RemoveAt(fromIndex);
+			}
+			_values.InsertRange(toIndex, values);
+		}
+
+		/// <inheritdoc />
+		public override void Remove(IReadOnlyList<TSource> items, int index)
+		{
+			_result = _result.RemoveRange(index, items.Count);
+			for (var i = 0; i < items.Count; i++)
+			{
+				_values[index].Dispose();
+				_values.RemoveAt(index);
+			}
+		}
+
+		/// <inheritdoc />
+		public override void Reset(IReadOnlyList<TSource> oldItems, IReadOnlyList<TSource> newItems)
+		{
+			Debug.Assert(oldItems.Count == _values.Count);
+
+			foreach (var value in _values)
+			{
+				value.Dispose();
+			}
+
+			_result = DifferentialImmutableList<TResult>.Empty;
+			_values.Clear();
+
+			Add(newItems, 0);
+		}
+	}
+
+	private class Value : IDisposable
+	{
+		private readonly ListAsyncProjectionHelper<TSource, TResult> _owner;
+		private readonly CancellationTokenSource _ct = new();
+
+		private readonly TSource _source;
+		private Exception? _error;
+
+		public Value(ListAsyncProjectionHelper<TSource, TResult> owner, TSource source)
+		{
+			_owner = owner;
+			_source = source;
+			Result = owner._syncProjection(source);
+
+			_ = StartAsyncProjection();
+		}
+
+		public TResult Result { get; private set; }
+
+		private async Task StartAsyncProjection()
+		{
+			try
+			{
+				var asyncResult = _owner._asyncProjection.Invoke(_source, Result, _ct.Token);
+				if (asyncResult.IsCompletedSuccessfully)
+				{
+					// Fast path that prevents too much Update if async projection is actually sync!
+					// If faulted, let throw and _owner.ReportException as error in async projection are expected to be exposed in the CurrentError
+					Result = asyncResult.Result;
+					return;
+				}
+
+				try
+				{
+					Interlocked.Increment(ref _owner._pending);
+					Result = await asyncResult.ConfigureAwait(false);
+				}
+				finally
+				{
+					Interlocked.Decrement(ref _owner._pending);
+				}
+
+				if (!_ct.IsCancellationRequested)
+				{
+					_owner.ReportResult(this, Result);
+				}
+			}
+			catch (OperationCanceledException) when (_ct.IsCancellationRequested)
+			{
+			}
+			catch (Exception error)
+			{
+				_error = error;
+				if (!_ct.IsCancellationRequested)
+				{
+					_owner.ReportException(error);
+				}
+			}
+		}
+
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			_ct.Cancel();
+			if (_error is {} error)
+			{
+				_owner.RemoveException(error);
+			}
+		}
+	}
+
+	/// <inheritdoc />
+	public void Dispose()
+	{
+		lock (_stateGate)
+		{
+			Update(ImmutableList<TSource>.Empty, _analyzer.GetResetChange(_currentSourceItems, ImmutableList<TSource>.Empty));
+			_isDisposed = true;
+		}
+	}
+}

--- a/src/Uno.Extensions.Reactive/Utils/SelectionHelper.cs
+++ b/src/Uno.Extensions.Reactive/Utils/SelectionHelper.cs
@@ -13,7 +13,7 @@ internal static class SelectionHelper
 			return ranges;
 		}
 
-		using var enumerator = ranges.OrderBy(range => range.Length).GetEnumerator();
+		using var enumerator = ranges.OrderBy(range => range.FirstIndex).GetEnumerator();
 		if (!enumerator.MoveNext())
 		{
 			return Array.Empty<SelectionIndexRange>();


### PR DESCRIPTION
## Feature
Add ability to asynchronously project each item of a `ListFeed` (i.e. N+1 API calls)

## What is the new behavior?
We can project each item of a `ListFeed` without waiting for the end of the projection of each item to display the list in the UI, including with pagination.

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
