### PR TITLE
fix: FeedView loading state

### DIFF
--- a/src/Uno.Extensions.Reactive.UI/Utils/SmoothVisualState/ISmoothVisualStateAware.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/SmoothVisualState/ISmoothVisualStateAware.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Linq;
+
+namespace Uno.Extensions.Reactive.UI;
+
+/// <summary>
+/// Flags a <see cref="Control"/> that is aware of the <see cref="SmoothVisualStateManager"/> and can provide additional information to it.
+/// </summary>
+public interface ISmoothVisualStateAware
+{
+	/// <summary>
+	/// Flag that indicates that considering the state of the control, state should be applied without any delay.
+	/// </summary>
+	public bool ShouldGoToStateSync { get; }
+}

--- a/src/Uno.Extensions.Reactive.UI/Utils/SmoothVisualState/SmoothStateRuleResult.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/SmoothVisualState/SmoothStateRuleResult.cs
@@ -1,13 +1,20 @@
-﻿#pragma warning disable CS1591 // XML Doc, will be moved elsewhere
-
-using System;
+﻿using System;
 using System.Linq;
 
 namespace Uno.Extensions.Reactive.UI;
 
+/// <summary>
+/// The result of a <see cref="SmoothVisualStateRule"/>.
+/// </summary>
 public struct SmoothStateRuleResult
 {
+	/// <summary>
+	/// The delay to wait before going to the next state.
+	/// </summary>
 	public TimeSpan? Delay { get; set; }
 
+	/// <summary>
+	/// The minimal duration to stay in the state.
+	/// </summary>
 	public TimeSpan? MinDuration { get; set; }
 }

--- a/src/Uno.Extensions.Reactive.UI/Utils/SmoothVisualState/SmoothVisualStateRule.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/SmoothVisualState/SmoothVisualStateRule.cs
@@ -1,22 +1,50 @@
-﻿#pragma warning disable CS1591 // XML Doc, will be moved elsewhere
-
-using System;
+﻿using System;
 using System.Linq;
 
 namespace Uno.Extensions.Reactive.UI;
 
+/// <summary>
+/// A rule used by a <see cref="SmoothVisualStateManager"/> to determine the delay to wait before going to the target state.
+/// </summary>
 public class SmoothVisualStateRule
 {
+	/// <summary>
+	/// The name of the <see cref="VisualStateGroup"/> to which this rule applies to.
+	/// `null` to apply to any group.
+	/// </summary>
 	public string? Group { get; set; }
 
+	/// <summary>
+	/// The name of the current <see cref="VisualState"/> for this rule to be considered.
+	/// `null` to apply to any visual state.
+	/// </summary>
 	public string? From { get; set; }
 
+	/// <summary>
+	/// The name of the target <see cref="VisualState"/> for this rule to be considered.
+	/// `null` to apply to any visual state.
+	/// </summary>
 	public string? To { get; set; }
 
+	/// <summary>
+	/// The delay to wait before going to the target state.
+	/// `null` to not apply any delay.
+	/// </summary>
 	public TimeSpan? Delay { get; set; }
 
+	/// <summary>
+	/// The minimum duration to stay in the target state before moving to any next state.
+	/// `null` to not apply any minimum duration.
+	/// </summary>
 	public TimeSpan? MinDuration { get; set; }
 
+	/// <summary>
+	/// Gets the <see cref="SmoothStateRuleResult"/> for the given <paramref name="group"/>, <paramref name="current"/> and <paramref name="target"/> states.
+	/// </summary>
+	/// <param name="group">The visual state group for which this rule should be applied.</param>
+	/// <param name="current">The current visual state, if any.</param>
+	/// <param name="target">The target visual state</param>
+	/// <returns>The delay and minimum duration that should be applied to go to the target visual state.</returns>
 	public SmoothStateRuleResult Get(VisualStateGroup group, VisualState? current, VisualState target)
 	{
 		if (Group is not null && group.Name != Group)

--- a/src/Uno.Extensions.Reactive.UI/Utils/SmoothVisualState/SmoothVisualStateRuleCollection.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/SmoothVisualState/SmoothVisualStateRuleCollection.cs
@@ -1,11 +1,12 @@
-﻿#pragma warning disable CS1591 // XML Doc, will be moved elsewhere
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Uno.Extensions.Reactive.UI;
 
+/// <summary>
+/// A collection of <see cref="SmoothVisualStateRule"/>.
+/// </summary>
 public class SmoothVisualStateRuleCollection : List<SmoothVisualStateRule>
 {
 }

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.Loadable.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.Loadable.cs
@@ -4,7 +4,7 @@ using Uno.Toolkit;
 
 namespace Uno.Extensions.Reactive.UI;
 
-partial class FeedView : ILoadable
+partial class FeedView : ILoadable, ISmoothVisualStateAware
 {
 	private bool _isLoading = true; // True by default, so we are considered as loading even before the source is being set.
 	private event EventHandler? _isLoadingChanged;
@@ -27,4 +27,9 @@ partial class FeedView : ILoadable
 			_isLoadingChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
+
+	// If we are loading and there is listener for the IsLoadingChanged event, it usually means that we have a parent LoadingView,
+	// so we should go to the state synchronously to avoid flicker between loading states of the LoadingView and the FeedView.
+	/// <inheritdoc />
+	bool ISmoothVisualStateAware.ShouldGoToStateSync => _isLoading && _isLoadingChanged is not null;
 }

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.xaml
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.xaml
@@ -36,8 +36,9 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="uer:FeedView">
-					<Grid VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-						  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}">
+					<Grid
+						VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+						HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}">
 						<VisualStateManager.CustomVisualStateManager>
 							<uer:SmoothVisualStateManager>
 								<uer:SmoothVisualStateRule MinDuration="0:0:0.500" />
@@ -165,7 +166,7 @@
 
 						<Grid
 							x:Name="ProgressRoot"
-							Visibility="Visible">
+							Visibility="Collapsed">
 							<ContentPresenter
 								x:Name="ProgressPresenter"
 								Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=State.Progress}"


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/1150
closes https://github.com/unoplatform/uno.extensions/issues/1318

## Bugfix
1. Loading state of ILoadable disapear earlier than FeedView's loading state
1. Default FeedView style does not hide the loading state

## What is the current behavior?
1. Default style of the `FeedView` uses a `SmoothVisualStateManager` that can defer `GoToState` to avoid flickers, but when used in conjunction of a `LoadingView` this cause states to not be sychronized. 
2. The loading presenter is `Visible` by default

## What is the new behavior?
1. The `FeedView` can now inform the `SmoothVisualStateManager` that states should not be deffered for initial loading (if the usage of a `LoadingView` is detected.
2. 🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
