### PR TITLE
fix: Adding fallback resource loading behaviour

### DIFF
--- a/src/Uno.Extensions.Hosting.UI/AppHostingEnvironment.cs
+++ b/src/Uno.Extensions.Hosting.UI/AppHostingEnvironment.cs
@@ -9,9 +9,11 @@ public class AppHostingEnvironment : HostingEnvironment, IAppHostEnvironment, ID
 	, IHasAddressBar
 #endif
 {
-	public string? AppDataPath { get; set; }
+	public string? AppDataPath { get; init; }
 
-    public static AppHostingEnvironment FromHostEnvironment(IHostEnvironment host, string? appDataPath)
+	public Assembly? HostAssembly { get; init; }
+
+    public static AppHostingEnvironment FromHostEnvironment(IHostEnvironment host, string? appDataPath, Assembly hostAssembly)
     {
         return new AppHostingEnvironment
         {
@@ -19,8 +21,9 @@ public class AppHostingEnvironment : HostingEnvironment, IAppHostEnvironment, ID
             ApplicationName = host.ApplicationName,
             ContentRootFileProvider = host.ContentRootFileProvider,
             ContentRootPath = host.ContentRootPath,
-            EnvironmentName = host.EnvironmentName
-        };
+            EnvironmentName = host.EnvironmentName,
+			HostAssembly = hostAssembly
+		};
     }
 
 #if __WASM__

--- a/src/Uno.Extensions.Hosting.UI/GlobalUsings.cs
+++ b/src/Uno.Extensions.Hosting.UI/GlobalUsings.cs
@@ -3,6 +3,7 @@ global using System.Collections.Generic;
 global using System.IO;
 global using System.Linq;
 global using System.Reflection;
+global using System.Runtime.CompilerServices;
 global using System.Threading;
 global using System.Threading.Tasks;
 global using Microsoft.Extensions.Configuration;

--- a/src/Uno.Extensions.Hosting.UI/UnoHost.cs
+++ b/src/Uno.Extensions.Hosting.UI/UnoHost.cs
@@ -1,13 +1,10 @@
-﻿using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
-using Windows.Storage;
-
-namespace Uno.Extensions.Hosting;
+﻿namespace Uno.Extensions.Hosting;
 
 public static class UnoHost
 {
 	public static IHostBuilder CreateDefaultBuilder(string[]? args = null)
 	{
+		var callingAssembly = Assembly.GetCallingAssembly();
 		return new HostBuilder()
 			.ConfigureCustomDefaults(args)
 			.ConfigureAppConfiguration((ctx, appConfig) =>
@@ -32,7 +29,7 @@ public static class UnoHost
 					Directory.CreateDirectory(dataFolder);
 				}
 #endif
-				var appHost = AppHostingEnvironment.FromHostEnvironment(ctx.HostingEnvironment, dataFolder);
+				var appHost = AppHostingEnvironment.FromHostEnvironment(ctx.HostingEnvironment, dataFolder, callingAssembly);
 				ctx.HostingEnvironment = appHost;
 			})
 			.ConfigureServices((ctx, services) =>

--- a/src/Uno.Extensions.Hosting/IAppHostEnvironment.cs
+++ b/src/Uno.Extensions.Hosting/IAppHostEnvironment.cs
@@ -1,6 +1,9 @@
-﻿namespace Uno.Extensions.Hosting;
+﻿using System.Reflection;
+
+namespace Uno.Extensions.Hosting;
 
 public interface IAppHostEnvironment : IHostEnvironment
 {
     public string? AppDataPath { get; }
+	public Assembly? HostAssembly { get; }
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOnePage.xaml
@@ -21,6 +21,9 @@
 			<TextBlock HorizontalAlignment="Center"
 					   FontSize="24"
 					   x:Uid="Localization_Greeting" />
+			<TextBlock HorizontalAlignment="Center"
+					   FontSize="24"
+					   Text="{Binding ApplicationNameInCode}"/>
 			<utu:ChipGroup x:Name="LanguageChipGroup"
 						   SelectionMode="Single"
 						   SelectedItem="{Binding SelectedCulture, Mode=TwoWay}"

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOneViewModel.cs
@@ -8,6 +8,10 @@ namespace TestHarness.Ext.Navigation.Localization;
 public partial class LocalizationOneViewModel : ObservableObject
 {
 	private readonly ILocalizationService _localizationService;
+	
+	[ObservableProperty]
+	private string _applicationNameInCode;
+
 	public LocalizationOneViewModel(
 		ILocalizationService localizationService,
 		IStringLocalizer localizer)
@@ -15,7 +19,7 @@ public partial class LocalizationOneViewModel : ObservableObject
 		_localizationService = localizationService;
 		SupportedCultures = _localizationService.SupportedCultures;
 
-		var language = localizer[_localizationService.CurrentCulture.Name ?? "en"];
+		ApplicationNameInCode = localizer.GetString("ApplicationName");
 	}
 
 	public CultureInfo[] SupportedCultures { get; }


### PR DESCRIPTION
GitHub Issue (If applicable): #1307 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Resources aren't loaded from the class library (new solution structure), only the primary assembly (ie the target platform assembly)

## What is the new behavior?

The assembly that defines the host builder is registered as the primary resource location and used to locate resources. If no resources exist, or no match, the default resource loader (ie the target platform assembly) is used.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
