### PR TITLE
fix: Preventing nav on null item selection

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Controls/SelectorRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/SelectorRequestHandler.cs
@@ -16,7 +16,7 @@ public class SelectorRequestHandler : ControlRequestHandlerBase<Selector>
 			var navdata = sender.GetData() ?? data;
 			var path = sender.GetRequest();
 			var nav = sender.Navigator();
-			if (nav is null)
+			if (nav is null || navdata is null)
 			{
 				return;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): #1331 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Navigation is triggered on selection changed even when selected item is null

## What is the new behavior?

No navigation when selected item is null

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
