### PR TITLE
fix: Correct flyout behaviour with navigation

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Controls/NavigationFlyout.xaml
+++ b/src/Uno.Extensions.Navigation.UI/Controls/NavigationFlyout.xaml
@@ -3,8 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:uen="using:Uno.Extensions.Navigation.UI"
-        Placement="Full"
-        FlyoutPresenterStyle="{StaticResource MaterialFlyoutPresenterStyle}">
+        Placement="Full">
 
     <Grid>
         <Frame uen:Region.Attached="True"

--- a/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
@@ -18,6 +18,9 @@ public static class ServiceCollectionExtensions
 		var routes = createRouteRegistry?.Invoke(services) ?? new RouteRegistry(services);
 		routeBuilder?.Invoke(views, routes);
 
+		// Only fall back to the navigation flyout if one hasn't already been registered
+		services.AddTransient<Flyout, NavigationFlyout>();
+
 		return services
 					.AddSingleton<NavigationConfig>(sp =>
 					{
@@ -41,7 +44,6 @@ public static class ServiceCollectionExtensions
 					.AddHostedService<BrowserAddressBarService>()
 					.AddScoped<Navigator>()
 
-					.AddTransient<Flyout, NavigationFlyout>()
 
 					// Register the region for each control type
 					.AddRegion<Frame, FrameNavigator>()


### PR DESCRIPTION
GitHub Issue (If applicable): 
closes: #1340 
closes: #1341 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

- Uses Material style for flyout
- ModalFlyoutStyle isn't used because the registration is overwritten by Navigationflyout

## What is the new behavior?

NavigationFlyout only registered if no Flyout has already been registered
Material style isn't explicitly referenced (will be picked up by implicit style if Material is used)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
