### PR TITLE
fix: Localization fix via appbuilder

### DIFF
--- a/src/Uno.Extensions.Hosting.UI/ApplicationBuilder.cs
+++ b/src/Uno.Extensions.Hosting.UI/ApplicationBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace Uno.Extensions.Hosting;
 
-internal record ApplicationBuilder(Application App, LaunchActivatedEventArgs Arguments) : IApplicationBuilder
+internal record ApplicationBuilder(Application App, LaunchActivatedEventArgs Arguments, Assembly ApplicationAssembly) : IApplicationBuilder
 {
 	private readonly List<Action<IHostBuilder>> _delegates = new List<Action<IHostBuilder>>();
 
@@ -15,7 +15,7 @@ internal record ApplicationBuilder(Application App, LaunchActivatedEventArgs Arg
 
 	public IHost Build()
 	{
-		var builder = UnoHost.CreateDefaultBuilder();
+		var builder = UnoHost.CreateDefaultBuilder(ApplicationAssembly);
 		foreach (var del in _delegates)
 		{
 			del(builder);

--- a/src/Uno.Extensions.Hosting.UI/ApplicationExtensions.cs
+++ b/src/Uno.Extensions.Hosting.UI/ApplicationExtensions.cs
@@ -12,5 +12,5 @@ public static class ApplicationExtensions
 	/// <param name="args">The <see cref="LaunchActivatedEventArgs" /> passed to OnLaunched.</param>
 	/// <returns></returns>
 	public static IApplicationBuilder CreateBuilder(this Application app, LaunchActivatedEventArgs args) =>
-		new ApplicationBuilder(app, args);
+		new ApplicationBuilder(app, args, Assembly.GetCallingAssembly());
 }

--- a/src/Uno.Extensions.Hosting.UI/UnoHost.cs
+++ b/src/Uno.Extensions.Hosting.UI/UnoHost.cs
@@ -5,6 +5,11 @@ public static class UnoHost
 	public static IHostBuilder CreateDefaultBuilder(string[]? args = null)
 	{
 		var callingAssembly = Assembly.GetCallingAssembly();
+		return CreateDefaultBuilder(callingAssembly, args);
+	}
+
+	internal static IHostBuilder CreateDefaultBuilder(Assembly applicationAssembly, string[]? args = null)
+	{
 		return new HostBuilder()
 			.ConfigureCustomDefaults(args)
 			.ConfigureAppConfiguration((ctx, appConfig) =>
@@ -29,7 +34,7 @@ public static class UnoHost
 					Directory.CreateDirectory(dataFolder);
 				}
 #endif
-				var appHost = AppHostingEnvironment.FromHostEnvironment(ctx.HostingEnvironment, dataFolder, callingAssembly);
+				var appHost = AppHostingEnvironment.FromHostEnvironment(ctx.HostingEnvironment, dataFolder, applicationAssembly);
 				ctx.HostingEnvironment = appHost;
 			})
 			.ConfigureServices((ctx, services) =>


### PR DESCRIPTION
GitHub Issue (If applicable): #1307

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Calling assembly correctly set when calling UnoHost directly. Doesn't work with ApplicationBuilder pattern

## What is the new behavior?

ApplicationBuilder pattern correctly sets calling assembly when invoking UnoHost

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
