### PR TITLE
fix: Correct selection change for when addeditems is null

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Controls/SelectorRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/SelectorRequestHandler.cs
@@ -31,7 +31,9 @@ public class SelectorRequestHandler : ControlRequestHandlerBase<Selector>
 			{
 				return;
 			}
-			var data = sender.GetData() ?? actionArgs?.AddedItems?.FirstOrDefault();
+			var data = sender.GetData() ??
+							actionArgs?.AddedItems?.FirstOrDefault() ??
+							sender.SelectedItem; // In some cases, AddedItems is null, even though SelectedItem is not null
 
 			if(data is null)
 			{
@@ -59,8 +61,14 @@ public class SelectorRequestHandler : ControlRequestHandlerBase<Selector>
 		{
 			connect = () =>
 			{
-				lv.ItemClick += clickAction;
-				viewList.SelectionChanged += selectionAction;
+				if (lv.IsItemClickEnabled)
+				{
+					lv.ItemClick += clickAction;
+				}
+				else
+				{
+					viewList.SelectionChanged += selectionAction;
+				}
 			};
 
 			disconnect = () =>

--- a/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
@@ -31,6 +31,8 @@ public static class FrameworkElementExtensions
 		var nav = elementRegion.Navigator();
 		if (nav is not null)
 		{
+			var initialNavigation = () => nav.NavigateRouteAsync(root, initialRoute ?? string.Empty);
+
 			var start = () => Task.CompletedTask;
 			if (initialNavigate is not null)
 			{
@@ -48,7 +50,12 @@ public static class FrameworkElementExtensions
 			{
 				start = () => nav.NavigateRouteAsync(root, initialRoute ?? string.Empty);
 			}
-			var startupTask = elementRegion.Services!.Startup(start);
+			var fullstart = async () =>
+			{
+				await initialNavigation();
+				await start();
+			};
+			var startupTask = elementRegion.Services!.Startup(fullstart);
 			return startupTask;
 		}
 		return Task.CompletedTask;

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoTaskListPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoTaskListPage.xaml
@@ -87,7 +87,6 @@
 						<ListView ItemsSource="{Binding CompletedTasks}"
 								  uen:Navigation.Request="Task"
 								  SelectionMode="None"
-								  IsItemClickEnabled="True"
 								  x:Name="CompletedTasks"
 								  ItemTemplate="{StaticResource TaskTemplate}" />
 					</Grid>
@@ -97,7 +96,6 @@
 						<ListView ItemsSource="{Binding ActiveTasks}"
 								  uen:Navigation.Request="Task"
 								  SelectionMode="None"
-								  IsItemClickEnabled="True"
 								  x:Name="ActiveTasks"
 								  ItemTemplate="{StaticResource TaskTemplate}" />
 					</Grid>


### PR DESCRIPTION
GitHub Issue (If applicable): #1344 #1365

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

If AddedItems is empty navigation isn't done, even if SelectedItems has a value

## What is the new behavior?

Fallback to SelectedItems if AddedItems is null
Also, prevents multiple handlers so ItemClick is used if IsItemClickEnabled set to true

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
