### PR TITLE
fix: Correcting behaviour for when theme set to system

### DIFF
--- a/src/Uno.Extensions.Toolkit.UI/ThemeService.cs
+++ b/src/Uno.Extensions.Toolkit.UI/ThemeService.cs
@@ -124,15 +124,13 @@ internal class ThemeService : IThemeService, IDisposable
 			return false;
 		}
 
-		var newTheme = theme;
-		if (theme == AppTheme.System)
+		rootElement.RequestedTheme = theme switch
 		{
-			//Set System theme
-			var systemTheme = SystemThemeHelper.GetCurrentOsTheme();
-			newTheme = systemTheme == ApplicationTheme.Dark ? AppTheme.Dark : AppTheme.Light;
-		}
-
-		rootElement.RequestedTheme = newTheme == AppTheme.Dark ? ElementTheme.Dark : ElementTheme.Light;
+			AppTheme.System => ElementTheme.Default,
+			AppTheme.Dark => ElementTheme.Dark,
+			AppTheme.Light => ElementTheme.Light,
+			_ => ElementTheme.Default,
+		};
 
 		SaveDesiredTheme(theme);
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1374 

# PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

System theme is used to explicitly set dark or light theme instead of default on root element

## What is the new behavior?

Root element RequestedTheme is set to Default if the selected theme is system

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
