### PR TITLE
fix: Resource loading for shared projects

### DIFF
--- a/src/Uno.Extensions.Localization.UI/ResourceLoaderStringLocalizer.cs
+++ b/src/Uno.Extensions.Localization.UI/ResourceLoaderStringLocalizer.cs
@@ -36,7 +36,7 @@ public class ResourceLoaderStringLocalizer : IStringLocalizer
 		var mainResourceMap = new ResourceManager().MainResourceMap;
 		// TryGetSubtree can return null if no resources found, so defalut to main resource map if not found
 		_defaultResourceMap = mainResourceMap.TryGetSubtree(SearchLocation) ?? mainResourceMap;
-		_appResourceMap = mainResourceMap.TryGetSubtree(appHostEnvironment.HostAssembly?.GetName().Name).TryGetSubtree(SearchLocation) ?? mainResourceMap;
+		_appResourceMap = mainResourceMap.TryGetSubtree(appHostEnvironment.HostAssembly?.GetName().Name)?.TryGetSubtree(SearchLocation) ?? _defaultResourceMap;
 #else
 		_defaultResourceLoader = ResourceLoader.GetForViewIndependentUse();
 		try
@@ -63,17 +63,24 @@ public class ResourceLoaderStringLocalizer : IStringLocalizer
 		{
 			throw new ArgumentNullException(nameof(name));
 		}
-
+		string? resource = null;
+		try
+		{
 #if WINDOWS
-		var resource = _appResourceMap.GetValue(name)?.ValueAsString ??
-						_defaultResourceMap.GetValue(name)?.ValueAsString;
+			resource = _appResourceMap.GetValue(name)?.ValueAsString ??
+							_defaultResourceMap.GetValue(name)?.ValueAsString;
 #else
-		var resource = _appResourceLoader?.GetString(name) ??
+		resource = _appResourceLoader?.GetString(name) ??
 			_defaultResourceLoader.GetString(name);
 #endif
 
-		if (_treatEmptyAsNotFound &&
-			string.IsNullOrEmpty(resource))
+			if (_treatEmptyAsNotFound &&
+				string.IsNullOrEmpty(resource))
+			{
+				resource = null;
+			}
+		}
+		catch
 		{
 			resource = null;
 		}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Try to access ResourceLoaderStringLocalizer raises exception because sub-tree resource loader is missing

## What is the new behavior?

Null checking avoids this issue

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
