### PR TITLE
fix: Fixing issue with Android 12+ startup where loading indicator shows briefly

### DIFF
--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -25,10 +25,10 @@
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
 		<PackageVersion Include="Uno.Material" Version="2.5.3" />
 		<PackageVersion Include="Uno.Material.WinUI" Version="2.5.3" />
-		<PackageVersion Include="Uno.Toolkit.UI" Version="2.6.0-dev.35" />
-		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.6.0-dev.35" />
-		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.35" />
-		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.6.0-dev.35" />
+		<PackageVersion Include="Uno.Toolkit.UI" Version="2.6.0-dev.38" />
+		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.6.0-dev.38" />
+		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.38" />
+		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.6.0-dev.38" />
 		<PackageVersion Include="Uno.UI" Version="4.9.0-dev.609" />
 		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
 		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.9.0-dev.609" />

--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -25,20 +25,20 @@
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
 		<PackageVersion Include="Uno.Material" Version="2.5.3" />
 		<PackageVersion Include="Uno.Material.WinUI" Version="2.5.3" />
-		<PackageVersion Include="Uno.Toolkit.UI" Version="2.5.5" />
-		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.5.5" />
-		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.5.5" />
-		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.5.5" />
-		<PackageVersion Include="Uno.UI" Version="4.8.15" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.15" />
-		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.8.15" />
-		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.8.15" />
-		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.8.15" />
-		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.8.15" />
-		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.8.15" />
+		<PackageVersion Include="Uno.Toolkit.UI" Version="2.6.0-dev.35" />
+		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.6.0-dev.35" />
+		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.35" />
+		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.6.0-dev.35" />
+		<PackageVersion Include="Uno.UI" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.9.0-dev.609" />
 		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.12" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.12" />
-		<PackageVersion Include="Uno.WinUI" Version="4.8.15" />
+		<PackageVersion Include="Uno.WinUI" Version="4.9.0-dev.609" />
 	</ItemGroup>
 </Project>

--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -25,10 +25,10 @@
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
 		<PackageVersion Include="Uno.Material" Version="2.5.3" />
 		<PackageVersion Include="Uno.Material.WinUI" Version="2.5.3" />
-		<PackageVersion Include="Uno.Toolkit.UI" Version="2.6.0-dev.38" />
-		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.6.0-dev.38" />
-		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.38" />
-		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.6.0-dev.38" />
+		<PackageVersion Include="Uno.Toolkit.UI" Version="2.6.0-dev.40" />
+		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.6.0-dev.40" />
+		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.40" />
+		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.6.0-dev.40" />
 		<PackageVersion Include="Uno.UI" Version="4.9.0-dev.609" />
 		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
 		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.9.0-dev.609" />

--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -29,16 +29,16 @@
 		<PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.6.0-dev.40" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.40" />
 		<PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.6.0-dev.40" />
-		<PackageVersion Include="Uno.UI" Version="4.9.0-dev.609" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
-		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.9.0-dev.609" />
-		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.9.0-dev.609" />
-		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.9.0-dev.609" />
-		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.9.0-dev.609" />
-		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.UI" Version="4.9.0-dev.587" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.587" />
+		<PackageVersion Include="Uno.UI.RemoteControl" Version="4.9.0-dev.587" />
+		<PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.9.0-dev.587" />
+		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.9.0-dev.587" />
+		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.9.0-dev.587" />
+		<PackageVersion Include="Uno.UI.WebAssembly" Version="4.9.0-dev.587" />
 		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.12" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.12" />
-		<PackageVersion Include="Uno.WinUI" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.WinUI" Version="4.9.0-dev.587" />
 	</ItemGroup>
 </Project>

--- a/samples/Playground/Playground.Shared/App.xaml.cs
+++ b/samples/Playground/Playground.Shared/App.xaml.cs
@@ -28,9 +28,6 @@ public sealed partial class App : Application
 			.ConfigureApp()
 			.UseToolkitNavigation();
 		_window = appBuilder.Window;
-#if NET5_0_OR_GREATER && WINDOWS
-		_window.Activate();
-#endif
 
 		var hostingOption = InitOption.Splash;
 
@@ -105,7 +102,6 @@ public sealed partial class App : Application
 				appRoot.SplashScreen.Initialize(_window, args);
 
 				_window.Content = appRoot;
-				_window.Activate();
 
 				_host = await _window.InitializeNavigationAsync(
 							async () =>
@@ -121,7 +117,7 @@ public sealed partial class App : Application
 							// Option 2: Specify route name
 							// initialRoute: "Shell"
 							// Option 3: Specify the view model. To avoid reflection, you can still define a routemap
-							initialViewModel: typeof(ShellViewModel)
+							initialViewModel: typeof(HomeViewModel)
 						);
 				break;
 

--- a/samples/Playground/Playground.Shared/ViewModels/ShellViewModel.cs
+++ b/samples/Playground/Playground.Shared/ViewModels/ShellViewModel.cs
@@ -11,6 +11,6 @@ public class ShellViewModel
 
 		// Option 2: Only specify the ShellViewModel - this will inject a FrameView and so
 		// the INavigator corresponds to the Frame (ie no need to nest navigation)
-		navigator.NavigateViewAsync<HomePage>(this);
+		//navigator.NavigateViewAsync<HomePage>(this);
 	}
 }

--- a/samples/Playground/Playground.Shared/ViewModels/ThemeSwitchViewModel.cs
+++ b/samples/Playground/Playground.Shared/ViewModels/ThemeSwitchViewModel.cs
@@ -9,7 +9,7 @@ public partial class ThemeSwitchViewModel:ObservableObject
 	private readonly IThemeService _ts;
 
 	[ObservableProperty]
-	private string isDarkTheme;
+	private string isDarkTheme = string.Empty;
 
 	public ThemeSwitchViewModel(IThemeService themeService,IDispatcher dispatcher)
 	{

--- a/samples/Playground/Playground.Windows/Playground.Windows.csproj
+++ b/samples/Playground/Playground.Windows/Playground.Windows.csproj
@@ -60,7 +60,6 @@
 		<PackageReference Include="Uno.WinUI" />
 		<PackageReference Include="Uno.Material.WinUI" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" />
-		<PackageReference Include="Uno.Toolkit.WinUI" />
 	</ItemGroup>
 
 	<!-- 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -41,9 +41,9 @@
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
 		<PackageVersion Include="Uno.Extensions.Markup.Generators" Version="1.0.0-dev.166" />
 		<PackageVersion Include="Uno.Roslyn" Version="1.3.0-dev.12" />
-		<PackageVersion Include="Uno.Toolkit" Version="2.6.0-dev.38" />
-		<PackageVersion Include="Uno.Toolkit.UI" Version="2.6.0-dev.38" />
-		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.38" />
+		<PackageVersion Include="Uno.Toolkit" Version="2.6.0-dev.40" />
+		<PackageVersion Include="Uno.Toolkit.UI" Version="2.6.0-dev.40" />
+		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.40" />
 		<PackageVersion Include="Uno.UI" Version="4.8.15" />
 		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.15"/>
 		<PackageVersion Include="Uno.UI.MSAL"  Version="4.8.15" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -41,9 +41,9 @@
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
 		<PackageVersion Include="Uno.Extensions.Markup.Generators" Version="1.0.0-dev.166" />
 		<PackageVersion Include="Uno.Roslyn" Version="1.3.0-dev.12" />
-		<PackageVersion Include="Uno.Toolkit" Version="2.5.5" />
-		<PackageVersion Include="Uno.Toolkit.UI" Version="2.5.5" />
-		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.5.5" />
+		<PackageVersion Include="Uno.Toolkit" Version="2.6.0-dev.38" />
+		<PackageVersion Include="Uno.Toolkit.UI" Version="2.6.0-dev.38" />
+		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.38" />
 		<PackageVersion Include="Uno.UI" Version="4.8.15" />
 		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.15"/>
 		<PackageVersion Include="Uno.UI.MSAL"  Version="4.8.15" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -44,15 +44,15 @@
 		<PackageVersion Include="Uno.Toolkit" Version="2.6.0-dev.40" />
 		<PackageVersion Include="Uno.Toolkit.UI" Version="2.6.0-dev.40" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.40" />
-		<PackageVersion Include="Uno.UI" Version="4.8.15" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.15"/>
-		<PackageVersion Include="Uno.UI.MSAL"  Version="4.8.15" />
-		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.8.15" />
+		<PackageVersion Include="Uno.UI" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609"/>
+		<PackageVersion Include="Uno.UI.MSAL"  Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.9.0-dev.609" />
 		<PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageVersion Include="Uno.WinUI" Version="4.8.15" />
+		<PackageVersion Include="Uno.WinUI" Version="4.9.0-dev.609" />
 		<PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
-		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.8.15" />
-		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.8.15" />
+		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.9.0-dev.609" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />
 		<PackageVersion Include="xunit" Version="2.4.1" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -44,15 +44,15 @@
 		<PackageVersion Include="Uno.Toolkit" Version="2.6.0-dev.40" />
 		<PackageVersion Include="Uno.Toolkit.UI" Version="2.6.0-dev.40" />
 		<PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.40" />
-		<PackageVersion Include="Uno.UI" Version="4.9.0-dev.609" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609"/>
-		<PackageVersion Include="Uno.UI.MSAL"  Version="4.9.0-dev.609" />
-		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.UI" Version="4.9.0-dev.587" />
+		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.587"/>
+		<PackageVersion Include="Uno.UI.MSAL"  Version="4.9.0-dev.587" />
+		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="4.9.0-dev.587" />
 		<PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageVersion Include="Uno.WinUI" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.WinUI" Version="4.9.0-dev.587" />
 		<PackageVersion Include="Uno.WinUI.Markup" Version="4.6.0-dev.16" />
-		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.9.0-dev.609" />
-		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.9.0-dev.609" />
+		<PackageVersion Include="Uno.WinUI.MSAL" Version="4.9.0-dev.587" />
+		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="4.9.0-dev.587" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />
 		<PackageVersion Include="xunit" Version="2.4.1" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/Uno.Extensions.Navigation.Toolkit/ApplicationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/ApplicationBuilderExtensions.cs
@@ -6,11 +6,41 @@ public static class ApplicationBuilderExtensions
 	{
 		public ContentControl CreateDefaultView() => new LoadingView();
 
-		public void InitializeViewHost(FrameworkElement element, Task loadingTask)
+		public void InitializeViewHost(Window window, FrameworkElement element, Task loadingTask)
 		{
-			if (element is LoadingView loadingView)
+			//if (element is LoadingView loadingView)
+			//{
+			//	loadingView.Source = new LoadingTask(loadingTask, element);
+			//}
+
+			var activate = true;
+			if (element is LoadingView lv)
 			{
-				loadingView.Source = new LoadingTask(loadingTask, element);
+				var activateTask = loadingTask;
+				if (lv is ExtendedSplashScreen splash)
+				{
+					if (!splash.SplashIsEnabled)
+					{
+						// Splash isn't enabled, so don't activate until loading completed
+						activate = false;
+
+						splash.UseTransitions = false;
+
+						activateTask = new Func<Task>(async () =>
+						{
+							await loadingTask;
+							window.Activate();
+						})();
+					}
+				}
+				var loading = new LoadingTask(activateTask, element);
+				lv.Source = loading;
+			}
+
+			if (activate)
+			{
+				// Activate immediately to show the splash screen
+				window.Activate();
 			}
 		}
 

--- a/src/Uno.Extensions.Navigation.Toolkit/ApplicationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/ApplicationBuilderExtensions.cs
@@ -8,40 +8,7 @@ public static class ApplicationBuilderExtensions
 
 		public void InitializeViewHost(Window window, FrameworkElement element, Task loadingTask)
 		{
-			//if (element is LoadingView loadingView)
-			//{
-			//	loadingView.Source = new LoadingTask(loadingTask, element);
-			//}
-
-			var activate = true;
-			if (element is LoadingView lv)
-			{
-				var activateTask = loadingTask;
-				if (lv is ExtendedSplashScreen splash)
-				{
-					if (!splash.SplashIsEnabled)
-					{
-						// Splash isn't enabled, so don't activate until loading completed
-						activate = false;
-
-						splash.UseTransitions = false;
-
-						activateTask = new Func<Task>(async () =>
-						{
-							await loadingTask;
-							window.Activate();
-						})();
-					}
-				}
-				var loading = new LoadingTask(activateTask, element);
-				lv.Source = loading;
-			}
-
-			if (activate)
-			{
-				// Activate immediately to show the splash screen
-				window.Activate();
-			}
+			window.ApplyLoadingTask(element, loadingTask);
 		}
 
 		public void PreInitialize(FrameworkElement element, IApplicationBuilder builder)

--- a/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
@@ -30,12 +30,38 @@ public static class WindowExtensions
 			buildHost,
 			navigationRoot,
 			initialRoute, initialView, initialViewModel,
-			(root, navInit) =>
+			async (root, navInit) =>
 				{
-					var loading = new LoadingTask(navInit, root);
+					var activate = true;
 					if (root is LoadingView lv)
 					{
+						var loadingTask = navInit;
+						if (lv is ExtendedSplashScreen splash)
+						{
+							if (!splash.SplashIsEnabled)
+							{
+								// Splash isn't enabled, so don't activate until loading completed
+								activate = false;
+
+								// TODO: Change this to use UseTransitions
+								splash.DisableAnimations = true;
+
+								loadingTask = new Func<Task>(async () =>
+								{
+									await navInit;
+									window.Activate();
+								})();
+
+
+							}
+						}
+						var loading = new LoadingTask(loadingTask, root);
 						lv.Source = loading;
+					}
+					if (activate)
+					{
+						// Activate immediately to show the splash screen
+						window.Activate();
 					}
 				},
 			initialNavigate

--- a/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
@@ -30,7 +30,7 @@ public static class WindowExtensions
 			buildHost,
 			navigationRoot,
 			initialRoute, initialView, initialViewModel,
-			(root, navInit) =>
+			(window, root, navInit) =>
 				{
 					var activate = true;
 					if (root is LoadingView lv)

--- a/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
@@ -30,7 +30,7 @@ public static class WindowExtensions
 			buildHost,
 			navigationRoot,
 			initialRoute, initialView, initialViewModel,
-			async (root, navInit) =>
+			(root, navInit) =>
 				{
 					var activate = true;
 					if (root is LoadingView lv)

--- a/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
@@ -43,21 +43,19 @@ public static class WindowExtensions
 								// Splash isn't enabled, so don't activate until loading completed
 								activate = false;
 
-								// TODO: Change this to use UseTransitions
-								splash.DisableAnimations = true;
+								splash.UseTransitions = false;
 
 								loadingTask = new Func<Task>(async () =>
 								{
 									await navInit;
 									window.Activate();
 								})();
-
-
 							}
 						}
 						var loading = new LoadingTask(loadingTask, root);
 						lv.Source = loading;
 					}
+
 					if (activate)
 					{
 						// Activate immediately to show the splash screen

--- a/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
@@ -30,39 +30,41 @@ public static class WindowExtensions
 			buildHost,
 			navigationRoot,
 			initialRoute, initialView, initialViewModel,
-			(window, root, navInit) =>
-				{
-					var activate = true;
-					if (root is LoadingView lv)
-					{
-						var loadingTask = navInit;
-						if (lv is ExtendedSplashScreen splash)
-						{
-							if (!splash.SplashIsEnabled)
-							{
-								// Splash isn't enabled, so don't activate until loading completed
-								activate = false;
-
-								splash.UseTransitions = false;
-
-								loadingTask = new Func<Task>(async () =>
-								{
-									await navInit;
-									window.Activate();
-								})();
-							}
-						}
-						var loading = new LoadingTask(loadingTask, root);
-						lv.Source = loading;
-					}
-
-					if (activate)
-					{
-						// Activate immediately to show the splash screen
-						window.Activate();
-					}
-				},
+			ApplyLoadingTask,
 			initialNavigate
 			);
+	}
+
+	internal static void ApplyLoadingTask(this Window window, FrameworkElement root, Task navInit)
+	{
+		var activate = true;
+		if (root is LoadingView lv)
+		{
+			var loadingTask = navInit;
+			if (lv is ExtendedSplashScreen splash)
+			{
+				if (!splash.SplashIsEnabled)
+				{
+					// Splash isn't enabled, so don't activate until loading completed
+					activate = false;
+
+					splash.UseTransitions = false;
+
+					loadingTask = new Func<Task>(async () =>
+					{
+						await navInit;
+						window.Activate();
+					})();
+				}
+			}
+			var loading = new LoadingTask(loadingTask, root);
+			lv.Source = loading;
+		}
+
+		if (activate)
+		{
+			// Activate immediately to show the splash screen
+			window.Activate();
+		}
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/ApplicationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ApplicationBuilderExtensions.cs
@@ -38,7 +38,6 @@ public static class ApplicationBuilderExtensions
 		};
 
 		appBuilder.Window.Content = appRoot;
-		appBuilder.Window.Activate();
 
 		return await appBuilder.Window.InternalInitializeNavigationAsync(
 			buildHost: () => Task.FromResult(appBuilder.Build()),

--- a/src/Uno.Extensions.Navigation.UI/ApplicationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ApplicationBuilderExtensions.cs
@@ -21,7 +21,7 @@ public static class ApplicationBuilderExtensions
 			navRoot = contentProvider.ContentControl;
 		}
 
-		Action<FrameworkElement, Task> initializeViewHost = (_, _) => { };
+		Action<Window, FrameworkElement, Task> initializeViewHost = (_, _, _) => { };
 		if (appBuilder.Properties.TryGetValue(typeof(IRootViewInitializer), out var propValue) && propValue is IRootViewInitializer initializer)
 		{
 			navRoot ??= initializer.CreateDefaultView();

--- a/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
@@ -46,10 +46,6 @@ public static class FrameworkElementExtensions
 			{
 				start = () => nav.NavigateViewModelAsync(root, initialViewModel);
 			}
-			//else
-			//{
-			//	start = () => nav.NavigateRouteAsync(root, initialRoute ?? string.Empty);
-			//}
 			var fullstart = async () =>
 			{
 				await initialNavigation();

--- a/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
@@ -46,10 +46,10 @@ public static class FrameworkElementExtensions
 			{
 				start = () => nav.NavigateViewModelAsync(root, initialViewModel);
 			}
-			else
-			{
-				start = () => nav.NavigateRouteAsync(root, initialRoute ?? string.Empty);
-			}
+			//else
+			//{
+			//	start = () => nav.NavigateRouteAsync(root, initialRoute ?? string.Empty);
+			//}
 			var fullstart = async () =>
 			{
 				await initialNavigation();

--- a/src/Uno.Extensions.Navigation.UI/IRootViewInitializer.cs
+++ b/src/Uno.Extensions.Navigation.UI/IRootViewInitializer.cs
@@ -19,7 +19,8 @@ internal interface IRootViewInitializer
 	/// <summary>
 	/// Provide a startup delegate that can wait for the host startup
 	/// </summary>
+	/// <param name="window"></param>
 	/// <param name="element"></param>
 	/// <param name="loadingTask"></param>
-	void InitializeViewHost(FrameworkElement element, Task loadingTask);
+	void InitializeViewHost(Window window, FrameworkElement element, Task loadingTask);
 }

--- a/src/Uno.Extensions.Navigation.UI/ServiceProviderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ServiceProviderExtensions.cs
@@ -181,7 +181,6 @@ public static class ServiceProviderExtensions
 		if (window.Content is null)
 		{
 			window.Content = navigationRoot;
-			window.Activate();
 		}
 
 		var buildTask = window.BuildAndInitializeHostAsync(navigationRoot, buildHost, initialRoute, initialView, initialViewModel, initialNavigate);

--- a/src/Uno.Extensions.Navigation.UI/ServiceProviderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ServiceProviderExtensions.cs
@@ -175,7 +175,7 @@ public static class ServiceProviderExtensions
 		string? initialRoute = "",
 		Type? initialView = null,
 		Type? initialViewModel = null,
-		Action<FrameworkElement, Task>? initializeViewHost = null,
+		Action<Window, FrameworkElement, Task>? initializeViewHost = null,
 		Func<IServiceProvider, INavigator, Task>? initialNavigate = null)
 	{
 		if (window.Content is null)
@@ -184,7 +184,7 @@ public static class ServiceProviderExtensions
 		}
 
 		var buildTask = window.BuildAndInitializeHostAsync(navigationRoot, buildHost, initialRoute, initialView, initialViewModel, initialNavigate);
-		initializeViewHost?.Invoke(navigationRoot, buildTask);
+		initializeViewHost?.Invoke(window, navigationRoot, buildTask);
 		return buildTask;
 	}
 
@@ -207,6 +207,9 @@ public static class ServiceProviderExtensions
 		await Task.Run(() => host.StartAsync());
 
 		await startup;
+
+		// Fallback to make sure the window is activated
+		window.Activate();
 
 		return host;
 	}

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
@@ -30,11 +30,11 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageReference Include="Uno.WinUI" Version="4.9.0-dev.609" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.609" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI" Version="4.9.0-dev.587" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.587" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.587" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.587" />
 	</ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net6.0-android'">

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Mobile/Uno.Extensions.RuntimeTests.Mobile.csproj
@@ -30,11 +30,11 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageReference Include="Uno.WinUI" Version="4.8.15" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.15" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.15" />
+		<PackageReference Include="Uno.WinUI" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.609" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.8.15" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.609" />
 	</ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net6.0-android'">

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
@@ -19,10 +19,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.8.15" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.15" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.15" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.8.15" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.609" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.609" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Gtk/Uno.Extensions.RuntimeTests.Skia.Gtk.csproj
@@ -19,10 +19,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.9.0-dev.609" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.609" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.9.0-dev.587" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.587" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.587" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.587" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
@@ -26,10 +26,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.9.0-dev.609" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.609" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.9.0-dev.587" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.587" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.587" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.587" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
@@ -26,10 +26,10 @@
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.8.15" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.15" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.15" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.8.15" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.609" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.609" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
@@ -49,12 +49,12 @@
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.8.15" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.15" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.15" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.609" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.12" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.12" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.8.15" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.609" />
 	</ItemGroup>
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems')" />
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\common.props" />

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Wasm/Uno.Extensions.RuntimeTests.Wasm.csproj
@@ -49,12 +49,12 @@
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.9.0-dev.609" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.609" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.9.0-dev.587" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.587" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.587" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.12" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.12" />
-		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.609" />
+		<PackageReference Include="Uno.WinUI.Lottie" Version="4.9.0-dev.587" />
 	</ItemGroup>
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems" Label="Shared" Condition="Exists('..\Uno.Extensions.RuntimeTests.Shared\Uno.Extensions.RuntimeTests.Shared.projitems')" />
 	<Import Project="..\Uno.Extensions.RuntimeTests.Shared\common.props" />

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -42,15 +42,15 @@
     <PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.6.0-dev.40" />
     <PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.40" />
     <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.6.0-dev.40" />
-    <PackageVersion Include="Uno.UI" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.UI.MSAL" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.UI" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.UI.MSAL" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.9.0-dev.587" />
     <PackageVersion Include="Uno.UITest" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.32" />
@@ -58,13 +58,13 @@
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.12" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.12" />
-    <PackageVersion Include="Uno.WinUI" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.609" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.WinUI" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.587" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.9.0-dev.587" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -42,15 +42,15 @@
     <PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.6.0-dev.40" />
     <PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.40" />
     <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.6.0-dev.40" />
-    <PackageVersion Include="Uno.UI" Version="4.8.15" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.15" />
-    <PackageVersion Include="Uno.UI.MSAL" Version="4.8.15" />
-    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.8.15" />
-    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.8.15" />
-    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.8.15" />
-    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.8.15" />
-    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.8.15" />
-    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.8.15" />
+    <PackageVersion Include="Uno.UI" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.UI.MSAL" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.UI.RemoteControl" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.UI.Skia.Gtk" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.UI.Skia.Linux.FrameBuffer" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.UI.Skia.Tizen" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.UI.Skia.Wpf" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.UI.WebAssembly" Version="4.9.0-dev.609" />
     <PackageVersion Include="Uno.UITest" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.32" />
     <PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.32" />
@@ -58,13 +58,13 @@
     <PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
     <PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.12" />
     <PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.12" />
-    <PackageVersion Include="Uno.WinUI" Version="4.8.15" />
-    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.8.15" />
-    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.8.15" />
-    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.8.15" />
-    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.8.15" />
-    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.8.15" />
-    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.8.15" />
+    <PackageVersion Include="Uno.WinUI" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.WinUI.Skia.Gtk" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.WinUI.Skia.Wpf" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.WinUI.MSAL" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.609" />
+    <PackageVersion Include="Uno.WinUI.WebAssembly" Version="4.9.0-dev.609" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -38,10 +38,10 @@
     <PackageVersion Include="Uno.Material" Version="2.5.3" />
     <PackageVersion Include="Uno.Material.WinUI" Version="2.5.3" />
     <PackageVersion Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="7.1.11" />
-    <PackageVersion Include="Uno.Toolkit.UI" Version="2.5.5" />
-    <PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.5.5" />
-    <PackageVersion Include="Uno.Toolkit.WinUI" Version="2.5.5" />
-    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.5.5" />
+    <PackageVersion Include="Uno.Toolkit.UI" Version="2.6.0-dev.40" />
+    <PackageVersion Include="Uno.Toolkit.UI.Material" Version="2.6.0-dev.40" />
+    <PackageVersion Include="Uno.Toolkit.WinUI" Version="2.6.0-dev.40" />
+    <PackageVersion Include="Uno.Toolkit.WinUI.Material" Version="2.6.0-dev.40" />
     <PackageVersion Include="Uno.UI" Version="4.8.15" />
     <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.15" />
     <PackageVersion Include="Uno.UI.MSAL" Version="4.8.15" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1399

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Extended splash screen shows on Android 12+ before content of app

## What is the new behavior?

Extended splash screen doesn't show

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
