### PR TITLE
fix: Handling keys that have dots

### DIFF
--- a/src/Uno.Extensions.Localization.UI/ResourceLoaderStringLocalizer.cs
+++ b/src/Uno.Extensions.Localization.UI/ResourceLoaderStringLocalizer.cs
@@ -87,9 +87,17 @@ public class ResourceLoaderStringLocalizer : IStringLocalizer
 
 		var notFound = resource == null;
 
+
+		if (notFound &&
+			name.Contains("."))
+		{
+			return GetLocalizedString(name.Replace(".", "/"));
+		}
+
+
 		resource ??= name;
 
-		var value = arguments.Any()
+		var value = !notFound && arguments.Any()
 			? string.Format(CultureInfo.CurrentCulture, resource, arguments)
 			: resource;
 

--- a/src/Uno.Extensions.Localization.UI/ResourceLoaderStringLocalizer.cs
+++ b/src/Uno.Extensions.Localization.UI/ResourceLoaderStringLocalizer.cs
@@ -1,5 +1,3 @@
-﻿
-
 #if WINDOWS
 using Microsoft.Windows.ApplicationModel.Resources;
 #endif
@@ -87,13 +85,11 @@ public class ResourceLoaderStringLocalizer : IStringLocalizer
 
 		var notFound = resource == null;
 
-
 		if (notFound &&
 			name.Contains("."))
 		{
 			return GetLocalizedString(name.Replace(".", "/"));
 		}
-
 
 		resource ??= name;
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOnePage.xaml
@@ -24,6 +24,9 @@
 			<TextBlock HorizontalAlignment="Center"
 					   FontSize="24"
 					   Text="{Binding ApplicationNameInCode}"/>
+			<TextBlock HorizontalAlignment="Center"
+					   FontSize="24"
+					   Text="{Binding KeyWithDots}"/>
 			<utu:ChipGroup x:Name="LanguageChipGroup"
 						   SelectionMode="Single"
 						   SelectedItem="{Binding SelectedCulture, Mode=TwoWay}"

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/LocalizationOneViewModel.cs
@@ -12,6 +12,9 @@ public partial class LocalizationOneViewModel : ObservableObject
 	[ObservableProperty]
 	private string _applicationNameInCode;
 
+	[ObservableProperty]
+	private string _keyWithDots;
+
 	public LocalizationOneViewModel(
 		ILocalizationService localizationService,
 		IStringLocalizer localizer)
@@ -20,6 +23,7 @@ public partial class LocalizationOneViewModel : ObservableObject
 		SupportedCultures = _localizationService.SupportedCultures;
 
 		ApplicationNameInCode = localizer.GetString("ApplicationName");
+		KeyWithDots = localizer.GetString("Key.With.Dots");
 	}
 
 	public CultureInfo[] SupportedCultures { get; }

--- a/testing/TestHarness/TestHarness.Shared/Strings/en-AU/Resources.resw
+++ b/testing/TestHarness/TestHarness.Shared/Strings/en-AU/Resources.resw
@@ -120,6 +120,9 @@
   <data name="ApplicationName" xml:space="preserve">
     <value>TestHarness</value>
   </data>
+  <data name="Key.With.Dots" xml:space="preserve">
+    <value>TestData-AU</value>
+  </data>
   <data name="Localization_Greeting.Text" xml:space="preserve">
     <value>G'Day Mate</value>
   </data>

--- a/testing/TestHarness/TestHarness.Shared/Strings/en/Resources.resw
+++ b/testing/TestHarness/TestHarness.Shared/Strings/en/Resources.resw
@@ -120,6 +120,9 @@
   <data name="ApplicationName" xml:space="preserve">
     <value>TestHarness</value>
   </data>
+  <data name="Key.With.Dots" xml:space="preserve">
+    <value>TestData-EN</value>
+  </data>
   <data name="Localization_Greeting.Text" xml:space="preserve">
     <value>Hello</value>
   </data>

--- a/testing/TestHarness/TestHarness.Shared/Strings/fr/Resources.resw
+++ b/testing/TestHarness/TestHarness.Shared/Strings/fr/Resources.resw
@@ -120,6 +120,9 @@
   <data name="ApplicationName" xml:space="preserve">
     <value>TestHarness</value>
   </data>
+  <data name="Key.With.Dots" xml:space="preserve">
+    <value>TestData-FR</value>
+  </data>
   <data name="Localization_Greeting.Text" xml:space="preserve">
     <value>Bonjour</value>
   </data>


### PR DESCRIPTION
GitHub Issue (If applicable): #681

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Keys with dots aren't resolved because resource contains / instead of .

## What is the new behavior?

Fallback for resource keys with . to replace with /

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
