### PR TITLE
fix: Selecting default culture based on current thread culture

### DIFF
--- a/src/Uno.Extensions.Localization.UI/LocalizationService.cs
+++ b/src/Uno.Extensions.Localization.UI/LocalizationService.cs
@@ -27,17 +27,29 @@ public class LocalizationService : IServiceInitialize, ILocalizationService, IDi
 			var settingsCulture = _settings?.CurrentValue?.CurrentCulture?.AsCulture();
 			if (settingsCulture is null)
 			{
-				var defaultCulture = PrimaryLanguageOverride ??
-							CultureInfo.DefaultThreadCurrentUICulture?.Name ??
-							CultureInfo.DefaultThreadCurrentCulture?.Name ??
-							_uiThread?.CurrentUICulture?.Name ??
-							_uiThread?.CurrentCulture?.Name;
-				settingsCulture = string.IsNullOrWhiteSpace(defaultCulture) ?
-									SupportedCultures.First() :
-									SupportedCultures.FirstOrDefault(x => x.Name == defaultCulture) ??      // Handles full culture match  eg en-AU == en-AU
-										SupportedCultures.FirstOrDefault(x => x.Name.StartsWith(defaultCulture)) ?? // Handles language only match eg en-AU.StartsWith(en)
-										SupportedCultures.First();
+				var defaultLanguage = PrimaryLanguageOverride ?? string.Empty;
 
+				var defaultCulture =
+							CultureInfo.DefaultThreadCurrentUICulture ??
+							CultureInfo.DefaultThreadCurrentCulture ??
+							_uiThread?.CurrentUICulture ??
+							_uiThread?.CurrentCulture;
+
+				if (!string.IsNullOrWhiteSpace(defaultLanguage))
+				{
+					settingsCulture =
+										SupportedCultures.FirstOrDefault(x => x.Name == defaultLanguage) ??      // Handles full culture match  eg en-AU == en-AU
+											SupportedCultures.FirstOrDefault(x => x.Name.StartsWith(defaultLanguage)); // Handles language only match eg en-AU.StartsWith(en)
+				}
+
+
+				settingsCulture ??=
+									defaultCulture is null ?
+									SupportedCultures.First() :
+									SupportedCultures.FirstOrDefault(x => x.Name == defaultCulture.Name) ??      // Handles full culture match  eg en-AU == en-AU
+										SupportedCultures.FirstOrDefault(x => x.Name.StartsWith(defaultCulture.Name)) ?? // Handles language only match eg en-AU.StartsWith(en)
+										SupportedCultures.FirstOrDefault(x => x.Name.StartsWith(defaultCulture.TwoLetterISOLanguageName)) ?? // Handles language only match eg en-AU.StartsWith(en) (where defaultCulture is en-AU)
+										SupportedCultures.First();
 			}
 			return settingsCulture;
 		}

--- a/src/Uno.Extensions.Localization.UI/LocalizationSettingsExtensions.cs
+++ b/src/Uno.Extensions.Localization.UI/LocalizationSettingsExtensions.cs
@@ -4,7 +4,7 @@ public static class LocalizationSettingsExtensions
 {
 	public static CultureInfo[] AsCultures(this string[] cultures)
 	{
-		return (from c in cultures
+		return (from c in cultures.Distinct()
 				let cult = c.AsCulture()
 				where cult is not null
 				select cult).ToArray();

--- a/testing/TestHarness/TestHarness.Shared/App.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/App.xaml.cs
@@ -36,7 +36,7 @@ public sealed partial class App : Application
 		var host = UnoHost
 					.CreateDefaultBuilder()
 					.UseConfiguration(
-						configureHostConfiguration: builder => builder.AddSectionFromEntity(new LocalizationConfiguration { Cultures = new[] { "en", "en-AU", "fr" } }))
+						configureHostConfiguration: builder => builder.AddSectionFromEntity(new LocalizationConfiguration { Cultures = new[] {"es", "en", "en-AU", "fr" } }))
 					.UseLocalization()
 					.Build();
 		var locals = host.Services.GetServices<IServiceInitialize>();

--- a/testing/TestHarness/TestHarness.Shared/Ext/Localization/appsettings.locale.json
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Localization/appsettings.locale.json
@@ -1,5 +1,5 @@
 ﻿{
   "LocalizationConfiguration": {
-    "Cultures": [ "en", "en-AU", "fr" ]
+    "Cultures": [ "es", "en", "en-AU", "fr" ]
   }
 }

--- a/testing/TestHarness/TestHarness.Shared/appsettings.localizationconfiguration.json
+++ b/testing/TestHarness/TestHarness.Shared/appsettings.localizationconfiguration.json
@@ -1,5 +1,5 @@
 ﻿{
   "LocalizationConfiguration": {
-    "Cultures": [ "en", "fr" ]
+    "Cultures": [ "fr", "en" ]
   }
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1419

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Culture defaults to first in appsettings.json instead of current culture

## What is the new behavior?

Current culture used to select default culture from localization config

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
