### PR TITLE
docs: fix formatting of  [!CAUTION] callout so it displays correctly

### DIFF
--- a/doc/Reference/Reactive/listfeed.md
+++ b/doc/Reference/Reactive/listfeed.md
@@ -26,7 +26,7 @@ which will trigger the load of the next page using the delegate that you provide
 public IListFeed<City> Cities => ListFeed.AsyncPaginated(async (page, ct) => _service.GetCities(pageIndex: page.Index, perPage: 20));
 ```
 
-[!CAUTION]
+> [!CAUTION]
 > On the `Page` struct you have a `DesiredSize` property.
 > This is the number of items the view is requesting to properly fill its "viewport", 
 > **BUT** there is no garantee that this value remains the same between multi pages, espcially if the user resize the app.


### PR DESCRIPTION


<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes

- Project automation
- Other... Please describe:

-->

- Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Display looks like this:

![image](https://github.com/unoplatform/uno.extensions/assets/189547/c1ffeb59-2fa8-4d3b-9ad9-eae4e1c42029)

but it should look like this:

![image](https://github.com/unoplatform/uno.extensions/assets/189547/9139d53a-1edb-43f9-8cfa-a030d654837b)
(From [the State ](https://platform.uno/docs/articles/external/uno.extensions/doc/Reference/Reactive/state.html#set))

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

formatted correctly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
