### PR TITLE
fix: Updating Skia/Wasm target packages to net6

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -92,13 +92,13 @@
 			<GeneratorOutputPath>$(MSBuildProjectDirectory)\$(IntermediateOutputPath)\PackGenerators\</GeneratorOutputPath>
 		</PropertyGroup>
 		<MSBuild Projects="@(GeneratorProjectReference)"
-				 Properties="Configuration=$(Configuration);OutputPath=$(GeneratorOutputPath)" />
+				 Properties="Configuration=$(Configuration);OutputPath=$(GeneratorOutputPath);TargetFramework=netstandard2.0" />
 	</Target>
 
 	<Target Name="GeneratorPack"
 			AfterTargets="PackageGeneratorBuild">
 		<ItemGroup>
-			<None Include="$(GeneratorOutputPath)**\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+			<None Include="$(GeneratorOutputPath)**\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Exclude="@(None)" Visible="false" />
 		</ItemGroup>
 	</Target>
 

--- a/src/Uno.CrossTargeting.props
+++ b/src/Uno.CrossTargeting.props
@@ -6,13 +6,13 @@
 		<Message Text="Building target framework: $(TargetFramework)" Importance="high" Condition="'$(TargetFramework)'!=''" />
 	</Target>
 
-	<Target Name="_UnoOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">
+	<Target Name="_UnoOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(NugetOverrideVersion)'!=''">
 
 		<PropertyGroup>
 			<_TargetNugetPackageId Condition="'$(PackageId)'!=''">$(PackageId)</_TargetNugetPackageId>
 			<_TargetNugetPackageId Condition="'$(PackageId)'==''">$(AssemblyName)</_TargetNugetPackageId>
-			<_TargetNugetFolder Condition="'$(ToolOfPackage)'!=''">$(USERPROFILE)\.nuget\packages\$(ToolOfPackage)\$(UnoNugetOverrideVersion)\analyzers\dotnet\cs</_TargetNugetFolder>
-			<_TargetNugetFolder Condition="'$(ToolOfPackage)'==''">$(USERPROFILE)\.nuget\packages\$(_TargetNugetPackageId)\$(UnoNugetOverrideVersion)\lib\$(TargetFramework)</_TargetNugetFolder>
+			<_TargetNugetFolder Condition="'$(ToolOfPackage)'!=''">$(USERPROFILE)\.nuget\packages\$(ToolOfPackage)\$(NugetOverrideVersion)\analyzers\dotnet\cs</_TargetNugetFolder>
+			<_TargetNugetFolder Condition="'$(ToolOfPackage)'==''">$(USERPROFILE)\.nuget\packages\$(_TargetNugetPackageId)\$(NugetOverrideVersion)\lib\$(TargetFramework)</_TargetNugetFolder>
 		</PropertyGroup>
 
 		<ItemGroup>

--- a/src/Uno.Extensions.Logging/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Logging/HostBuilderExtensions.cs
@@ -23,14 +23,14 @@ public static class HostBuilderExtensions
 #if !__WASM__
 #if __IOS__
 #pragma warning disable CA1416 // Validate platform compatibility: The net6.0 version is not used on older versions of OS
-					builder.AddProvider(new global::Uno.Extensions.Logging.OSLogLoggerProvider());
+						builder.AddProvider(new global::Uno.Extensions.Logging.OSLogLoggerProvider());
 #pragma warning restore CA1416 // Validate platform compatibility
-#elif NET6_0_OR_GREATER // Console isn't supported on all Xamarin targets, so only adding for net6.0 and above
-					builder.AddConsole();
+#elif NET6_0_OR_GREATER || __SKIA__ // Console isn't supported on all Xamarin targets, so only adding for net6.0 and above
+						builder.AddConsole();
 #endif
 						builder.AddDebug();
 #elif __WASM__
-					builder.AddProvider(new global::Uno.Extensions.Logging.WebAssembly.WebAssemblyConsoleLoggerProvider());
+						builder.AddProvider(new global::Uno.Extensions.Logging.WebAssembly.WebAssemblyConsoleLoggerProvider());
 #endif
 					}
 

--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -26,7 +26,18 @@
 
       The UnoTargetFrameworkMobileOverride property is use only in Mobile (i.e. the single-project used by net6-ios/android/mac/catalyst)
 		-->
-    <UnoTargetFrameworkMobileOverride>net6.0-ios</UnoTargetFrameworkMobileOverride>
-    <UnoTargetFrameworkOverride>$(UnoTargetFrameworkMobileOverride);netstandard2.0</UnoTargetFrameworkOverride>
+   <!-- <UnoTargetFrameworkMobileOverride>net6.0-ios</UnoTargetFrameworkMobileOverride>-->
+    <!-- <UnoTargetFrameworkOverride>$(UnoTargetFrameworkMobileOverride);netstandard2.0</UnoTargetFrameworkOverride>-->
+
+	<!--
+
+			### NugetOverrideVersion ###
+
+				Allows the override of the nuget local cache.
+				Set it to the version you want to override, used in another app.
+				You will see the override path in the build output.
+				The packages are located under this directory: "%USERPROFILE%\.nuget\packages". -->
+
+	<!-- <NugetOverrideVersion>2.3.0</NugetOverrideVersion> -->
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): #1476

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Skia/Wasm target packages are netstandard2.0, meaning that #if NET6 conditional includes aren't valid

## What is the new behavior?

Skia/Wasm targets net6.0

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
