### PR TITLE
ci: Update chrome for wasm tests

### DIFF
--- a/build/ci/scripts/wasm-uitest-run.sh
+++ b/build/ci/scripts/wasm-uitest-run.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 
 export UNO_UITEST_TARGETURI=http://localhost:5000
 export UNO_UITEST_DRIVERPATH_CHROME=$BUILD_SOURCESDIRECTORY/build/node_modules/chromedriver/lib/chromedriver
-export UNO_UITEST_CHROME_BINARY_PATH=$BUILD_SOURCESDIRECTORY/build/node_modules/puppeteer/.local-chromium/linux-800071/chrome-linux/chrome
+export UNO_UITEST_CHROME_BINARY_PATH=$BUILD_SOURCESDIRECTORY/build/node_modules/puppeteer/.local-chromium/linux-991974/chrome-linux/chrome
 export UNO_UITEST_SCREENSHOT_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/screenshots/wasm
 export BIN_LOG_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/wasm-uitest.binlog
 export UNO_UITEST_PLATFORM=Browser
@@ -28,8 +28,8 @@ dotnet run --project $UNO_UITEST_WASM_PROJECT -c Release --no-build &
 
 cd $BUILD_SOURCESDIRECTORY/build
 
-npm i chromedriver@86.0.0
-npm i puppeteer@5.3.1
+npm i chromedriver@102.0.0
+npm i puppeteer@14.1.0
 wget $UNO_UITEST_NUGET_URL
 mono nuget.exe install NUnit.ConsoleRunner -Version $UNO_UITEST_NUNIT_VERSION
 


### PR DESCRIPTION
Adjust chrome for wasm tests to support SIMD for bootstrapper 8.x