### PR TITLE
test(mvux): implicit commands off and explicit command on test method

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_Methods_Then_GenerateCommands.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_Methods_Then_GenerateCommands.cs
@@ -828,6 +828,13 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 		public void WithExplicitAttribute() { }
 	}
 
+	public partial class When_ImplicitCommandEnabled_ViewModel
+	{
+
+		[Reactive.Commands.Command(false)]
+		public void WithExplicitAttribute() { }
+	}
+
 	[TestMethod]
 	public async Task When_ImplicitCommandDisabled_ViewModel_Then_CommandNotGenerated()
 	{
@@ -852,6 +859,15 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 
 		MemberInfo GetMember(string name)
 			=> typeof(BindableWhen_ImplicitCommandDisabled_ViewModel).GetMember(name, BindingFlags.Instance | BindingFlags.Public).Single();
+	}
+
+	[TestMethod]
+	public async Task When_ImplicitCommandEnabledAndUseExplicitAttribute_ViewModel_Then_CommandNotGenerated()
+	{
+		GetMember(nameof(When_ImplicitCommandEnabled_ViewModel.WithExplicitAttribute)).Should().NotBeNull().And.BeAssignableTo<MethodInfo>();
+
+		MemberInfo GetMember(string name)
+			=> typeof(BindableWhen_ImplicitCommandEnabled_ViewModel).GetMember(name, BindingFlags.Instance | BindingFlags.Public).Single();
 	}
 
 	[ImplicitFeedCommandParameters(false)]


### PR DESCRIPTION
GitHub Issue (If applicable): #1482

Closes #1482.

## PR Type

- Test

What kind of change does this PR introduce?
This adds a test case demonstrating enabling a specific method for command generation while implicit commands disabled.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)