### PR TITLE
fix: Data should be attached to request without Options wrapper

### DIFF
--- a/src/Uno.Extensions.Navigation.Toolkit/Controls/TabBarItemRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/Controls/TabBarItemRequestHandler.cs
@@ -1,16 +1,22 @@
 ﻿namespace Uno.Extensions.Navigation.Toolkit.Controls;
 
-public class TabBarItemRequestHandler : ActionRequestHandlerBase<TabBarItem>
+/// <summary>
+/// Navigation request handler for <see cref="TabBarItem"/> controls.
+/// </summary>
+/// <param name="HandlerLogger">Logger for logging</param>
+/// <param name="Resolver">Resolver for navigation</param>
+public sealed record TabBarItemRequestHandler(ILogger<TabBarItemRequestHandler> HandlerLogger, IRouteResolver Resolver) : ActionRequestHandlerBase<TabBarItem>(HandlerLogger, Resolver)
 {
-	public TabBarItemRequestHandler(IRouteResolver routes) : base(routes)
-	{
-	}
-
+	/// <inheritdoc/>
 	public override IRequestBinding? Bind(FrameworkElement view)
 	{
 		var viewButton = view as TabBarItem;
 		if (viewButton is null)
 		{
+			if (Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage($"Bind: {view.GetType()} is not an instance, or is not a TabBarItem");
+			}
 			return default;
 		}
 

--- a/src/Uno.Extensions.Navigation.Toolkit/GlobalUsings.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/GlobalUsings.cs
@@ -6,6 +6,7 @@ global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Hosting;
 global using Microsoft.Extensions.Logging;
 global using Uno.Extensions.Hosting;
+global using Uno.Extensions.Logging;
 global using Uno.Extensions.Navigation;
 global using Uno.Extensions.Navigation.Navigators;
 global using Uno.Extensions.Navigation.Regions;

--- a/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
@@ -34,7 +34,8 @@ public abstract record ActionRequestHandlerBase<TView>(ILogger Logger, IRouteRes
 		where TElement : FrameworkElement
 	{
 		var viewToBind = view;
-		async void action(FrameworkElement element, RoutedEventArgs? eventArgs)
+
+		async void Action(FrameworkElement element, RoutedEventArgs? eventArgs)
 		{
 			var path = element.GetRequest();
 			var nav = element.Navigator();
@@ -132,7 +133,7 @@ public abstract record ActionRequestHandlerBase<TView>(ILogger Logger, IRouteRes
 			}
 		}
 
-		var handler = eventHandler(action);
+		var handler = eventHandler(Action);
 
 		var subscribed = false;
 		if (view.IsLoaded)
@@ -145,7 +146,7 @@ public abstract record ActionRequestHandlerBase<TView>(ILogger Logger, IRouteRes
 			subscribe(viewToBind, handler);
 		}
 
-		void loadedHandler(object s, RoutedEventArgs e)
+		void LoadedHandler(object s, RoutedEventArgs e)
 		{
 			if (!subscribed)
 			{
@@ -157,8 +158,8 @@ public abstract record ActionRequestHandlerBase<TView>(ILogger Logger, IRouteRes
 				subscribe(viewToBind, handler);
 			}
 		}
-		view.Loaded += loadedHandler;
-		void unloadedHandler(object s, RoutedEventArgs e)
+		view.Loaded += LoadedHandler;
+		void UnloadedHandler(object s, RoutedEventArgs e)
 		{
 			if (subscribed)
 			{
@@ -170,8 +171,8 @@ public abstract record ActionRequestHandlerBase<TView>(ILogger Logger, IRouteRes
 				unsubscribe(viewToBind, handler);
 			}
 		}
-		view.Unloaded += unloadedHandler;
+		view.Unloaded += UnloadedHandler;
 
-		return new RequestBinding(viewToBind, loadedHandler, unloadedHandler);
+		return new RequestBinding(viewToBind, LoadedHandler, UnloadedHandler);
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
@@ -1,16 +1,30 @@
 ﻿namespace Uno.Extensions.Navigation.UI;
 
-public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBase<TView>
+/// <summary>
+/// Base class for request handlers that bind to a specific control type with an callback actions that should be
+/// called when subscribing and unsubscribing to a control specific event.
+/// </summary>
+/// <typeparam name="TView">The type of control to handle requests for</typeparam>
+/// <param name="Logger">Logger for Logging</param>
+/// <param name="Resolver">Resolver to be used in navigation</param>
+public abstract record ActionRequestHandlerBase<TView>(ILogger Logger, IRouteResolver Resolver) : ControlRequestHandlerBase<TView>(Logger)
 	where TView : FrameworkElement
 {
-	private readonly IRouteResolver _resolver;
-	protected ActionRequestHandlerBase(IRouteResolver routes)
-	{
-		_resolver = routes;
-	}
+	/// <summary>
+	/// Overridable default qualifier to use when navigating to a route without a qualifier.
+	/// </summary>
+	protected virtual string DefaultQualifier { get; } = Qualifiers.None;
 
-	protected string DefaultQualifier { get; init; } = Qualifiers.None;
-
+	/// <summary>
+	/// Abstraction for creating a request binding that navigates based on an event
+	/// </summary>
+	/// <typeparam name="TElement">The type of control to create the binding for</typeparam>
+	/// <typeparam name="TEventHandler">The type of event handler to be bound</typeparam>
+	/// <param name="view">The view to bind to </param>
+	/// <param name="eventHandler">The function that returns an event handler for the action</param>
+	/// <param name="subscribe">Callback to subscribe the event handler</param>
+	/// <param name="unsubscribe">Callback to unsubscribe the event handler</param>
+	/// <returns></returns>
 	protected IRequestBinding? BindAction<TElement, TEventHandler>(
 		TElement view,
 		Func<Action<FrameworkElement, RoutedEventArgs?>, TEventHandler> eventHandler,
@@ -20,13 +34,17 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 		where TElement : FrameworkElement
 	{
 		var viewToBind = view;
-		Action<FrameworkElement, RoutedEventArgs?> action = async (element, eventArgs) =>
+		async void action(FrameworkElement element, RoutedEventArgs? eventArgs)
 		{
 			var path = element.GetRequest();
 			var nav = element.Navigator();
 
 			if (nav is null)
 			{
+				if (Logger.IsEnabled(LogLevel.Warning))
+				{
+					Logger.LogWarningMessage("No navigator found");
+				}
 				return;
 			}
 
@@ -41,12 +59,21 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 			{
 				var dataObject = binding.DataItem;
 				var bindingPathSegments = binding.ParentBinding.Path?.Path?.Split('.').ToArray() ?? Array.Empty<string>();
-				for (int i = 0; i < bindingPathSegments.Length; i++)
+				for (var i = 0; i < bindingPathSegments.Length; i++)
 				{
-					var prop = dataObject.GetType().GetProperty(bindingPathSegments[i]);
+					var segment = bindingPathSegments[i];
+					if (Logger.IsEnabled(LogLevel.Trace))
+					{
+						Logger.LogTraceMessage($"Attempting to retrieve binding segment: {segment}");
+					}
+					var prop = dataObject.GetType().GetProperty(segment);
 					if (i == bindingPathSegments.Length - 1)
 					{
 						resultType = prop?.PropertyType;
+						if (Logger.IsEnabled(LogLevel.Trace))
+						{
+							Logger.LogTraceMessage(resultType is not null ? $"Result type {resultType.Name}" : "No result type");
+						}
 					}
 					else
 					{
@@ -55,13 +82,16 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 
 					if (dataObject is null)
 					{
+						if (Logger.IsEnabled(LogLevel.Trace))
+						{
+							Logger.LogTraceMessage("Binding property returned null");
+						}
 						break;
 					}
 				}
 			}
 			routeHint = routeHint with
 			{
-				//Data = data?.GetType(),
 				Result = resultType
 			};
 
@@ -72,47 +102,75 @@ public abstract class ActionRequestHandlerBase<TView> : ControlRequestHandlerBas
 			var response = await nav.NavigateRouteHintAsync(routeHint, element, data, CancellationToken.None);
 
 			if (binding is not null &&
-			binding.ParentBinding.Mode == BindingMode.TwoWay)
+				binding.ParentBinding.Mode == BindingMode.TwoWay)
 			{
+				if (Logger.IsEnabled(LogLevel.Trace))
+				{
+					Logger.LogTraceMessage("Two way binding, so waiting for result of navigation response");
+				}
 				var resultResponse = response?.AsResultResponse();
 				if (resultResponse is not null)
 				{
 					var result = await resultResponse.UntypedResult;
 					if (result.IsSome(out var resultValue))
 					{
+						if (Logger.IsEnabled(LogLevel.Trace))
+						{
+							Logger.LogTraceMessage("Data returned from navigation so setting Data attached property and updating binding");
+						}
+
 						element.SetData(resultValue);
 						binding.UpdateSource();
 					}
+					else
+					{
+						if (Logger.IsEnabled(LogLevel.Trace))
+						{
+							Logger.LogTraceMessage("No data returned from navigation");
+						}
+					}
 				}
 			}
-		};
+		}
 
 		var handler = eventHandler(action);
 
-		bool subscribed = false;
+		var subscribed = false;
 		if (view.IsLoaded)
 		{
 			subscribed = true;
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTraceMessage("Subscribing");
+			}
 			subscribe(viewToBind, handler);
 		}
 
-		RoutedEventHandler loadedHandler = (s, e) =>
+		void loadedHandler(object s, RoutedEventArgs e)
 		{
 			if (!subscribed)
 			{
 				subscribed = true;
+				if (Logger.IsEnabled(LogLevel.Trace))
+				{
+					Logger.LogTraceMessage("Subscribing");
+				}
 				subscribe(viewToBind, handler);
 			}
-		};
+		}
 		view.Loaded += loadedHandler;
-		RoutedEventHandler unloadedHandler = (s, e) =>
+		void unloadedHandler(object s, RoutedEventArgs e)
 		{
 			if (subscribed)
 			{
 				subscribed = false;
+				if (Logger.IsEnabled(LogLevel.Trace))
+				{
+					Logger.LogTraceMessage("Unsubscribing");
+				}
 				unsubscribe(viewToBind, handler);
 			}
-		};
+		}
 		view.Unloaded += unloadedHandler;
 
 		return new RequestBinding(viewToBind, loadedHandler, unloadedHandler);

--- a/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ActionRequestHandlerBase.cs
@@ -101,8 +101,7 @@ public abstract record ActionRequestHandlerBase<TView>(ILogger Logger, IRouteRes
 
 			var response = await nav.NavigateRouteHintAsync(routeHint, element, data, CancellationToken.None);
 
-			if (binding is not null &&
-				binding.ParentBinding.Mode == BindingMode.TwoWay)
+			if (binding?.ParentBinding.Mode == BindingMode.TwoWay)
 			{
 				if (Logger.IsEnabled(LogLevel.Trace))
 				{

--- a/src/Uno.Extensions.Navigation.UI/Controls/ButtonBaseRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ButtonBaseRequestHandler.cs
@@ -10,10 +10,9 @@ public sealed record ButtonBaseRequestHandler(ILogger<ButtonBaseRequestHandler> 
 	/// <inheritdoc/>
 	public override IRequestBinding? Bind(FrameworkElement view)
 	{
-		var viewButton = view as ButtonBase;
-		if (viewButton is null)
+		if (view is not ButtonBase viewButton)
 		{
-			if(Logger.IsEnabled(LogLevel.Warning))
+			if (Logger.IsEnabled(LogLevel.Warning))
 			{
 				Logger.LogWarningMessage($"Bind: {view?.GetType()} is not a ButtonBase");
 			}

--- a/src/Uno.Extensions.Navigation.UI/Controls/ButtonBaseRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ButtonBaseRequestHandler.cs
@@ -1,21 +1,34 @@
 ﻿namespace Uno.Extensions.Navigation.UI;
 
-public class ButtonBaseRequestHandler : ActionRequestHandlerBase<ButtonBase>
+/// <summary>
+/// Handler for navigation request for a ButtonBase.
+/// </summary>
+/// <param name="HandlerLogger">Logger for Logging</param>
+/// <param name="Resolver">Resolve for navigation</param>
+public sealed record ButtonBaseRequestHandler(ILogger<ButtonBaseRequestHandler> HandlerLogger, IRouteResolver Resolver) : ActionRequestHandlerBase<ButtonBase>(HandlerLogger, Resolver)
 {
-	public ButtonBaseRequestHandler(IRouteResolver routes) : base(routes)
-	{
-	}
-
+	/// <inheritdoc/>
 	public override IRequestBinding? Bind(FrameworkElement view)
 	{
 		var viewButton = view as ButtonBase;
 		if (viewButton is null)
 		{
+			if(Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage($"Bind: {view?.GetType()} is not a ButtonBase");
+			}
 			return null;
 		}
 
 		return BindAction(viewButton,
-			action => new RoutedEventHandler((sender, args) => action((ButtonBase)sender, args)),
+			action => new RoutedEventHandler((sender, args) =>
+			{
+				if (Logger.IsEnabled(LogLevel.Trace))
+				{
+					Logger.LogTraceMessage("Button clicked");
+				}
+				action((ButtonBase)sender, args);
+			}),
 			(element, handler) => element.Click += handler,
 			(element, handler) => element.Click -= handler);
 	}

--- a/src/Uno.Extensions.Navigation.UI/Controls/FrameView.xaml.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/FrameView.xaml.cs
@@ -1,11 +1,21 @@
 ﻿namespace Uno.Extensions.Navigation.UI.Controls;
 
+/// <summary>
+/// Wrapper for a <see cref="Frame"/> that can be used when navigating to a page to
+/// make it easy to do subsequent forward/backward navigation.
+/// </summary>
 public sealed partial class FrameView : UserControl
 {
+	/// <summary>
+	/// Constructor for the FrameView.
+	/// </summary>
 	public FrameView()
 	{
-		this.InitializeComponent();
+		InitializeComponent();
 	}
 
+	/// <summary>
+	/// Returns the Navigator for the Frame region
+	/// </summary>
 	public INavigator? Navigator => NavigationFrame.Navigator();
 }

--- a/src/Uno.Extensions.Navigation.UI/Controls/IRequestBinding.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/IRequestBinding.cs
@@ -1,6 +1,12 @@
 ﻿namespace Uno.Extensions.Navigation.UI;
 
+/// <summary>
+/// Defines method for unbinding a request handler from a view.
+/// </summary>
 public interface IRequestBinding
 {
+	/// <summary>
+	/// Method to unbind the request handler.
+	/// </summary>
 	void Unbind();
 }

--- a/src/Uno.Extensions.Navigation.UI/Controls/IRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/IRequestHandler.cs
@@ -1,8 +1,21 @@
 ﻿namespace Uno.Extensions.Navigation.UI;
 
+/// <summary>
+/// Defines Bind and CanBind methods to bind a view to a navigation request.
+/// </summary>
 public interface IRequestHandler
 {
+	/// <summary>
+	/// Indicates whether the handler can bind to the specified view.
+	/// </summary>
+	/// <param name="view">The view to test</param>
+	/// <returns>true if handler can be bound to a view</returns>
 	bool CanBind(FrameworkElement view);
 
+	/// <summary>
+	/// Binds the handler to the specified view.
+	/// </summary>
+	/// <param name="view">The view to bind to</param>
+	/// <returns>The binding that can be used to unbind from the view</returns>
 	IRequestBinding? Bind(FrameworkElement view);
 }

--- a/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
@@ -4,18 +4,28 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Uno.Extensions.Navigation.UI;
 
-public class ItemsRepeaterRequestHandler : ControlRequestHandlerBase<ItemsRepeater>
+/// <summary>
+/// Navigation handler for the ItemsRepeater control.
+/// </summary>
+/// <param name="HandlerLogger">Logger for Logging</param>
+public sealed record ItemsRepeaterRequestHandler(ILogger<ItemsRepeaterRequestHandler> HandlerLogger) : ControlRequestHandlerBase<ItemsRepeater>(HandlerLogger)
 {
+	/// <inheritdoc/>
 	public override IRequestBinding? Bind(FrameworkElement view)
 	{
 		var viewToBind = view;
 		var viewList = view as ItemsRepeater;
 		if (viewList is null)
 		{
+			if (Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage($"Bind: {view?.GetType()} is not an ItemsRepeater");
+			}
+
 			return default;
 		}
 
-		Func<FrameworkElement, object?, Task> action = async (sender, data) =>
+		async Task action(FrameworkElement sender, object? data)
 		{
 			var navdata = data;
 			var path = sender.GetRequest();
@@ -26,12 +36,12 @@ public class ItemsRepeaterRequestHandler : ControlRequestHandlerBase<ItemsRepeat
 			}
 
 			await nav.NavigateRouteAsync(sender, path, Qualifiers.None, navdata);
-		};
+		}
 
 		var isCaptured = false;
 		object? dataContext = default;
 		FrameworkElement? pointerElement = default;
-		PointerEventHandler pointerPressed = (actionSender, actionArgs) =>
+		void pointerPressed(object actionSender, PointerRoutedEventArgs actionArgs)
 		{
 			var sender = actionSender as ItemsRepeater;
 			if (sender is null)
@@ -57,9 +67,9 @@ public class ItemsRepeaterRequestHandler : ControlRequestHandlerBase<ItemsRepeat
 				}
 			}
 
-		};
+		}
 
-		PointerEventHandler pointerReleased = async (actionSender, actionArgs) =>
+		async void pointerReleased(object actionSender, PointerRoutedEventArgs actionArgs)
 		{
 			var sender = actionSender as ItemsRepeater;
 			if (sender is null)
@@ -84,40 +94,40 @@ public class ItemsRepeaterRequestHandler : ControlRequestHandlerBase<ItemsRepeat
 					actionArgs.Handled = true;
 					await action(sender, dataContext);
 				}
-				
+
 				isCaptured = false;
 				dataContext = null;
 				pointerElement = null;
 			}
 
-		};
+		}
 
 
-		Action connect = () =>
+		void connect()
 		{
 			viewList.PointerPressed += pointerPressed;
 			viewList.PointerReleased += pointerReleased;
-		};
-		Action disconnect = () =>
+		}
+		void disconnect()
 		{
 			viewList.PointerPressed -= pointerPressed;
 			viewList.PointerReleased -= pointerReleased;
-		};
+		}
 
 		if (viewList.IsLoaded)
 		{
 			connect();
 		}
 
-		RoutedEventHandler loadedHandler = (s, e) =>
+		void loadedHandler(object s, RoutedEventArgs e)
 		{
 			connect();
-		};
+		}
 		viewList.Loaded += loadedHandler;
-		RoutedEventHandler unloadedHandler = (s, e) =>
+		void unloadedHandler(object s, RoutedEventArgs e)
 		{
 			disconnect();
-		};
+		}
 		viewList.Unloaded += unloadedHandler;
 		return new RequestBinding(viewToBind, loadedHandler, unloadedHandler);
 	}

--- a/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/ItemsRepeaterRequestHandler.cs
@@ -25,7 +25,7 @@ public sealed record ItemsRepeaterRequestHandler(ILogger<ItemsRepeaterRequestHan
 			return default;
 		}
 
-		async Task action(FrameworkElement sender, object? data)
+		async Task Action(FrameworkElement sender, object? data)
 		{
 			var navdata = data;
 			var path = sender.GetRequest();
@@ -41,7 +41,7 @@ public sealed record ItemsRepeaterRequestHandler(ILogger<ItemsRepeaterRequestHan
 		var isCaptured = false;
 		object? dataContext = default;
 		FrameworkElement? pointerElement = default;
-		void pointerPressed(object actionSender, PointerRoutedEventArgs actionArgs)
+		void PointerPressed(object actionSender, PointerRoutedEventArgs actionArgs)
 		{
 			var sender = actionSender as ItemsRepeater;
 			if (sender is null)
@@ -69,7 +69,7 @@ public sealed record ItemsRepeaterRequestHandler(ILogger<ItemsRepeaterRequestHan
 
 		}
 
-		async void pointerReleased(object actionSender, PointerRoutedEventArgs actionArgs)
+		async void PointerReleased(object actionSender, PointerRoutedEventArgs actionArgs)
 		{
 			var sender = actionSender as ItemsRepeater;
 			if (sender is null)
@@ -92,7 +92,7 @@ public sealed record ItemsRepeaterRequestHandler(ILogger<ItemsRepeaterRequestHan
 				if (pointerInControl)
 				{
 					actionArgs.Handled = true;
-					await action(sender, dataContext);
+					await Action(sender, dataContext);
 				}
 
 				isCaptured = false;
@@ -103,32 +103,32 @@ public sealed record ItemsRepeaterRequestHandler(ILogger<ItemsRepeaterRequestHan
 		}
 
 
-		void connect()
+		void Connect()
 		{
-			viewList.PointerPressed += pointerPressed;
-			viewList.PointerReleased += pointerReleased;
+			viewList.PointerPressed += PointerPressed;
+			viewList.PointerReleased += PointerReleased;
 		}
-		void disconnect()
+		void Disconnect()
 		{
-			viewList.PointerPressed -= pointerPressed;
-			viewList.PointerReleased -= pointerReleased;
+			viewList.PointerPressed -= PointerPressed;
+			viewList.PointerReleased -= PointerReleased;
 		}
 
 		if (viewList.IsLoaded)
 		{
-			connect();
+			Connect();
 		}
 
-		void loadedHandler(object s, RoutedEventArgs e)
+		void LoadedHandler(object s, RoutedEventArgs e)
 		{
-			connect();
+			Connect();
 		}
-		viewList.Loaded += loadedHandler;
-		void unloadedHandler(object s, RoutedEventArgs e)
+		viewList.Loaded += LoadedHandler;
+		void UnloadedHandler(object s, RoutedEventArgs e)
 		{
-			disconnect();
+			Disconnect();
 		}
-		viewList.Unloaded += unloadedHandler;
-		return new RequestBinding(viewToBind, loadedHandler, unloadedHandler);
+		viewList.Unloaded += UnloadedHandler;
+		return new RequestBinding(viewToBind, LoadedHandler, UnloadedHandler);
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/Controls/NavigationFlyout.xaml
+++ b/src/Uno.Extensions.Navigation.UI/Controls/NavigationFlyout.xaml
@@ -4,7 +4,6 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:uen="using:Uno.Extensions.Navigation.UI"
         Placement="Full">
-
     <Grid>
         <Frame uen:Region.Attached="True"
                HorizontalAlignment="Stretch"

--- a/src/Uno.Extensions.Navigation.UI/Controls/NavigationFlyout.xaml.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/NavigationFlyout.xaml.cs
@@ -1,11 +1,15 @@
 ﻿namespace Uno.Extensions.Navigation.UI.Controls;
 
+/// <summary>
+/// Full screen flyout that can be used for navigation.
+/// </summary>
 public sealed partial class NavigationFlyout : Flyout
 {
+	/// <summary>
+	/// Creates a new instance of the <see cref="NavigationFlyout"/> class.
+	/// </summary>
 	public NavigationFlyout()
 	{
 		this.InitializeComponent();
 	}
-
 }
-

--- a/src/Uno.Extensions.Navigation.UI/Controls/NavigationRequestBinder.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/NavigationRequestBinder.cs
@@ -44,6 +44,14 @@ internal class NavigationRequestBinder
 				if (handler is not null)
 				{
 					var binding = handler.Bind(element);
+
+
+					// Unbind existing binding if it doesn't match this binding
+					if (element.GetRequestBinding() is { } existing)
+					{
+						existing.Unbind();
+					}
+
 					if (binding is not null)
 					{
 						element.SetRequestBinding(binding);

--- a/src/Uno.Extensions.Navigation.UI/Controls/NavigationRequestBinder.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/NavigationRequestBinder.cs
@@ -1,6 +1,6 @@
 ﻿namespace Uno.Extensions.Navigation.UI;
 
-public class NavigationRequestBinder
+internal class NavigationRequestBinder
 {
 	public NavigationRequestBinder(FrameworkElement view)
 	{

--- a/src/Uno.Extensions.Navigation.UI/Controls/NavigationViewItemRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/NavigationViewItemRequestHandler.cs
@@ -13,8 +13,7 @@ public sealed record NavigationViewItemRequestHandler(ILogger<NavigationViewItem
 	/// <inheritdoc/>
 	public override IRequestBinding? Bind(FrameworkElement view)
 	{
-		var viewButton = view as NavigationViewItem;
-		if (viewButton is null)
+		if (view is not NavigationViewItem viewButton)
 		{
 			if (Logger.IsEnabled(LogLevel.Warning))
 			{

--- a/src/Uno.Extensions.Navigation.UI/Controls/NavigationViewItemRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/NavigationViewItemRequestHandler.cs
@@ -3,17 +3,23 @@ using NavigationView = Microsoft.UI.Xaml.Controls.NavigationView;
 
 namespace Uno.Extensions.Navigation.UI;
 
-public class NavigationViewItemRequestHandler : ActionRequestHandlerBase<NavigationViewItem>
+/// <summary>
+/// Navigation request handler for <see cref="NavigationViewItem"/>.
+/// </summary>
+/// <param name="HandlerLogger">Logger for logging</param>
+/// <param name="Resolver">Resolver for navigation</param>
+public sealed record NavigationViewItemRequestHandler(ILogger<NavigationViewItemRequestHandler> HandlerLogger, IRouteResolver Resolver) : ActionRequestHandlerBase<NavigationViewItem>(HandlerLogger, Resolver)
 {
-	public NavigationViewItemRequestHandler(IRouteResolver routes) : base(routes)
-	{
-	}
-
+	/// <inheritdoc/>
 	public override IRequestBinding? Bind(FrameworkElement view)
 	{
 		var viewButton = view as NavigationViewItem;
 		if (viewButton is null)
 		{
+			if (Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage($"Bind: {view?.GetType()} is not a NavigationViewItem");
+			}
 			return default;
 		}
 

--- a/src/Uno.Extensions.Navigation.UI/Controls/RequestBinding.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/RequestBinding.cs
@@ -1,0 +1,32 @@
+﻿namespace Uno.Extensions.Navigation.UI;
+
+/// <summary>
+/// Record that references callbacks to be invoked when a view is loaded and unloaded
+/// </summary>
+/// <param name="View">The view to attach/detach event handlers</param>
+/// <param name="LoadedHandler">The loaded callback</param>
+/// <param name="UnloadedHandler">The unloaded callback</param>
+public record RequestBinding (
+	FrameworkElement View,
+	RoutedEventHandler LoadedHandler,
+	RoutedEventHandler UnloadedHandler) : IRequestBinding
+{
+	void IRequestBinding.Unbind()
+	{
+		if (LoadedHandler is not null)
+		{
+			if (View is not null)
+			{
+				View.Loaded -= LoadedHandler;
+			}
+		}
+		if (UnloadedHandler is not null)
+		{
+			UnloadedHandler(View, null);
+			if (View is not null)
+			{
+				View.Unloaded -= UnloadedHandler;
+			}
+		}
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/Controls/SelectorRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/SelectorRequestHandler.cs
@@ -27,7 +27,8 @@ public class SelectorRequestHandler : ControlRequestHandlerBase<Selector>
 		SelectionChangedEventHandler selectionAction = async (actionSender, actionArgs) =>
 		{
 			var sender = actionSender as Selector;
-			if (sender is null)
+			if (sender is null ||
+				(sender is ListViewBase lvb && lvb.IsItemClickEnabled))
 			{
 				return;
 			}
@@ -35,7 +36,7 @@ public class SelectorRequestHandler : ControlRequestHandlerBase<Selector>
 							actionArgs?.AddedItems?.FirstOrDefault() ??
 							sender.SelectedItem; // In some cases, AddedItems is null, even though SelectedItem is not null
 
-			if(data is null)
+			if (data is null)
 			{
 				return;
 			}
@@ -46,7 +47,7 @@ public class SelectorRequestHandler : ControlRequestHandlerBase<Selector>
 		ItemClickEventHandler clickAction = async (actionSender, actionArgs) =>
 		{
 			var sender = actionSender as ListViewBase;
-			if (sender is null)
+			if (!(sender?.IsItemClickEnabled ?? false))
 			{
 				return;
 			}
@@ -61,14 +62,8 @@ public class SelectorRequestHandler : ControlRequestHandlerBase<Selector>
 		{
 			connect = () =>
 			{
-				if (lv.IsItemClickEnabled)
-				{
-					lv.ItemClick += clickAction;
-				}
-				else
-				{
-					viewList.SelectionChanged += selectionAction;
-				}
+				lv.ItemClick += clickAction;
+				viewList.SelectionChanged += selectionAction;
 			};
 
 			disconnect = () =>
@@ -88,7 +83,7 @@ public class SelectorRequestHandler : ControlRequestHandlerBase<Selector>
 			connect();
 		}
 
-		RoutedEventHandler loadedHandler =  (s, e) =>
+		RoutedEventHandler loadedHandler = (s, e) =>
 		{
 			connect();
 		};

--- a/src/Uno.Extensions.Navigation.UI/Controls/SelectorRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/SelectorRequestHandler.cs
@@ -20,7 +20,7 @@ public record SelectorRequestHandler(ILogger<SelectorRequestHandler> HandlerLogg
 			return default;
 		}
 
-		async Task action(FrameworkElement sender, object data)
+		async Task Action(FrameworkElement sender, object data)
 		{
 			var navdata = sender.GetData() ?? data;
 			var path = sender.GetRequest();
@@ -33,7 +33,7 @@ public record SelectorRequestHandler(ILogger<SelectorRequestHandler> HandlerLogg
 			await nav.NavigateRouteAsync(sender, path, Qualifiers.None, navdata);
 		}
 
-		async void selectionAction(object actionSender, SelectionChangedEventArgs actionArgs)
+		async void SelectionAction(object actionSender, SelectionChangedEventArgs actionArgs)
 		{
 			var sender = actionSender as Selector;
 			if (sender is null ||
@@ -50,10 +50,10 @@ public record SelectorRequestHandler(ILogger<SelectorRequestHandler> HandlerLogg
 				return;
 			}
 
-			await action(sender, data);
+			await Action(sender, data);
 		}
 
-		async void clickAction(object actionSender, ItemClickEventArgs actionArgs)
+		async void ClickAction(object actionSender, ItemClickEventArgs actionArgs)
 		{
 			var sender = actionSender as ListViewBase;
 			if (!(sender?.IsItemClickEnabled ?? false))
@@ -62,7 +62,7 @@ public record SelectorRequestHandler(ILogger<SelectorRequestHandler> HandlerLogg
 			}
 			var data = sender.GetData() ?? actionArgs.ClickedItem;
 
-			await action(sender, data);
+			await Action(sender, data);
 		}
 
 		Action? connect = null;
@@ -71,20 +71,20 @@ public record SelectorRequestHandler(ILogger<SelectorRequestHandler> HandlerLogg
 		{
 			connect = () =>
 			{
-				lv.ItemClick += clickAction;
-				viewList.SelectionChanged += selectionAction;
+				lv.ItemClick += ClickAction;
+				viewList.SelectionChanged += SelectionAction;
 			};
 
 			disconnect = () =>
 			{
-				lv.ItemClick -= clickAction;
-				viewList.SelectionChanged -= selectionAction;
+				lv.ItemClick -= ClickAction;
+				viewList.SelectionChanged -= SelectionAction;
 			};
 		}
 		else
 		{
-			connect = () => viewList.SelectionChanged += selectionAction;
-			disconnect = () => viewList.SelectionChanged -= selectionAction;
+			connect = () => viewList.SelectionChanged += SelectionAction;
+			disconnect = () => viewList.SelectionChanged -= SelectionAction;
 		}
 
 		if (viewList.IsLoaded)
@@ -92,16 +92,16 @@ public record SelectorRequestHandler(ILogger<SelectorRequestHandler> HandlerLogg
 			connect();
 		}
 
-		void loadedHandler(object s, RoutedEventArgs e)
+		void LoadedHandler(object s, RoutedEventArgs e)
 		{
 			connect();
 		}
-		viewList.Loaded += loadedHandler;
-		void unloadedHandler(object s, RoutedEventArgs e)
+		viewList.Loaded += LoadedHandler;
+		void UnloadedHandler(object s, RoutedEventArgs e)
 		{
 			disconnect();
 		}
-		viewList.Unloaded += unloadedHandler;
-		return new RequestBinding(viewToBind, loadedHandler, unloadedHandler);
+		viewList.Unloaded += UnloadedHandler;
+		return new RequestBinding(viewToBind, LoadedHandler, UnloadedHandler);
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/Controls/TapRequestHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/TapRequestHandler.cs
@@ -1,15 +1,21 @@
 ﻿namespace Uno.Extensions.Navigation.UI;
 
-public class TapRequestHandler : ActionRequestHandlerBase<FrameworkElement>
+/// <summary>
+/// Navigation request handler for tap event
+/// </summary>
+/// <param name="HandlerLogger">Logger for logging</param>
+/// <param name="Resolver">Resolver for navigation</param>
+public record TapRequestHandler(ILogger<TapRequestHandler> HandlerLogger, IRouteResolver Resolver) : ActionRequestHandlerBase<FrameworkElement>(HandlerLogger, Resolver)
 {
-	public TapRequestHandler(IRouteResolver routes) : base(routes)
-	{
-	}
-
+	/// <inheritdoc/>
 	public override IRequestBinding? Bind(FrameworkElement view)
 	{
 		if (view is null)
 		{
+			if (Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage($"Bind: view is null");
+			}
 			return null;
 		}
 

--- a/src/Uno.Extensions.Navigation.UI/Navigation.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigation.cs
@@ -2,19 +2,19 @@
 
 public static class Navigation
 {
-    public static readonly DependencyProperty RequestProperty =
-        DependencyProperty.RegisterAttached(
-            "Request",
-            typeof(string),
-            typeof(Navigation),
-            new PropertyMetadata(null, RequestChanged));
+	public static readonly DependencyProperty RequestProperty =
+		DependencyProperty.RegisterAttached(
+			"Request",
+			typeof(string),
+			typeof(Navigation),
+			new PropertyMetadata(null, RequestChanged));
 
-    public static readonly DependencyProperty DataProperty =
-    DependencyProperty.RegisterAttached(
-        "Data",
-        typeof(object),
-        typeof(Navigation),
-        new PropertyMetadata(null));
+	public static readonly DependencyProperty DataProperty =
+	DependencyProperty.RegisterAttached(
+		"Data",
+		typeof(object),
+		typeof(Navigation),
+		new PropertyMetadata(null));
 
 	internal static readonly DependencyProperty RequestBindingProperty =
 	DependencyProperty.RegisterAttached(
@@ -24,44 +24,41 @@ public static class Navigation
 		new PropertyMetadata(null));
 
 	private static void RequestChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-    {
-        if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
-        {
-            return;
-        }
+	{
+		if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
+		{
+			return;
+		}
 
-        if (d is FrameworkElement element)
-        {
-			if (e.NewValue is not null)
-			{
-				_ = new NavigationRequestBinder(element);
-			}
-        }
-    }
+		if (d is FrameworkElement element && e.NewValue is not null)
+		{
+			_ = new NavigationRequestBinder(element);
+		}
+	}
 
-    public static void SetRequest(this FrameworkElement element, string value)
-    {
-        element.SetValue(RequestProperty, value);
-    }
+	public static void SetRequest(this FrameworkElement element, string value)
+	{
+		element.SetValue(RequestProperty, value);
+	}
 
-    public static string GetRequest(this FrameworkElement element)
-    {
-        return (string)element.GetValue(RequestProperty);
-    }
+	public static string GetRequest(this FrameworkElement element)
+	{
+		return (string)element.GetValue(RequestProperty);
+	}
 
-    public static void SetData(this FrameworkElement element, object? value)
-    {
-        element.SetValue(DataProperty, value);
-    }
+	public static void SetData(this FrameworkElement element, object? value)
+	{
+		element.SetValue(DataProperty, value);
+	}
 
-    public static object? GetData(this FrameworkElement element)
-    {
-        return (object)element.GetValue(DataProperty);
-    }
+	public static object? GetData(this FrameworkElement element)
+	{
+		return (object)element.GetValue(DataProperty);
+	}
 
 	internal static object? GetDataFromOriginalSource(this FrameworkElement element, object? originalSource)
 	{
-		if(originalSource is FrameworkElement fe &&
+		if (originalSource is FrameworkElement fe &&
 			element != fe)
 		{
 			return fe.GetData() ?? element.GetDataFromOriginalSource(VisualTreeHelper.GetParent(fe));

--- a/src/Uno.Extensions.Navigation.UI/Navigation.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigation.cs
@@ -32,7 +32,15 @@ public static class Navigation
 
         if (d is FrameworkElement element)
         {
-            _ = new NavigationRequestBinder(element);
+			if (element.GetRequestBinding() is { } binding)
+			{
+				binding.Unbind();
+			}
+
+			if (e.NewValue is not null)
+			{
+				_ = new NavigationRequestBinder(element);
+			}
         }
     }
 
@@ -67,12 +75,12 @@ public static class Navigation
 		return default;
 	}
 
-	public static void SetRequestBinding(this FrameworkElement element, IRequestBinding value)
+	internal static void SetRequestBinding(this FrameworkElement element, IRequestBinding value)
 	{
 		element.SetValue(RequestBindingProperty, value);
 	}
 
-	public static IRequestBinding GetRequestBinding(this FrameworkElement element)
+	internal static IRequestBinding GetRequestBinding(this FrameworkElement element)
 	{
 		return (IRequestBinding)element.GetValue(RequestBindingProperty);
 	}

--- a/src/Uno.Extensions.Navigation.UI/Navigation.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigation.cs
@@ -32,11 +32,6 @@ public static class Navigation
 
         if (d is FrameworkElement element)
         {
-			if (element.GetRequestBinding() is { } binding)
-			{
-				binding.Unbind();
-			}
-
 			if (e.NewValue is not null)
 			{
 				_ = new NavigationRequestBinder(element);

--- a/src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs
@@ -91,14 +91,6 @@ public static class NavigationRequestExtensions
 		}
 
 		var route = new Route(qualifier, routeBase, path, paras);
-		//if ((route.IsBackOrCloseNavigation() && !route.IsClearBackstack()) &&
-		//	data is not null &&
-		//	data is not IOption)
-		//{
-		//	data = Option.Some<object>(data);
-		//	paras[string.Empty] = data;
-		//	route = route with { Data = paras };
-		//}
 		return route;
 	}
 

--- a/src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs
@@ -91,14 +91,14 @@ public static class NavigationRequestExtensions
 		}
 
 		var route = new Route(qualifier, routeBase, path, paras);
-		if ((route.IsBackOrCloseNavigation() && !route.IsClearBackstack()) &&
-			data is not null &&
-			data is not IOption)
-		{
-			data = Option.Some<object>(data);
-			paras[string.Empty] = data;
-			route = route with { Data = paras };
-		}
+		//if ((route.IsBackOrCloseNavigation() && !route.IsClearBackstack()) &&
+		//	data is not null &&
+		//	data is not IOption)
+		//{
+		//	data = Option.Some<object>(data);
+		//	paras[string.Empty] = data;
+		//	route = route with { Data = paras };
+		//}
 		return route;
 	}
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoTaskListPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoTaskListPage.xaml
@@ -39,6 +39,14 @@
 								Value="Visible" />
 						<Setter Target="TaskDetails.(uen:Region.Attached)"
 								Value="true" />
+						<Setter Target="ActiveTasks.SelectionMode"
+								Value="Single" />
+						<Setter Target="CompletedTasks.SelectionMode"
+								Value="Single" />
+						<Setter Target="ActiveTasks.IsItemClickEnabled"
+								Value="false" />
+						<Setter Target="ActiveTasks.IsItemClickEnabled"
+								Value="false" />
 					</VisualState.Setters>
 				</VisualState>
 				<VisualState x:Name="Narrow">
@@ -87,6 +95,7 @@
 						<ListView ItemsSource="{Binding CompletedTasks}"
 								  uen:Navigation.Request="Task"
 								  SelectionMode="None"
+								  IsItemClickEnabled="true"
 								  x:Name="CompletedTasks"
 								  ItemTemplate="{StaticResource TaskTemplate}" />
 					</Grid>
@@ -96,6 +105,7 @@
 						<ListView ItemsSource="{Binding ActiveTasks}"
 								  uen:Navigation.Request="Task"
 								  SelectionMode="None"
+								  IsItemClickEnabled="true"
 								  x:Name="ActiveTasks"
 								  ItemTemplate="{StaticResource TaskTemplate}" />
 					</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoTaskListPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/ToDo/ToDoTaskListPage.xaml
@@ -39,14 +39,6 @@
 								Value="Visible" />
 						<Setter Target="TaskDetails.(uen:Region.Attached)"
 								Value="true" />
-						<Setter Target="ActiveTasks.SelectionMode"
-								Value="Single" />
-						<Setter Target="CompletedTasks.SelectionMode"
-								Value="Single" />
-						<Setter Target="ActiveTasks.IsItemClickEnabled"
-								Value="false" />
-						<Setter Target="ActiveTasks.IsItemClickEnabled"
-								Value="false" />
 					</VisualState.Setters>
 				</VisualState>
 				<VisualState x:Name="Narrow">
@@ -94,8 +86,6 @@
 									  Visibility="Collapsed">
 						<ListView ItemsSource="{Binding CompletedTasks}"
 								  uen:Navigation.Request="Task"
-								  SelectionMode="None"
-								  IsItemClickEnabled="true"
 								  x:Name="CompletedTasks"
 								  ItemTemplate="{StaticResource TaskTemplate}" />
 					</Grid>
@@ -104,8 +94,6 @@
 									  Visibility="Collapsed">
 						<ListView ItemsSource="{Binding ActiveTasks}"
 								  uen:Navigation.Request="Task"
-								  SelectionMode="None"
-								  IsItemClickEnabled="true"
 								  x:Name="ActiveTasks"
 								  ItemTemplate="{StaticResource TaskTemplate}" />
 					</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationFivePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationFivePage.xaml
@@ -62,6 +62,14 @@
 			<Button AutomationProperties.AutomationId="FivePageRootThreeSevenClearPageButton"
 					Content="-/Three/Seven (will navigate to Seven with Six and Three in backstack)"
 					uen:Navigation.Request="-/PageNavigationThree/PageNavigationSeven" />
+
+
+			<Button AutomationProperties.AutomationId="FivePageToSixPageViewModelWithDataButton"
+					Content="Six (ViewModel - With Data)"
+					Click="{x:Bind ViewModel.GoToSixWithData}" />
+			<Button AutomationProperties.AutomationId="FivePageToSixPageViewModelWithDataAndBackButton"
+					Content="Six (ViewModel - With Data and Back)"
+					Click="{x:Bind ViewModel.GoToSixWithDataAndBack}" />
 		</StackPanel>
 	</Grid>
 </Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationFiveViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationFiveViewModel.cs
@@ -8,4 +8,16 @@ public record PageNavigationFiveViewModel(INavigator Navigator, IDispatcher Disp
 		await Settings.UpdateAsync(s => s with { PagesVisited = s.PagesVisited.Add(this.GetType().Name) });
 		await Navigator.GoBack(this);
 	}
+
+	public async void GoToSixWithData()
+	{
+		await Settings.UpdateAsync(s => s with { PagesVisited = s.PagesVisited.Add(this.GetType().Name) });
+		await Navigator.NavigateViewModelAsync<PageNavigationSixViewModel>(this, data: new Widget { Name="Bob"});
+	}
+
+	public async void GoToSixWithDataAndBack()
+	{
+		await Settings.UpdateAsync(s => s with { PagesVisited = s.PagesVisited.Add(this.GetType().Name) });
+		await Navigator.NavigateViewModelAsync<PageNavigationSixViewModel>(this, data: new Widget { Name = "Bob" }, qualifier:Qualifiers.NavigateBack);
+	}
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationRegisterHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationRegisterHostInit.cs
@@ -13,7 +13,7 @@ public class PageNavigationRegisterHostInit: PageNavigationHostInit
 			new ViewMap<PageNavigationFourPage, PageNavigationFourViewModel>(),
 			new ViewMap<PageNavigationFivePage, PageNavigationFiveViewModel>(),
 			new ViewMap<PageNavigationSixPage, PageNavigationSixViewModel>(),
-			new ViewMap<PageNavigationSevenPage, PageNavigationSevenViewModel>(),
+			new DataViewMap<PageNavigationSevenPage, PageNavigationSevenViewModel, Widget>(),
 			new ViewMap<PageNavigationEightPage, PageNavigationEightViewModel>(),
 			new ViewMap<PageNavigationNinePage, PageNavigationNineViewModel>(),
 			new ViewMap<PageNavigationTenPage, PageNavigationTenViewModel>(),

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationSixPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationSixPage.xaml
@@ -25,6 +25,9 @@
 			<Button AutomationProperties.AutomationId="SixPageBackButton"
 					Content="Back"
 					uen:Navigation.Request="-" />
+			<Button AutomationProperties.AutomationId="SixPageToSevenPageViewModelButton"
+					Content="Seven (ViewModel)"
+					Click="{x:Bind ViewModel.GoToSeven}" />
 
 		</StackPanel>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationSixViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/PageNavigation/PageNavigationSixViewModel.cs
@@ -1,7 +1,11 @@
 ﻿namespace TestHarness.Ext.Navigation.PageNavigation;
 
-public record PageNavigationSixViewModel (INavigator Navigator, IDispatcher Dispatcher, IWritableOptions<PageNavigationSettings> Settings)
+public record PageNavigationSixViewModel (INavigator Navigator, IDispatcher Dispatcher, IWritableOptions<PageNavigationSettings> Settings, Widget Data)
 	: BasePageNavigationViewModel(Dispatcher)
 {
-
+	public async void GoToSeven()
+	{
+		await Settings.UpdateAsync(s => s with { PagesVisited = s.PagesVisited.Add(this.GetType().Name) });
+		await Navigator.NavigateViewModelAsync<PageNavigationSevenViewModel>(this);
+	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): fixes: #1368

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Route creation was setting data to be Options<Data> when it's a back request (or with - prefix). This meant that data wasn't being correctly applied when creating new view models

## What is the new behavior?

Routes only contain raw data, with Options<Data> being created, if required, by the NavigationRequest (see https://github.com/unoplatform/uno.extensions/pull/1495/files#r1201776822)
Also includes code refactor and documentation for public types/methods
Also adds logging to various types/methods

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
