### PR TITLE
fix: Preventing crash when app data folder doesn't exist

### DIFF
--- a/src/Uno.Extensions.Authentication.MSAL/MsalAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.MSAL/MsalAuthenticationProvider.cs
@@ -32,7 +32,7 @@ internal record MsalAuthenticationProvider(
 		Settings?.Build?.Invoke(builder);
 
 		_scopes = config.Scopes ?? new string[] { };
-		if(_scopes.Length == 0 &&
+		if (_scopes.Length == 0 &&
 			Settings?.Scopes is not null)
 		{
 			_scopes = Settings.Scopes;
@@ -140,6 +140,15 @@ internal record MsalAuthenticationProvider(
 			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Setting up storage location");
 
 			var folderPath = await Storage.CreateFolderAsync(Name.ToLower());
+			if (folderPath is null)
+			{
+				if (Logger.IsEnabled(LogLevel.Warning))
+				{
+					Logger.LogWarningMessage($"Folder should not be null, exiting Msal storage setup");
+				}
+				return;
+			}
+
 			Console.WriteLine($"Folder: {folderPath}");
 			var filePath = Path.Combine(folderPath, CacheFileName);
 			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"MSAL cache {filePath}");

--- a/src/Uno.Extensions.Authentication.MSAL/MsalAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.MSAL/MsalAuthenticationProvider.cs
@@ -134,10 +134,17 @@ internal record MsalAuthenticationProvider(
 			_isCompleted = true;
 
 #if WINDOWS_UWP || !NET6_0_OR_GREATER
-			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"No further action required for setting up storage");
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTraceMessage($"No further action required for setting up storage");
+			}
+
 			return;
 #else
-			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Setting up storage location");
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTraceMessage($"Setting up storage location");
+			}
 
 			var folderPath = await Storage.CreateFolderAsync(Name.ToLower());
 			if (folderPath is null)
@@ -149,9 +156,17 @@ internal record MsalAuthenticationProvider(
 				return;
 			}
 
-			Console.WriteLine($"Folder: {folderPath}");
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTraceMessage($"Folder: {folderPath}");
+			}
+
 			var filePath = Path.Combine(folderPath, CacheFileName);
-			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"MSAL cache {filePath}");
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTraceMessage($"MSAL cache {filePath}");
+			}
+
 			var builder = new StorageCreationPropertiesBuilder(CacheFileName, folderPath);
 			Settings?.Store?.Invoke(builder);
 			var storage = builder.Build();
@@ -161,12 +176,18 @@ internal record MsalAuthenticationProvider(
 			var cacheHelper = await MsalCacheHelper.CreateAsync(storage);
 #endif
 			cacheHelper.RegisterCache(_pca!.UserTokenCache);
-			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"MSAL storage setup completed");
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTraceMessage($"MSAL storage setup completed");
+			}
 #endif
 		}
 		catch (Exception ex)
 		{
-			if (Logger.IsEnabled(LogLevel.Error)) Logger.LogErrorMessage($"Error setting up storage for MSAL - {ex.Message}");
+			if (Logger.IsEnabled(LogLevel.Error))
+			{
+				Logger.LogErrorMessage($"Error setting up storage for MSAL - {ex.Message}");
+			}
 		}
 	}
 

--- a/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
@@ -73,7 +73,7 @@ public static class ConfigBuilderExtensions
 		static string? FilePath(HostBuilderContext hctx)
 		{
 			var file = $"{ConfigurationFolderName}/{string.Format(AppConfiguration.FileNameTemplate, typeof(TSettingsOptions).Name)}";
-			var appData = (hctx.HostingEnvironment as IAppHostEnvironment)?.AppDataPath;
+			var appData = hctx.HostingEnvironment.GetAppDataPath();
 			if(appData is null)
 			{
 				return default;

--- a/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
@@ -70,10 +70,14 @@ public static class ConfigBuilderExtensions
 			configSection = ctx => ctx.Configuration.GetSection(typeof(TSettingsOptions).Name);
 		}
 
-		static string FilePath(HostBuilderContext hctx)
+		static string? FilePath(HostBuilderContext hctx)
 		{
 			var file = $"{ConfigurationFolderName}/{string.Format(AppConfiguration.FileNameTemplate, typeof(TSettingsOptions).Name)}";
-			var appData = (hctx.HostingEnvironment as IAppHostEnvironment)?.AppDataPath ?? string.Empty;
+			var appData = (hctx.HostingEnvironment as IAppHostEnvironment)?.AppDataPath;
+			if(appData is null)
+			{
+				return default;
+			}
 			var path = Path.Combine(appData, file);
 			return path;
 		}
@@ -86,8 +90,14 @@ public static class ConfigBuilderExtensions
 			})
 				.ConfigureServices((ctx, services) =>
 				{
+					var configPath = FilePath(ctx);
+					if (configPath is null)
+					{
+						return;
+					}
+
 					var section = configSection(ctx);
-					services.ConfigureAsWritable<TSettingsOptions>(section, FilePath(ctx));
+					services.ConfigureAsWritable<TSettingsOptions>(section, configPath);
 				}
 
 			).AsConfigBuilder();

--- a/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
@@ -74,7 +74,7 @@ public static class ConfigBuilderExtensions
 		{
 			var file = $"{ConfigurationFolderName}/{string.Format(AppConfiguration.FileNameTemplate, typeof(TSettingsOptions).Name)}";
 			var appData = hctx.HostingEnvironment.GetAppDataPath();
-			if(appData is null)
+			if (appData is not { Length: > 0 })
 			{
 				return default;
 			}
@@ -91,7 +91,7 @@ public static class ConfigBuilderExtensions
 				.ConfigureServices((ctx, services) =>
 				{
 					var configPath = FilePath(ctx);
-					if (configPath is null)
+					if (configPath is not { Length: > 0 })
 					{
 						return;
 					}

--- a/src/Uno.Extensions.Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ConfigurationBuilderExtensions.cs
@@ -5,7 +5,7 @@ public static class ConfigurationBuilderExtensions
 	private static IConfigurationBuilder AddConfigurationFile(this IConfigurationBuilder configurationBuilder, HostBuilderContext hostingContext, string configurationFileName)
 	{
 		var relativePath = $"{ConfigBuilderExtensions.ConfigurationFolderName}/{configurationFileName}";
-		var rootFolder = (hostingContext.HostingEnvironment as IAppHostEnvironment)?.AppDataPath;
+		var rootFolder = hostingContext.HostingEnvironment.GetAppDataPath();
 		if(rootFolder is null)
 		{
 			return configurationBuilder;

--- a/src/Uno.Extensions.Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ConfigurationBuilderExtensions.cs
@@ -5,7 +5,11 @@ public static class ConfigurationBuilderExtensions
 	private static IConfigurationBuilder AddConfigurationFile(this IConfigurationBuilder configurationBuilder, HostBuilderContext hostingContext, string configurationFileName)
 	{
 		var relativePath = $"{ConfigBuilderExtensions.ConfigurationFolderName}/{configurationFileName}";
-		var rootFolder = (hostingContext.HostingEnvironment as IAppHostEnvironment)?.AppDataPath ?? String.Empty;
+		var rootFolder = (hostingContext.HostingEnvironment as IAppHostEnvironment)?.AppDataPath;
+		if(rootFolder is null)
+		{
+			return configurationBuilder;
+		}
 		var fullPath = Path.Combine(rootFolder, relativePath);
 		return configurationBuilder.AddJsonFile(fullPath, optional: true, reloadOnChange: false);
 	}

--- a/src/Uno.Extensions.Configuration/ReloadService.cs
+++ b/src/Uno.Extensions.Configuration/ReloadService.cs
@@ -1,6 +1,6 @@
 ﻿namespace Uno.Extensions.Configuration;
 
-public class ReloadService : IHostedService, IStartupService
+internal class ReloadService : IHostedService, IStartupService
 {
 	public ReloadService(
 		ILogger<ReloadService> logger,
@@ -12,7 +12,10 @@ public class ReloadService : IHostedService, IStartupService
 		Reload = reload;
 		Config = configRoot;
 		Storage = storage;
-		if(Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Created");
+		if (Logger.IsEnabled(LogLevel.Debug))
+		{
+			Logger.LogDebugMessage($"Created");
+		}
 	}
 
 	private IStorage Storage { get; }
@@ -28,7 +31,10 @@ public class ReloadService : IHostedService, IStartupService
 	public async Task StartAsync(CancellationToken cancellationToken)
 	{
 		var folderPath = await Storage.CreateFolderAsync(ConfigBuilderExtensions.ConfigurationFolderName);
-		if(Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($@"Folder path should be '{folderPath}'");
+		if (Logger.IsEnabled(LogLevel.Debug))
+		{
+			Logger.LogDebugMessage($@"Application data path is '{folderPath}'");
+		}
 
 		var fileProviders = Config.Providers;
 		var reloadEnabled = false;
@@ -44,12 +50,23 @@ public class ReloadService : IHostedService, IStartupService
 
 		}
 
-		foreach (var configSource in configSourceFiles)
+		if (folderPath is not null)
 		{
-			await CopyApplicationFileToLocal(folderPath, configSource.ToLower());
+			if (Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage($@"Application data path should not be null");
+			}
+
+			foreach (var configSource in configSourceFiles)
+			{
+				await CopyApplicationFileToLocal(folderPath, configSource.ToLower());
+			}
 		}
 
-		if(Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Started");
+		if (Logger.IsEnabled(LogLevel.Debug))
+		{
+			Logger.LogDebugMessage($"Started");
+		}
 
 		if (reloadEnabled)
 		{
@@ -67,7 +84,7 @@ public class ReloadService : IHostedService, IStartupService
 			if (settings is not null &&
 				!string.IsNullOrWhiteSpace(settings))
 			{
-				if(Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($@"Settings '{settings}'");
+				if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($@"Settings '{settings}'");
 				var fullPath = Path.Combine(localFolderPath, file);
 				await Storage.WriteFileAsync(fullPath, settings, false);
 			}
@@ -80,7 +97,7 @@ public class ReloadService : IHostedService, IStartupService
 
 	public Task StopAsync(CancellationToken cancellationToken)
 	{
-		if(Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Stopped");
+		if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Stopped");
 		return Task.CompletedTask;
 	}
 

--- a/src/Uno.Extensions.Configuration/ReloadService.cs
+++ b/src/Uno.Extensions.Configuration/ReloadService.cs
@@ -52,25 +52,28 @@ internal class ReloadService : IHostedService, IStartupService
 
 		if (folderPath is not null)
 		{
-			if (Logger.IsEnabled(LogLevel.Warning))
-			{
-				Logger.LogWarningMessage($@"Application data path should not be null");
-			}
-
 			foreach (var configSource in configSourceFiles)
 			{
 				await CopyApplicationFileToLocal(folderPath, configSource.ToLower());
 			}
 		}
-
-		if (Logger.IsEnabled(LogLevel.Debug))
+		else
 		{
-			Logger.LogDebugMessage($"Started");
+			if (Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage($@"Application data path should not be null");
+			}
 		}
+
 
 		if (reloadEnabled)
 		{
 			await Reload.ReloadAllFileConfigurationProviders();
+		}
+
+		if (Logger.IsEnabled(LogLevel.Debug))
+		{
+			Logger.LogDebugMessage($"Startup completed");
 		}
 
 		StartupCompletion.TrySetResult(true);
@@ -84,20 +87,30 @@ internal class ReloadService : IHostedService, IStartupService
 			if (settings is not null &&
 				!string.IsNullOrWhiteSpace(settings))
 			{
-				if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($@"Settings '{settings}'");
+				if (Logger.IsEnabled(LogLevel.Debug))
+				{
+					Logger.LogDebugMessage($@"Settings '{settings}'");
+				}
+
 				var fullPath = Path.Combine(localFolderPath, file);
 				await Storage.WriteFileAsync(fullPath, settings, false);
 			}
 		}
 		catch
 		{
-			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTrace($"{file} not included as content");
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTrace($"{file} not included as content");
+			}
 		}
 	}
 
 	public Task StopAsync(CancellationToken cancellationToken)
 	{
-		if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Stopped");
+		if (Logger.IsEnabled(LogLevel.Debug))
+		{
+			Logger.LogDebugMessage($"Stopped");
+		}
 		return Task.CompletedTask;
 	}
 

--- a/src/Uno.Extensions.Configuration/Reloader.cs
+++ b/src/Uno.Extensions.Configuration/Reloader.cs
@@ -16,30 +16,44 @@ internal class Reloader
 
 	public async Task ReloadAllFileConfigurationProviders(string? configFile = default)
 	{
-		if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Reloading config");
-
+		if (Logger.IsEnabled(LogLevel.Debug))
+		{
+			Logger.LogDebugMessage($"Reloading configuration - started");
+		}
 
 		var fileProviders = Config.Providers;
 		foreach (var fp in fileProviders)
 		{
-			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($@"Config provider of type '{fp.GetType().Name}'");
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTraceMessage($@"Config provider of type '{fp.GetType().Name}'");
+			}
+
 			if (fp is FileConfigurationProvider fcp && (configFile is null || configFile.ToLower().Contains(fcp.Source.Path.Split('/', '\\').Last().ToLower())))
 			{
-				if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($@"Loading from file '{fcp.Source.Path}'");
+				if (Logger.IsEnabled(LogLevel.Trace))
+				{
+					Logger.LogTraceMessage($@"Loading from file '{fcp.Source.Path}'");
+				}
+
 				var provider = fcp.Source.FileProvider;
 				var info = provider.GetFileInfo(fcp.Source.Path);
 				if (!File.Exists(info.PhysicalPath))
 				{
-					if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($@"File doesn't exist '{info.PhysicalPath}'");
+					if (Logger.IsEnabled(LogLevel.Trace))
+					{
+						Logger.LogTraceMessage($@"File doesn't exist '{info.PhysicalPath}'");
+					}
 				}
 				else
 				{
-					if (Logger.IsEnabled(LogLevel.Debug))
+					if (Logger.IsEnabled(LogLevel.Trace))
 					{
 						var contents = File.ReadAllText(info.PhysicalPath);
-						Logger.LogDebugMessage($@"Contents '{contents}'");
-						Logger.LogDebugMessage($@"Loading from full path '{info.PhysicalPath}'");
+						Logger.LogTraceMessage($@"Contents '{contents}'");
+						Logger.LogTraceMessage($@"Loading from full path '{info.PhysicalPath}'");
 					}
+
 					await ReadWriteLock.WaitAsync();
 					try
 					{
@@ -52,6 +66,9 @@ internal class Reloader
 				}
 			}
 		}
-		if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Reloading configuration complete");
+		if (Logger.IsEnabled(LogLevel.Debug))
+		{
+			Logger.LogDebugMessage($"Reloading configuration complete");
+		}
 	}
 }

--- a/src/Uno.Extensions.Configuration/Reloader.cs
+++ b/src/Uno.Extensions.Configuration/Reloader.cs
@@ -1,6 +1,6 @@
 ﻿namespace Uno.Extensions.Configuration;
 
-public class Reloader
+internal class Reloader
 {
 	internal static SemaphoreSlim ReadWriteLock = new SemaphoreSlim(1);
 

--- a/src/Uno.Extensions.Configuration/WritableOptions.cs
+++ b/src/Uno.Extensions.Configuration/WritableOptions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Uno.Extensions.Configuration;
 
-public class WritableOptions<T> : IWritableOptions<T>
+internal class WritableOptions<T> : IWritableOptions<T>
 	where T : class, new()
 {
 	private readonly IOptionsMonitor<T> _options;

--- a/src/Uno.Extensions.Hosting.UI/AppHostingEnvironment.cs
+++ b/src/Uno.Extensions.Hosting.UI/AppHostingEnvironment.cs
@@ -4,7 +4,7 @@ using Uno.Foundation;
 
 namespace Uno.Extensions.Hosting;
 
-public class AppHostingEnvironment : HostingEnvironment, IAppHostEnvironment, IDataFolderProvider
+internal class AppHostingEnvironment : HostingEnvironment, IAppHostEnvironment, IDataFolderProvider
 #if __WASM__
 	, IHasAddressBar
 #endif
@@ -12,19 +12,6 @@ public class AppHostingEnvironment : HostingEnvironment, IAppHostEnvironment, ID
 	public string? AppDataPath { get; init; }
 
 	public Assembly? HostAssembly { get; init; }
-
-    public static AppHostingEnvironment FromHostEnvironment(IHostEnvironment host, string? appDataPath, Assembly hostAssembly)
-    {
-        return new AppHostingEnvironment
-        {
-            AppDataPath = appDataPath,
-            ApplicationName = host.ApplicationName,
-            ContentRootFileProvider = host.ContentRootFileProvider,
-            ContentRootPath = host.ContentRootPath,
-            EnvironmentName = host.EnvironmentName,
-			HostAssembly = hostAssembly
-		};
-    }
 
 #if __WASM__
 	public async Task UpdateAddressBar(Uri applicationUri)

--- a/src/Uno.Extensions.Hosting.UI/HostEnvironmentExtensions.cs
+++ b/src/Uno.Extensions.Hosting.UI/HostEnvironmentExtensions.cs
@@ -1,0 +1,27 @@
+﻿namespace Uno.Extensions.Hosting;
+
+/// <summary>
+/// Extension methods for the IHostEnvironment type
+/// </summary>
+public static class HostEnvironmentExtensions
+{
+	/// <summary>
+	/// Creats an IAppHostEnvironment from an IHostEnvironment
+	/// </summary>
+	/// <param name="host">The source IHostEnvironment</param>
+	/// <param name="appDataPath">The app data path</param>
+	/// <param name="hostAssembly">The host assembly</param>
+	/// <returns></returns>
+	public static IAppHostEnvironment FromHostEnvironment(this IHostEnvironment host, string? appDataPath, Assembly hostAssembly)
+	{
+		return new AppHostingEnvironment
+		{
+			AppDataPath = appDataPath,
+			ApplicationName = host.ApplicationName,
+			ContentRootFileProvider = host.ContentRootFileProvider,
+			ContentRootPath = host.ContentRootPath,
+			EnvironmentName = host.EnvironmentName,
+			HostAssembly = hostAssembly
+		};
+	}
+}

--- a/src/Uno.Extensions.Hosting.UI/UnoHost.cs
+++ b/src/Uno.Extensions.Hosting.UI/UnoHost.cs
@@ -2,6 +2,7 @@
 
 public static class UnoHost
 {
+	private const string DefaultUnoAppName = "unoapp";
 	public static IHostBuilder CreateDefaultBuilder(string[]? args = null)
 	{
 		var callingAssembly = Assembly.GetCallingAssembly();
@@ -27,7 +28,7 @@ public static class UnoHost
 
 				if (string.IsNullOrWhiteSpace(dataFolder))
 				{
-					var appName = Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty;
+					var appName = Assembly.GetEntryAssembly()?.GetName().Name ?? DefaultUnoAppName;
 					dataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), appName);
 				}
 

--- a/src/Uno.Extensions.Hosting.UI/UnoHost.cs
+++ b/src/Uno.Extensions.Hosting.UI/UnoHost.cs
@@ -22,19 +22,22 @@ public static class UnoHost
 				catch
 				{
 					// This will throw an exception on WinUI if unpackaged, so dataFolder will be null
+					// Can also be null on Linux FrameBuffer
 				}
-#if WINUI && WINDOWS
-				var appName = Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty;
+
 				if (string.IsNullOrWhiteSpace(dataFolder))
 				{
+					var appName = Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty;
 					dataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), appName);
 				}
-				if (!Directory.Exists(dataFolder))
+
+				if (!string.IsNullOrWhiteSpace(dataFolder) &&
+					!Directory.Exists(dataFolder))
 				{
 					Directory.CreateDirectory(dataFolder);
 				}
-#endif
-				var appHost = AppHostingEnvironment.FromHostEnvironment(ctx.HostingEnvironment, dataFolder, applicationAssembly);
+
+				var appHost = ctx.HostingEnvironment.FromHostEnvironment(dataFolder, applicationAssembly);
 				ctx.HostingEnvironment = appHost;
 			})
 			.ConfigureServices((ctx, services) =>

--- a/src/Uno.Extensions.Hosting/HostEnvironmentExtensions.cs
+++ b/src/Uno.Extensions.Hosting/HostEnvironmentExtensions.cs
@@ -1,0 +1,16 @@
+﻿
+namespace Uno.Extensions.Hosting;
+
+/// <summary>
+/// Extensions for the IHostEnvironment interface.
+/// </summary>
+public static class HostEnvironmentExtensions
+{
+	/// <summary>
+	/// Returns the AppDataPath from the IHostEnvironment if it is an IAppHostEnvironment.
+	/// </summary>
+	/// <param name="hostEnvironment">The IHostEnvironment to retrieve path from</param>
+	/// <returns>Path to application data folder to be used by the application</returns>
+	public static string GetAppDataPath(this IHostEnvironment hostEnvironment)
+		=> (hostEnvironment as IAppHostEnvironment)?.AppDataPath ?? string.Empty;
+}

--- a/src/Uno.Extensions.Hosting/IAppHostEnvironment.cs
+++ b/src/Uno.Extensions.Hosting/IAppHostEnvironment.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Microsoft.Extensions.Logging;
 
 namespace Uno.Extensions.Hosting;
 

--- a/src/Uno.Extensions.Hosting/IAppHostEnvironment.cs
+++ b/src/Uno.Extensions.Hosting/IAppHostEnvironment.cs
@@ -2,8 +2,18 @@
 
 namespace Uno.Extensions.Hosting;
 
+/// <summary>
+/// Interface that extends the IHostEnvironment with app specific properties for an application
+/// </summary>
 public interface IAppHostEnvironment : IHostEnvironment
 {
-    public string? AppDataPath { get; }
-	public Assembly? HostAssembly { get; }
+	/// <summary>
+	/// Gets a path where app data can be stored
+	/// </summary>
+    string? AppDataPath { get; }
+
+	/// <summary>
+	/// Gets a reference to the host assembly
+	/// </summary>
+	Assembly? HostAssembly { get; }
 }

--- a/src/Uno.Extensions.Hosting/IAppHostEnvironment.cs
+++ b/src/Uno.Extensions.Hosting/IAppHostEnvironment.cs
@@ -11,7 +11,7 @@ public interface IAppHostEnvironment : IHostEnvironment
 	/// <summary>
 	/// Gets a path where app data can be stored
 	/// </summary>
-    string? AppDataPath { get; }
+	string? AppDataPath { get; }
 
 	/// <summary>
 	/// Gets a reference to the host assembly

--- a/src/Uno.Extensions.Logging.Serilog/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Logging.Serilog/HostBuilderExtensions.cs
@@ -89,7 +89,7 @@ public static class HostBuilderExtensions
 
         private static string? GetLogFilePath(HostBuilderContext hostBuilderContext)
         {
-            var logDirectory = (hostBuilderContext.HostingEnvironment as IAppHostEnvironment)?.AppDataPath ?? string.Empty;
+            var logDirectory = hostBuilderContext.HostingEnvironment.GetAppDataPath();
             if (string.IsNullOrWhiteSpace(logDirectory))
             {
                 return null;

--- a/src/Uno.Extensions.Storage.UI/FileStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/FileStorage.cs
@@ -1,14 +1,18 @@
 ﻿namespace Uno.Extensions.Storage;
 
-internal record FileStorage(IDataFolderProvider DataFolderProvider) : IStorage
+internal record FileStorage(ILogger Logger, IDataFolderProvider DataFolderProvider) : IStorage
 {
 	private Task<bool> FileExistsInPackage(string fileName) => Uno.UI.Toolkit.StorageFileHelper.ExistsInPackage(fileName);
 
 	public async Task<string?> CreateFolderAsync(string foldername)
 	{
 		var path = DataFolderProvider.AppDataPath;
-		if(path is null)
+		if (path is null)
 		{
+			if (Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage("No application data path, so unable to create folder");
+			}
 			return default;
 		}
 
@@ -23,20 +27,41 @@ internal record FileStorage(IDataFolderProvider DataFolderProvider) : IStorage
 		{
 			if (!await FileExistsInPackage(filename))
 			{
+				if (Logger.IsEnabled(LogLevel.Warning))
+				{
+					Logger.LogWarningMessage($"File '{filename}' does not exist in package");
+				}
 				return default;
 			}
 
-			var storageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri($"ms-appx:///{filename}"));
+			var fileUri = new Uri($"ms-appx:///{filename}");
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTraceMessage($"Reading file '{fileUri}'");
+			}
+			var storageFile = await StorageFile.GetFileFromApplicationUriAsync(fileUri);
 			if (File.Exists(storageFile.Path))
 			{
+				if (Logger.IsEnabled(LogLevel.Trace))
+				{
+					Logger.LogTraceMessage($"Reading file with path '{storageFile.Path}' that does exist");
+				}
 				var settings = File.ReadAllText(storageFile.Path);
 				return settings;
 			}
 
+			if (Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage($"File doesn't exist with path '{storageFile.Path}'");
+			}
 			return default;
 		}
-		catch
+		catch (Exception ex)
 		{
+			if (Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage($"Unable to read file '{filename}' due to exception {ex.Message}");
+			}
 			return default;
 		}
 
@@ -48,6 +73,10 @@ internal record FileStorage(IDataFolderProvider DataFolderProvider) : IStorage
 		{
 			if (!await FileExistsInPackage(filename))
 			{
+				if (Logger.IsEnabled(LogLevel.Warning))
+				{
+					Logger.LogWarningMessage($"File '{filename}' does not exist in package");
+				}
 				return default;
 			}
 
@@ -63,9 +92,20 @@ internal record FileStorage(IDataFolderProvider DataFolderProvider) : IStorage
 
 	public async Task WriteFileAsync(string filename, string text, bool overwrite)
 	{
-		if (!File.Exists(filename) || overwrite)
+		try
 		{
-			File.WriteAllText(filename, text);
+			if (!File.Exists(filename) || overwrite)
+			{
+				File.WriteAllText(filename, text);
+			}
+		}
+		catch (Exception ex)
+		{
+			if (Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage($"Unable to write file '{filename}' due to exception {ex.Message}");
+			}
+			throw;
 		}
 	}
 

--- a/src/Uno.Extensions.Storage.UI/FileStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/FileStorage.cs
@@ -1,12 +1,18 @@
 ﻿namespace Uno.Extensions.Storage;
 
-public record FileStorage(IDataFolderProvider DataFolderProvider) : IStorage
+internal record FileStorage(IDataFolderProvider DataFolderProvider) : IStorage
 {
 	private Task<bool> FileExistsInPackage(string fileName) => Uno.UI.Toolkit.StorageFileHelper.ExistsInPackage(fileName);
 
-	public async Task<string> CreateFolderAsync(string foldername)
+	public async Task<string?> CreateFolderAsync(string foldername)
 	{
-		var localFolder = await StorageFolder.GetFolderFromPathAsync(DataFolderProvider.AppDataPath!);
+		var path = DataFolderProvider.AppDataPath;
+		if(path is null)
+		{
+			return default;
+		}
+
+		var localFolder = await StorageFolder.GetFolderFromPathAsync(path);
 		var folder = await localFolder.CreateFolderAsync(foldername, CreationCollisionOption.OpenIfExists);
 		return folder.Path;
 	}

--- a/src/Uno.Extensions.Storage/IStorage.cs
+++ b/src/Uno.Extensions.Storage/IStorage.cs
@@ -1,12 +1,37 @@
 ﻿namespace Uno.Extensions.Storage;
 
+/// <summary>
+/// Wrapper for accessing file storage for application
+/// </summary>
 public interface IStorage
 {
-	Task<string> CreateFolderAsync(string foldername);
+	/// <summary>
+	/// Create a folder relative to app data
+	/// </summary>
+	/// <param name="foldername">The name of the folder to create</param>
+	/// <returns>Folder path is folder successfully created</returns>
+	Task<string?> CreateFolderAsync(string foldername);
 
+	/// <summary>
+	/// Reads a file from the application package
+	/// </summary>
+	/// <param name="filename">The relative path to the file to read</param>
+	/// <returns>The text contents of the file if the file can be read</returns>
 	Task<string?> ReadPackageFileAsync(string filename);
 
+	/// <summary>
+	/// Opens a file for reading from the application package
+	/// </summary>
+	/// <param name="filename">The relative path to the file to read</param>
+	/// <returns>Stream for the file if it can be opened</returns>
 	Task<Stream?> OpenPackageFileAsync(string filename);
 
+	/// <summary>
+	/// Writes to a file relative to app data
+	/// </summary>
+	/// <param name="filename">The relative path to the file to write</param>
+	/// <param name="text">The text to write</param>
+	/// <param name="overwrite">Whether to override existing file</param>
+	/// <returns>Awaitable task</returns>
 	Task WriteFileAsync(string filename, string text, bool overwrite);
 }

--- a/testing/TestHarness/TestHarness.Skia.Gtk/TestHarness.Skia.Gtk.csproj
+++ b/testing/TestHarness/TestHarness.Skia.Gtk/TestHarness.Skia.Gtk.csproj
@@ -45,6 +45,7 @@
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Configuration\Uno.Extensions.Configuration.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Localization.UI\Uno.Extensions.Localization.WinUI.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Core\Uno.Extensions.Core.csproj" />
+		<ProjectReference Include="..\..\..\src\Uno.Extensions.Core.Generators\Uno.Extensions.Core.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Hosting.UI\Uno.Extensions.Hosting.WinUI.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Hosting\Uno.Extensions.Hosting.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Logging.Serilog\Uno.Extensions.Logging.Serilog.csproj" />
@@ -54,6 +55,7 @@
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Navigation\Uno.Extensions.Navigation.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Reactive.UI\Uno.Extensions.Reactive.WinUI.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Reactive\Uno.Extensions.Reactive.csproj" />
+		<ProjectReference Include="..\..\..\src\Uno.Extensions.Reactive.Generator\Uno.Extensions.Reactive.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Serialization.Http\Uno.Extensions.Serialization.Http.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Serialization.Refit\Uno.Extensions.Serialization.Refit.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Serialization\Uno.Extensions.Serialization.csproj" />


### PR DESCRIPTION
GitHub Issue (If applicable): #1494

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

See #1494

## What is the new behavior?

App data folder should be created if doesn't exist
Configuration (settings) isn't loaded if app data folder doesn't exist

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
