### PR TITLE
Remove duplicate icon file from nuget package

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -109,7 +109,7 @@
 		<DefineConstants>$(DefineConstants);__WINDOWS__</DefineConstants>
 		<TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
 	</PropertyGroup>
-	
+
 	<PropertyGroup Condition="$(_IsWinUI)">
 		<DefineConstants>$(DefineConstants);__WINDOWS__</DefineConstants>
 	</PropertyGroup>
@@ -127,10 +127,6 @@
 		<IsGeneratorProject>False</IsGeneratorProject>
 		<IsGeneratorProject Condition="$(MSBuildProjectName.Contains('Generator'))">True</IsGeneratorProject>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<None Include="$(MSBuildThisFileDirectory)..\build\uno-logo.png" Pack="true" Visible="false" PackagePath="\"/>
-	</ItemGroup>
 
 	<Choose>
 		<When Condition="$(IsTestProject) Or $(IsSampleProject)">


### PR DESCRIPTION
GitHub Issue (If applicable): #

- n/a

## PR Type

What kind of change does this PR introduce?

- Other

## What is the current behavior?

The metadata props downloads the correct icon file and we also pack the old icon file

## What is the new behavior?

We only use the metadata props to download and use the correct icon file