### PR TITLE
fix: Adding null check before calling Update on Bindings

### DIFF
--- a/src/Uno.Extensions.Navigation.Generators/ForceBindingsUpdateGenTool_1.cs
+++ b/src/Uno.Extensions.Navigation.Generators/ForceBindingsUpdateGenTool_1.cs
@@ -61,8 +61,11 @@ internal class ForceBindingsUpdateGenTool_1 : ICodeGenTool
 			bases: updateInterface,
 			code: $@"
 				ValueTask IForceBindingsUpdate.ForceBindingsUpdateAsync()
-				{{	
-					this.Bindings.Update();
+				{{
+					if(this.Bindings is not null)
+					{{
+						this.Bindings.Update();
+					}}
 					return ValueTask.CompletedTask;
 				}}
 			");


### PR DESCRIPTION
GitHub Issue (If applicable): #1534 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Null reference on WinUI in certain cases when calling Update when Bindings is null

## What is the new behavior?

Null check prevents calling Update when Bindings is null

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ X ] Tested code with current [supported SDKs](../README.md#supported)
- [ N/A ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ N/A ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ X ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ X ] Contains **NO** breaking changes
- [ N/A ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ X ] Associated with an issue (GitHub or internal)

