### PR TITLE
fix: Closing flyout on cancellation

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
@@ -59,6 +59,15 @@ public class FlyoutNavigator : ControlNavigator
 			injectedFlyout = !(mapping?.RenderView?.IsSubclassOf(typeof(Flyout)) ?? false);
 			var viewModel = await CreateViewModel(Region.Services, request, route, mapping);
 			_flyout = await DisplayFlyout(request, mapping?.RenderView, viewModel, injectedFlyout);
+
+			if (request.Cancellation.HasValue &&
+				request.Cancellation.Value.CanBeCanceled)
+			{
+				request.Cancellation.Value.Register(async () =>
+				{
+					await this.Dispatcher.ExecuteAsync(() => CloseFlyout());
+				});
+			}
 		}
 		var responseRequest = injectedFlyout ? Route.Empty : route with { Path = null };
 		return responseRequest;

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -17,7 +17,7 @@
 		<PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
 		<PackageVersion Include="Microsoft.Toolkit.Uwp.UI" Version="7.1.2" />
 		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.7.1" />
-		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.2.230118.102" />
+		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.3.230602002" />
 		<PackageVersion Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
 		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 		<PackageVersion Include="Refit" Version="6.3.2" />
@@ -70,7 +70,7 @@
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 		<PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
 		<PackageVersion Include="NUnit" Version="3.13.3" />
-		<PackageVersion Include="NUnit3TestAdapter" Version="4.3.0-alpha-net7.4" />
+		<PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageVersion Include="NunitXml.TestLogger" Version="3.0.131" />
 		<PackageVersion Include="Xamarin.Google.Android.Material" Version="1.4.0.4" />
 		<PackageVersion Include="Xamarin.UITest" Version="4.1.2" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsBasicFlyout.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsBasicFlyout.xaml
@@ -11,7 +11,8 @@
 	<Grid>
 		<TextBlock Text="Shown in Flyout" />
 		<StackPanel VerticalAlignment="Bottom">
-			<Button Content="Close from XAML"
+			<Button  AutomationProperties.AutomationId="DialogsFlyoutDialogCloseButton"
+					 Content="Close from XAML"
 					uen:Navigation.Request="-" />
 			<Button Content="Close from ViewModel"
 					Click="{x:Bind ViewModel.Close}" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml
@@ -26,6 +26,8 @@
 						Click="FlyoutFromBackgroundClick" />
 				<Button Content="Flyout from Background Thread requesting data"
 						Click="FlyoutFromBackgroundRequestingDataClick" />
+				<Button Content="Flyout requesting data with cancellation (2s)"
+						Click="FlyoutRequestingDataWithCancelClick" />
 				<TextBlock Text="{Binding FlyoutData.Id}" />
 				<Button uen:Navigation.Request="!DialogsComplexFlyout"
 						uen:Navigation.Data="{Binding FlyoutData, Mode=TwoWay}"

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml
@@ -20,13 +20,17 @@
 
 		<ScrollViewer Grid.Row="1">
 			<StackPanel>
-				<Button uen:Navigation.Request="!DialogsBasic"
+				<Button AutomationProperties.AutomationId="FlyoutDialogXamlButton"
+						uen:Navigation.Request="!DialogsBasic"
 						Content="Flyout from Xaml" />
-				<Button Content="Flyout from Background Thread"
+				<Button  AutomationProperties.AutomationId="FlyoutDialogCodebehindButton"
+						 Content="Flyout from Background Thread"
 						Click="FlyoutFromBackgroundClick" />
-				<Button Content="Flyout from Background Thread requesting data"
+				<Button  AutomationProperties.AutomationId="FlyoutDialogCodebehindBackgroundButton"
+						 Content="Flyout from Background Thread requesting data"
 						Click="FlyoutFromBackgroundRequestingDataClick" />
-				<Button Content="Flyout requesting data with cancellation (2s)"
+				<Button AutomationProperties.AutomationId="FlyoutDialogCodebehindWithCancelButton"
+						Content="Flyout requesting data with cancellation (2s)"
 						Click="FlyoutRequestingDataWithCancelClick" />
 				<TextBlock Text="{Binding FlyoutData.Id}" />
 				<Button uen:Navigation.Request="!DialogsComplexFlyout"

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml.cs
@@ -29,4 +29,11 @@ public sealed partial class DialogsFlyoutsPage : Page
 		});
 
 	}
+
+	private async void FlyoutRequestingDataWithCancelClick(object sender, RoutedEventArgs args)
+	{
+		var cancelSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+		var nav = this.Navigator()!;
+		var result = await nav.NavigateRouteForResultAsync<Widget>(new object(), "!DialogsBasic", cancellation: cancelSource.Token).AsResult();
+	}
 }

--- a/testing/TestHarness/TestHarness.UITest/Constants.cs
+++ b/testing/TestHarness/TestHarness.UITest/Constants.cs
@@ -4,7 +4,7 @@ namespace TestHarness.UITest;
 
 public class Constants
 {
-	public readonly static string WebAssemblyDefaultUri = "https://localhost:49198";
+	public readonly static string WebAssemblyDefaultUri = "https://localhost:52584";
 	public readonly static string iOSAppName = "uno.platform.extensions.demo";
 	public readonly static string AndroidAppName = "uno.platform.extensions.demo";
 	public readonly static string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Dialogs/Given_FlyoutDialog.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Dialogs/Given_FlyoutDialog.cs
@@ -1,0 +1,49 @@
+﻿namespace TestHarness.UITest;
+
+public class Given_FlyoutDialog : NavigationTestBase
+{
+	[TestCase("FlyoutDialogXamlButton", 0, false)]
+	[TestCase("FlyoutDialogCodebehindButton", 0, false)]
+	[TestCase("FlyoutDialogCodebehindBackgroundButton", 0, false)]
+	[TestCase("FlyoutDialogCodebehindWithCancelButton", 0, false)]
+	[TestCase("FlyoutDialogCodebehindWithCancelButton", 3, true)]
+	public async Task When_FlyoutsButton(string dialogButton, int delayInSeconds, bool dialogCancelled)
+	{
+		InitTestSection(TestSections.Navigation_Dialogs);
+
+		App.WaitThenTap("FlyoutsButton");
+
+		App.WaitElement("DialogsFlyoutsPage");
+		var screenBefore = TakeScreenshot("When_Dialog_Before");
+		App.Tap(dialogButton);
+		await Task.Delay(500); // Make sure the dialog is showing completely
+		var screenAfter = TakeScreenshot("When_Dialog_After");
+		ImageAssert.AreNotEqual(screenBefore, screenAfter);
+
+		if (delayInSeconds > 0)
+		{
+			await Task.Delay(delayInSeconds * 1000);
+			var screenAfterDelay = TakeScreenshot("When_Dialog_After_Delay");
+			if (dialogCancelled)
+			{
+				ImageAssert.AreNotEqual(screenAfter, screenAfterDelay);
+			}
+			else
+			{
+				ImageAssert.AreEqual(screenAfter, screenAfterDelay, tolerance: PixelTolerance.Exclusive(Constants.DefaultPixelTolerance));
+
+			}
+		}
+
+		if (!dialogCancelled)
+		{
+			App.WaitThenTap("DialogsFlyoutDialogCloseButton");
+		}
+
+		await Task.Delay(AppExtensions.UIWaitTimeInMilliseconds);
+
+		var screenClosed = TakeScreenshot("When_Dialog_Closed");
+		ImageAssert.AreEqual(screenBefore, screenClosed,tolerance: PixelTolerance.Exclusive(Constants.DefaultPixelTolerance));
+	}
+
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #1480

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Flyout remains open when cancellation token cancelled

## What is the new behavior?

Flyout closes when token cancelled

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [N/A] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
