### PR TITLE
feat: Added INavigator to both NavigationResponse as well as IRouteNotifier

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/IRouteUpdater.cs
+++ b/src/Uno.Extensions.Navigation.UI/IRouteUpdater.cs
@@ -4,6 +4,6 @@ internal interface IRouteUpdater
 {
 	void StartNavigation(INavigator navigator, IRegion region, NavigationRequest request);
 
-	void EndNavigation(INavigator navigator, IRegion region, NavigationRequest request);
+	void EndNavigation(INavigator navigator, IRegion region, NavigationRequest request, NavigationResponse? response);
 }
 

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
@@ -181,7 +181,7 @@ public abstract class ControlNavigator : Navigator
 
 		UpdateRoute(executedRoute);
 
-		return new NavigationResponse(executedRoute ?? Route.Empty);
+		return new NavigationResponse(executedRoute ?? Route.Empty, Navigator: this);
 	}
 
 	protected virtual void UpdateRoute(Route? route)

--- a/src/Uno.Extensions.Navigation.UI/Regions/NavigationRegion.cs
+++ b/src/Uno.Extensions.Navigation.UI/Regions/NavigationRegion.cs
@@ -27,9 +27,7 @@ public sealed class NavigationRegion : IRegion
 		}
 	}
 
-#if DEBUG
 	private INavigator? Navigator => this.Navigator();
-#endif
 
 	public IServiceProvider? Services
 	{

--- a/src/Uno.Extensions.Navigation.UI/Regions/NavigationRegion.cs
+++ b/src/Uno.Extensions.Navigation.UI/Regions/NavigationRegion.cs
@@ -2,56 +2,60 @@
 
 public sealed class NavigationRegion : IRegion
 {
-    public string? Name { get; private set; }
+	public string? Name { get; private set; }
 
-    public FrameworkElement? View { get; }
+	public FrameworkElement? View { get; }
 
-    private IServiceProvider? _services;
-    private IRegion? _parent;
+	private IServiceProvider? _services;
+	private IRegion? _parent;
 	private bool _isRoot;
 	private bool _isLoaded;
-    public IRegion? Parent
-    {
-        get => _parent;
-        private set
-        {
-            if (_parent is not null)
-            {
-                _parent.Children.Remove(this);
-            }
-            _parent = value;
-            if (_parent is not null)
-            {
-                _parent.Children.Add(this);
-            }
-        }
-    }
+	public IRegion? Parent
+	{
+		get => _parent;
+		private set
+		{
+			if (_parent is not null)
+			{
+				_parent.Children.Remove(this);
+			}
+			_parent = value;
+			if (_parent is not null)
+			{
+				_parent.Children.Add(this);
+			}
+		}
+	}
 
-    public IServiceProvider? Services
-    {
-        get
-        {
+#if DEBUG
+	private INavigator? Navigator => this.Navigator();
+#endif
+
+	public IServiceProvider? Services
+	{
+		get
+		{
 			if (_services is null && Parent is not null)
-            {
+			{
 
 				_services = Parent?.Services?.CreateNavigationScope();
-                if (_services is null)
-                {
-                    return null;
-                }
+				if (_services is null)
+				{
+					return null;
+				}
 
-                _services.AddScopedInstance<IRegion>(this);
-                var serviceFactory = _services.GetRequiredService<INavigatorFactory>();
+				_services.AddScopedInstance<IRegion>(this);
+				var serviceFactory = _services.GetRequiredService<INavigatorFactory>();
 #pragma warning disable CS8603 // Possible null reference return.
-                _services.AddScopedInstance<INavigator>(() => serviceFactory.CreateService(this));
+				_services.AddScopedInstance<INavigator>(() => serviceFactory.CreateService(this));
 #pragma warning restore CS8603 // Possible null reference return.
-            }
+			}
 
-            return _services;
-        }
-    }
+			return _services;
+		}
+	}
 
-    public ICollection<IRegion> Children { get; } = new List<IRegion>();
+	public ICollection<IRegion> Children { get; } = new List<IRegion>();
 
 	public NavigationRegion(FrameworkElement? view = null, IServiceProvider? services = null)
 	{
@@ -100,66 +104,66 @@ public sealed class NavigationRegion : IRegion
 	}
 
 	private async void ViewLoaded(object sender, RoutedEventArgs e)
-    {
-        await HandleLoading();
-    }
+	{
+		await HandleLoading();
+	}
 
 #if WINDOWS_UWP || WINUI || NETSTANDARD
-    private async void ViewLoading(FrameworkElement sender, object args)
+	private async void ViewLoading(FrameworkElement sender, object args)
 #else
     private async void ViewLoading(DependencyObject sender, object args)
 #endif
-    {
-        await HandleLoading();
-    }
+	{
+		await HandleLoading();
+	}
 
-    private void ViewUnloaded(object sender, RoutedEventArgs e)
-    {
-        if (View is null ||
+	private void ViewUnloaded(object sender, RoutedEventArgs e)
+	{
+		if (View is null ||
 			!_isLoaded)
-        {
-            return;
-        }
+		{
+			return;
+		}
 
 		_isLoaded = false;
 
 		View.Loading += ViewLoading;
-        View.Loaded += ViewLoaded;
-        View.Unloaded -= ViewUnloaded;
+		View.Loaded += ViewLoaded;
+		View.Unloaded -= ViewUnloaded;
 
-        Parent = null;
-    }
+		Parent = null;
+	}
 
-    private Task HandleLoading()
-    {
+	private Task HandleLoading()
+	{
 		if (View is null)
-        {
-            return Task.CompletedTask;
-        }
+		{
+			return Task.CompletedTask;
+		}
 
-        AssignParent();
+		AssignParent();
 
-        return View.IsLoaded ? HandleLoaded() : Task.CompletedTask;
-    }
+		return View.IsLoaded ? HandleLoaded() : Task.CompletedTask;
+	}
 
-    private void AssignParent()
-    {
-        if (View is null || _isRoot || !View.GetAttached())
-        {
-            return;
-        }
+	private void AssignParent()
+	{
+		if (View is null || _isRoot || !View.GetAttached())
+		{
+			return;
+		}
 
-        if (Parent is null)
-        {
-            var parent = View.FindParentRegion(out var routeName);
-            Name = routeName;
-            if (parent is not null)
-            {
-                Parent = parent;
-            }
-        }
+		if (Parent is null)
+		{
+			var parent = View.FindParentRegion(out var routeName);
+			Name = routeName;
+			if (parent is not null)
+			{
+				Parent = parent;
+			}
+		}
 
-		if(Parent is null && !_isRoot && _services is null)
+		if (Parent is null && !_isRoot && _services is null)
 		{
 			var sp = View.FindServiceProvider();
 			var services = sp?.CreateNavigationScope();
@@ -177,36 +181,36 @@ public sealed class NavigationRegion : IRegion
 				_ = services.Startup(start);
 			}
 		}
-    }
+	}
 
-    public void ReassignParent()
-    {
-        Parent = null;
-        AssignParent();
-    }
+	public void ReassignParent()
+	{
+		Parent = null;
+		AssignParent();
+	}
 
-    private async Task HandleLoaded()
-    {
-        if (View is null || _isLoaded)
-        {
-            return;
-        }
+	private async Task HandleLoaded()
+	{
+		if (View is null || _isLoaded)
+		{
+			return;
+		}
 		_isLoaded = true;
 
 		View.Loading -= ViewLoading;
-        View.Loaded -= ViewLoaded;
-        View.Unloaded += ViewUnloaded;
+		View.Loaded -= ViewLoaded;
+		View.Unloaded += ViewUnloaded;
 
-        // Force the lookup (and creation) of the navigator
-        // This is required to intercept control event such as
-        // navigating forward/backward on frame, or switching tabs
+		// Force the lookup (and creation) of the navigator
+		// This is required to intercept control event such as
+		// navigating forward/backward on frame, or switching tabs
 		var navigator = this.Navigator();
 
-		if(navigator is not null)
+		if (navigator is not null)
 		{
 			foreach (var child in Children.OfType<NavigationRegion>())
 			{
-				if(child._isLoaded && child._services is null)
+				if (child._isLoaded && child._services is null)
 				{
 					// This will force the setup of Services, which will
 					// in turn force the creation of the navigator
@@ -214,7 +218,7 @@ public sealed class NavigationRegion : IRegion
 				}
 			}
 		}
-    }
+	}
 
 	public async Task<string> GetStringAsync()
 	{
@@ -224,37 +228,37 @@ public sealed class NavigationRegion : IRegion
 	}
 
 	private static async Task PrintAllRegions(StringBuilder builder, IRegion region)
-    {
-        if (!string.IsNullOrWhiteSpace(region.Name))
-        {
-            builder.Append($@"{region.Name}");
-        }
+	{
+		if (!string.IsNullOrWhiteSpace(region.Name))
+		{
+			builder.Append($@"{region.Name}");
+		}
 
-        if (region.View is not null)
-        {
-            builder.Append($@"({region.View.GetType().Name})-");
-        }
+		if (region.View is not null)
+		{
+			builder.Append($@"({region.View.GetType().Name})-");
+		}
 
 		await region.View.EnsureLoaded();
-        var nav = region.Navigator();
-        if (nav is not null)
-        {
-            builder.Append($"{nav.ToString()}");
-        }
+		var nav = region.Navigator();
+		if (nav is not null)
+		{
+			builder.Append($"{nav.ToString()}");
+		}
 
-        if (region.Children.Any())
-        {
-            builder.Append(" [");
-        }
+		if (region.Children.Any())
+		{
+			builder.Append(" [");
+		}
 
-        foreach (var child in region.Children)
-        {
-            await PrintAllRegions(builder, child);
-        }
+		foreach (var child in region.Children)
+		{
+			await PrintAllRegions(builder, child);
+		}
 
-        if (region.Children.Any())
-        {
-            builder.Append("]");
-        }
-    }
+		if (region.Children.Any())
+		{
+			builder.Append("]");
+		}
+	}
 }

--- a/src/Uno.Extensions.Navigation.UI/ResponseNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/ResponseNavigator.cs
@@ -88,7 +88,7 @@ public class ResponseNavigator<TResult> : IResponseNavigator, IInstance<IService
 		{
 			navResponse.Result.ContinueWith(x => ApplyResult(x.Result));
 		}
-		return new NavigationResultResponse<TResult>(response?.Route ?? Route.Empty, ResultCompletion.Task, response?.Success ?? false);
+		return new NavigationResultResponse<TResult>(response?.Route ?? Route.Empty, ResultCompletion.Task, response?.Success ?? false, response?.Navigator ?? this);
 	}
 
 	public Task<bool> CanNavigate(Route route) => Navigation.CanNavigate(route);

--- a/src/Uno.Extensions.Navigation.UI/RouteChangedEventArgs.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteChangedEventArgs.cs
@@ -1,12 +1,29 @@
 ﻿namespace Uno.Extensions.Navigation;
 
+/// <summary>
+/// Event args for when a route has changed
+/// </summary>
 public class RouteChangedEventArgs : EventArgs
 {
+	/// <summary>
+	/// The root region where the route has changed
+	/// </summary>
 	public IRegion Region { get; }
 
-	public RouteChangedEventArgs(IRegion region)
+	/// <summary>
+	/// The navigator where the route changed (leaf region in hierarchy)
+	/// </summary>
+	public INavigator? Navigator { get; }
+
+	/// <summary>
+	/// Constructs a new instance
+	/// </summary>
+	/// <param name="region">The root region where route was changed</param>
+	/// <param name="navigator">The navigator that changed the route</param>
+	public RouteChangedEventArgs(IRegion region, INavigator? navigator)
 	{
 		Region = region;
+		Navigator = navigator;
 	}
 }
 

--- a/src/Uno.Extensions.Navigation.UI/RouteNotifier.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteNotifier.cs
@@ -4,7 +4,7 @@ using Uno.Extensions.Logging;
 
 namespace Uno.Extensions.Navigation;
 
-public class RouteNotifier : IRouteNotifier, IRouteUpdater
+internal class RouteNotifier : IRouteNotifier, IRouteUpdater
 {
 	public event EventHandler<RouteChangedEventArgs>? RouteChanged;
 
@@ -35,11 +35,11 @@ public class RouteNotifier : IRouteNotifier, IRouteUpdater
 		}
 		if (Logger.IsEnabled(LogLevel.Trace))
 		{
-			navigationSegments[id].AppendLine($"[{id} - {PerformanceTimer.Split(id).TotalMilliseconds}] {navigator.GetType().Name} - {region.Name??"unnamed"} - {request.Route} {(request.Route.IsInternal?"(internal)":"")}");
+			navigationSegments[id].AppendLine($"[{id} - {PerformanceTimer.Split(id).TotalMilliseconds}] {navigator.GetType().Name} - {region.Name ?? "unnamed"} - {request.Route} {(request.Route.IsInternal ? "(internal)" : "")}");
 		}
 	}
 
-	public void EndNavigation(INavigator navigator, IRegion region, NavigationRequest request)
+	public void EndNavigation(INavigator navigator, IRegion region, NavigationRequest request, NavigationResponse? response)
 	{
 		var id = request.Id;
 		runningNavigations[id] = runningNavigations[id] - 1;
@@ -53,7 +53,7 @@ public class RouteNotifier : IRouteNotifier, IRouteUpdater
 				Logger.LogTraceMessage($"Post-navigation (summary):\n{navigationSegments[id]}");
 			}
 			navigationSegments.Remove(id);
-			RouteChanged?.Invoke(this, new RouteChangedEventArgs(region.Root()));
+			RouteChanged?.Invoke(this, new RouteChangedEventArgs(region.Root(), response?.Navigator));
 		}
 	}
 }

--- a/src/Uno.Extensions.Navigation/NavigationResponse.cs
+++ b/src/Uno.Extensions.Navigation/NavigationResponse.cs
@@ -1,12 +1,19 @@
 ﻿namespace Uno.Extensions.Navigation;
 
-#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
-
-public record NavigationResultResponse(Route? Route, Task<IOption> UntypedResult, bool Success = true) : NavigationResponse(Route, Success)
+/// <summary>
+/// Navigation response with result
+/// </summary>
+/// <param name="Route">The Route that was navigated to</param>
+/// <param name="UntypedResult">The untyped result of navigation</param>
+/// <param name="Success">Whether or not navigation was successful </param>
+/// <param name="Navigator">The INavigator instance that processed the final segment of the Route</param>
+public record NavigationResultResponse(
+	Route? Route, Task<IOption> UntypedResult,
+	bool Success = true, INavigator? Navigator = default) : NavigationResponse(Route, Success, Navigator)
 {
 	internal NavigationResultResponse<TResult> AsResultResponse<TResult>()
 	{
-		if(this is NavigationResultResponse<TResult> typedResult)
+		if (this is NavigationResultResponse<TResult> typedResult)
 		{
 			return typedResult;
 		}
@@ -24,7 +31,7 @@ public record NavigationResultResponse(Route? Route, Task<IOption> UntypedResult
 			return optionResult;
 		}
 
-		if(resultData.SomeOrDefault() is TResult someResult)
+		if (resultData.SomeOrDefault() is TResult someResult)
 		{
 			return Option.Some(someResult);
 		}
@@ -33,11 +40,20 @@ public record NavigationResultResponse(Route? Route, Task<IOption> UntypedResult
 	}
 }
 
-public record NavigationResultResponse<TResult>(Route? Route, Task<Option<TResult>> Result, bool Success = true)
+/// <summary>
+/// Navigation response with Typed result
+/// </summary>
+/// <typeparam name="TResult"></typeparam>
+/// <param name="Route">The Route that was navigated to</param>
+/// <param name="Result">The result of navigation</param>
+/// <param name="Success">Whether or not navigation was successful </param>
+/// <param name="Navigator">The INavigator instance that processed the final segment of the Route</param>
+public record NavigationResultResponse<TResult>(Route? Route, Task<Option<TResult>> Result, bool Success = true, INavigator? Navigator = default)
 	: NavigationResultResponse(
 		Route,
 		AsOption(Result),
-		Success)
+		Success,
+		Navigator)
 {
 
 	private static async Task<IOption> AsOption(Task<Option<TResult>> result)
@@ -47,9 +63,11 @@ public record NavigationResultResponse<TResult>(Route? Route, Task<Option<TResul
 	}
 }
 
-public record NavigationResponse(Route? Route = null, bool Success = true)
-{
-}
-
-#pragma warning restore SA1313 // Parameter names should begin with lower-case letter
+/// <summary>
+/// Navigation response
+/// </summary>
+/// <param name="Route">The Route that was navigated to</param>
+/// <param name="Success">Whether or not navigation was successful </param>
+/// <param name="Navigator">The INavigator instance that processed the final segment of the Route</param>
+public record NavigationResponse(Route? Route = null, bool Success = true, INavigator? Navigator = default);
 

--- a/testing/TestHarness/TestHarness.Shared/BaseHostInitialization.cs
+++ b/testing/TestHarness/TestHarness.Shared/BaseHostInitialization.cs
@@ -6,7 +6,7 @@ public abstract class BaseHostInitialization : IHostInitialization
 
 	public virtual IHost InitializeHost()
 	{
-		return UnoHost
+		var host = UnoHost
 				.CreateDefaultBuilder()
 
 				.Use(builder => Environment(builder))
@@ -24,6 +24,14 @@ public abstract class BaseHostInitialization : IHostInitialization
 				.Use(builder => Localization(builder))
 
 				.Build(enableUnoLogging: true);
+
+		var notifier = host.Services.GetService<IRouteNotifier>();
+		notifier.RouteChanged += (s, e) =>
+		{
+			Debug.WriteLine($"Navigated to {e.Region?.Name}");
+		};
+
+		return host;
 	}
 
 	protected virtual IHostBuilder Localization(IHostBuilder builder)


### PR DESCRIPTION
GitHub Issue (If applicable): #1675

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Hard using either IRouteNotifier or NavigationResponse to access the INavigator of the newly created view. Particulalry useful for dialogs where having a reference to the INavigator allows it to be closed.


## What is the new behavior?

IRouteNotifier RouteChangedEventArgs now includes INavigator that represents where the view changed. NavigationResponse also has a reference to the INavigator that changed the route.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
