### PR TITLE
test(mvux): Ensure that feed parameters shares the same context as the Model

### DIFF
--- a/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_VMWithCommands.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_VMWithCommands.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.UI;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Extensions.Reactive.WinUI.Tests.Generator;
+
+[TestClass]
+[RunsOnUIThread]
+public partial class Given_VMWithCommands
+{
+	public partial class When_ParameterFeed_Then_SubscribedWithSameContext_ViewModel
+	{
+		public int FeedInvokeCount { get; private set; }
+
+		public int CommandLastParameter { get; private set; } = -1;
+
+		public IFeed<int> MyFeed => Feed.Async(async ct => ++FeedInvokeCount);
+
+		public void DoSomething(int myFeed, CancellationToken ct)
+			=> CommandLastParameter = myFeed;
+	}
+
+	[TestMethod]
+	public async Task When_ParameterFeed_Then_SubscribedWithSameContext()
+	{
+		var vm = new BindableWhen_ParameterFeed_Then_SubscribedWithSameContext_ViewModel();
+
+		await UIHelper.WaitFor(() => vm.MyFeed != 0, default);
+
+		var current = vm.MyFeed;
+		vm.DoSomething.Execute(null);
+
+		await UIHelper.WaitFor(() => vm.Model.CommandLastParameter != -1, default);
+
+		Assert.AreEqual(1, vm.FeedInvokeCount);
+		Assert.AreEqual(current, vm.Model.CommandLastParameter);
+	}
+
+	[TestMethod]
+	public async Task When_ParameterFeed_Then_SubscribedWithSameContext_UsingUI()
+	{
+		FeedView view;
+		Button doSomething;
+		var vm = new BindableWhen_ParameterFeed_Then_SubscribedWithSameContext_ViewModel();
+		var ui = new StackPanel
+		{
+			DataContext = vm,
+			Children =
+			{
+				(view = new FeedView()),
+				(doSomething = new Button())
+			}
+		};
+
+		view.SetBinding(FeedView.SourceProperty, new Binding { Path = new PropertyPath("MyFeed") });
+		doSomething.SetBinding(Button.CommandProperty, new Binding { Path = new PropertyPath("DoSomething") });
+
+		await UIHelper.Load(ui, default);
+
+		await UIHelper.WaitFor(() => vm.MyFeed is not 0, default);
+
+		var current = vm.MyFeed;
+		doSomething.Command.Execute(null);
+
+		await UIHelper.WaitFor(() => vm.Model.CommandLastParameter != -1, default);
+
+		Assert.AreEqual(1, vm.FeedInvokeCount);
+		Assert.AreEqual(current, vm.Model.CommandLastParameter);
+	}
+}

--- a/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_VMWithCommands.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_VMWithCommands.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions.Reactive.UI;
 using Uno.UI.RuntimeTests;
+using Button = Microsoft.UI.Xaml.Controls.Button;
 
 namespace Uno.Extensions.Reactive.WinUI.Tests.Generator;
 

--- a/src/Uno.Extensions.Reactive/Utils/FeedUIHelper.cs
+++ b/src/Uno.Extensions.Reactive/Utils/FeedUIHelper.cs
@@ -48,7 +48,17 @@ public static class FeedUIHelper
 		}
 	}
 
-	private static async ValueTask<IAsyncEnumerator<T>> GetSourceEnumerator<T>(ISignal<T> signal, SourceContext context)
+	private static async ValueTask<IAsyncEnumerator<Message<T>>> GetSourceEnumerator<T>(IFeed<T> signal, SourceContext context)
+	{
+		var ct = context.Token;
+		var src = DispatcherHelper.HasThreadAccess
+			? await Task.Run(() => context.GetOrCreateSource(signal), ct).ConfigureAwait(false)
+			: context.GetOrCreateSource(signal);
+
+		return src.GetAsyncEnumerator(ct);
+	}
+
+	private static async ValueTask<IAsyncEnumerator<TMessage>> GetSourceEnumerator<TMessage>(ISignal<TMessage> signal, SourceContext context)
 	{
 		var ct = context.Token;
 		var src = DispatcherHelper.HasThreadAccess


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/1622

## Tests
Ensure that feed parameters shares the same context as the Model

## What is the current behavior?
In old versions of reactive it might happen that context used for command's "feed parameters" was not the same as the model itself.

## What is the new behavior?
Add tests to enforce no regression

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
