### PR TITLE
fix: Only including using when on supported tfm

### DIFF
--- a/src/Uno.Extensions.Maui.UI/build/Package.targets
+++ b/src/Uno.Extensions.Maui.UI/build/Package.targets
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition=" '$(ImplicitUsings)' == 'true' OR '$(ImplicitUsings)' == 'enable' ">
-		<Using Include="Uno.Extensions.Maui" />
+		<Using Include="Uno.Extensions.Maui"  Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' OR $(TargetFramework.Contains('windows10'))" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #https://github.com/unoplatform/uno.extensions-private/issues/79

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Global usings for unsupported tfms (eg net7.0) will cause a build error

## What is the new behavior?

Only add global usings for ios, android and winui

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
