### PR TITLE
fix: Ensuring Region.Logger is set before navigation proceeds

### DIFF
--- a/samples/Playground/Playground.Shared/App.xaml.cs
+++ b/samples/Playground/Playground.Shared/App.xaml.cs
@@ -204,4 +204,11 @@ public sealed partial class App : Application
 		}
 	}
 
+
+}
+
+public class LongStartHostedService : IHostedService
+{
+	public Task StartAsync(CancellationToken cancellationToken) => Task.Delay(10000, cancellationToken);
+	public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/samples/Playground/Playground.Shared/AppHost.cs
+++ b/samples/Playground/Playground.Shared/AppHost.cs
@@ -58,7 +58,8 @@ internal static class AppHost
 
 							)
 
-					.AddHostedService<SimpleStartupService>();
+					.AddHostedService<SimpleStartupService>()
+					.AddHostedService<LongStartHostedService>();
 			})
 
 

--- a/samples/Playground/Playground.Shared/Services/SimpleStartupService.cs
+++ b/samples/Playground/Playground.Shared/Services/SimpleStartupService.cs
@@ -2,7 +2,7 @@
 {
 	public class SimpleStartupService:IHostedService, IStartupService
 	{
-		private TaskCompletionSource<object> _completion = new TaskCompletionSource<object>();
+		private TaskCompletionSource<bool> _completion = new TaskCompletionSource<bool>();
 		public Task StartAsync(CancellationToken cancellationToken)
 		{
 			_completion.SetResult(true);

--- a/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
@@ -137,7 +137,7 @@ public static class FrameworkElementExtensions
 			return Task.CompletedTask;
 		}
 
-		var completion = new TaskCompletionSource<object>();
+		var completion = new TaskCompletionSource<bool>();
 
 		// Note: We're attaching to three different events to
 		// a) always detect when element is loaded (sometimes Loaded is never fired)
@@ -165,7 +165,7 @@ public static class FrameworkElementExtensions
 				rego?.Dispose();
 
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-				completion.TrySetResult(null);
+				completion.TrySetResult(true);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
 				element.Loaded -= loaded;

--- a/src/Uno.Extensions.Navigation.UI/NavigationHostedService.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationHostedService.cs
@@ -2,7 +2,7 @@
 
 internal record NavigationHostedService(ILogger<NavigationRegion> RegionLogger) : IHostedService, IStartupService
 {
-	private TaskCompletionSource<object> _completion = new TaskCompletionSource<object>();
+	private TaskCompletionSource<bool> _completion = new TaskCompletionSource<bool>();
 
 	public Task StartAsync(CancellationToken cancellationToken)
 	{

--- a/src/Uno.Extensions.Navigation.UI/NavigationHostedService.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationHostedService.cs
@@ -1,12 +1,17 @@
 ﻿namespace Uno.Extensions.Navigation.UI;
 
-internal record NavigationHostedService(ILogger<NavigationRegion> RegionLogger) : IHostedService
+internal record NavigationHostedService(ILogger<NavigationRegion> RegionLogger) : IHostedService, IStartupService
 {
+	private TaskCompletionSource<object> _completion = new TaskCompletionSource<object>();
+
 	public Task StartAsync(CancellationToken cancellationToken)
 	{
 		Region.Logger = RegionLogger;
+		_completion.SetResult(true);
 		return Task.CompletedTask;
 	}
 
 	public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+	public Task StartupComplete() => _completion.Task;
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #1732 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Region.Logger isn't set if startup takes too long

## What is the new behavior?

Region.Logger is always set before nav takes place

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
