### PR TITLE
Provide Maui Resource Dictionary

### DIFF
--- a/src/Uno.Extensions.Maui.UI/Internals/MauiContentHost.cs
+++ b/src/Uno.Extensions.Maui.UI/Internals/MauiContentHost.cs
@@ -2,9 +2,9 @@
 
 internal class MauiContentHost : Microsoft.Maui.Controls.ContentView
 {
-	public MauiContentHost(ResourceDictionary resources)
+	public MauiContentHost(MauiResourceDictionary resources)
 	{
-		Resources = resources.ToMauiResources();
+		Resources = resources;
 		HorizontalOptions = LayoutOptions.Fill;
 		VerticalOptions = LayoutOptions.Fill;
 	}

--- a/src/Uno.Extensions.Maui.UI/MauiHost.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiHost.cs
@@ -97,11 +97,11 @@ public partial class MauiHost : ContentControl
 
 		if (_host is null)
 		{
-			_host = new MauiContentHost(resources)
+			var resourceManager = MauiContext.Services.GetRequiredService<MauiResourceManager>();
+			_host = new MauiContentHost(resourceManager.CreateMauiResources(resources))
 			{
 				BindingContext = DataContext,
 				Content = MauiContent
-
 			};
 
 			try

--- a/src/Uno.Extensions.Maui.UI/Uno.Extensions.Maui.WinUI.csproj
+++ b/src/Uno.Extensions.Maui.UI/Uno.Extensions.Maui.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\tfms-ui-maui.props" />
 
 	<PropertyGroup>
@@ -10,7 +10,7 @@
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
 
 		<IsMauiEmbedding>false</IsMauiEmbedding>
-		<IsMauiEmbedding Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' OR $(TargetFramework.Contains('windows10'))" >true</IsMauiEmbedding>
+		<IsMauiEmbedding Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' OR $(TargetFramework.Contains('windows10'))">true</IsMauiEmbedding>
 		<DefineConstants Condition="$(IsMauiEmbedding)">$(DefineConstants);MAUI_EMBEDDING</DefineConstants>
 	</PropertyGroup>
 
@@ -52,6 +52,7 @@
 		<Otherwise>
 			<ItemGroup>
 				<Compile Remove="Internals\*.cs" />
+				<None Include="Internals\*.cs" />
 			</ItemGroup>
 		</Otherwise>
 	</Choose>


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes unoplatform/uno.extensions-private#102

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

There is no good way to inject "Application Level Resources" into Maui Embedding

## What is the new behavior?

We now have an extension method on the MauiAppBuilder to provide a Maui ResourceDictionary which can be injected into the MauiContentHost providing all of the resources which you might normally put in a Maui Application, thus eliminating the need to inject these into each custom user control.
