### PR TITLE
feat: Add ability to project to paginated by cursor list feed

### DIFF
--- a/build/ci/templates/dotnet-install-windows.yml
+++ b/build/ci/templates/dotnet-install-windows.yml
@@ -1,5 +1,5 @@
 parameters:
-  DotNetVersion: '7.0.x'
+  DotNetVersion: '7.0.306'
   UnoCheck_Version: '1.11.0-dev.2'
   UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/146b0b4b23d866bef455494a12ad7ffd2f6f2d20/manifests/uno.ui.manifest.json'
 

--- a/src/Uno.Extensions.Reactive/Core/Feed.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.cs
@@ -139,5 +139,43 @@ public static partial class Feed
 				return items;
 			});
 	}
+
+	/// <summary>
+	/// Projects each value of a source feed into a paginated collection.
+	/// </summary>
+	/// <typeparam name="TSource">Type of the value of the feed.</typeparam>
+	/// <typeparam name="TCursor">Type of the cursor that is used to identify a page to load.</typeparam>
+	/// <typeparam name="TResult">Type of the value of the items in resulting list feed.</typeparam>
+	/// <param name="source">The source feed to project.</param>
+	/// <param name="firstPage">The cursor of the first page.</param>
+	/// <param name="getPage">The async method to load a page of items.</param>
+	/// <returns>A paginated list feed.</returns>
+	public static IListFeed<TResult> SelectPaginatedByCursorAsync<TSource, TCursor, TResult>(
+		this IFeed<TSource> source,
+		TCursor firstPage,
+		GetPage<TCursor, TResult> getPage)
+		where TSource : notnull
+	{
+		return AttachedProperty.GetOrCreate(source, (firstPage, getPage), Create).AsListFeed();
+
+		static IFeed<IImmutableList<TResult>> Create(IFeed<TSource> parameter, (TCursor firstPage, GetPage< TCursor, TResult> getPage) args)
+			=> new DynamicFeed<IImmutableList<TResult>>(async _ =>
+			{
+				FeedExecution.Current!.EnableRefresh();
+
+				var value = await parameter;
+				if (value is null)
+				{
+					return ImmutableList<TResult>.Empty;
+				}
+
+				var items = await FeedExecution.Current!.GetPaginated<TResult>(
+					b => b
+						.ByCursor(args.firstPage)
+						.GetPage(args.getPage));
+
+				return items;
+			});
+	}
 	#endregion
 }

--- a/src/Uno.Extensions.Reactive/Core/Feed.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.cs
@@ -134,7 +134,7 @@ public static partial class Feed
 				var items = await FeedExecution.Current!.GetPaginated<TResult>(
 					b => b
 						.ByIndex()
-						.GetPage(async (req, ct) => await gp(value, req, ct)));
+						.GetPage((req, ct) => gp(value, req, ct)));
 
 				return items;
 			});
@@ -153,12 +153,12 @@ public static partial class Feed
 	public static IListFeed<TResult> SelectPaginatedByCursorAsync<TSource, TCursor, TResult>(
 		this IFeed<TSource> source,
 		TCursor firstPage,
-		GetPage<TCursor, TResult> getPage)
+		GetPage<TSource, TCursor, TResult> getPage)
 		where TSource : notnull
 	{
 		return AttachedProperty.GetOrCreate(source, (firstPage, getPage), Create).AsListFeed();
 
-		static IFeed<IImmutableList<TResult>> Create(IFeed<TSource> parameter, (TCursor firstPage, GetPage< TCursor, TResult> getPage) args)
+		static IFeed<IImmutableList<TResult>> Create(IFeed<TSource> parameter, (TCursor firstPage, GetPage<TSource, TCursor, TResult> getPage) args)
 			=> new DynamicFeed<IImmutableList<TResult>>(async _ =>
 			{
 				FeedExecution.Current!.EnableRefresh();
@@ -172,7 +172,7 @@ public static partial class Feed
 				var items = await FeedExecution.Current!.GetPaginated<TResult>(
 					b => b
 						.ByCursor(args.firstPage)
-						.GetPage(args.getPage));
+						.GetPage((token, count, ct) => args.getPage(value, token, count, ct)));
 
 				return items;
 			});

--- a/src/Uno.Extensions.Reactive/Sources/PageResult.cs
+++ b/src/Uno.Extensions.Reactive/Sources/PageResult.cs
@@ -17,6 +17,18 @@ namespace Uno.Extensions.Reactive.Sources;
 public delegate ValueTask<PageResult<TCursor, TItem>> GetPage<TCursor, TItem>(TCursor cursor, uint? desiredPageSize, CancellationToken ct);
 
 /// <summary>
+/// Load a page of items of a paginated list.
+/// </summary>
+/// <typeparam name="TParam">Type of the parameter used to build the paginated list.</typeparam>
+/// <typeparam name="TCursor">Type of the cursor used by the pagination</typeparam>
+/// <typeparam name="TItem">Type of the items of the list.</typeparam>
+/// <param name="parameter">The parameter used to create the paginated list (changing the value of this will reset the cursor to the first page).</param>
+/// <param name="cursor">The cursor of the page to load.</param>
+/// <param name="desiredPageSize">The desired page size if any.</param>
+/// <param name="ct">A cancellation to cancel the async operation.</param>
+public delegate ValueTask<PageResult<TCursor, TItem>> GetPage<in TParam, TCursor, TItem>(TParam parameter, TCursor cursor, uint? desiredPageSize, CancellationToken ct);
+
+/// <summary>
 /// A page of items for a paginated list of items.
 /// </summary>
 /// <typeparam name="TCursor">The cursor used to track the pagination.</typeparam>


### PR DESCRIPTION
## Feature
Add ability to project to paginated by cursor list feed

## What is the current behavior?
We can have paginated list by cursor without parameter or by index with (or without) parameter, but we cannot have a paginated list by cursor with parameter.

## What is the new behavior?
We can!

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
