### PR TITLE
fix: FeedView not initializing properly is not visible on first load

### DIFF
--- a/src/Uno.Extensions.Reactive.UI.Tests/Given_FeedView.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Given_FeedView.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions.Reactive.Core;
 using Uno.Extensions.Reactive.Testing;
@@ -40,6 +41,28 @@ public class Given_FeedView : FeedTests
 
 		await UIHelper.WaitFor(() => isLoadingValues.Count > 0, CT);
 	}
+
+	[TestMethod]
+	public async Task When_NotVisible_Then_DoesNotSubscribeToSource()
+	{
+		// This tests will also ensure that is the FeedView will not try to GoToState while it does not have any template yet.
+
+		var isLoaded = false;
+		var src = Feed.Async(async ct => isLoaded = true);
+		var sut = new FeedView { Source = src };
+		var root = new Grid { Visibility = Visibility.Collapsed, Children = { sut } };
+
+		await UIHelper.Load(root, CT);
+
+		isLoaded.Should().BeFalse("The FeedView should not have subscribed to the source while it is not visible.");
+
+		root.Visibility = Visibility.Visible;
+
+		await UIHelper.WaitFor(() => isLoaded, CT);
+
+		isLoaded.Should().BeTrue("The FeedView should have subscribed to the source when it became visible.");
+	}
+
 
 	[TestMethod]
 	public async Task When_GetSource_Then_ContextContainsDispatcher()

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Shared/App.xaml.cs
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Shared/App.xaml.cs
@@ -45,13 +45,13 @@ namespace Uno.Extensions.RuntimeTests
 		{
 #if NET6_0_OR_GREATER && WINDOWS && !HAS_UNO
 			_window = new Window();
-			_window.Activate();
 #else
 			_window = Microsoft.UI.Xaml.Window.Current;
 #endif
 
 			ForceAssemblyLoading();
 			_window.Content ??= new Uno.UI.RuntimeTests.UnitTestsControl();
+			_window.Activate();
 		}
 
 		/// <summary>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Windows/Properties/launchsettings.json
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Windows/Properties/launchsettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+	"RuntimeTests.Windows (Package)": {
+	  "commandName": "MsixPackage"
+	},
+	"RuntimeTests.Windows (Unpackaged)": {
+	  "commandName": "Project"
+	}
+  }
+}

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Windows/Uno.Extensions.RuntimeTests.Windows.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Windows/Uno.Extensions.RuntimeTests.Windows.csproj
@@ -9,9 +9,15 @@
 		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
 		<PublishProfile>win10-$(Platform).pubxml</PublishProfile>
 		<UseWinUI>true</UseWinUI>
-		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
+		<EnableMsixTooling>true</EnableMsixTooling>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 		<DefineConstants>$(DefineConstants);WINDOWS_WINUI;WINUI</DefineConstants>
+
+		<!-- Uncomment for Unpackaged builds -->
+		<!-- For Unpackaged builds, change version of SDK to previous stable release https://github.com/microsoft/WindowsAppSDK/issues/3591 -->
+		<!--<WindowsPackageType>None</WindowsPackageType>
+		<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+		<SelfContained>true</SelfContained>-->
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -26,7 +32,7 @@
 
 	<ItemGroup>
 		<PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.3" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
@@ -37,7 +43,7 @@
 	<!-- Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
 		 Tools extension to be activated for this project even if the Windows App SDK Nuget
 		 package has not yet been restored -->
-	<ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnablePreviewMsixTooling)'=='true'">
+	<ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
 		<ProjectCapability Include="Msix"/>
 	</ItemGroup>
 	

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Windows/Uno.Extensions.RuntimeTests.Windows.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Windows/Uno.Extensions.RuntimeTests.Windows.csproj
@@ -13,11 +13,10 @@
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 		<DefineConstants>$(DefineConstants);WINDOWS_WINUI;WINUI</DefineConstants>
 
-		<!-- Uncomment for Unpackaged builds -->
-		<!-- For Unpackaged builds, change version of SDK to previous stable release https://github.com/microsoft/WindowsAppSDK/issues/3591 -->
-		<!--<WindowsPackageType>None</WindowsPackageType>
+		<!-- Comment this out if you want to handle distributing the WinAppSdk -->
 		<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
-		<SelfContained>true</SelfContained>-->
+		<!-- Uncomment for to package dotnet in addition to WinAppSdk -->
+		<!-- <SelfContained>true</SelfContained>-->
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/1666

## Bugfix
FeedView not initializing properly is not visible on first load

## What is the current behavior?
`FeedView` subscribes to its `Source` on loaded, no matter if the template has yet been applied or not. This drives the `FeedView` to invoke some `GoToState` which does nothing, and will not do it again when template is being applied.

## What is the new behavior?
We wait to have both being loaded and have a template applied before subscribing to the `Source`. 

Note: This also make sure to not load some data if useless, which is the expected default behavior so far.

## PR Checklist
- [ x Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
