### PR TITLE
build: Adjust generator packaging to not require double build

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -86,23 +86,6 @@
 		<WriteLinesToFile File="$(_AndroidResourceDesignerFile)" Lines="// Empty Content from uno.ui Directory.Build.targets." />
 	</Target>
 
-	<!-- NOTE: This is due to a Race Condition with MSBuild where the dll may not yet exist on a clean build -->
-	<Target Name="PackageGeneratorBuild"
-			AfterTargets="Build">
-		<PropertyGroup>
-			<GeneratorOutputPath>$(MSBuildProjectDirectory)\$(IntermediateOutputPath)\PackGenerators\</GeneratorOutputPath>
-		</PropertyGroup>
-		<MSBuild Projects="@(GeneratorProjectReference)"
-				 Properties="Configuration=$(Configuration);OutputPath=$(GeneratorOutputPath);TargetFramework=netstandard2.0" />
-	</Target>
-
-	<Target Name="GeneratorPack"
-			AfterTargets="PackageGeneratorBuild">
-		<ItemGroup>
-			<None Include="$(GeneratorOutputPath)**\*.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Exclude="@(None)" Visible="false" />
-		</ItemGroup>
-	</Target>
-
 	<Import Project="winappsdk-workaround.targets" Condition="exists('winappsdk-workaround.targets')" />
 	<Import Project="xamarinmac-workaround.targets" Condition="exists('xamarinmac-workaround.targets') and $(TargetFramework.ToLower().StartsWith('xamarin')) and $(TargetFramework.ToLower().Contains('mac'))" />
 	<Import Project="Directory.UnoMetadata.targets" />

--- a/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
+++ b/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
@@ -45,11 +45,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<GeneratorProjectReference Include="..\Uno.Extensions.Core.Generators\Uno.Extensions.Core.Generators.csproj" />
+		<ProjectReference Include="..\Uno.Extensions.Core.Generators\Uno.Extensions.Core.Generators.csproj" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<None Include="..\Uno.Extensions.Core.Generators\buildTransitive\Uno.Extensions.Core.props" Pack="true" PackagePath="buildTransitive" />
+		<None Include="..\Uno.Extensions.Core.Generators\bin\Uno.Extensions.Core.Generators\$(Configuration)\netstandard2.0\Uno.Extensions.Core.Generators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Navigation/Uno.Extensions.Navigation.csproj
+++ b/src/Uno.Extensions.Navigation/Uno.Extensions.Navigation.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Extensions.Navigation.Generators\Uno.Extensions.Navigation.Generators.csproj" ReferenceOutputAssembly="false" />
-		<None Include="..\Uno.Extensions.Core.Generators\bin\Uno.Extensions.Core.Generators\$(Configuration)\netstandard2.0\Uno.Extensions.Core.Generators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+		<None Include="..\Uno.Extensions.Navigation.Generators\bin\Uno.Extensions.Navigation.Generators\$(Configuration)\netstandard2.0\Uno.Extensions.Navigation.Generators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Navigation/Uno.Extensions.Navigation.csproj
+++ b/src/Uno.Extensions.Navigation/Uno.Extensions.Navigation.csproj
@@ -17,7 +17,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<GeneratorProjectReference Include="..\Uno.Extensions.Navigation.Generators\Uno.Extensions.Navigation.Generators.csproj" />
+		<ProjectReference Include="..\Uno.Extensions.Navigation.Generators\Uno.Extensions.Navigation.Generators.csproj" ReferenceOutputAssembly="false" />
+		<None Include="..\Uno.Extensions.Core.Generators\bin\Uno.Extensions.Core.Generators\$(Configuration)\netstandard2.0\Uno.Extensions.Core.Generators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Reactive/Uno.Extensions.Reactive.csproj
+++ b/src/Uno.Extensions.Reactive/Uno.Extensions.Reactive.csproj
@@ -28,7 +28,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<GeneratorProjectReference Include="..\Uno.Extensions.Reactive.Generator\Uno.Extensions.Reactive.Generator.csproj" />
+		<ProjectReference Include="..\Uno.Extensions.Reactive.Generator\Uno.Extensions.Reactive.Generator.csproj" ReferenceOutputAssembly="false" />
+		<None Include="..\Uno.Extensions.Reactive.Generator\bin\Uno.Extensions.Reactive.Generator\$(Configuration)\netstandard2.0\Uno.Extensions.Reactive.Generator.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`DownloadAndSetPackageIcon` can be run twice for the same project.

![image](https://github.com/unoplatform/uno.extensions/assets/31348972/d1d87fa8-3635-4ce2-ab47-17758562ea33)


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
