### PR TITLE
fix: Fix projected pagination cycling

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Core/Given_TokenSet.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Given_TokenSet.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions.Reactive.Sources;
@@ -84,7 +81,7 @@ public class Given_TokenSet
 	}
 
 	[TestMethod]
-	public void When_IsGreaterThan()
+	public void When_IsGreaterOrEqualsThan()
 	{
 		var sut = Get((0, 42), (1, 42));
 
@@ -116,6 +113,17 @@ public class Given_TokenSet
 		sut.IsGreaterOrEquals(Get((0, 41), (1, 43), (2, 1))).Should().BeFalse(because: "token for ctx 1 is lower than 44");
 		sut.IsGreaterOrEquals(Get((0, 42), (1, 43), (2, 1))).Should().BeFalse(because: "token for ctx 1 is lower than 44");
 		sut.IsGreaterOrEquals(Get((0, 43), (1, 43), (2, 1))).Should().BeFalse(because: "token for ctx 0 is lower than 43 and token for ctx 1 is lower than 44");
+	}
+
+	[TestMethod]
+	public void When_Empty_Then_IsGreaterOrEqualsThan()
+	{
+		var sut = Get();
+
+		sut.IsEmpty.Should().BeTrue();
+
+		sut.IsGreaterOrEquals(Get((0, 42))).Should().BeFalse();
+		sut.IsGreaterOrEquals(Get()).Should().BeTrue();
 	}
 
 	[TestMethod]
@@ -154,6 +162,17 @@ public class Given_TokenSet
 	}
 
 	[TestMethod]
+	public void When_Empty_Then_IsLowerThan()
+	{
+		var sut = Get();
+
+		sut.IsEmpty.Should().BeTrue();
+
+		sut.IsLower(Get((0, 42))).Should().BeTrue();
+		sut.IsLower(Get()).Should().BeFalse();
+	}
+
+	[TestMethod]
 	public void When_IsLowerOrEqualsThan()
 	{
 		var sut = Get((0, 42), (1, 42));
@@ -186,6 +205,17 @@ public class Given_TokenSet
 		sut.IsLowerOrEquals(Get((0, 41), (1, 43), (2, 1))).Should().BeFalse(because: "token for ctx 0 is lower than 42");
 		sut.IsLowerOrEquals(Get((0, 42), (1, 43), (2, 1))).Should().BeTrue();
 		sut.IsLowerOrEquals(Get((0, 43), (1, 43), (2, 1))).Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void When_Empty_Then_IsLowerOrEqualsThan()
+	{
+		var sut = Get();
+
+		sut.IsEmpty.Should().BeTrue();
+
+		sut.IsLowerOrEquals(Get((0,42))).Should().BeTrue();
+		sut.IsLowerOrEquals(Get()).Should().BeTrue();
 	}
 
 	private TokenSet<TestToken> Get(params (uint ctx, uint seq)[] seqs) => new(seqs.Select(v => new TestToken(this, v.ctx, v.seq)).ToImmutableList());

--- a/src/Uno.Extensions.Reactive/Core/Axes/TokenSet.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/TokenSet.cs
@@ -51,6 +51,11 @@ internal record TokenSet<TToken>(IImmutableList<TToken> Tokens)
 	/// <returns>'true' if given collection contains a version greater or equals to the version contained by this collection, 'false' otherwise.</returns>
 	public bool IsLower(TokenSet<TToken> other)
 	{
+		if (IsEmpty)
+		{
+			return !other.IsEmpty;
+		}
+
 		var joined = Tokens
 			.Join(
 				other.Tokens,
@@ -78,6 +83,11 @@ internal record TokenSet<TToken>(IImmutableList<TToken> Tokens)
 	/// <returns>'true' if given collection contains a version greater or equals to the version contained by this collection, 'false' otherwise.</returns>
 	public bool IsLowerOrEquals(TokenSet<TToken> other)
 	{
+		if (IsEmpty)
+		{
+			return true;
+		}
+
 		var joined = Tokens
 			.Join(
 				other.Tokens,
@@ -96,7 +106,7 @@ internal record TokenSet<TToken>(IImmutableList<TToken> Tokens)
 	/// <param name="axis">The axis of the token collection.</param>
 	/// <returns>'true' if message contains a lower version to the version contained by this collection, 'false' otherwise.</returns>
 	public bool IsGreaterOrEquals(IMessage message, MessageAxis<TokenSet<TToken>> axis)
-	=> IsGreaterOrEquals(message.Current.Get(axis) ?? Empty);
+		=> IsGreaterOrEquals(message.Current.Get(axis) ?? Empty);
 
 	/// <summary>
 	/// Check if the version defined in this collection are all greater or equals than versions defined in the given set
@@ -105,6 +115,11 @@ internal record TokenSet<TToken>(IImmutableList<TToken> Tokens)
 	/// <returns>'true' if given collection contains a lower version to the version contained by this collection, 'false' otherwise.</returns>
 	public bool IsGreaterOrEquals(TokenSet<TToken> other)
 	{
+		if (IsEmpty)
+		{
+			return other.IsEmpty;
+		}
+
 		var joined = Tokens
 			.Join(
 				other.Tokens,

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Feed/FeedDependency.T.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Feed/FeedDependency.T.cs
@@ -85,19 +85,7 @@ internal sealed class FeedDependency<T> : FeedDependency, IDependency
 	}
 
 	private bool IsActive(FeedExecution execution)
-	{
-		if (_current is { } current)
-		{
-			Debug.Assert(execution == current.execution);
-
-			if (current.execution == execution)
-			{
-				return true;
-			}
-		}
-
-		return false;
-	}
+		=> _current is { } current && current.execution == execution;
 
 	private void Init(FeedExecution execution, IDisposable @lock)
 	{

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Pagination/PaginationDependency.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Pagination/PaginationDependency.cs
@@ -72,7 +72,7 @@ internal class PaginationDependency<TItem> : IDependency
 
 			Update(_pageInfo with { Tokens = req.Token });
 
-			// Push the _pageInfo in loading so the token will be propagated even in transient messages.
+			// Configure the _pageInfo in OnExecuting so the token will be propagated even in transient messages.
 			execution.Enqueue(m => m.Paginated(_pageInfo));
 		}
 	}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/1757

## Bugfix
Pagination with parameter can produce empty `TokenSet` for which comparison is not valid.

## What is the current behavior?
On first page an empty token set is return, causing the `ListView` to not wait properly for pagination result, driving to infinitely re-request more items.

## What is the new behavior?
Empty `TokenSet` are always consider as "lower than" any non empty token set.

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
