### PR TITLE
feat(compatTypes): Add generator for few more compatibility types

### DIFF
--- a/src/Uno.Extensions.Core.Generators/Compat/CompatibilityTypesGenerationContext.cs
+++ b/src/Uno.Extensions.Core.Generators/Compat/CompatibilityTypesGenerationContext.cs
@@ -7,10 +7,17 @@ namespace Uno.Extensions.Generators.CompatibilityTypes;
 internal record CompatibilityTypesGenerationContext(
 	GeneratorExecutionContext Context,
 
+	[ContextType("System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute?")] INamedTypeSymbol? DynamicallyAccessedMembersAttribute,
+	[ContextType("System.Diagnostics.CodeAnalysis.MaybeNullAttribute?")] INamedTypeSymbol? MaybeNullAttribute, // .net std 2.1 and above
+	[ContextType("System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute?")] INamedTypeSymbol? MaybeNullWhenAttribute, // .net std 2.1 and above
+	[ContextType("System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute?")] INamedTypeSymbol? MemberNotNullWhenAttribute, // .net std 2.1 and above
 	[ContextType("System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute?")] INamedTypeSymbol? NotNullIfNotNullAttribute, // .net std 2.1 and above
 	[ContextType("System.Diagnostics.CodeAnalysis.NotNullWhenAttribute?")] INamedTypeSymbol? NotNullWhenAttribute, // .net std 2.1 and above
-	[ContextType("System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute?")] INamedTypeSymbol? MemberNotNullWhenAttribute, // .net std 2.1 and above
 
+	[ContextType("System.Reflection.Metadata.MetadataUpdateHandlerAttribute?")] INamedTypeSymbol? MetadataUpdateHandlerAttribute,
+
+	[ContextType("System.Runtime.CompilerServices.CreateNewOnMetadataUpdateAttribute?")] INamedTypeSymbol? CreateNewOnMetadataUpdateAttribute,
 	[ContextType("System.Runtime.CompilerServices.IsExternalInit?")] INamedTypeSymbol? IsExternalInit, // .net 5 and above only
+	[ContextType("System.Runtime.CompilerServices.MetadataUpdateOriginalTypeAttribute?")] INamedTypeSymbol? MetadataUpdateOriginalTypeAttribute,
 	[ContextType("System.Runtime.CompilerServices.ModuleInitializerAttribute?")] INamedTypeSymbol? ModuleInitializerAttribute // .net 5 and above only
 );

--- a/src/Uno.Extensions.Core.Generators/Compat/CompatibilityTypesGenerationTool.cs
+++ b/src/Uno.Extensions.Core.Generators/Compat/CompatibilityTypesGenerationTool.cs
@@ -20,6 +20,23 @@ internal class CompatibilityTypesGenerationTool : ICodeGenTool
 	{
 		var assembly = _context.Context.Compilation.Assembly;
 
+		// System.Diagnostics.CodeAnalysis
+		if (!(_context.DynamicallyAccessedMembersAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableDynamicallyAccessedMembersAttribute"))
+		{
+			yield return (nameof(_context.DynamicallyAccessedMembersAttribute), GetDynamicallyAccessedMembersAttribute());
+		}
+		if (!(_context.MaybeNullAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableMaybeNullAttribute"))
+		{
+			yield return (nameof(_context.MaybeNullAttribute), GetMaybeNullAttribute());
+		}
+		if (!(_context.MaybeNullWhenAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableMaybeNullWhenAttribute"))
+		{
+			yield return (nameof(_context.MaybeNullWhenAttribute), GetMaybeNullWhenAttribute());
+		}
+		if (!(_context.MemberNotNullWhenAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableMemberNotNullWhenAttribute"))
+		{
+			yield return (nameof(_context.MemberNotNullWhenAttribute), GetMemberNotNullWhenAttribute());
+		}
 		if (!(_context.NotNullIfNotNullAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableNotNullIfNotNullAttribute"))
 		{
 			yield return (nameof(_context.NotNullIfNotNullAttribute), GetNotNullIfNotNullAttribute());
@@ -28,16 +45,28 @@ internal class CompatibilityTypesGenerationTool : ICodeGenTool
 		{
 			yield return (nameof(_context.NotNullWhenAttribute), GetNotNullWhenAttribute());
 		}
-		if (!(_context.MemberNotNullWhenAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableMemberNotNullWhenAttribute"))
+
+		// System.Reflection.Metadata
+		if (!(_context.MetadataUpdateHandlerAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableMetadataUpdateHandlerAttribute"))
 		{
-			yield return (nameof(_context.MemberNotNullWhenAttribute), GetMemberNotNullWhenAttribute());
+			yield return (nameof(_context.MetadataUpdateHandlerAttribute), GetMetadataUpdateHandlerAttribute());
+		}
+
+		// System.Runtime.CompilerServices
+		if (!(_context.CreateNewOnMetadataUpdateAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableCreateNewOnMetadataUpdateAttribute"))
+		{
+			yield return (nameof(_context.CreateNewOnMetadataUpdateAttribute), GetCreateNewOnMetadataUpdateAttribute());
 		}
 		if (!(_context.IsExternalInit?.IsAccessibleTo(assembly, allowInternalsVisibleTo: false) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableIsExternalInit"))
 		{
 			// Note: about 'allowInternalsVisibleTo: false'
-			//		For the compiler to allow 'init' keyword, the IsExternalInit must be either public in a ref assembly, either declared in teh current assembly.
+			//		For the compiler to allow 'init' keyword, the IsExternalInit must be either public in a ref assembly, either declared in the current assembly.
 			//		This means that it does not allow an internal class that has been made accessible to the current assembly using `InternalsVisibleTo`
 			yield return (nameof(_context.IsExternalInit), GetIsExternalInit());
+		}
+		if (!(_context.MetadataUpdateOriginalTypeAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableMetadataUpdateOriginalTypeAttribute"))
+		{
+			yield return (nameof(_context.MetadataUpdateOriginalTypeAttribute), GetMetadataUpdateOriginalTypeAttribute());
 		}
 		if (!(_context.ModuleInitializerAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableModuleInitializerAttribute"))
 		{
@@ -45,42 +74,136 @@ internal class CompatibilityTypesGenerationTool : ICodeGenTool
 		}
 	}
 
-	private string GetModuleInitializerAttribute()
+	#region System.Diagnostics.CodeAnalysis
+	private string GetDynamicallyAccessedMembersAttribute()
 		=> $@"{this.GetFileHeader(3)}
 
 			// Note: You can disable the generation of this file by setting in your project the property
-			//		 <UnoExtensionsGeneration_DisableModuleInitializerAttribute>true</UnoExtensionsGeneration_DisableModuleInitializerAttribute>
+			//		 <UnoExtensionsGeneration_DisableDynamicallyAccessedMembersAttribute>true</UnoExtensionsGeneration_DisableDynamicallyAccessedMembersAttribute>
 
-			using global::System;
-
-			namespace System.Runtime.CompilerServices
+			namespace System.Diagnostics.CodeAnalysis
 			{{
-				/// <summary>
-				/// Used to indicate to the compiler that a method should be called in its containing module's initializer.
-				/// </summary>
-				{this.GetCodeGenAttribute()}
-				[global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false)]
-				internal sealed class ModuleInitializerAttribute : global::System.Attribute
+				/// <summary>Indicates that certain members on a specified <see cref=""T:System.Type"" /> are accessed dynamically, for example, through <see cref=""N:System.Reflection"" />.</summary>
+				[global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Interface | global::System.AttributeTargets.Parameter | global::System.AttributeTargets.ReturnValue | global::System.AttributeTargets.GenericParameter, Inherited = false)]
+				internal sealed class DynamicallyAccessedMembersAttribute : global::System.Attribute
+				{{
+					/// <summary>Initializes a new instance of the <see cref=""T:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute"" /> class with the specified member types.</summary>
+					/// <param name=""memberTypes"">The types of the dynamically accessed members.</param>
+					public DynamicallyAccessedMembersAttribute(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes memberTypes)
+						=> this.MemberTypes = memberTypes;
+
+					/// <summary>Gets the <see cref=""T:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes"" /> that specifies the type of dynamically accessed members.</summary>
+					public global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberTypes {{ get; }}
+				}}
+
+				/// <summary>Specifies the types of members that are dynamically accessed.
+				/// This enumeration has a <see cref=""T:System.FlagsAttribute"" /> attribute that allows a bitwise combination of its member values.</summary>
+				[Flags]
+				internal enum DynamicallyAccessedMemberTypes
+				{{
+					/// <summary>Specifies no members.</summary>
+					None = 0,
+					/// <summary>Specifies the default, parameterless public constructor.</summary>
+					PublicParameterlessConstructor = 1,
+					/// <summary>Specifies all public constructors.</summary>
+					PublicConstructors = 3,
+					/// <summary>Specifies all non-public constructors.</summary>
+					NonPublicConstructors = 4,
+					/// <summary>Specifies all public methods.</summary>
+					PublicMethods = 8,
+					/// <summary>Specifies all non-public methods.</summary>
+					NonPublicMethods = 16, // 0x00000010
+					/// <summary>Specifies all public fields.</summary>
+					PublicFields = 32, // 0x00000020
+					/// <summary>Specifies all non-public fields.</summary>
+					NonPublicFields = 64, // 0x00000040
+					/// <summary>Specifies all public nested types.</summary>
+					PublicNestedTypes = 128, // 0x00000080
+					/// <summary>Specifies all non-public nested types.</summary>
+					NonPublicNestedTypes = 256, // 0x00000100
+					/// <summary>Specifies all public properties.</summary>
+					PublicProperties = 512, // 0x00000200
+					/// <summary>Specifies all non-public properties.</summary>
+					NonPublicProperties = 1024, // 0x00000400
+					/// <summary>Specifies all public events.</summary>
+					PublicEvents = 2048, // 0x00000800
+					/// <summary>Specifies all non-public events.</summary>
+					NonPublicEvents = 4096, // 0x00001000
+					/// <summary>Specifies all interfaces implemented by the type.</summary>
+					Interfaces = 8192, // 0x00002000
+					/// <summary>Specifies all members.</summary>
+					All = -1, // 0xFFFFFFFF
+				}}
+			}}".Align(0);
+
+	private string GetMaybeNullAttribute()
+		=> $@"{this.GetFileHeader(3)}
+
+			// Note: You can disable the generation of this file by setting in your project the property
+			//		 <UnoExtensionsGeneration_DisableMaybeNullAttribute>true</UnoExtensionsGeneration_DisableMaybeNullAttribute>
+
+			namespace System.Diagnostics.CodeAnalysis
+			{{
+				/// <summary>Specifies that an output may be <see langword=""null"" /> even if the corresponding type disallows it.</summary>
+				[global::System.AttributeUsage(global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Parameter | global::System.AttributeTargets.ReturnValue, Inherited = false)]
+				internal sealed class MaybeNullAttribute : global::System.Attribute
 				{{
 				}}
 			}}".Align(0);
 
-	private string GetIsExternalInit()
+	private string GetMaybeNullWhenAttribute()
 		=> $@"{this.GetFileHeader(3)}
 
 			// Note: You can disable the generation of this file by setting in your project the property
-			//		 <UnoExtensionsGeneration_DisableIsExternalInit>true</UnoExtensionsGeneration_DisableIsExternalInit>
+			//		 <UnoExtensionsGeneration_DisableMaybeNullWhenAttribute>true</UnoExtensionsGeneration_DisableMaybeNullWhenAttribute>
+
+			namespace System.Diagnostics.CodeAnalysis
+			{{
+				/// <summary>Specifies that when a method returns <see cref=""P:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.ReturnValue"" />, the parameter may be <see langword=""null"" /> even if the corresponding type disallows it.</summary>
+				[global::System.AttributeUsage(global::System.AttributeTargets.Parameter, Inherited = false)]
+				internal sealed class MaybeNullWhenAttribute : global::System.Attribute
+				{{
+					/// <summary>Initializes the attribute with the specified return value condition.</summary>
+					/// <param name=""returnValue"">The return value condition. If the method returns this value, the associated parameter may be <see langword=""null"" />.</param>
+					public MaybeNullWhenAttribute(bool returnValue)
+						=> this.ReturnValue = returnValue;
+
+					/// <summary>Gets the return value condition.</summary>
+					/// <returns>The return value condition. If the method returns this value, the associated parameter may be <see langword=""null"" />.</returns>
+					public bool ReturnValue {{ get; }}
+				}}
+			}}".Align(0);
+
+	public string GetNotNullWhenAttribute()
+		=> $@"{this.GetFileHeader(3)}
+
+			// Note: You can disable the generation of this file by setting in your project the property
+			//		 <UnoExtensionsGeneration_DisableNotNullWhenAttribute>true</UnoExtensionsGeneration_DisableNotNullWhenAttribute>
 
 			using global::System;
 
-			namespace System.Runtime.CompilerServices
+			namespace System.Diagnostics.CodeAnalysis
 			{{
 				/// <summary>
-				/// Reserved to be used by the compiler for tracking metadata. This class should not be used by developers in source code.
+				/// Specifies that when a method returns <see cref=""ReturnValue""/>, the parameter will not be null even if the corresponding type allows it.
 				/// </summary>
+				[global::System.AttributeUsage(global::System.AttributeTargets.Parameter, Inherited = false)]
 				{this.GetCodeGenAttribute()}
-				internal static class IsExternalInit
+				internal class NotNullWhenAttribute : global::System.Attribute
 				{{
+					/// <summary>
+					/// Gets the return value condition.
+					/// </summary>
+					public bool ReturnValue {{ get; }}
+
+					/// <summary>
+					/// The return value condition. If the method returns this value, the associated parameter will not be null.
+					/// </summary>
+					/// <param name=""returnValue""></param>
+					public NotNullWhenAttribute(bool returnValue)
+					{{
+						ReturnValue = returnValue;
+					}}
 				}}
 			}}
 			".Align(0);
@@ -122,13 +245,16 @@ internal class CompatibilityTypesGenerationTool : ICodeGenTool
 	private string GetMemberNotNullWhenAttribute()
 		=> $@"{this.GetFileHeader(3)}
 
+			// Note: You can disable the generation of this file by setting in your project the property
+			//		 <UnoExtensionsGeneration_DisableMemberNotNullWhenAttribute>true</UnoExtensionsGeneration_DisableMemberNotNullWhenAttribute>
+
 			using global::System;
 
 			namespace System.Diagnostics.CodeAnalysis
 			{{
 				/// <summary>Specifies that the method or property will ensure that the listed field and property members have non-null values when returning with the specified return value condition.</summary>
 				[global::System.AttributeUsage(global::System.AttributeTargets.Method | global::System.AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
-				public sealed class MemberNotNullWhenAttribute : global::System.Attribute
+				internal sealed class MemberNotNullWhenAttribute : global::System.Attribute
 				{{
 					/// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
 					/// <param name=""returnValue"">The return value condition. If the method returns this value, the associated parameter will not be <see langword=""null"" />.</param>
@@ -156,40 +282,112 @@ internal class CompatibilityTypesGenerationTool : ICodeGenTool
 				}}
 			}}
 			".Align(0);
+	#endregion
 
-	public string GetNotNullWhenAttribute()
+	#region System.Reflection.Metadata
+	private string GetMetadataUpdateHandlerAttribute()
 		=> $@"{this.GetFileHeader(3)}
 
 			// Note: You can disable the generation of this file by setting in your project the property
-			//		 <UnoExtensionsGeneration_DisableNotNullWhenAttribute>true</UnoExtensionsGeneration_DisableNotNullWhenAttribute>
+			//		 <UnoExtensionsGeneration_DisableMetadataUpdateHandlerAttribute>true</UnoExtensionsGeneration_DisableMetadataUpdateHandlerAttribute>
 
-			using global::System;
-
-			namespace System.Diagnostics.CodeAnalysis
+			namespace System.Reflection.Metadata
 			{{
-				/// <summary>
-				/// Specifies that when a method returns <see cref=""ReturnValue""/>, the parameter will not be null even if the corresponding type allows it.
-				/// </summary>
-				[global::System.AttributeUsage(global::System.AttributeTargets.Parameter, Inherited = false)]
-				{this.GetCodeGenAttribute()}
-				internal class NotNullWhenAttribute : global::System.Attribute
+				/// <summary>Indicates that a type that should receive notifications of metadata updates.</summary>
+				[global::System.AttributeUsage(global::System.AttributeTargets.Assembly, AllowMultiple = true)]
+				internal sealed class MetadataUpdateHandlerAttribute : global::System.Attribute
 				{{
-					/// <summary>
-					/// Gets the return value condition.
-					/// </summary>
-					public bool ReturnValue {{ get; }}
+					/// <summary>Initializes the attribute.</summary>
+					/// <param name=""handlerType"">A type that handles metadata updates and that should be notified when any occur.</param>
+					public MetadataUpdateHandlerAttribute([global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)] global::System.Type handlerType)
+						=> this.HandlerType = handlerType;
 
-					/// <summary>
-					/// The return value condition. If the method returns this value, the associated parameter will not be null.
-					/// </summary>
-					/// <param name=""returnValue""></param>
-					public NotNullWhenAttribute(bool returnValue)
-					{{
-						ReturnValue = returnValue;
-					}}
+					/// <summary>Gets the type that handles metadata updates and that should be notified when any occur.</summary>
+					[global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
+					public global::System.Type HandlerType {{ get; }}
 				}}
 			}}
 			".Align(0);
+	#endregion
+
+	#region System.Runtime.CompilerServices
+	private string GetCreateNewOnMetadataUpdateAttribute()
+		=> $@"{this.GetFileHeader(3)}
+
+			// Note: You can disable the generation of this file by setting in your project the property
+			//		 <UnoExtensionsGeneration_DisableCreateNewOnMetadataUpdateAttribute>true</UnoExtensionsGeneration_DisableCreateNewOnMetadataUpdateAttribute>
+
+			namespace System.Runtime.CompilerServices
+			{{
+				/// <summary>Indicates a type should be replaced rather than updated when applying metadata updates.</summary>
+				[global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct, AllowMultiple = false)]
+				internal sealed class CreateNewOnMetadataUpdateAttribute : global::System.Attribute
+				{{
+				}}
+			}}".Align(0);
+
+	private string GetIsExternalInit()
+		=> $@"{this.GetFileHeader(3)}
+
+			// Note: You can disable the generation of this file by setting in your project the property
+			//		 <UnoExtensionsGeneration_DisableIsExternalInit>true</UnoExtensionsGeneration_DisableIsExternalInit>
+
+			using global::System;
+
+			namespace System.Runtime.CompilerServices
+			{{
+				/// <summary>
+				/// Reserved to be used by the compiler for tracking metadata. This class should not be used by developers in source code.
+				/// </summary>
+				{this.GetCodeGenAttribute()}
+				internal static class IsExternalInit
+				{{
+				}}
+			}}
+			".Align(0);
+
+	private string GetMetadataUpdateOriginalTypeAttribute()
+		=> $@"{this.GetFileHeader(3)}
+
+			// Note: You can disable the generation of this file by setting in your project the property
+			//		 <UnoExtensionsGeneration_DisableMetadataUpdateOriginalTypeAttribute>true</UnoExtensionsGeneration_DisableMetadataUpdateOriginalTypeAttribute>
+
+			namespace System.Runtime.CompilerServices
+			{{
+				/// <summary>Emitted by the compiler when a type that's marked with <see cref=""T:System.Runtime.CompilerServices.CreateNewOnMetadataUpdateAttribute"" /> is updated during a hot reload session.</summary>
+				[global::System.AttributeUsage(global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+				internal class MetadataUpdateOriginalTypeAttribute : global::System.Attribute
+				{{
+					/// <summary>Initializes a new instance of the <see cref=""T:System.Runtime.CompilerServices.MetadataUpdateOriginalTypeAttribute"" /> class.</summary>
+					/// <param name=""originalType"">The original type that was updated.</param>
+					public MetadataUpdateOriginalTypeAttribute(global::System.Type originalType)
+						=> this.OriginalType = originalType;
+
+					/// <summary>Gets the original version of the type that this attribute is attached to.</summary>
+					public global::System.Type OriginalType {{ get; }}
+				}}
+			}}".Align(0);
+
+	private string GetModuleInitializerAttribute()
+		=> $@"{this.GetFileHeader(3)}
+
+			// Note: You can disable the generation of this file by setting in your project the property
+			//		 <UnoExtensionsGeneration_DisableModuleInitializerAttribute>true</UnoExtensionsGeneration_DisableModuleInitializerAttribute>
+
+			using global::System;
+
+			namespace System.Runtime.CompilerServices
+			{{
+				/// <summary>
+				/// Used to indicate to the compiler that a method should be called in its containing module's initializer.
+				/// </summary>
+				{this.GetCodeGenAttribute()}
+				[global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false)]
+				internal sealed class ModuleInitializerAttribute : global::System.Attribute
+				{{
+				}}
+			}}".Align(0);
+	#endregion
 
 	private bool GetIsDisabled(string propertyName)
 		=> bool.TryParse(_context.Context.GetMSBuildPropertyValue(propertyName), out var isDisabled) && isDisabled;


### PR DESCRIPTION
linked to https://github.com/unoplatform/uno.extensions/issues/1674

## Feature
Add generator for few more compatibility types

## What is the current behavior?
Some compat types are not generated

## What is the new behavior?
They are!

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
