### PR TITLE
Initialize Application Handler

### DIFF
--- a/src/Uno.Extensions.Maui.UI/Internals/MauiEmbeddingInitializer.cs
+++ b/src/Uno.Extensions.Maui.UI/Internals/MauiEmbeddingInitializer.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Maui.Internals;
+﻿using Microsoft.Maui.ApplicationModel;
+
+namespace Uno.Extensions.Maui.Internals;
 
 internal class MauiEmbeddingInitializer : IMauiInitializeService
 {
@@ -13,9 +15,23 @@ internal class MauiEmbeddingInitializer : IMauiInitializeService
 	{
 		var resources = _app.Resources.ToMauiResources();
 		var iApp = services.GetRequiredService<global::Microsoft.Maui.IApplication>();
-		if (HasResources(resources) && iApp is MauiApplication mauiApp)
+		if (iApp is MauiApplication mauiApp)
 		{
-			mauiApp.Resources.MergedDictionaries.Add(resources);
+			// Inject WinUI Resources to the MauiApplication
+			if (HasResources(resources))
+			{
+				mauiApp.Resources.MergedDictionaries.Add(resources);
+			}
+
+			// Initialize the MauiApplication to ensure there is a Window and MainPage to ensure references to these will work.
+			mauiApp.MainPage = new Microsoft.Maui.Controls.Page();
+
+			// Make sure the requested app theme matches our app
+			mauiApp.UserAppTheme = _app.RequestedTheme switch
+			{
+				ApplicationTheme.Dark => AppTheme.Dark,
+				_ => AppTheme.Light
+			};
 		}
 	}
 

--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.android.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.android.cs
@@ -1,0 +1,36 @@
+﻿#if ANDROID
+namespace Uno.Extensions.Maui;
+
+partial class MauiEmbedding
+{
+	private static MauiAppBuilder RegisterPlatformServices(this MauiAppBuilder builder, Application app)
+	{
+		if (Android.App.Application.Context is not Android.App.Application androidApp)
+		{
+			throw new MauiEmbeddingException($"Expected 'Android.App.Application.Context' to be 'Android.App.Application', but got '{Android.App.Application.Context.GetType().FullName}'.");
+		}
+		builder.Services.AddSingleton<Android.App.Application>(androidApp)
+			.AddTransient<Android.App.Activity>(_ =>
+			{
+				if (UI.ContextHelper.Current is Android.App.Activity currentActivity)
+					return currentActivity;
+
+				throw new MauiEmbeddingException("Could not find a current Activity.");
+			});
+		return builder;
+	}
+
+	private static void InitializeMauiEmbeddingApp(this MauiApp mauiApp)
+	{
+		var androidApp = mauiApp.Services.GetRequiredService<Android.App.Application>();
+		var scope = mauiApp.Services.CreateScope();
+		var rootContext = new MauiContext(scope.ServiceProvider, androidApp);
+		rootContext.InitializeScopedServices();
+
+		var iApp = mauiApp.Services.GetRequiredService<IApplication>();
+		IPlatformApplication.Current = new EmbeddingApp(scope.ServiceProvider, iApp);
+
+		androidApp.SetApplicationHandler(iApp, rootContext);
+	}
+}
+#endif

--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.apple.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.apple.cs
@@ -1,0 +1,27 @@
+﻿#if IOS || MACCATALYST
+using UIKit;
+
+namespace Uno.Extensions.Maui;
+
+partial class MauiEmbedding
+{
+	private static MauiAppBuilder RegisterPlatformServices(this MauiAppBuilder builder, Application app)
+	{
+		builder.Services.AddTransient<UIWindow>(sp => sp.GetRequiredService<Application>().Window!)
+			.AddSingleton<IUIApplicationDelegate>(sp => sp.GetRequiredService<Application>());
+
+		return builder;
+	}
+
+	private static void InitializeMauiEmbeddingApp(this MauiApp mauiApp)
+	{
+		var rootContext = new MauiContext(mauiApp.Services);
+		rootContext.InitializeScopedServices();
+
+		var iApp = mauiApp.Services.GetRequiredService<IApplication>();
+		IPlatformApplication.Current = new EmbeddingApp(mauiApp.Services, iApp);
+		var appDelegate = mauiApp.Services.GetRequiredService<IUIApplicationDelegate>();
+		appDelegate.SetApplicationHandler(iApp, rootContext);
+	}
+}
+#endif

--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
@@ -6,20 +6,8 @@ namespace Uno.Extensions.Maui;
 /// <summary>
 /// Embedding support for Microsoft.Maui controls in Uno Platform app hosts.
 /// </summary>
-public static class MauiEmbedding
+public static partial class MauiEmbedding
 {
-#if MAUI_EMBEDDING
-	private static MauiApp? _app;
-	internal static IMauiContext MauiContext =>
-#if ANDROID
-		_app is not null ? new MauiContext(_app.Services, UI.ContextHelper.Current)
-			: throw new MauiEmbeddingInitializationException();
-#else
-		_app is not null ? new MauiContext(_app.Services)
-			: throw new MauiEmbeddingInitializationException();
-#endif
-#endif
-
 	/// <summary>
 	/// Registers Maui embedding in the Uno Platform app builder.
 	/// </summary>
@@ -62,56 +50,32 @@ public static class MauiEmbedding
 	{
 #if MAUI_EMBEDDING
 		var mauiAppBuilder = MauiApp.CreateBuilder()
-				.UseMauiEmbedding<TApp>();
+			.UseMauiEmbedding<TApp>()
+			.RegisterPlatformServices(app);
+
+		mauiAppBuilder.Services.AddSingleton<Microsoft.UI.Xaml.Application>(_ => app)
+			.AddSingleton<IMauiInitializeService, MauiEmbeddingInitializer>();
 
 		// HACK: https://github.com/dotnet/maui/pull/16758
 		mauiAppBuilder.Services.RemoveAll<IApplication>()
 			.AddSingleton<IApplication, TApp>();
 
-#if WINDOWS
-		_ = mauiAppBuilder.Services.RemoveWhere(sd =>
-					sd.ServiceType == typeof(IMauiInitializeService) &&
-										(
-											// Match using Name since the types are internal to Maui
-											sd.ImplementationType is { Name: "MauiControlsInitializer" } ||
-											sd.ImplementationType is { Name: "MauiCoreInitializer" }
-										));
-#endif
-
 		configure?.Invoke(mauiAppBuilder);
 
-#if ANDROID
-		if (Android.App.Application.Context is not Android.App.Application androidApp)
-		{
-			throw new InvalidOperationException($"Expected 'Android.App.Application.Context' to be 'Android.App.Application', but got '{Android.App.Application.Context.GetType().FullName}'.");
-		}
-		mauiAppBuilder.Services.AddSingleton<Android.App.Application>(androidApp)
-			.AddTransient<Android.App.Activity>(_ =>
-			{
-				if (UI.ContextHelper.Current is Android.App.Activity currentActivity)
-					return currentActivity;
-
-				throw new InvalidOperationException("Could not find a current Activity.");
-			});
-#elif IOS || MACCATALYST
-		mauiAppBuilder.Services.AddTransient<UIKit.UIWindow>(_ =>
-			app.Window!)
-			.AddSingleton<UIKit.IUIApplicationDelegate>(app);
-#endif
-
-		mauiAppBuilder.Services.AddSingleton<Microsoft.UI.Xaml.Application>(_ => app)
-			.AddSingleton<IMauiInitializeService, MauiEmbeddingInitializer>();
-		_app = mauiAppBuilder.Build();
-
-		// Initialize the MauiApplication to ensure there is a Window and MainPage to ensure references to these will work.
-		var iApp = _app.Services.GetRequiredService<IApplication>();
-		IPlatformApplication.Current = new EmbeddingApp(_app.Services, iApp);
-		if (iApp is MauiApplication mauiApplication)
-		{
-			mauiApplication.MainPage = new Microsoft.Maui.Controls.Page();
-		}
+		var mauiApp = mauiAppBuilder.Build();
+		mauiApp.InitializeMauiEmbeddingApp();
 #endif
 		return app;
+	}
+
+	private static void InitializeScopedServices(this IMauiContext scopedContext)
+	{
+		var scopedServices = scopedContext.Services.GetServices<IMauiInitializeScopedService>();
+
+		foreach (var service in scopedServices)
+		{
+			service.Initialize(scopedContext.Services);
+		}
 	}
 
 	// NOTE: This was part of the POC and is out of scope for the MVP. Keeping it in case we want to add it back later.

--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.windows.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.windows.cs
@@ -1,0 +1,31 @@
+﻿#if WINDOWS
+using Microsoft.Maui.Hosting;
+
+namespace Uno.Extensions.Maui;
+
+partial class MauiEmbedding
+{
+	private static MauiAppBuilder RegisterPlatformServices(this MauiAppBuilder builder, Application app)
+	{
+		//_ = builder.Services.RemoveWhere(sd =>
+		//			sd.ServiceType == typeof(IMauiInitializeService) &&
+		//								(
+		//									// Match using Name since the types are internal to Maui
+		//									sd.ImplementationType is { Name: "MauiControlsInitializer" } ||
+		//									sd.ImplementationType is { Name: "MauiCoreInitializer" }
+		//								));
+		return builder;
+	}
+
+	private static void InitializeMauiEmbeddingApp(this MauiApp mauiApp)
+	{
+		var rootContext = new MauiContext(mauiApp.Services);
+		rootContext.InitializeScopedServices();
+
+		var iApp = mauiApp.Services.GetRequiredService<IApplication>();
+		IPlatformApplication.Current = new EmbeddingApp(mauiApp.Services, iApp);
+		var app = mauiApp.Services.GetRequiredService<Application>();
+		app.SetApplicationHandler(iApp, rootContext);
+	}
+}
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): #

- n/a

## PR Type

What kind of change does this PR introduce?

- Refactoring

## What is the current behavior?

The MauiContext is created on the fly from the MauiApp

## What is the new behavior?

The Application is initialized with a Maui Handler / MauiContext. This follows the pattern Maui uses internally and allows us to grab the correct context off of the Application. Makes more direct use of IPlatformApplication.