### PR TITLE
Initializing Application Window and Main Page

### DIFF
--- a/samples/MauiEmbedding/MauiEmbedding/App.cs
+++ b/samples/MauiEmbedding/MauiEmbedding/App.cs
@@ -13,6 +13,7 @@ public class App : EmbeddingApplication
 		var builder = this.CreateBuilder(args)
 			// Add navigation support for toolkit controls such as TabBar and NavigationView
 			.UseToolkitNavigation()
+			.UseMauiEmbedding<MauiControls.App>(maui => maui.UseCustomLibrary())
 			.Configure(host => host
 #if DEBUG
 				// Switch to Development environment when running in DEBUG
@@ -61,7 +62,6 @@ public class App : EmbeddingApplication
 					// TODO: Register your services
 					//services.AddSingleton<IMyService, MyService>();
 				})
-				.UseMauiEmbedding<MauiControls.App>(this, maui => maui.UseCustomLibrary())
 				.UseNavigation(RegisterRoutes)
 			);
 		MainWindow = builder.Window;

--- a/src/Uno.Extensions.Maui.UI/Internals/EmbeddedWindowHandler.cs
+++ b/src/Uno.Extensions.Maui.UI/Internals/EmbeddedWindowHandler.cs
@@ -1,0 +1,14 @@
+﻿namespace Uno.Extensions.Maui.Internals;
+
+internal class EmbeddedWindowHandler : IElementHandler
+{
+	public object? PlatformView { get; set; }
+	public IElement? VirtualView { get; set; }
+	public IMauiContext? MauiContext { get; set; }
+
+	public void DisconnectHandler() { }
+	public void Invoke(string command, object? args = null) { }
+	public void SetMauiContext(IMauiContext mauiContext) => MauiContext = mauiContext;
+	public void SetVirtualView(IElement view) => VirtualView = view;
+	public void UpdateValue(string property) { }
+}

--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.android.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.android.cs
@@ -42,5 +42,6 @@ partial class MauiEmbedding
 		Microsoft.Maui.ApplicationModel.Platform.Init(androidApp);
 
 		androidApp.SetApplicationHandler(iApp, rootContext);
+		InitializeApplicationMainPage(iApp);
 	}
 }

--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.apple.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.apple.cs
@@ -1,4 +1,4 @@
-﻿using UIKit;
+using UIKit;
 using Uno.Extensions.Maui.Platform;
 
 namespace Uno.Extensions.Maui;
@@ -26,8 +26,9 @@ partial class MauiEmbedding
 			throw new MauiEmbeddingException(Properties.Resources.TheApplicationMustInheritFromEmbeddingApplication);
 		}
 
-		// TODO: Evaluate getting the Root View Controller for a Platform.Init for Maui
+		Microsoft.Maui.ApplicationModel.Platform.Init(() => app.Window!.RootViewController!);
 		embeddingApp.InitializeApplication(mauiApp.Services, iApp);
 		app.SetApplicationHandler(iApp, rootContext);
+		InitializeApplicationMainPage(iApp);
 	}
 }

--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Maui;
+using Uno.Extensions.Hosting;
 
 namespace Uno.Extensions.Maui;
 
@@ -13,10 +13,22 @@ public static partial class MauiEmbedding
 	/// </summary>
 	/// <returns>The updated app builder.</returns>
 	/// <param name="builder">The IHost builder.</param>
-	/// <param name="app">The Uno app.</param>
 	/// <param name="configure">Optional lambda to configure the Maui app builder.</param>
-	public static IHostBuilder UseMauiEmbedding(this IHostBuilder builder, Microsoft.UI.Xaml.Application app, Action<MauiAppBuilder>? configure = null) =>
-		builder.UseMauiEmbedding<MauiApplication>(app, configure);
+	public static IApplicationBuilder UseMauiEmbedding(this IApplicationBuilder builder, Action<MauiAppBuilder>? configure = null) =>
+		builder.UseMauiEmbedding<MauiApplication>(configure);
+
+	/// <summary>
+	/// Registers Maui embedding in the Uno Platform app builder.
+	/// </summary>
+	/// <returns>The updated app builder.</returns>
+	/// <param name="builder">The IHost builder.</param>
+	/// <param name="configure">Optional lambda to configure the Maui app builder.</param>
+	public static IApplicationBuilder UseMauiEmbedding<TApp>(this IApplicationBuilder builder, Action<MauiAppBuilder>? configure = null)
+		where TApp : MauiApplication
+	{
+		builder.App.UseMauiEmbedding<TApp>(builder.Window, configure);
+		return builder;
+	}
 
 	/// <summary>
 	/// Registers Maui embedding in the Uno Platform app builder.
@@ -24,40 +36,42 @@ public static partial class MauiEmbedding
 	/// <returns>The updated app builder.</returns>
 	/// <param name="builder">The IHost builder.</param>
 	/// <param name="app">The Uno app.</param>
+	/// <param name="window">The Main Application Window.</param>
 	/// <param name="configure">Optional lambda to configure the Maui app builder.</param>
-	public static IHostBuilder UseMauiEmbedding<TApp>(this IHostBuilder builder, Microsoft.UI.Xaml.Application app, Action<MauiAppBuilder>? configure = null)
+	public static IHostBuilder UseMauiEmbedding(this IHostBuilder builder, Microsoft.UI.Xaml.Application app, Microsoft.UI.Xaml.Window window, Action<MauiAppBuilder>? configure = null) =>
+		builder.UseMauiEmbedding<MauiApplication>(app, window, configure);
+
+	/// <summary>
+	/// Registers Maui embedding in the Uno Platform app builder.
+	/// </summary>
+	/// <returns>The updated app builder.</returns>
+	/// <param name="builder">The IHost builder.</param>
+	/// <param name="app">The Uno app.</param>
+	/// <param name="window">The Main Application Window.</param>
+	/// <param name="configure">Optional lambda to configure the Maui app builder.</param>
+	public static IHostBuilder UseMauiEmbedding<TApp>(this IHostBuilder builder, Microsoft.UI.Xaml.Application app, Microsoft.UI.Xaml.Window window, Action<MauiAppBuilder>? configure = null)
 		where TApp : MauiApplication
 	{
-		app.UseMauiEmbedding<TApp>(configure);
+		app.UseMauiEmbedding<TApp>(window, configure);
 		return builder;
 	}
 
-	private class MauiHostProviderFactory : IServiceProviderFactory<IServiceProvider>
-	{
-		public IServiceProvider CreateBuilder(IServiceCollection services) => services.BuildServiceProvider();
-		public IServiceProvider CreateServiceProvider(IServiceProvider containerBuilder) => containerBuilder;
-	}
-
-	private class UnoHostProviderFactory : IServiceProviderFactory<IServiceCollection>
-	{
-		public IServiceCollection CreateBuilder(IServiceCollection services) => throw new NotImplementedException();
-		public IServiceProvider CreateServiceProvider(IServiceCollection containerBuilder) => containerBuilder.BuildServiceProvider();
-	}
+	/// <summary>
+	/// Registers Maui embedding with WinUI3 and WPF application builder.
+	/// </summary>
+	/// <param name="app">The Uno app.</param>
+	/// <param name="window">The Main Application Window.</param>
+	/// <param name="configure">Optional lambda to configure the Maui app builder.</param>
+	public static Microsoft.UI.Xaml.Application UseMauiEmbedding(this Microsoft.UI.Xaml.Application app, Microsoft.UI.Xaml.Window window, Action<MauiAppBuilder>? configure = null) =>
+		app.UseMauiEmbedding<MauiApplication>(window, configure);
 
 	/// <summary>
 	/// Registers Maui embedding with WinUI3 and WPF application builder.
 	/// </summary>
 	/// <param name="app">The Uno app.</param>
+	/// <param name="window">The Main Application Window.</param>
 	/// <param name="configure">Optional lambda to configure the Maui app builder.</param>
-	public static Microsoft.UI.Xaml.Application UseMauiEmbedding(this Microsoft.UI.Xaml.Application app, Action<MauiAppBuilder>? configure = null) =>
-		app.UseMauiEmbedding<MauiApplication>(configure);
-
-	/// <summary>
-	/// Registers Maui embedding with WinUI3 and WPF application builder.
-	/// </summary>
-	/// <param name="app">The Uno app.</param>
-	/// <param name="configure">Optional lambda to configure the Maui app builder.</param>
-	public static Microsoft.UI.Xaml.Application UseMauiEmbedding<TApp>(this Microsoft.UI.Xaml.Application app, Action<MauiAppBuilder>? configure = null)
+	public static Microsoft.UI.Xaml.Application UseMauiEmbedding<TApp>(this Microsoft.UI.Xaml.Application app, Microsoft.UI.Xaml.Window window, Action<MauiAppBuilder>? configure = null)
 		where TApp : MauiApplication
 	{
 #if MAUI_EMBEDDING
@@ -65,7 +79,8 @@ public static partial class MauiEmbedding
 			.UseMauiEmbedding<TApp>()
 			.RegisterPlatformServices(app);
 
-		mauiAppBuilder.Services.AddSingleton<Microsoft.UI.Xaml.Application>(_ => app)
+		mauiAppBuilder.Services.AddSingleton(app)
+			.AddSingleton(window)
 			.AddSingleton<IMauiInitializeService, MauiEmbeddingInitializer>();
 
 		// HACK: https://github.com/dotnet/maui/pull/16758
@@ -80,6 +95,8 @@ public static partial class MauiEmbedding
 		return app;
 	}
 
+#if MAUI_EMBEDDING
+
 	private static void InitializeScopedServices(this IMauiContext scopedContext)
 	{
 		var scopedServices = scopedContext.Services.GetServices<IMauiInitializeScopedService>();
@@ -89,6 +106,50 @@ public static partial class MauiEmbedding
 			service.Initialize(scopedContext.Services);
 		}
 	}
+
+	private static void InitializeApplicationMainPage(IApplication iApp)
+	{
+		if (iApp is not MauiApplication app || app.Handler?.MauiContext is null)
+		{
+			// NOTE: This method is supposed to be called immediately after we initialize the Application Handler
+			// This should never actually happen but is required due to nullability
+			return;
+		}
+
+		var context = app.Handler.MauiContext;
+
+		// Create an Application Main Page and initialize a Handler with the Maui Context
+		var page = new ContentPage();
+		app.MainPage = page;
+		_ = page.ToPlatform(context);
+
+		// Create a Maui Window and initialize a Handler shim. This will expose the actual Application Window
+		var virtualWindow = new Microsoft.Maui.Controls.Window(page);
+		virtualWindow.Handler = new EmbeddedWindowHandler
+		{
+#if IOS || MACCATALYST
+			PlatformView = context.Services.GetRequiredService<Microsoft.UI.Xaml.Application>().Window,
+#elif ANDROID
+			PlatformView = context.Services.GetRequiredService<Android.App.Activity>(),
+#elif WINDOWS
+			PlatformView = context.Services.GetRequiredService<Microsoft.UI.Xaml.Window>(),
+#endif
+			VirtualView = virtualWindow,
+			MauiContext = context
+		};
+
+		app.SetCoreWindow(virtualWindow);
+	}
+
+	private static void SetCoreWindow(this IApplication app, Microsoft.Maui.Controls.Window window)
+	{
+		if(app.Windows is List<Microsoft.Maui.Controls.Window> windows)
+		{
+			windows.Add(window);
+		}
+	}
+
+#endif
 
 	// NOTE: This was part of the POC and is out of scope for the MVP. Keeping it in case we want to add it back later.
 	/*

--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.windows.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.windows.cs
@@ -38,5 +38,6 @@ partial class MauiEmbedding
 
 		embeddingApp.InitializeApplication(mauiApp.Services, iApp);
 		app.SetApplicationHandler(iApp, rootContext);
+		InitializeApplicationMainPage(iApp);
 	}
 }

--- a/src/Uno.Extensions.Maui.UI/MauiHost.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiHost.cs
@@ -95,6 +95,12 @@ public partial class MauiHost : ContentControl
 		DataContextChanged += OnDataContextChanged;
 		Unloaded += OnMauiContentUnloaded;
 		ActualThemeChanged += OnActualThemeChanged;
+		SizeChanged += OnSizeChanged;
+	}
+
+	private void OnSizeChanged(object sender, SizeChangedEventArgs e)
+	{
+		EmbeddedView?.PlatformSizeChanged();
 	}
 
 	private void OnActualThemeChanged(FrameworkElement sender, object args)

--- a/src/Uno.Extensions.Maui.UI/MauiHost.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiHost.cs
@@ -100,7 +100,7 @@ public partial class MauiHost : ContentControl
 
 	private void OnSizeChanged(object sender, SizeChangedEventArgs e)
 	{
-		EmbeddedView?.PlatformSizeChanged();
+		VisualElement?.PlatformSizeChanged();
 	}
 
 	private void OnActualThemeChanged(FrameworkElement sender, object args)

--- a/src/Uno.Extensions.Maui.UI/Uno.Extensions.Maui.WinUI.csproj
+++ b/src/Uno.Extensions.Maui.UI/Uno.Extensions.Maui.WinUI.csproj
@@ -58,6 +58,10 @@
 		<None Include="MauiThickness.cs" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <ProjectReference Include="..\Uno.Extensions.Hosting.UI\Uno.Extensions.Hosting.WinUI.csproj" />
+	</ItemGroup>
+
 	<Choose>
 		<When Condition="$(IsMauiEmbedding)">
 			<PropertyGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes unoplatform/uno.extensions-private#106

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

While we initialize the IApplication with a Handler, there is no Window set and the MainPage also remains uninitialized.

## What is the new behavior?

We now make sure the Application.MainPage is also set on a Window and that the Window is added to the IApplication.Windows. Both then receive a Handler with the MauiContext 
