### PR TITLE
set the page after initializing the Handler

### DIFF
--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
@@ -124,7 +124,7 @@ public static partial class MauiEmbedding
 		_ = page.ToPlatform(context);
 
 		// Create a Maui Window and initialize a Handler shim. This will expose the actual Application Window
-		var virtualWindow = new Microsoft.Maui.Controls.Window(page);
+		var virtualWindow = new Microsoft.Maui.Controls.Window();
 		virtualWindow.Handler = new EmbeddedWindowHandler
 		{
 #if IOS || MACCATALYST
@@ -137,6 +137,7 @@ public static partial class MauiEmbedding
 			VirtualView = virtualWindow,
 			MauiContext = context
 		};
+		virtualWindow.Page = page;
 
 		app.SetCoreWindow(virtualWindow);
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix


## What is the current behavior?

We set the page in the window constructor... this can generate an exception where the Window Handler is not yet initialized.

## What is the new behavior?

Set the Page on the Window after the Window Handler is set.
