### PR TITLE
fix: Enable region navigation for null request

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigation.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigation.cs
@@ -30,13 +30,13 @@ public static class Navigation
 			return;
 		}
 
-		if (d is FrameworkElement element)
+		if (d is FrameworkElement element && e.NewValue is not null)
 		{
 			_ = new NavigationRequestBinder(element);
 		}
 	}
 
-	public static void SetRequest(this FrameworkElement element, string value)
+	public static void SetRequest(this FrameworkElement element, string? value = "")
 	{
 		element.SetValue(RequestProperty, value);
 	}

--- a/src/Uno.Extensions.Navigation.UI/Navigation.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigation.cs
@@ -30,7 +30,7 @@ public static class Navigation
 			return;
 		}
 
-		if (d is FrameworkElement element && e.NewValue is not null)
+		if (d is FrameworkElement element)
 		{
 			_ = new NavigationRequestBinder(element);
 		}


### PR DESCRIPTION
We can change this to set the `NavigationRequestBinder` even the value is null (this PR). It looks like null or empty/whitespace string is treated the same way anyway, and will be picked up here:

https://github.com/unoplatform/uno.extensions/blob/a7151a1a06fe65fd2ebf4ebc3cf267d197d4a48c/src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs#L13-L14