### PR TITLE
fix: Setting Activity in Android context

### DIFF
--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
@@ -126,7 +126,12 @@ public static partial class MauiEmbedding
 			return;
 		}
 
+#if ANDROID
+		var services = app.Handler.MauiContext.Services;
+		var context = new MauiContext(services, services.GetRequiredService<Android.App.Activity>());
+#else
 		var context = app.Handler.MauiContext;
+#endif
 
 		// Create an Application Main Page and initialize a Handler with the Maui Context
 		var page = new ContentPage();
@@ -171,7 +176,6 @@ public static partial class MauiEmbedding
 		Interop.MauiInterop.MapControl<TWinUI, TMaui>();
 		return builder;
 	}
-
 	public static MauiAppBuilder MapStyleHandler<THandler>(this MauiAppBuilder builder)
 		where THandler : Interop.IWinUIToMauiStyleHandler, new()
 	{

--- a/src/Uno.Extensions.Maui.UI/MauiHost.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiHost.cs
@@ -42,8 +42,12 @@ public partial class MauiHost : ContentControl
 		try
 		{
 			var app = MauiApplication.Current;
+#if ANDROID
+			var services = app.Handler.MauiContext.Services;
+			var mauiContext = new MauiContext(services, services.GetRequiredService<Android.App.Activity>());
+#else
 			var mauiContext = MauiApplication.Current.Handler.MauiContext;
-
+#endif
 			// Allow the use of Dependency Injection for the View
 			var instance = ActivatorUtilities.CreateInstance(mauiContext.Services, type);
 			if(instance is VisualElement visualElement)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Android context not being correctly set on MauiContext causing issues with alertmanager

## What is the new behavior?

Android context correctly set

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
