### PR TITLE
fix: Adding UIWindow to the service container

### DIFF
--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
@@ -143,7 +143,7 @@ public static partial class MauiEmbedding
 		virtualWindow.Handler = new EmbeddedWindowHandler
 		{
 #if IOS || MACCATALYST
-			PlatformView = context.Services.GetRequiredService<Microsoft.UI.Xaml.Application>().Window,
+			PlatformView = context.Services.GetRequiredService<UIKit.UIWindow>(),
 #elif ANDROID
 			PlatformView = context.Services.GetRequiredService<Android.App.Activity>(),
 #elif WINDOWS

--- a/src/Uno.Extensions.Maui.UI/Properties/Resources.Designer.cs
+++ b/src/Uno.Extensions.Maui.UI/Properties/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Uno.Extensions.Maui.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to CoreWindow is missing _window internal field required to access UIWindow, you may need an updated version of the Uno.Extension.Maui.WinUI package..
+        /// </summary>
+        internal static string MissingWindowPrivateField {
+            get {
+                return ResourceManager.GetString("MissingWindowPrivateField", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No value provided for the Maui Color..
         /// </summary>
         internal static string NoColorValueProvided {

--- a/src/Uno.Extensions.Maui.UI/Properties/Resources.resx
+++ b/src/Uno.Extensions.Maui.UI/Properties/Resources.resx
@@ -123,6 +123,9 @@
   <data name="MauiEmbeddingInitializationExceptionMessage" xml:space="preserve">
     <value>You must call UseMauiEmbedding from the Application</value>
   </data>
+  <data name="MissingWindowPrivateField" xml:space="preserve">
+    <value>CoreWindow is missing _window internal field required to access UIWindow, you may need an updated version of the Uno.Extension.Maui.WinUI package.</value>
+  </data>
   <data name="NoColorValueProvided" xml:space="preserve">
     <value>No value provided for the Maui Color.</value>
   </data>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

UIWindow isn't accessible

## What is the new behavior?

UIWindow is added to the maui context service container

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
