### PR TITLE
Ensure Platform.CurrentActivity is set

### DIFF
--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.android.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.android.cs
@@ -28,6 +28,7 @@ partial class MauiEmbedding
 	private static void InitializeMauiEmbeddingApp(this MauiApp mauiApp, Application app)
 	{
 		var androidApp = mauiApp.Services.GetRequiredService<Android.App.Application>();
+		var activity = mauiApp.Services.GetRequiredService<Android.App.Activity>();
 		var scope = mauiApp.Services.CreateScope();
 		var rootContext = new MauiContext(scope.ServiceProvider, androidApp);
 		rootContext.InitializeScopedServices();
@@ -39,7 +40,10 @@ partial class MauiEmbedding
 		}
 
 		embeddingApp.InitializeApplication(scope.ServiceProvider, iApp);
-		Microsoft.Maui.ApplicationModel.Platform.Init(androidApp);
+
+		// Initializing with the Activity to set the current activity.
+		// The Bundle is not actually used by Maui
+		Microsoft.Maui.ApplicationModel.Platform.Init(activity, null);
 
 		androidApp.SetApplicationHandler(iApp, rootContext);
 		InitializeApplicationMainPage(iApp);


### PR DESCRIPTION
GitHub Issue (If applicable): #

- closes #1876 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The Android Platform is initialized with the Android App as part of the Maui Embedding Initialization after the MainActivity has been created.

## What is the new behavior?

The Android Platform is initialized using the current Activity so that the Platform.CurrentActivity will have an initial value.
