### PR TITLE
fix: Registering settings by name

### DIFF
--- a/src/Uno.Extensions.Authentication.MSAL/MsalAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.MSAL/MsalAuthenticationProvider.cs
@@ -11,7 +11,7 @@ namespace Uno.Extensions.Authentication.MSAL;
 
 internal record MsalAuthenticationProvider(
 		ILogger<MsalAuthenticationProvider> ProviderLogger,
-		IOptions<MsalConfiguration> Configuration,
+		IOptionsSnapshot<MsalConfiguration> Configuration,
 		ITokenCache Tokens,
 		IStorage Storage,
 		MsalAuthenticationSettings? Settings = null) : BaseAuthenticationProvider(ProviderLogger, DefaultName, Tokens)
@@ -25,7 +25,7 @@ internal record MsalAuthenticationProvider(
 	public void Build()
 	{
 		if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Building MSAL Provider");
-		var config = Configuration.Value ?? new MsalConfiguration();
+		var config = Configuration.Get(Name) ?? new MsalConfiguration();
 		var builder = PublicClientApplicationBuilder.CreateWithApplicationOptions(config);
 
 		if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Invoking settings Build callback");

--- a/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationProvider.cs
@@ -6,7 +6,7 @@ namespace Uno.Extensions.Authentication.Oidc;
 
 internal record OidcAuthenticationProvider(
 		ILogger<OidcAuthenticationProvider> ProviderLogger,
-		IOptions<OidcClientOptions> Configuration,
+		IOptionsSnapshot<OidcClientOptions> Configuration,
 		ITokenCache Tokens,
 		OidcAuthenticationSettings? Settings = null) : BaseAuthenticationProvider(ProviderLogger, DefaultName, Tokens)
 {
@@ -16,7 +16,7 @@ internal record OidcAuthenticationProvider(
 
 	public void Build()
 	{
-		var config = Settings?.Options ?? Configuration.Value ?? new OidcClientOptions();
+		var config = Settings?.Options ?? Configuration.Get(Name) ?? new OidcClientOptions();
 
 		if (PlatformHelper.IsWebAssembly)
 		{

--- a/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationProvider.cs
@@ -1,9 +1,11 @@
-﻿namespace Uno.Extensions.Authentication.Web;
+﻿using Microsoft.Extensions.Options;
+
+namespace Uno.Extensions.Authentication.Web;
 
 internal record WebAuthenticationProvider
 (
 	ILogger<WebAuthenticationProvider> ProviderLogger,
-	Microsoft.Extensions.Options.IOptions<WebConfiguration> Configuration,
+	IOptionsSnapshot<WebConfiguration> Configuration,
 	IServiceProvider Services,
 	ITokenCache Tokens
 ) : BaseAuthenticationProvider(ProviderLogger, DefaultName, Tokens)
@@ -22,7 +24,7 @@ internal record WebAuthenticationProvider
 			if (_internalSettings is null)
 			{
 				_internalSettings = Settings ?? new WebAuthenticationSettings();
-				var config = Configuration.Value;
+				var config = Configuration.Get(Name);
 				if (config is not null)
 				{
 					_internalSettings = _internalSettings with
@@ -213,7 +215,7 @@ internal record WebAuthenticationProvider
 internal record WebAuthenticationProvider<TService>
 (
 	ILogger<WebAuthenticationProvider<TService>> ServiceLogger,
-	Microsoft.Extensions.Options.IOptions<WebConfiguration> Configuration,
+	IOptionsSnapshot<WebConfiguration> Configuration,
 	IServiceProvider Services,
 	ITokenCache Tokens
 ) : WebAuthenticationProvider(ServiceLogger, Configuration, Services, Tokens)

--- a/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
@@ -106,6 +106,9 @@ public static class ConfigBuilderExtensions
 	/// <param name="configurationSection">
 	/// The configuration section to retrieve.
 	/// </param>
+	/// <param name="configSection">
+	/// A delegate that returns the configuration section to retrieve.
+	/// </param>
 	/// <returns>
 	/// An instance of the <see cref="IConfigBuilder"/> for chaining.
 	/// </returns>

--- a/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
@@ -111,35 +111,20 @@ public static class ConfigBuilderExtensions
 	/// </returns>
 	public static IConfigBuilder Section<TSettingsOptions>(
 		this IConfigBuilder hostBuilder,
-		string configurationSection)
-			where TSettingsOptions : class, new()
-	{
-		return hostBuilder.Section<TSettingsOptions>(ctx => ctx.Configuration.GetSection(configurationSection));
-	}
-
-	/// <summary>
-	/// Sets up the host builder to register a specific configuration section
-	/// </summary>
-	/// <typeparam name="TSettingsOptions">
-	/// The type that the configuration section will be deserialized to.
-	/// </typeparam>
-	/// <param name="hostBuilder">
-	/// The <see cref="IConfigBuilder"/> to configure.
-	/// </param>
-	/// <param name="configSection">
-	/// A delegate that returns the configuration section to retrieve.
-	/// </param>
-	/// <returns>
-	/// An instance of the <see cref="IConfigBuilder"/> for chaining.
-	/// </returns>
-	public static IConfigBuilder Section<TSettingsOptions>(
-		this IConfigBuilder hostBuilder,
+		string? configurationSection = "",
 		Func<HostBuilderContext, IConfigurationSection>? configSection = null)
 			where TSettingsOptions : class, new()
 	{
 		if (configSection is null)
 		{
-			configSection = ctx => ctx.Configuration.GetSection(typeof(TSettingsOptions).Name);
+			if (configurationSection is { Length: > 0 })
+			{
+				configSection = ctx => ctx.Configuration.GetSection(configurationSection);
+			}
+			else
+			{
+				configSection = ctx => ctx.Configuration.GetSection(typeof(TSettingsOptions).Name);
+			}
 		}
 
 		static string? FilePath(HostBuilderContext hctx)
@@ -169,7 +154,7 @@ public static class ConfigBuilderExtensions
 					}
 
 					var section = configSection(ctx);
-					services.ConfigureAsWritable<TSettingsOptions>(section, configPath);
+					services.ConfigureAsWritable<TSettingsOptions>(section, configPath, configurationSection);
 				}
 
 			).AsConfigBuilder();

--- a/src/Uno.Extensions.Configuration/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ServiceCollectionExtensions.cs
@@ -18,11 +18,13 @@ public static class ServiceCollectionExtensions
 	/// <param name="services">The Microsoft.Extensions.DependencyInjection.IServiceCollection to add the services to.</param>
 	/// <param name="section">The Microsoft.Extensions.Configuration.IConfigurationSection to retrieve.</param>
 	/// <param name="file">The full path to the file where updated section data will be written.</param>
+	/// <param name="name">The named options value to register</param>
 	/// <returns>The Microsoft.Extensions.DependencyInjection.IServiceCollection so that additional calls can be chained.</returns>
 	public static IServiceCollection ConfigureAsWritable<T>(
 		this IServiceCollection services,
 		IConfigurationSection section,
-		string file)
+		string file,
+		string? name = "")
 			where T : class, new()
 	{
 		return services
@@ -30,8 +32,8 @@ public static class ServiceCollectionExtensions
 			// we can use a local copy of ConfigurationBinder that handles ImmutableList
 			//.Configure<T>(section)
 			.AddOptions()
-			.AddSingleton<IOptionsChangeTokenSource<T>>(new ConfigurationChangeTokenSource<T>(Options.DefaultName, section))
-			.AddSingleton<IConfigureOptions<T>>(new Uno.Extensions.Configuration.Internal.NamedConfigureFromConfigurationOptions<T>(Options.DefaultName, section, _ => { }))
+			.AddSingleton<IOptionsChangeTokenSource<T>>(new ConfigurationChangeTokenSource<T>(name ?? Options.DefaultName, section))
+			.AddSingleton<IConfigureOptions<T>>(new Uno.Extensions.Configuration.Internal.NamedConfigureFromConfigurationOptions<T>(name ?? Options.DefaultName, section, _ => { }))
 
 			.AddTransient<IWritableOptions<T>>(provider =>
 			{

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Oidc/OidcAuthenticationHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Oidc/OidcAuthenticationHostInit.cs
@@ -7,9 +7,8 @@ public class OidcAuthenticationHostInit : BaseHostInitialization
 	protected override IHostBuilder Custom(IHostBuilder builder)
 	{
 		return builder
-							.UseAuthentication(auth =>
-					auth
-					.AddOidc(oidc =>
+				.UseAuthentication(auth =>
+					auth.AddOidc(oidc =>
 						oidc
 							.Authority("https://demo.duendesoftware.com/")
 							.ClientId("interactive.confidential")
@@ -17,7 +16,11 @@ public class OidcAuthenticationHostInit : BaseHostInitialization
 							.Scope("openid profile email api offline_access")
 							.RedirectUri("oidc-auth://callback")
 							.PostLogoutRedirectUri("oidc-auth://callback")
-						))
+						)
+						.AddOidc(name: "OpenIdConnectEndpoint")
+						.AddOidc(name: "DifferentOpenIdConnectEndpoint")
+						.AddOidc(name: "AnotherOpenIdConnectEndpoint")
+					)
 
 				.ConfigureServices(services =>
 					services

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Oidc/appsettings.oidc.json
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Oidc/appsettings.oidc.json
@@ -8,5 +8,17 @@
   "OidcAuthenticationTestEndpoint": {
     "Url": "https://demo.duendesoftware.com",
     "UseNativeHandler": true
+  },
+  "DifferentOpenIdConnectEndpoint": {
+    "Authority": "https://different.endpoint.com/",
+    "ClientId": "different.clientid",
+    "ClientSecret": "differentsecret",
+    "Scope": "openid different scope offline_access"
+  },
+  "AnotherOpenIdConnectEndpoint": {
+    "Authority": "https://another.endpoint.com/",
+    "ClientId": "another.clientid",
+    "ClientSecret": "anothersecret",
+    "Scope": "openid another scope offline_access"
   }
 }

--- a/testing/TestHarness/TestHarness.Windows/Package.appxmanifest
+++ b/testing/TestHarness/TestHarness.Windows/Package.appxmanifest
@@ -39,6 +39,13 @@
         <uap:DefaultTile Wide310x150Logo="Images\Wide310x150Logo.png" />
         <uap:SplashScreen Image="Images\SplashScreen.png" />
       </uap:VisualElements>
+		<Extensions>
+			<uap:Extension Category="windows.protocol">
+				<uap:Protocol Name="oidc-auth">
+					<uap:DisplayName>OidcSample</uap:DisplayName>
+				</uap:Protocol>
+			</uap:Extension>
+		</Extensions>
     </Application>
   </Applications>
 


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno.extensions/issues/1574

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Auth providers (MSAL, Web, OIDC) should load configuration sections that match the name provided during configuration. This is not the case, resulting in the last read settings being applied to all providers of a given type.
For example if there are mulitple OIDC auth registrations, currently they will all get the settings for the last registration.

## What is the new behavior?

Auth providers (MSAL, Web, OIDC) should load configuration sections that match the name provided during configuration.
Multiple auth registrations for the same type should get independent setttings

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [N/A] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [N/A] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
