### PR TITLE
feat: Adding maui and not_maui namespace definitions

### DIFF
--- a/src/Uno.Extensions.Maui.UI/build/Package.props
+++ b/src/Uno.Extensions.Maui.UI/build/Package.props
@@ -3,14 +3,24 @@
 		<IsMauiEmbedding>false</IsMauiEmbedding>
 		<IsMauiEmbedding Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' OR $(TargetFramework.Contains('windows10'))" >true</IsMauiEmbedding>
 		<DefineConstants Condition="$(IsMauiEmbedding)">$(DefineConstants);MAUI_EMBEDDING</DefineConstants>
-	</PropertyGroup>
-	<PropertyGroup>
+
 		<UseMaui>true</UseMaui>
 		<UseMauiAssets>false</UseMauiAssets>
 		<_MauiSkipSdkAutoImport>true</_MauiSkipSdkAutoImport>
 		<EnableDefaultXamlItems>false</EnableDefaultXamlItems>
 		<EnableDefaultMauiItems>false</EnableDefaultMauiItems>
 	</PropertyGroup>
+
+	<ItemGroup Condition="'$(IsMauiEmbedding)'=='True'">
+		<IncludeXamlNamespaces Include="maui" />
+		<ExcludeXamlNamespaces Include="not_maui" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(IsMauiEmbedding)'!='True'">
+		<IncludeXamlNamespaces Include="not_maui" />
+		<ExcludeXamlNamespaces Include="maui" />
+	</ItemGroup>
+
 	<Choose>
 		<When Condition="$(TargetFramework.Contains('windows10'))">
 			<PropertyGroup Condition=" '$(OutputType)' != 'WinExe' AND '$(OutputType)' != 'Exe' ">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

No custom namespaces for conditional xaml based on whether running on maui target or not

## What is the new behavior?

Can use maui and not_maui namespace prefixes to show different content depending on whether running on a maui target or not

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
