### PR TITLE
Added GetClaims to make both IdToken and AccessToken claims avaliable

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -33,6 +33,7 @@
 		<PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
 		<PackageVersion Include="Serilog.Sinks.Xamarin" Version="1.0.0" />
 		<PackageVersion Include="System.Collections.Immutable" Version="1.3.1" /> <!--Lower version breaks build of reactive.<UI|WinUI>-->
+		<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.0.2" />
 		<PackageVersion Include="System.Linq.Async" Version="4.0.0" />
 		<PackageVersion Include="System.Net.Http.WinHttpHandler" Version="6.0.1" />
 		<PackageVersion Include="System.Text.Json" Version="6.0.3" />

--- a/src/Uno.Extensions.Authentication.MSAL/MsalAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.MSAL/MsalAuthenticationProvider.cs
@@ -63,7 +63,8 @@ internal record MsalAuthenticationProvider(
 			var result = await AcquireTokenAsync(dispatcher);
 			return new Dictionary<string, string>
 							{
-								{ TokenCacheExtensions.AccessTokenKey, result?.AccessToken??string.Empty}
+								{ TokenCacheExtensions.AccessTokenKey, result?.AccessToken??string.Empty},
+								{ TokenCacheExtensions.IdTokenKey, result?.IdToken??string.Empty}
 							};
 		}
 		catch (MsalClientException ex)

--- a/src/Uno.Extensions.Authentication/AuthenticationService.cs
+++ b/src/Uno.Extensions.Authentication/AuthenticationService.cs
@@ -91,6 +91,20 @@ internal class AuthenticationService : IAuthenticationService
 		return isAuthenticated;
 	}
 
+	public async ValueTask<IEnumerable<Claim>> GetClaims(string tokenType = TokenCacheExtensions.IdTokenKey, CancellationToken? cancellationToken = default)
+	{
+		var ct = cancellationToken ?? CancellationToken.None;
+
+		var tokens = await _tokens.GetAsync(ct);
+
+		if(tokens.TryGetValue(tokenType, out var idToken))
+		{
+			var jwtToken = new JwtSecurityToken(idToken);
+			return jwtToken.Claims;
+		}
+		return Enumerable.Empty<Claim>();
+	}
+
 	private void TokensCleared(object sender, EventArgs e)
 	{
 		if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTraceMessage($"Tokens cleared, raising LoggedOut event");

--- a/src/Uno.Extensions.Authentication/GlobalUsings.cs
+++ b/src/Uno.Extensions.Authentication/GlobalUsings.cs
@@ -15,3 +15,5 @@ global using Uno.Extensions.Authentication.Handlers;
 global using Uno.Extensions.Hosting;
 global using Uno.Extensions.Logging;
 global using Uno.Extensions.Storage.KeyValueStorage;
+global using System.Security.Claims;
+global using System.IdentityModel.Tokens.Jwt;

--- a/src/Uno.Extensions.Authentication/IAuthenticationService.cs
+++ b/src/Uno.Extensions.Authentication/IAuthenticationService.cs
@@ -67,6 +67,19 @@ public interface IAuthenticationService
 	ValueTask<bool> IsAuthenticated(CancellationToken? cancellationToken = default);
 
 	/// <summary>
+	/// Gets claims associated with a specified token type.
+	/// </summary>
+	/// <param name="tokenType">
+	/// The token type <see cref="TokenCacheExtensions.IdTokenKey"/> or <see cref="TokenCacheExtensions.AccessTokenKey"/></param>
+	/// <param name="cancellationToken">
+	/// A cancellation token that can be used to cancel the operation. Optional
+	/// </param>
+	/// <returns>
+	/// A task that represents the asynchronous operation. The task result is a an enumerable of claims associated with the specified token.
+	/// </returns>
+	ValueTask<IEnumerable<Claim>> GetClaims(string tokenType = TokenCacheExtensions.IdTokenKey, CancellationToken? cancellationToken = default);
+
+	/// <summary>
 	/// Defines an event that is raised when the user is logged out.
 	/// </summary>
 	event EventHandler LoggedOut;

--- a/src/Uno.Extensions.Authentication/TokenCacheExtensions.cs
+++ b/src/Uno.Extensions.Authentication/TokenCacheExtensions.cs
@@ -21,6 +21,11 @@ public static class TokenCacheExtensions
 	public const string RefreshTokenKey = "RefreshToken";
 
 	/// <summary>
+	/// Defines a key for the token cache which corresponds to a Id token element.
+	/// </summary>
+	public const string IdTokenKey = "IdToken";
+
+	/// <summary>
 	/// Gets the access token from the token cache.
 	/// </summary>
 	/// <param name="cache">

--- a/src/Uno.Extensions.Authentication/Uno.Extensions.Authentication.csproj
+++ b/src/Uno.Extensions.Authentication/Uno.Extensions.Authentication.csproj
@@ -23,6 +23,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Hosting" />
 		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
At present it is not possible to retrieve the claims received when using the uno MSAL Authentication extensions

## What is the new behavior?

Added a `GetClaims` method to the `IAuthenticationService` to enable claims to be retrieved for either IdToken or AccessToken.


## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
A new dependancy to `System.IdentityModel.Tokens.Jwt` was required.
