### PR TITLE
fix: Fix MVUX hot reload support

### DIFF
--- a/src/Uno.Extensions.Core.Generators/Common/GenTool/CodeGenToolExtensions.cs
+++ b/src/Uno.Extensions.Core.Generators/Common/GenTool/CodeGenToolExtensions.cs
@@ -7,7 +7,7 @@ namespace Uno.Extensions.Generators;
 
 internal static class CodeGenToolExtensions
 {
-	private static SymbolDisplayFormat _symbolDeclaration = SymbolDisplayFormat
+	private static readonly SymbolDisplayFormat _symbolDeclaration = SymbolDisplayFormat
 		.MinimallyQualifiedFormat
 		.AddKindOptions(SymbolDisplayKindOptions.IncludeTypeKeyword); // Add `class`, `record` or `record struct`
 

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableFromFeedField.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableFromFeedField.cs
@@ -24,5 +24,5 @@ internal record BindableFromFeedField(IFieldSymbol _field, ITypeSymbol _valueTyp
 
 	/// <inheritdoc />
 	public string? GetInitialization()
-		=> $"{_field.Name} ??= new {_bindableValueType}(base.Property<{_valueType.ToFullString()}>(nameof({_field.Name}), {N.Ctor.Model}.{_field.Name} ?? throw new NullReferenceException(\"The feed field '{_field.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
+		=> $"{_field.Name} ??= new {_bindableValueType}(base.Property<{_valueType.ToFullString()}>(nameof({_field.Name}), ({NS.Reactive}.IFeed<{_valueType.ToFullString()}>) {N.Ctor.Model}.{_field.Name} ?? throw new NullReferenceException(\"The feed field '{_field.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
 }

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableFromFeedProperty.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableFromFeedProperty.cs
@@ -24,5 +24,5 @@ internal record BindableFromFeedProperty(IPropertySymbol _property, ITypeSymbol 
 
 	/// <inheritdoc />
 	public string? GetInitialization()
-		=> $"{_property.Name} ??= new {_bindableValueType}(base.Property<{_valueType.ToFullString()}>(nameof({_property.Name}), {N.Ctor.Model}.{_property.Name} ?? throw new NullReferenceException(\"The feed field '{_property.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
+		=> $"{_property.Name} ??= new {_bindableValueType}(base.Property<{_valueType.ToFullString()}>(nameof({_property.Name}), ({NS.Reactive}.IFeed<{_valueType.ToFullString()}>) {N.Ctor.Model}.{_property.Name} ?? throw new NullReferenceException(\"The feed field '{_property.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
 }

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListField.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListField.cs
@@ -23,7 +23,7 @@ internal record BindableListFromFeedOfListField(IFieldSymbol Field, ITypeSymbol 
 		=> @$"
 			if ({Field.Name} is null)
 			{{
-				var {Field.GetCamelCaseName()}Source = {N.Ctor.Model}.{Field.Name} ?? throw new NullReferenceException(""The list feed field '{Field.Name}' is null. Public feeds properties must be initialized in the constructor."");
+				var {Field.GetCamelCaseName()}Source = ({NS.Reactive}.IFeed<{CollectionType.ToFullString()}>) {N.Ctor.Model}.{Field.Name} ?? throw new NullReferenceException(""The list feed field '{Field.Name}' is null. Public feeds properties must be initialized in the constructor."");
 				var {Field.GetCamelCaseName()}SourceListFeed = {N.ListFeed.Extensions.ToListFeed}<{CollectionType.ToFullString()}, {ItemType.ToFullString()}>({Field.GetCamelCaseName()}Source);
 				var {Field.GetCamelCaseName()}SourceListState = {N.Ctor.Ctx}.GetOrCreateListState({Field.GetCamelCaseName()}SourceListFeed);
 				{Field.Name} = {NS.Bindings}.BindableHelper.CreateBindableList(nameof({Field.Name}), {Field.GetCamelCaseName()}SourceListState);

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListProperty.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListProperty.cs
@@ -23,7 +23,7 @@ internal record BindableListFromFeedOfListProperty(IPropertySymbol Property, ITy
 		=> @$"
 			if ({Property.Name} is null)
 			{{
-				var {Property.GetCamelCaseName()}Source = {N.Ctor.Model}.{Property.Name} ?? throw new NullReferenceException(""The list feed property '{Property.Name}' is null. Public feeds properties must be initialized in the constructor."");
+				var {Property.GetCamelCaseName()}Source = ({NS.Reactive}.IFeed<{CollectionType.ToFullString()}>) {N.Ctor.Model}.{Property.Name} ?? throw new NullReferenceException(""The list feed property '{Property.Name}' is null. Public feeds properties must be initialized in the constructor."");
 				var {Property.GetCamelCaseName()}SourceListFeed = {N.ListFeed.Extensions.ToListFeed}<{CollectionType.ToFullString()}, {ItemType.ToFullString()}>({Property.GetCamelCaseName()}Source);
 				var {Property.GetCamelCaseName()}SourceListState = {N.Ctor.Ctx}.GetOrCreateListState({Property.GetCamelCaseName()}SourceListFeed);
 				{Property.Name} = {NS.Bindings}.BindableHelper.CreateBindableList(nameof({Property.Name}), {Property.GetCamelCaseName()}SourceListState);

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedField.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedField.cs
@@ -26,7 +26,7 @@ internal record BindableListFromListFeedField(IFieldSymbol _field, ITypeSymbol _
 		=> @$"
 			if ({_field.Name} is null)
 			{{
-				var {_field.GetCamelCaseName()}Source = {N.Ctor.Model}.{_field.Name} ?? throw new NullReferenceException(""The list feed field '{_field.Name}' is null. Public feeds properties must be initialized in the constructor."");
+				var {_field.GetCamelCaseName()}Source = ({NS.Reactive}.IListFeed<{_valueType.ToFullString()}>) {N.Ctor.Model}.{_field.Name} ?? throw new NullReferenceException(""The list feed field '{_field.Name}' is null. Public feeds properties must be initialized in the constructor."");
 				var {_field.GetCamelCaseName()}SourceListState = {N.Ctor.Ctx}.GetOrCreateListState({_field.GetCamelCaseName()}Source);
 				{_field.Name} = {NS.Bindings}.BindableHelper.CreateBindableList(nameof({_field.Name}), {_field.GetCamelCaseName()}SourceListState);
 			}}";

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedProperty.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedProperty.cs
@@ -26,7 +26,7 @@ internal record BindableListFromListFeedProperty(IPropertySymbol _property, ITyp
 		=> @$"
 			if ({_property.Name} is null)
 			{{
-				var {_property.GetCamelCaseName()}Source = {N.Ctor.Model}.{_property.Name} ?? throw new NullReferenceException(""The list feed property '{_property.Name}' is null. Public feeds properties must be initialized in the constructor."");
+				var {_property.GetCamelCaseName()}Source = ({NS.Reactive}.IListFeed<{_valueType.ToFullString()}>) {N.Ctor.Model}.{_property.Name} ?? throw new NullReferenceException(""The list feed property '{_property.Name}' is null. Public feeds properties must be initialized in the constructor."");
 				var {_property.GetCamelCaseName()}SourceListState = {N.Ctor.Ctx}.GetOrCreateListState({_property.GetCamelCaseName()}Source);
 				{_property.Name} = {NS.Bindings}.BindableHelper.CreateBindableList(nameof({_property.Name}), {_property.GetCamelCaseName()}SourceListState);
 			}}";

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/PropertyFromFeedField.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/PropertyFromFeedField.cs
@@ -16,7 +16,7 @@ internal record PropertyFromFeedField(IFieldSymbol _field, ITypeSymbol _valueTyp
 
 	/// <inheritdoc />
 	public string GetBackingField()
-		=> $"private {NS.Bindings}.Bindable<{_valueType.ToFullString()}> _{_field.Name};";
+		=> $"private {NS.Bindings}.Bindable<{_valueType.ToFullString()}> _{_field.Name} {{ get; set; }}"; // Property for hot-reload
 
 	/// <inheritdoc />
 	public string GetDeclaration()
@@ -28,5 +28,5 @@ internal record PropertyFromFeedField(IFieldSymbol _field, ITypeSymbol _valueTyp
 
 	/// <inheritdoc />
 	public string GetInitialization()
-		=> $"_{_field.Name} ??= new {NS.Bindings}.Bindable<{_valueType.ToFullString()}>(base.Property<{_valueType.ToFullString()}>(nameof({_field.Name}), {N.Ctor.Model}.{_field.Name} ?? throw new NullReferenceException(\"The feed field '{_field.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
+		=> $"_{_field.Name} ??= new {NS.Bindings}.Bindable<{_valueType.ToFullString()}>(base.Property<{_valueType.ToFullString()}>(nameof({_field.Name}), ({NS.Reactive}.IFeed<{_valueType.ToFullString()}>) {N.Ctor.Model}.{_field.Name} ?? throw new NullReferenceException(\"The feed field '{_field.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
 }

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/PropertyFromFeedProperty.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/PropertyFromFeedProperty.cs
@@ -16,7 +16,7 @@ internal record PropertyFromFeedProperty(IPropertySymbol _property, ITypeSymbol 
 
 	/// <inheritdoc />
 	public string GetBackingField()
-		=> $"private {NS.Bindings}.Bindable<{_valueType.ToFullString()}> _{_property.GetCamelCaseName()};";
+		=> $"private {NS.Bindings}.Bindable<{_valueType.ToFullString()}> _{_property.GetCamelCaseName()} {{ get; set; }}"; // Property for hot-reload
 
 	/// <inheritdoc />
 	public string GetDeclaration()
@@ -28,5 +28,5 @@ internal record PropertyFromFeedProperty(IPropertySymbol _property, ITypeSymbol 
 
 	/// <inheritdoc />
 	public string? GetInitialization()
-		=> $"_{_property.GetCamelCaseName()} ??= new {NS.Bindings}.Bindable<{_valueType.ToFullString()}>(base.Property<{_valueType.ToFullString()}>(nameof({_property.Name}), {N.Ctor.Model}.{_property.Name} ?? throw new NullReferenceException(\"The feed property '{_property.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
+		=> $"_{_property.GetCamelCaseName()} ??= new {NS.Bindings}.Bindable<{_valueType.ToFullString()}>(base.Property<{_valueType.ToFullString()}>(nameof({_property.Name}), ({NS.Reactive}.IFeed<{_valueType.ToFullString()}>) {N.Ctor.Model}.{_property.Name} ?? throw new NullReferenceException(\"The feed property '{_property.Name}' is null. Public feeds fields must be initialized in the constructor.\")));";
 }

--- a/src/Uno.Extensions.Reactive.Tests/IntegrationTests/Given_HotReload.cs
+++ b/src/Uno.Extensions.Reactive.Tests/IntegrationTests/Given_HotReload.cs
@@ -69,6 +69,8 @@ public partial class Given_HotReload : FeedUITests
 	[MetadataUpdateOriginalType(typeof(When_UpdateValueTypeFeedInModel_Then_BindableUpdated_MyModel))]
 	public partial class When_UpdateValueTypeFeedInModel_Then_BindableUpdated_MyModel_v1
 	{
+		internal BindableWhen_UpdateValueTypeFeedInModel_Then_BindableUpdated_MyModel __reactiveBindableViewModel = default!;
+
 		public IFeed<string> MyFeed => Feed.Async(async ct => "Feed value from model v1");
 	}
 	#endregion
@@ -103,13 +105,14 @@ public partial class Given_HotReload : FeedUITests
 	[MetadataUpdateOriginalType(typeof(When_UpdateRecordFeedInModel_Then_BindableUpdated_MyModel))]
 	public partial class When_UpdateRecordFeedInModel_Then_BindableUpdated_MyModel_v1
 	{
+		internal BindableWhen_UpdateRecordFeedInModel_Then_BindableUpdated_MyModel __reactiveBindableViewModel = default!;
+
 		public IFeed<When_UpdateRecordFeedInModel_Then_BindableUpdated_Record> MyFeed => Feed.Async(async ct => new When_UpdateRecordFeedInModel_Then_BindableUpdated_Record("Feed value from model v1"));
 	}
 	#endregion
 
 	#region When_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated
 	[TestMethod]
-	[Ignore("WIP")]
 	public async Task When_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated()
 	{
 		var bindable = new BindableWhen_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyModel();
@@ -117,9 +120,11 @@ public partial class Given_HotReload : FeedUITests
 		var tcs = new TaskCompletionSource();
 		Dispatcher.TryEnqueue(() => bindable.PropertyChanged += (s, e) => tcs.TrySetResult());
 
+		await WaitFor(() => bindable.MyFeed, "Feed value from original model");
+
 		HotReloadService.UpdateApplication(new[] { typeof(When_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyModel_v1) });
 
-		//await tcs.Task;
+		await tcs.Task;
 		await WaitFor(() => bindable.MyFeed, "Feed value from model v1");
 	}
 
@@ -134,13 +139,14 @@ public partial class Given_HotReload : FeedUITests
 	[MetadataUpdateOriginalType(typeof(When_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyModel))]
 	public partial class When_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyModel_v1
 	{
+		internal BindableWhen_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyModel __reactiveBindableViewModel = default!;
+
 		public IFeed<string> MyFeed => Feed.Dynamic(async ct => "Feed value from model v1");
 	}
 	#endregion
 
 	#region When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated
 	[TestMethod]
-	[Ignore("WIP")]
 	public async Task When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated()
 	{
 		var bindable = new BindableWhen_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyModel();
@@ -148,9 +154,11 @@ public partial class Given_HotReload : FeedUITests
 		var tcs = new TaskCompletionSource();
 		Dispatcher.TryEnqueue(() => bindable.PropertyChanged += (s, e) => tcs.TrySetResult());
 
+		await WaitFor(() => bindable.MyFeed.Value, "Feed value from original model");
+
 		HotReloadService.UpdateApplication(new[] { typeof(When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyModel_v1) });
 
-		//await tcs.Task;
+		await tcs.Task;
 		await WaitFor(() => bindable.MyFeed.Value, "Feed value from model v1");
 	}
 
@@ -167,6 +175,8 @@ public partial class Given_HotReload : FeedUITests
 	[MetadataUpdateOriginalType(typeof(When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyModel))]
 	public partial class When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyModel_v1
 	{
+		internal BindableWhen_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyModel __reactiveBindableViewModel = default!;
+
 		public IFeed<When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_Record> MyFeed => Feed.Dynamic(async ct => new When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_Record("Feed value from model v1"));
 	}
 	#endregion
@@ -197,7 +207,7 @@ public partial class Given_HotReload : FeedUITests
 				return;
 			}
 
-			await Task.Delay(1);
+			await Task.Delay(3);
 		}
 
 		throw new TimeoutException($"Expected '{expected}' but get '{actual()}' after {attempts}ms.");

--- a/src/Uno.Extensions.Reactive/Operators/HotSwapFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/HotSwapFeed.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -112,7 +113,8 @@ public sealed class HotSwapFeed<T> : IFeed<T>
 			if (_currentEnumerator.GetEnumerator(_context) is { } enumerator)
 			{
 				var moveNext = enumerator.MoveNextAsync().AsTask();
-				if (await Task.WhenAny(moveNext, next.Task).ConfigureAwait(false) == moveNext)
+				if (await Task.WhenAny(moveNext, next.Task).ConfigureAwait(false) == moveNext
+					&& await moveNext)
 				{
 					var canSkip = !_isFirstMessage && _isFirstMessageOfCurrentEnumerator;
 

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.cs
@@ -76,7 +76,7 @@ public abstract partial class BindableViewModelBase : IBindable, INotifyProperty
 
 		var state = ctx.GetOrCreateState(feed);
 
-		return CreateProperty(propertyName, (StateImpl<TProperty>)state, isReadOnly: true);
+		return CreateProperty(propertyName, (StateImpl<TProperty>)state, isReadOnly: feed != state);
 	}
 
 	/// <summary>

--- a/src/Uno.Extensions.Reactive/Presentation/Commands/Command.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Commands/Command.cs
@@ -20,7 +20,7 @@ public static class Command
 	/// <remarks>By default, this will log the error.</remarks>
 	/// <remarks>This is designed to be a "last chance" handler, you should handle exceptions in each command.</remarks>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
-	public static Action<Exception> DefaultErrorHandler { get; set; } = e => typeof(AsyncCommand).Log().Error(e, "Failed to execute command.");
+	public static Action<Exception> DefaultErrorHandler { get; set; } = e => LogExtensions.Log<AsyncCommand>().Error(e, "Failed to execute command.");
 
 	/// <summary>
 	/// Creates a command from an async method

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Feed/FeedDependency.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Feed/FeedDependency.cs
@@ -8,7 +8,7 @@ namespace Uno.Extensions.Reactive.Sources;
 
 internal abstract class FeedDependency
 {
-	private static readonly ILogger _log = typeof(FeedDependency).Log();
+	private static readonly ILogger _log = typeof(FeedDependency).CreateLog();
 
 	public static async ValueTask<Message<T>?> TryGetCurrentMessage<T>(IFeed<T> feed)
 		=> FeedExecution.Current is { } exec

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/DynamicFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/DynamicFeed.cs
@@ -27,11 +27,6 @@ internal sealed class DynamicFeed<T> : IFeed<T>
 	{
 		await using var session = new FeedSession<T>(this, context, _dataProvider, ct);
 
-		if (FeedConfiguration.EffectiveHotReload.HasFlag(HotReloadSupport.DynamicFeed))
-		{
-			session.EnableHotReload();
-		}
-
 		while (await session.MoveNextAsync())
 		{
 			yield return session.Current;

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/FeedSession.T.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/FeedSession.T.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Uno.Extensions.Reactive.Config;
 using Uno.Extensions.Reactive.Core;
 using Uno.Extensions.Reactive.Utils;
+using static System.Collections.Specialized.BitVector32;
 
 namespace Uno.Extensions.Reactive.Sources;
 
@@ -23,6 +25,11 @@ internal sealed partial class FeedSession<TResult> : FeedSession, IAsyncEnumerat
 		_messages = new(ReplayMode.EnabledForFirstEnumeratorOnly);
 		_inner = _messages.GetAsyncEnumerator(ct);
 		_message = new(_messages.TrySetNext);
+
+		if (FeedConfiguration.EffectiveHotReload.HasFlag(HotReloadSupport.DynamicFeed))
+		{
+			this.EnableHotReload();
+		}
 
 		Execute(new ExecuteRequest(this, "Initial load"));
 	}

--- a/src/Uno.Extensions.Reactive/Utils/Logging/LogExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/Logging/LogExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
@@ -36,6 +38,14 @@ internal static class LogExtensions
 	public static void SetProvider(ILoggerProvider provider)
 		=> _provider = provider;
 
+	public static ILogger CreateLog(string categoryName)
+		=> _provider?.CreateLogger(categoryName)
+			?? FindUnoAmbientLogger()?.CreateLogger(categoryName)
+			?? NullLogger.Instance;
+
+	public static ILogger CreateLog(this Type type)
+		=> CreateLog(type.FullName ?? type.ToString());
+
 	public static ILogger Log<T>()
 		=> Holder<T>.Logger;
 
@@ -68,6 +78,6 @@ internal static class LogExtensions
 
 	private static class Holder<T>
 	{
-		public static ILogger Logger { get; } = _provider?.CreateLogger(typeof(T).FullName) ?? FindUnoAmbientLogger()?.CreateLogger(typeof(T).FullName) ?? NullLogger.Instance;
+		public static ILogger Logger { get; } = CreateLog(typeof(T).FullName);
 	}
 }


### PR DESCRIPTION
## Bugfix
Fix MVUX hot reload support

## What is the current behavior?
Needs to restart the app too often

## What is the new behavior?
* Generate property instead of fields (supported by hot-reload)
* Generate the missing CreateNew... attribute on Model

## PR Checklist

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
