### PR TITLE
fix: Make the HR to be enabled on MVUX if app is built in DEBUG

### DIFF
--- a/src/Uno.Extensions.Reactive/Config/ModuleFeedConfiguration.cs
+++ b/src/Uno.Extensions.Reactive/Config/ModuleFeedConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions.Reactive.Logging;
@@ -15,7 +16,7 @@ namespace Uno.Extensions.Reactive.Config;
 public static class ModuleFeedConfiguration
 {
 	private static readonly ILogger _log = LogExtensions.Log<FeedConfiguration>();
-	private static int _isHotReloadConfigured;
+	private static readonly string? _entryAssembly = Assembly.GetEntryAssembly()?.GetName().Name;
 
 	/// <summary>
 	/// Configures hot-reload for MVUX framework.
@@ -27,7 +28,7 @@ public static class ModuleFeedConfiguration
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static void ConfigureHotReload(string module, bool isEnabled)
 	{
-		if (Interlocked.Increment(ref _isHotReloadConfigured) is 1)
+		if (_entryAssembly?.Equals(module, StringComparison.OrdinalIgnoreCase) ?? false)
 		{
 			// Note: it's fine to directly use FeedConfiguration.HotReload as it's internal for now.
 			// We should consider to have a dedicated flag otherwise (to not wipe the config of the user).

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceSettingsPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Apps/Commerce/CommerceSettingsPage.xaml.cs
@@ -8,10 +8,7 @@ using Windows.Foundation.Collections;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 


### PR DESCRIPTION
## Bugfix
Make the HR to be enabled on MVUX if app is built in DEBUG

## What is the current behavior?
We assume that the first module initialized is the app head, but it might not be the case

## What is the new behavior?
We check the module assembly name with the entry assembly name

## PR Checklist

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
