### PR TITLE
chore: add markdown linter rules for code blocks

### DIFF
--- a/doc/.markdownlint.json
+++ b/doc/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+    "default": true,
+    "MD013": false,
+    "no-hard-tabs": {"code_blocks": false}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Other... Please describe: Adding linter support for the documentation

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Adding support for the Markdown linter and enabling the Code Block to remove the warning with the indentation.

This is the default configuration :

```
{
    "default": true,
    "MD013": false,
}
```

adding 

```
    "no-hard-tabs": {"code_blocks": false}
```

Will disable checking for hard tabs on code blocks.

| Before | After |
| :--:  | :---: |
| <img width="1696" alt="mk-linter-before" src="https://github.com/unoplatform/uno.extensions/assets/1900897/192bc8cd-04ee-494e-b96d-b1ba2336c171">|<img width="1701" alt="mk-linter-after" src="https://github.com/unoplatform/uno.extensions/assets/1900897/7ae45668-82c3-4fb5-9543-115b5ae9d9bc">|


Important: Ideally, we should use this for all our Markdown-based documentation, but starting with this repository.

Useful VSCode Extension: https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
