### PR TITLE
fix: Navigation to implicit route clears backstack

### DIFF
--- a/src/Uno.Extensions-packageonly.slnf
+++ b/src/Uno.Extensions-packageonly.slnf
@@ -39,6 +39,7 @@
       "Uno.Extensions.Logging\\Uno.Extensions.Logging.WinUI.Wasm.csproj",
       "Uno.Extensions.Logging\\Uno.Extensions.Logging.WinUI.csproj",
       "Uno.Extensions.Maui.UI\\Uno.Extensions.Maui.WinUI.csproj",
+      "Uno.Extensions.Maui.WinUI.Markup\\Uno.Extensions.Maui.WinUI.Markup.csproj",
       "Uno.Extensions.Navigation.Generators\\Uno.Extensions.Navigation.Generators.csproj",
       "Uno.Extensions.Navigation.Toolkit\\Uno.Extensions.Navigation.Toolkit.UI.csproj",
       "Uno.Extensions.Navigation.Toolkit\\Uno.Extensions.Navigation.Toolkit.WinUI.csproj",

--- a/src/Uno.Extensions.Maui.WinUI.Markup/Uno.Extensions.Maui.WinUI.Markup.csproj
+++ b/src/Uno.Extensions.Maui.WinUI.Markup/Uno.Extensions.Maui.WinUI.Markup.csproj
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<UseMaui>true</UseMaui>
 		<RootNamespace>Uno.Extensions.Maui</RootNamespace>
-		<NoWarn>$(NoWarn);NU5104;NU5048;NU1009</NoWarn>
+		<NoWarn>$(NoWarn);NU5104;NU5048;NU1009;NU1504</NoWarn>
 		<Description>Extensions to embed .NET MAUI controls within your Uno app using C# Markup.</Description>
 		<!--Temporary disable missing XML doc until fixed in the whole package-->
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
@@ -12,9 +12,11 @@
 		<IsMauiEmbedding>false</IsMauiEmbedding>
 		<IsMauiEmbedding Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' OR $(TargetFramework.Contains('windows10'))">true</IsMauiEmbedding>
 		<DefineConstants Condition="$(IsMauiEmbedding)">$(DefineConstants);MAUI_EMBEDDING</DefineConstants>
+		<WinAppSdkVersion>1.3.230724000</WinAppSdkVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging" />
 		<PackageReference Include="Uno.WinUI.Markup" />
 		<PackageReference Include="Uno.Extensions.Markup.Generators" PrivateAssets="All" />
 	</ItemGroup>

--- a/src/Uno.Extensions.Maui.WinUI.Markup/Uno.Extensions.Maui.WinUI.Markup.csproj
+++ b/src/Uno.Extensions.Maui.WinUI.Markup/Uno.Extensions.Maui.WinUI.Markup.csproj
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<UseMaui>true</UseMaui>
 		<RootNamespace>Uno.Extensions.Maui</RootNamespace>
-		<NoWarn>$(NoWarn);NU5104;NU5048;NU1009;NU1504</NoWarn>
+		<NoWarn>$(NoWarn);NU5104;NU5048;NU1009;NU1504;CS0436</NoWarn>
 		<Description>Extensions to embed .NET MAUI controls within your Uno app using C# Markup.</Description>
 		<!--Temporary disable missing XML doc until fixed in the whole package-->
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>

--- a/src/Uno.Extensions.Navigation.UI/MappedRouteResolver.cs
+++ b/src/Uno.Extensions.Navigation.UI/MappedRouteResolver.cs
@@ -56,7 +56,8 @@ public class MappedRouteResolver : RouteResolverDefault
 		}
 
 		var routeInfo = base.InternalDefaultMapping(path, view, viewModel);
-		if (routeInfo != null)
+		if (routeInfo?.ViewModel != null &&
+			_viewModelMappings.TryGetValue(routeInfo.ViewModel, out var bindableViewModel))
 		{
 			return FromRouteMap(new RouteMap(
 				Path: routeInfo.Path,
@@ -69,15 +70,12 @@ public class MappedRouteResolver : RouteResolverDefault
 							UntypedToQuery: routeInfo.ToQuery,
 							UntypedFromQuery: routeInfo.FromQuery),
 						ResultData: routeInfo.ResultData,
-						MappedViewModel: routeInfo.ViewModel is not null ?
-											_viewModelMappings.TryGetValue(routeInfo.ViewModel, out var bindableViewModel) ?
-												bindableViewModel : default
-											: default),
+						MappedViewModel: bindableViewModel),
 				IsDefault: routeInfo.IsDefault,
 				DependsOn: routeInfo.DependsOn,
 				Init: routeInfo.Init
 				));
 		}
-		return default;
+		return routeInfo;
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/MappedRouteResolver.cs
+++ b/src/Uno.Extensions.Navigation.UI/MappedRouteResolver.cs
@@ -44,4 +44,32 @@ public class MappedRouteResolver : RouteResolverDefault
 		}
 		return base.InternalFindByViewModel(viewModelType);
 	}
+
+	protected override RouteInfo? InternalDefaultMapping(string? path = null, Type? view = null, Type? viewModel = null)
+	{
+		var routeInfo = base.InternalDefaultMapping(path, view, viewModel);
+		if (routeInfo != null)
+		{
+			return FromRouteMap(new RouteMap(
+				Path: routeInfo.Path,
+				View: new MappedViewMap(
+						View: null,
+						ViewSelector: routeInfo.View,
+						ViewModel: routeInfo.ViewModel,
+						Data: new DataMap(
+							Data: routeInfo.Data,
+							UntypedToQuery: routeInfo.ToQuery,
+							UntypedFromQuery: routeInfo.FromQuery),
+						ResultData: routeInfo.ResultData,
+						MappedViewModel: routeInfo.ViewModel is not null ?
+											_viewModelMappings.TryGetValue(routeInfo.ViewModel, out var bindableViewModel) ?
+												bindableViewModel : default
+											: default),
+				IsDefault: routeInfo.IsDefault,
+				DependsOn: routeInfo.DependsOn,
+				Init: routeInfo.Init
+				));
+		}
+		return default;
+	}
 }

--- a/src/Uno.Extensions.Navigation.UI/MappedRouteResolver.cs
+++ b/src/Uno.Extensions.Navigation.UI/MappedRouteResolver.cs
@@ -47,6 +47,14 @@ public class MappedRouteResolver : RouteResolverDefault
 
 	protected override RouteInfo? InternalDefaultMapping(string? path = null, Type? view = null, Type? viewModel = null)
 	{
+		// Check to see if the viewmodel type specified is actually a mapped viewmodel (eg a bindableviewmodel in case of mvux)
+		// If it is, set viewModel to be the un-mapped viewmodel type so that the routemap can be correctly created.
+		if(viewModel is not null &&
+			_viewModelMappings.FirstOrDefault(x=>x.Value==viewModel) is { } mapping)
+		{
+			viewModel = mapping.Key;
+		}
+
 		var routeInfo = base.InternalDefaultMapping(path, view, viewModel);
 		if (routeInfo != null)
 		{

--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -541,7 +541,8 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 			var currentRouteMap = Resolver.FindByPath(Route.Base);
 			if (currentRouteMap != null || routeMap != null)
 			{
-				if (currentRouteMap?.Parent != routeMap?.Parent)
+				if (routeMap?.Parent is not null &&
+					currentRouteMap?.Parent != routeMap?.Parent)
 				{
 					return false;
 				}

--- a/src/Uno.Extensions.Navigation.UI/NavigatorExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigatorExtensions.cs
@@ -51,6 +51,16 @@ public static class NavigatorExtensions
 	public static async Task<NavigationResponse?> GoBack(this INavigator navigator, object sender)
 	{
 		var dispatcher = navigator.Get<IServiceProvider>()!.GetRequiredService<IDispatcher>();
+
+		// Default to navigating back on the current navigator
+		if (await navigator.CanNavigate(new Route(Qualifiers.NavigateBack)))
+			//is ControlNavigator ctrlNav &&
+			//await dispatcher.ExecuteAsync(async ct => ctrlNav.CanGoBack))
+		{
+			return await navigator.NavigateBackAsync(sender);
+		}
+
+		// Otherwise, search the hierarchy for the deepest back navigator
 		var region = navigator.Get<IServiceProvider>()?.GetService<IRegion>();
 		region = region?.Root();
 		var gobackNavigator = await dispatcher.ExecuteAsync(async ct => region?.FindChildren(

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
@@ -223,7 +223,7 @@ public abstract class ControlNavigator : Navigator
 
 					// Attempt to create view model using the DI container
 					var dataFactor = services.GetRequiredService<NavigationDataProvider>();
-					dataFactor.Parameters = route.Data ?? new Dictionary<string, object>();
+					dataFactor.Parameters = parameters;
 
 					services.AddScopedInstance(request);
 

--- a/src/Uno.Extensions.Navigation.UI/RouteResolverDefault.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteResolverDefault.cs
@@ -41,17 +41,28 @@ public class RouteResolverDefault : RouteResolver
 
 	private RouteInfo[] DefaultMapping(string? path = null, Type? view = null, Type? viewModel = null)
 	{
-		if(path is null &&
+		var routeMap = InternalDefaultMapping(path,view, viewModel);
+		if(routeMap is not null)
+		{
+			Mappings.Add(routeMap);
+			return new[] { routeMap };
+		}
+		return Array.Empty<RouteInfo>();
+	}
+
+	protected virtual RouteInfo? InternalDefaultMapping(string? path = null, Type? view = null, Type? viewModel = null)
+	{
+		if (path is null &&
 			view is null &&
 			viewModel is null)
 		{
-			return Array.Empty<RouteInfo>();
+			return default;
 		}
 
 		if (!ReturnImplicitMapping)
 		{
 			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage("Implicit mapping disabled");
-			return Array.Empty<RouteInfo>();
+			return default;
 		}
 
 		// Trim any qualifiers
@@ -68,7 +79,7 @@ public class RouteResolverDefault : RouteResolver
 		if (path is null ||
 			string.IsNullOrWhiteSpace(path))
 		{
-			return Array.Empty<RouteInfo>();
+			return default;
 		}
 
 		// Attempt to find a viewmap to build the routeinfo from
@@ -122,13 +133,12 @@ public class RouteResolverDefault : RouteResolver
 			{
 				return IsDialogViewType(view);
 			});
-			Mappings.Add( defaultMap);
 			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Created default mapping - Path '{defaultMap.Path}'");
-			return new RouteInfo[] { defaultMap };
+			return defaultMap;
 		}
 
 		if (Logger.IsEnabled(LogLevel.Warning)) Logger.LogWarningMessage($"Unable to create default mapping");
-		return Array.Empty<RouteInfo>();
+		return default;
 	}
 
 	private Type? TypeFromPath(string path, bool allowMatchExact, IEnumerable<string> suffixes, Func<Type, bool>? condition = null)

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -53,10 +53,10 @@
 		<PackageVersion Include="Uno.UI.Skia.Tizen" Version="5.0.19" />
 		<PackageVersion Include="Uno.UI.Skia.Wpf" Version="5.0.19" />
 		<PackageVersion Include="Uno.UI.WebAssembly" Version="5.0.19" />
-		<PackageVersion Include="Uno.UITest" Version="1.1.0-dev.59" />
-		<PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.59" />
-		<PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.59" />
-		<PackageVersion Include="Uno.UITest.Helpers" Version="1.1.0-dev.59" />
+		<PackageVersion Include="Uno.UITest" Version="1.1.0-dev.70" />
+		<PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.70" />
+		<PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.70" />
+		<PackageVersion Include="Uno.UITest.Helpers" Version="1.1.0-dev.70" />
 		<PackageVersion Include="Uno.UniversalImageLoader" Version="1.9.36" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap" Version="7.0.12" />
 		<PackageVersion Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.12" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml
@@ -8,7 +8,6 @@
 	xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
 	mc:Ignorable="d">
-
 	<Grid>
 		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
 			<Button
@@ -39,7 +38,6 @@
 				AutomationProperties.AutomationId="FivePageToSixPageDataButton"
 				Command="{Binding GoToSixData}"
 				Content="Six (Data)" />
-
 		</StackPanel>
 	</Grid>
 </Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml
@@ -1,26 +1,44 @@
 ﻿<Page
-    x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveFivePage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  mc:Ignorable="d"
-	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveFivePage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	mc:Ignorable="d">
 
 	<Grid>
-		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center">
-			<Button AutomationProperties.AutomationId="FivePageBackButton"
-					Content="Back"
-					uen:Navigation.Request="-" />
-			<Button AutomationProperties.AutomationId="FivePageBackCodebehindButton"
-					Content="Back (Codebehind)"
-					Click="FivePageBackCodebehindClick" />
-			<Button AutomationProperties.AutomationId="FivePageBackViewModelButton"
-					Content="Back (ViewModel)"
-					Command="{Binding GoBack}" />
+		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+			<Button
+				uen:Navigation.Request="ReactiveSix"
+				AutomationProperties.AutomationId="FivePageToSixPageButton"
+				Content="Six" />
+			<Button
+				uen:Navigation.Request="-"
+				AutomationProperties.AutomationId="FivePageBackButton"
+				Content="Back" />
+			<Button
+				AutomationProperties.AutomationId="FivePageToSixPageCodebehindButton"
+				Click="FivePageToSixPageCodebehindClick"
+				Content="Six (Codebehind)" />
+			<Button
+				AutomationProperties.AutomationId="FivePageBackCodebehindButton"
+				Click="FivePageBackCodebehindClick"
+				Content="Back (Codebehind)" />
+			<Button
+				AutomationProperties.AutomationId="FivePageToSixPageViewModelButton"
+				Command="{Binding GoToSix}"
+				Content="Six (ViewModel)" />
+			<Button
+				AutomationProperties.AutomationId="FivePageBackViewModelButton"
+				Command="{Binding GoBack}"
+				Content="Back (ViewModel)" />
+			<Button
+				AutomationProperties.AutomationId="FivePageToSixPageDataButton"
+				Command="{Binding GoToSixData}"
+				Content="Six (Data)" />
 
 		</StackPanel>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml
@@ -10,6 +10,8 @@
 	mc:Ignorable="d">
 	<Grid>
 		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+			<TextBlock AutomationProperties.AutomationId="FivePageWidgetNameTextBlock" Text="{Binding DataModel.Widget.Name}" />
+
 			<Button
 				uen:Navigation.Request="ReactiveSix"
 				AutomationProperties.AutomationId="FivePageToSixPageButton"

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml.cs
@@ -9,6 +9,11 @@ public sealed partial class ReactiveFivePage : Page
 		this.InitializeComponent();
 	}
 
+	public async void FivePageToSixPageCodebehindClick(object sender, RoutedEventArgs e)
+	{
+		await this.Navigator()!.NavigateViewAsync<ReactiveSixPage>(this);
+	}
+
 	public async void FivePageBackCodebehindClick(object sender, RoutedEventArgs e)
 	{
 		await this.Navigator()!.NavigateBackAsync(this);

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFivePage.xaml.cs
@@ -1,6 +1,4 @@
-﻿
-
-namespace TestHarness.Ext.Navigation.Reactive;
+﻿namespace TestHarness.Ext.Navigation.Reactive;
 
 public sealed partial class ReactiveFivePage : Page
 {
@@ -18,5 +16,4 @@ public sealed partial class ReactiveFivePage : Page
 	{
 		await this.Navigator()!.NavigateBackAsync(this);
 	}
-
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFiveViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFiveViewModel.cs
@@ -9,6 +9,16 @@ public partial class ReactiveFiveViewModel : BaseViewModel
 
 	public IState<FiveModel?> DataModel { get; }
 
+	public async Task GoToSix()
+	{
+		await Navigator.NavigateViewModelAsync<ReactiveSixViewModel>(this);
+	}
+
+	public async Task GoToSixData()
+	{
+		await Navigator.NavigateDataAsync(this, data: new SixModel(new ReactiveWidget("From Five", 59)));
+	}
+
 	public async Task GoBack()
 	{
 		await Navigator.GoBack(this);

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFiveViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFiveViewModel.cs
@@ -16,7 +16,9 @@ public partial class ReactiveFiveViewModel : BaseViewModel
 
 	public async Task GoToSixData()
 	{
-		await Navigator.NavigateDataAsync(this, data: new SixModel(new ReactiveWidget("From Five", 59)));
+		// Note: NavigateDataAsync won't work since six isn't included in the routemap
+		// await Navigator.NavigateDataAsync(this, data: new SixModel(new ReactiveWidget("From Five", 59)));
+		await Navigator.NavigateViewModelAsync<ReactiveSixViewModel>(this, data: new SixModel(new ReactiveWidget("From Five", 59)));
 	}
 
 	public async Task GoBack()

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFourPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFourPage.xaml
@@ -1,38 +1,46 @@
 ﻿<Page
-    x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveFourPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  mc:Ignorable="d"
-	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveFourPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	mc:Ignorable="d">
 
 	<Grid>
-		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center">
-			<Button AutomationProperties.AutomationId="FourPageToFivePageButton"
-					Content="Five"
-					uen:Navigation.Request="Five" />
-			<Button AutomationProperties.AutomationId="FourPageBackButton"
-					Content="Back"
-					uen:Navigation.Request="-" />
-			<Button AutomationProperties.AutomationId="FourPageToFivePageCodebehindButton"
-					Content="Five (Codebehind)"
-					Click="FourPageToFivePageCodebehindClick"/>
-			<Button AutomationProperties.AutomationId="FourPageBackCodebehindButton"
-					Content="Back (Codebehind)"
-					Click="FourPageBackCodebehindClick"/>
-			<Button AutomationProperties.AutomationId="FourPageToFivePageViewModelButton"
-					Content="Five (ViewModel)"
-					Command="{Binding GoToFive}" />
-			<Button AutomationProperties.AutomationId="FourPageBackViewModelButton"
-					Content="Back (ViewModel)"
-					Command="{Binding GoBack}" />
-			<Button AutomationProperties.AutomationId="FourPageToFivePageDataButton"
-					Content="Five (Data)"
-					Command="{Binding GoToFiveData}" />
+		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+			<TextBlock AutomationProperties.AutomationId="FourPageWidgetNameTextBlock" Text="{Binding DataModel.Widget.Name}" />
+
+			<Button
+				uen:Navigation.Request="Five"
+				AutomationProperties.AutomationId="FourPageToFivePageButton"
+				Content="Five" />
+			<Button
+				uen:Navigation.Request="-"
+				AutomationProperties.AutomationId="FourPageBackButton"
+				Content="Back" />
+			<Button
+				AutomationProperties.AutomationId="FourPageToFivePageCodebehindButton"
+				Click="FourPageToFivePageCodebehindClick"
+				Content="Five (Codebehind)" />
+			<Button
+				AutomationProperties.AutomationId="FourPageBackCodebehindButton"
+				Click="FourPageBackCodebehindClick"
+				Content="Back (Codebehind)" />
+			<Button
+				AutomationProperties.AutomationId="FourPageToFivePageViewModelButton"
+				Command="{Binding GoToFive}"
+				Content="Five (ViewModel)" />
+			<Button
+				AutomationProperties.AutomationId="FourPageBackViewModelButton"
+				Command="{Binding GoBack}"
+				Content="Back (ViewModel)" />
+			<Button
+				AutomationProperties.AutomationId="FourPageToFivePageDataButton"
+				Command="{Binding GoToFiveData}"
+				Content="Five (Data)" />
 
 		</StackPanel>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFourPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveFourPage.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Reactive;
+﻿namespace TestHarness.Ext.Navigation.Reactive;
 public sealed partial class ReactiveFourPage : Page
 {
 	public ReactiveFourPage()
@@ -15,6 +14,4 @@ public sealed partial class ReactiveFourPage : Page
 	{
 		await this.Navigator()!.NavigateBackAsync(this);
 	}
-
-
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveHostInit.cs
@@ -26,7 +26,16 @@ public class ReactiveHostInit : BaseHostInitialization
 
 		views.Register(
 			new ViewMap<ReactiveOnePage, ReactiveOneViewModel>(),
-			new DataViewMap<ReactiveTwoPage, ReactiveTwoViewModel, TwoModel>(),
+			new DataViewMap<ReactiveTwoPage, ReactiveTwoViewModel, TwoModel>(FromQuery: async (IServiceProvider sp, IDictionary<string, object> args) =>
+			{
+				if (args.TryGetValue(string.Empty, out var data) &&
+					data is ThreeModel threeData)
+				{
+					return new TwoModel(threeData.Widget with { Name = "Adapted model" });
+				}
+
+				return default;
+			}),
 			new DataViewMap<ReactiveThreePage, ReactiveThreeViewModel, ThreeModel>(),
 			new DataViewMap<ReactiveFourPage, ReactiveFourViewModel, FourModel>(),
 			new DataViewMap<ReactiveFivePage, ReactiveFiveViewModel, FiveModel>(),
@@ -41,9 +50,10 @@ public class ReactiveHostInit : BaseHostInitialization
 			{
 					new RouteMap("One", View: views.FindByViewModel<ReactiveOneViewModel>()),
 					new RouteMap("Two", View: views.FindByViewModel<ReactiveTwoViewModel>()),
-					new RouteMap("Three", View: views.FindByViewModel<ReactiveThreeViewModel>()),
+					new RouteMap("Three", View: views.FindByViewModel<ReactiveThreeViewModel>(), DependsOn: "Two"),
 					new RouteMap("Four", View: views.FindByViewModel<ReactiveFourViewModel>()),
 					new RouteMap("Five", View: views.FindByViewModel<ReactiveFiveViewModel>()),
+					// Do NOT add "Six" as this has been intentionally omitted from the routemap to test implicit navigation
 					new RouteMap("LocalizedConfirm", View: localizedDialog)
 			}));
 	}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveMainPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveMainPage.xaml.cs
@@ -12,5 +12,4 @@ public sealed partial class ReactiveMainPage : BaseTestSectionPage
 	{
 		await Navigator.NavigateViewModelAsync<ReactiveOneViewModel>(this);
 	}
-
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOnePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOnePage.xaml
@@ -1,32 +1,44 @@
-﻿<Page x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveOnePage"
-	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	  xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
-	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  mc:Ignorable="d"
-	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+﻿<Page
+	x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveOnePage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	mc:Ignorable="d">
 
 	<Grid>
-		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center">
-			<Button AutomationProperties.AutomationId="OnePageToTwoPageButton"
-					Content="Two"
-					uen:Navigation.Request="Two" />
-			<Button AutomationProperties.AutomationId="OnePageToTwoPageCodebehindButton"
-					Content="Two (Codebehind)"
-					Click="OnePageToTwoPageCodebehindClick"
-					/>
-			<Button AutomationProperties.AutomationId="OnePageToTwoPageViewModelButton"
-					Content="Two (ViewModel)"
-					Command="{Binding GoToTwo}"/>
-			<Button AutomationProperties.AutomationId="OnePageToTwoPageDataButton"
-					Content="Two (Data)"
-					Command="{Binding GoToTwoData}" />
-			<Button AutomationProperties.AutomationId="OnePageDialogButton"
-					Content="Dialog"
-					Command="{Binding ShowDialog}" />
+		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+			<Button
+				uen:Navigation.Request="Two"
+				AutomationProperties.AutomationId="OnePageToTwoPageButton"
+				Content="Two" />
+			<Button
+				AutomationProperties.AutomationId="OnePageToTwoPageCodebehindButton"
+				Click="OnePageToTwoPageCodebehindClick"
+				Content="Two (Codebehind)" />
+			<Button
+				AutomationProperties.AutomationId="OnePageToTwoPageViewModelButton"
+				Command="{Binding GoToTwo}"
+				Content="Two (ViewModel)" />
+			<Button
+				AutomationProperties.AutomationId="OnePageToTwoPageDataButton"
+				Command="{Binding GoToTwoData}"
+				Content="Two (Data)" />
+			<Button
+				AutomationProperties.AutomationId="OnePageDialogButton"
+				Command="{Binding ShowDialog}"
+				Content="Dialog" />
+
+			<Button
+				AutomationProperties.AutomationId="OnePageToThreePageViewModelButton"
+				Command="{Binding GoToThree}"
+				Content="Three (ViewModel)" />
+			<Button AutomationProperties.AutomationId="OnePageToThreePageDataButton"
+					Command="{Binding GoToThreeData}"
+					Content="Three (Data)" />
 		</StackPanel>
 	</Grid>
 </Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOnePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOnePage.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Reactive;
+﻿namespace TestHarness.Ext.Navigation.Reactive;
 
 public sealed partial class ReactiveOnePage : Page
 {
@@ -12,5 +11,4 @@ public sealed partial class ReactiveOnePage : Page
 	{
 		await this.Navigator()!.NavigateViewAsync<ReactiveTwoPage>(this);
 	}
-
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOneViewModel.cs
@@ -13,6 +13,17 @@ public partial record ReactiveOneViewModel (INavigator Navigator)
 	{
 		await Navigator.NavigateDataAsync(this, data:new TwoModel(new ReactiveWidget("From Two",56)));
 	}
+
+	public async Task GoToThree()
+	{
+		await Navigator.NavigateViewModelAsync<ReactiveThreeViewModel>(this);
+	}
+
+	public async Task GoToThreeData()
+	{
+		await Navigator.NavigateDataAsync(this, data: new ThreeModel(new ReactiveWidget("From Three", 56)));
+	}
+
 	public async Task ShowDialog()
 	{
 		var result = await Navigator.ShowMessageDialogAsync<object>(this, "LocalizedConfirm");

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOneViewModel.cs
@@ -24,5 +24,6 @@ public record TwoModel(ReactiveWidget Widget);
 public record ThreeModel(ReactiveWidget Widget);
 public record FourModel(ReactiveWidget Widget);
 public record FiveModel(ReactiveWidget Widget);
+public record SixModel(ReactiveWidget Widget);
 
 public record ReactiveWidget(string Name, double Weight);

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixPage.xaml
@@ -10,6 +10,8 @@
 	mc:Ignorable="d">
 	<Grid>
 		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+			<TextBlock AutomationProperties.AutomationId="SixPageWidgetNameTextBlock" Text="{Binding DataModel.Widget.Name}" />
+
 			<Button
 				uen:Navigation.Request="-"
 				AutomationProperties.AutomationId="SixPageBackButton"

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixPage.xaml
@@ -1,26 +1,27 @@
 ﻿<Page
-    x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveSixPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  mc:Ignorable="d"
-	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-
+	x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveSixPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	mc:Ignorable="d">
 	<Grid>
-		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center">
-			<Button AutomationProperties.AutomationId="SixPageBackButton"
-					Content="Back"
-					uen:Navigation.Request="-" />
-			<Button AutomationProperties.AutomationId="SixPageBackCodebehindButton"
-					Content="Back (Codebehind)"
-					Click="SixPageBackCodebehindClick" />
-			<Button AutomationProperties.AutomationId="SixPageBackViewModelButton"
-					Content="Back (ViewModel)"
-					Command="{Binding GoBack}" />
+		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+			<Button
+				uen:Navigation.Request="-"
+				AutomationProperties.AutomationId="SixPageBackButton"
+				Content="Back" />
+			<Button
+				AutomationProperties.AutomationId="SixPageBackCodebehindButton"
+				Click="SixPageBackCodebehindClick"
+				Content="Back (Codebehind)" />
+			<Button
+				AutomationProperties.AutomationId="SixPageBackViewModelButton"
+				Command="{Binding GoBack}"
+				Content="Back (ViewModel)" />
 
 		</StackPanel>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixPage.xaml
@@ -1,0 +1,27 @@
+﻿<Page
+    x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveSixPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<StackPanel HorizontalAlignment="Center"
+					VerticalAlignment="Center">
+			<Button AutomationProperties.AutomationId="SixPageBackButton"
+					Content="Back"
+					uen:Navigation.Request="-" />
+			<Button AutomationProperties.AutomationId="SixPageBackCodebehindButton"
+					Content="Back (Codebehind)"
+					Click="SixPageBackCodebehindClick" />
+			<Button AutomationProperties.AutomationId="SixPageBackViewModelButton"
+					Content="Back (ViewModel)"
+					Command="{Binding GoBack}" />
+
+		</StackPanel>
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixPage.xaml.cs
@@ -1,6 +1,4 @@
-﻿
-
-namespace TestHarness.Ext.Navigation.Reactive;
+﻿namespace TestHarness.Ext.Navigation.Reactive;
 
 public sealed partial class ReactiveSixPage : Page
 {
@@ -13,5 +11,4 @@ public sealed partial class ReactiveSixPage : Page
 	{
 		await this.Navigator()!.NavigateBackAsync(this);
 	}
-
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixPage.xaml.cs
@@ -1,0 +1,17 @@
+﻿
+
+namespace TestHarness.Ext.Navigation.Reactive;
+
+public sealed partial class ReactiveSixPage : Page
+{
+	public ReactiveSixPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public async void SixPageBackCodebehindClick(object sender, RoutedEventArgs e)
+	{
+		await this.Navigator()!.NavigateBackAsync(this);
+	}
+
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixViewModel.cs
@@ -12,7 +12,6 @@ public partial class ReactiveSixViewModel : BaseViewModel
 
 	public IState<SixModel?> DataModel { get; }
 
-
 	public async Task GoBack()
 	{
 		await Navigator.GoBack(this);

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveSixViewModel.cs
@@ -1,0 +1,20 @@
+﻿using Uno.Extensions.Navigation;
+using Uno.Extensions.Reactive.Bindings;
+
+namespace TestHarness.Ext.Navigation.Reactive;
+
+public partial class ReactiveSixViewModel : BaseViewModel
+{
+	public ReactiveSixViewModel(INavigator navigator, SixModel? model) : base(navigator)
+	{
+		DataModel = State.Value(this, () => model);
+	}
+
+	public IState<SixModel?> DataModel { get; }
+
+
+	public async Task GoBack()
+	{
+		await Navigator.GoBack(this);
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreePage.xaml
@@ -1,38 +1,46 @@
 ﻿<Page
-    x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveThreePage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	  mc:Ignorable="d"
-	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveThreePage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	mc:Ignorable="d">
 
 	<Grid>
-		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center">
-			<Button AutomationProperties.AutomationId="ThreePageToFourPageButton"
-					Content="Four"
-					uen:Navigation.Request="Four" />
-			<Button AutomationProperties.AutomationId="ThreePageBackButton"
-					Content="Back"
-					uen:Navigation.Request="-" />
-			<Button AutomationProperties.AutomationId="ThreePageToFourPageCodebehindButton"
-					Content="Four (Codebehind)"
-					Click="ThreePageToFourPageCodebehindClick" />
-			<Button AutomationProperties.AutomationId="ThreePageBackCodebehindButton"
-					Content="Back (Codebehind)"
-					Click="ThreePageBackCodebehindClick" />
-			<Button AutomationProperties.AutomationId="ThreePageToFourPageViewModelButton"
-					Content="Four (ViewModel)"
-					Command="{Binding GoToFour}" />
-			<Button AutomationProperties.AutomationId="ThreePageBackViewModelButton"
-					Content="Back (ViewModel)"
-					Command="{Binding GoBack}" />
-			<Button AutomationProperties.AutomationId="ThreePageToFourPageDataButton"
-					Content="Four (Data)"
-					Command="{Binding GoToFourData}" />
+		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+			<TextBlock AutomationProperties.AutomationId="ThreePageWidgetNameTextBlock" Text="{Binding DataModel.Widget.Name}" />
+
+			<Button
+				uen:Navigation.Request="Four"
+				AutomationProperties.AutomationId="ThreePageToFourPageButton"
+				Content="Four" />
+			<Button
+				uen:Navigation.Request="-"
+				AutomationProperties.AutomationId="ThreePageBackButton"
+				Content="Back" />
+			<Button
+				AutomationProperties.AutomationId="ThreePageToFourPageCodebehindButton"
+				Click="ThreePageToFourPageCodebehindClick"
+				Content="Four (Codebehind)" />
+			<Button
+				AutomationProperties.AutomationId="ThreePageBackCodebehindButton"
+				Click="ThreePageBackCodebehindClick"
+				Content="Back (Codebehind)" />
+			<Button
+				AutomationProperties.AutomationId="ThreePageToFourPageViewModelButton"
+				Command="{Binding GoToFour}"
+				Content="Four (ViewModel)" />
+			<Button
+				AutomationProperties.AutomationId="ThreePageBackViewModelButton"
+				Command="{Binding GoBack}"
+				Content="Back (ViewModel)" />
+			<Button
+				AutomationProperties.AutomationId="ThreePageToFourPageDataButton"
+				Command="{Binding GoToFourData}"
+				Content="Four (Data)" />
 
 		</StackPanel>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreePage.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Reactive;
+﻿namespace TestHarness.Ext.Navigation.Reactive;
 public sealed partial class ReactiveThreePage : Page
 {
 	public ReactiveThreePage()
@@ -15,6 +14,4 @@ public sealed partial class ReactiveThreePage : Page
 	{
 		await this.Navigator()!.NavigateBackAsync(this);
 	}
-
-
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreeViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreeViewModel.cs
@@ -22,6 +22,7 @@ public partial class ReactiveThreeViewModel : BaseViewModel
 
 	public async Task GoBack()
 	{
-		await Navigator.GoBack(this);
+		var dataModel = await DataModel;
+		await Navigator.NavigateBackWithResultAsync(this, data: dataModel);
 	}
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveTwoPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveTwoPage.xaml
@@ -1,42 +1,49 @@
 ﻿<Page
-    x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveTwoPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
-	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	x:Class="TestHarness.Ext.Navigation.Reactive.ReactiveTwoPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:local="using:TestHarness.Ext.Navigation.Reactive"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	mc:Ignorable="d">
 	<Grid>
-		<StackPanel HorizontalAlignment="Center"
-					VerticalAlignment="Center">
-			<TextBlock Text="{Binding DataModel.Widget.Name}" />
-			<Button AutomationProperties.AutomationId="TwoPageToThreePageButton"
-					Content="Three"
-					uen:Navigation.Request="Three" />
-			<Button AutomationProperties.AutomationId="TwoPageBackButton"
-					Content="Back"
-					uen:Navigation.Request="-" />
-			<Button AutomationProperties.AutomationId="TwoPageToThreePageCodebehindButton"
-					Content="Three (Codebehind)"
-					Click="TwoPageToThreePageCodebehindClick"/>
-			<Button AutomationProperties.AutomationId="TwoPageBackCodebehindButton"
-					Content="Back (Codebehind)"
-					Click="TwoPageBackCodebehindClick"/>
-			<Button AutomationProperties.AutomationId="TwoPageToThreePageViewModelButton"
-					Content="Three (ViewModel)"
-					Command="{Binding GoToThree}" />
-			<Button AutomationProperties.AutomationId="TwoPageBackViewModelButton"
-					Content="Back (ViewModel)"
-					Command="{Binding GoBack}"/>
-			<Button AutomationProperties.AutomationId="TwoPageToThreePageDataButton"
-					Content="Three (Data)"
-					Command="{Binding GoToThreeData}" />
-			<Button AutomationProperties.AutomationId="TwoPageToThreePageDataButton"
-					Content="Three (XAML Data)"
-					uen:Navigation.Request="Three"
-					uen:Navigation.Data="{Binding NextModel.Value}"/>
+		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+			<TextBlock AutomationProperties.AutomationId="TwoPageWidgetNameTextBlock" Text="{Binding DataModel.Widget.Name}" />
+			<Button
+				uen:Navigation.Request="Three"
+				AutomationProperties.AutomationId="TwoPageToThreePageButton"
+				Content="Three" />
+			<Button
+				uen:Navigation.Request="-"
+				AutomationProperties.AutomationId="TwoPageBackButton"
+				Content="Back" />
+			<Button
+				AutomationProperties.AutomationId="TwoPageToThreePageCodebehindButton"
+				Click="TwoPageToThreePageCodebehindClick"
+				Content="Three (Codebehind)" />
+			<Button
+				AutomationProperties.AutomationId="TwoPageBackCodebehindButton"
+				Click="TwoPageBackCodebehindClick"
+				Content="Back (Codebehind)" />
+			<Button
+				AutomationProperties.AutomationId="TwoPageToThreePageViewModelButton"
+				Command="{Binding GoToThree}"
+				Content="Three (ViewModel)" />
+			<Button
+				AutomationProperties.AutomationId="TwoPageBackViewModelButton"
+				Command="{Binding GoBack}"
+				Content="Back (ViewModel)" />
+			<Button
+				AutomationProperties.AutomationId="TwoPageToThreePageDataButton"
+				Command="{Binding GoToThreeData}"
+				Content="Three (Data)" />
+			<Button
+				uen:Navigation.Data="{Binding NextModel.Value}"
+				uen:Navigation.Request="Three"
+				AutomationProperties.AutomationId="TwoPageToThreePageDataButton"
+				Content="Three (XAML Data)" />
 
 		</StackPanel>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveTwoPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveTwoPage.xaml.cs
@@ -16,5 +16,4 @@ public sealed partial class ReactiveTwoPage : Page
 	{
 		await this.Navigator()!.NavigateBackAsync(this);
 	}
-
 }

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -746,6 +746,9 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </_Globbled_Page>
+<Page Include="@(_Globbled_Page)">
+      <SubType>Designer</SubType>
+    </Page>
     <_Globbed_Compile Include="$(MSBuildThisFileDirectory)**/*.xaml.cs" Exclude="@(Compile)">
       <DependentUpon>%(Filename)</DependentUpon>
     </_Globbed_Compile>

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -346,6 +346,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Reactive\ReactiveOnePage.xaml.cs">
       <DependentUpon>ReactiveOnePage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Reactive\ReactiveSixPage.xaml.cs">
+      <DependentUpon>ReactiveSixPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Reactive\ReactiveSixViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Reactive\ReactiveOneViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Reactive\ReactiveThreePage.xaml.cs">
       <DependentUpon>ReactiveThreePage.xaml</DependentUpon>
@@ -742,9 +746,6 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </_Globbled_Page>
-    <Page Include="@(_Globbled_Page)">
-      <SubType>Designer</SubType>
-    </Page>
     <_Globbed_Compile Include="$(MSBuildThisFileDirectory)**/*.xaml.cs" Exclude="@(Compile)">
       <DependentUpon>%(Filename)</DependentUpon>
     </_Globbed_Compile>

--- a/testing/TestHarness/TestHarness.UITest/Constants.cs
+++ b/testing/TestHarness/TestHarness.UITest/Constants.cs
@@ -4,7 +4,7 @@ namespace TestHarness.UITest;
 
 public class Constants
 {
-	public readonly static string WebAssemblyDefaultUri = "https://localhost:52584";
+	public readonly static string WebAssemblyDefaultUri = "https://localhost:57208";
 	public readonly static string iOSAppName = "uno.platform.extensions.demo";
 	public readonly static string AndroidAppName = "uno.platform.extensions.demo";
 	public readonly static string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Reactive/Given_Reactive.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Reactive/Given_Reactive.cs
@@ -15,6 +15,8 @@ public class Given_Reactive : NavigationTestBase
 		App.WaitThenTap("TwoPageToThreePageButton");
 		App.WaitThenTap("ThreePageToFourPageButton");
 		App.WaitThenTap("FourPageToFivePageButton");
+		App.WaitThenTap("FivePageToSixPageButton");
+		App.WaitThenTap("SixPageBackButton");
 		App.WaitThenTap("FivePageBackButton");
 		App.WaitThenTap("FourPageBackButton");
 		App.WaitThenTap("ThreePageBackButton");
@@ -40,6 +42,8 @@ public class Given_Reactive : NavigationTestBase
 		App.WaitThenTap("TwoPageToThreePageCodebehindButton");
 		App.WaitThenTap("ThreePageToFourPageCodebehindButton");
 		App.WaitThenTap("FourPageToFivePageCodebehindButton");
+		App.WaitThenTap("FivePageToSixPageCodebehindButton");
+		App.WaitThenTap("SixPageBackCodebehindButton");
 		App.WaitThenTap("FivePageBackCodebehindButton");
 		App.WaitThenTap("FourPageBackCodebehindButton");
 		App.WaitThenTap("ThreePageBackCodebehindButton");
@@ -64,6 +68,8 @@ public class Given_Reactive : NavigationTestBase
 		App.WaitThenTap("TwoPageToThreePageViewModelButton");
 		App.WaitThenTap("ThreePageToFourPageViewModelButton");
 		App.WaitThenTap("FourPageToFivePageViewModelButton");
+		App.WaitThenTap("FivePageToSixPageViewModelButton");
+		App.WaitThenTap("SixPageBackViewModelButton");
 		App.WaitThenTap("FivePageBackViewModelButton");
 		App.WaitThenTap("FourPageBackViewModelButton");
 		App.WaitThenTap("ThreePageBackViewModelButton");

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Reactive/Given_Reactive.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Reactive/Given_Reactive.cs
@@ -81,4 +81,32 @@ public class Given_Reactive : NavigationTestBase
 		ImageAssert.AreEqual(screenBefore, screenAfter, tolerance: PixelTolerance.Exclusive(Constants.DefaultPixelTolerance));
 
 	}
+
+	[Test]
+	public void When_ReactiveDependsOnWithData()
+	{
+		InitTestSection(TestSections.Navigation_Reactive);
+
+		App.WaitThenTap("ShowOnePageButton");
+
+		App.WaitElement("OnePageToTwoPageViewModelButton");
+		var screenBefore = TakeScreenshot("When_PageNavigationViewModel_Before");
+		App.WaitThenTap("OnePageToThreePageDataButton");
+		App.WaitElement("ThreePageWidgetNameTextBlock");
+		var text = App.GetText("ThreePageWidgetNameTextBlock");
+		Assert.AreEqual("From Three", text);
+
+		App.WaitThenTap("ThreePageBackViewModelButton");
+		text = App.GetText("TwoPageWidgetNameTextBlock");
+		Assert.AreEqual("Adapted model", text);
+
+
+		App.WaitThenTap("TwoPageBackViewModelButton");
+
+
+		App.WaitElement("OnePageToTwoPageViewModelButton");
+		var screenAfter = TakeScreenshot("When_PageNavigationViewModel_After");
+		ImageAssert.AreEqual(screenBefore, screenAfter, tolerance: PixelTolerance.Exclusive(Constants.DefaultPixelTolerance));
+
+	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2032

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Implicit routes don't work with mvux
Navigating to implicit route clears frame backstack

## What is the new behavior?

Implicit routes work with mvux and navigating to an implicit route doesn't clear backstack

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
