### PR TITLE
docs: Fix "TIP" rendering

### DIFF
--- a/doc/Overview/Mvux/States.md
+++ b/doc/Overview/Mvux/States.md
@@ -84,7 +84,7 @@ public IState<int> MyState => State.FromFeed(this, MyFeed);
 
 > [!TIP]
 > A state can also be constructed manually by building its underlying Messages or Options.  
-This is intended for advanced users and is explained [here](xref:Overview.Reactive.State#create).
+> This is intended for advanced users and is explained [here](xref:Overview.Reactive.State#create).
 
 ### Usage of States
 

--- a/doc/Overview/Mvux/States.md
+++ b/doc/Overview/Mvux/States.md
@@ -83,7 +83,7 @@ public IState<int> MyState => State.FromFeed(this, MyFeed);
 #### Other ways to create states
 
 > [!TIP]
-A state can also be constructed manually by building its underlying Messages or Options.  
+> A state can also be constructed manually by building its underlying Messages or Options.  
 This is intended for advanced users and is explained [here](xref:Overview.Reactive.State#create).
 
 ### Usage of States


### PR DESCRIPTION
It currently doesn't render correctly:

![image](https://github.com/unoplatform/uno.extensions/assets/31348972/353b0309-40d4-4541-9508-8ba3f083c697)
