### PR TITLE
fix: Fix lot of nullable annotation issues 

### DIFF
--- a/src/Uno.Extensions.Reactive/Collections/CollectionChanged.cs
+++ b/src/Uno.Extensions.Reactive/Collections/CollectionChanged.cs
@@ -16,7 +16,7 @@ internal static class CollectionChanged
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Add"/> collection changed event args
 	/// </summary>
-	public static NotifyCollectionChangedEventArgs Add(object item, int index)
+	public static NotifyCollectionChangedEventArgs Add(object? item, int index)
 		=> new(NotifyCollectionChangedAction.Add, new[] { item }, index);
 
 	/// <summary>
@@ -28,7 +28,7 @@ internal static class CollectionChanged
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Remove"/> collection changed event args
 	/// </summary>
-	public static NotifyCollectionChangedEventArgs Remove(object item, int index)
+	public static NotifyCollectionChangedEventArgs Remove(object? item, int index)
 		=> new(NotifyCollectionChangedAction.Remove, new[] { item }, index);
 
 	/// <summary>
@@ -40,7 +40,7 @@ internal static class CollectionChanged
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Replace"/> collection changed event args
 	/// </summary>
-	public static NotifyCollectionChangedEventArgs Replace(object oldItem, object newItem, int index)
+	public static NotifyCollectionChangedEventArgs Replace(object? oldItem, object? newItem, int index)
 		=> new(NotifyCollectionChangedAction.Replace, new[] { newItem }, new[] { oldItem }, index);
 
 	/// <summary>
@@ -52,7 +52,7 @@ internal static class CollectionChanged
 	/// <summary>
 	/// Creates a <see cref="NotifyCollectionChangedAction.Move"/> collection changed event args
 	/// </summary>
-	public static NotifyCollectionChangedEventArgs Move(object item, int oldIndex, int newIndex)
+	public static NotifyCollectionChangedEventArgs Move(object? item, int oldIndex, int newIndex)
 		=> new(NotifyCollectionChangedAction.Move, new[] { item }, newIndex, oldIndex);
 
 	/// <summary>
@@ -82,27 +82,27 @@ internal static class CollectionChanged
 			case NotifyCollectionChangedAction.Add:
 				return new NotifyCollectionChangedEventArgs(
 					NotifyCollectionChangedAction.Add,
-					new MapReadOnlyList<TFrom, TTo>(converter, args.NewItems),
+					new MapReadOnlyList<TFrom, TTo>(converter, args.NewItems!),
 					args.NewStartingIndex);
 
 			case NotifyCollectionChangedAction.Move:
 				return new NotifyCollectionChangedEventArgs(
 					NotifyCollectionChangedAction.Move,
-					new MapReadOnlyList<TFrom, TTo>(converter, args.NewItems),
+					new MapReadOnlyList<TFrom, TTo>(converter, args.NewItems!),
 					args.NewStartingIndex,
 					args.OldStartingIndex);
 
 			case NotifyCollectionChangedAction.Replace:
 				return new NotifyCollectionChangedEventArgs(
 					NotifyCollectionChangedAction.Replace,
-					new MapReadOnlyList<TFrom, TTo>(converter, args.NewItems),
-					new MapReadOnlyList<TFrom, TTo>(converter, args.OldItems),
+					new MapReadOnlyList<TFrom, TTo>(converter, args.NewItems!),
+					new MapReadOnlyList<TFrom, TTo>(converter, args.OldItems!),
 					args.NewStartingIndex);
 
 			case NotifyCollectionChangedAction.Remove:
 				return new NotifyCollectionChangedEventArgs(
 					NotifyCollectionChangedAction.Remove,
-					new MapReadOnlyList<TFrom, TTo>(converter, args.OldItems),
+					new MapReadOnlyList<TFrom, TTo>(converter, args.OldItems!),
 					args.OldStartingIndex);
 
 			case NotifyCollectionChangedAction.Reset:
@@ -138,8 +138,8 @@ internal static class CollectionChanged
 			case NotifyCollectionChangedAction.Replace:
 				return new NotifyCollectionChangedEventArgs(
 					NotifyCollectionChangedAction.Replace,
-					args.NewItems,
-					args.OldItems,
+					args.NewItems!,
+					args.OldItems!,
 					args.NewStartingIndex + offset);
 
 			case NotifyCollectionChangedAction.Remove:
@@ -165,14 +165,14 @@ internal static class CollectionChanged
 	{
 		switch (arg.Action)
 		{
-			case NotifyCollectionChangedAction.Add when arg.NewItems.Count > 1:
+			case NotifyCollectionChangedAction.Add when arg.NewItems!.Count > 1:
 				for (var i = 0; i < arg.NewItems.Count; i++)
 				{
 					yield return Add(arg.NewItems[i], arg.NewStartingIndex + i);
 				}
 				break;
 
-			case NotifyCollectionChangedAction.Move when arg.NewItems.Count > 1:
+			case NotifyCollectionChangedAction.Move when arg.NewItems!.Count > 1:
 				if (arg.NewStartingIndex > arg.OldStartingIndex)
 				{
 					for (var i = 0; i < arg.NewItems.Count; i++)
@@ -189,8 +189,8 @@ internal static class CollectionChanged
 				}
 				break;
 
-			case NotifyCollectionChangedAction.Replace when arg.OldItems.Count > 1 || arg.NewItems.Count > 1:
-				for (var i = 0; i < Math.Min(arg.NewItems.Count, arg.OldItems.Count); i++)
+			case NotifyCollectionChangedAction.Replace when arg.OldItems!.Count > 1 || arg.NewItems!.Count > 1:
+				for (var i = 0; i < Math.Min(arg.NewItems!.Count, arg.OldItems.Count); i++)
 				{
 					yield return Replace(arg.OldItems[i], arg.NewItems[i], arg.OldStartingIndex + i);
 				}
@@ -204,7 +204,7 @@ internal static class CollectionChanged
 				}
 				break;
 
-			case NotifyCollectionChangedAction.Remove when arg.OldItems.Count > 1:
+			case NotifyCollectionChangedAction.Remove when arg.OldItems!.Count > 1:
 				for (var i = 0; i < arg.OldItems.Count; i++)
 				{
 					yield return Remove(arg.OldItems[i], arg.OldStartingIndex);
@@ -222,7 +222,7 @@ internal static class CollectionChanged
 	{
 		switch (arg.Action)
 		{
-			case NotifyCollectionChangedAction.Add when arg.NewItems.Count > 1:
+			case NotifyCollectionChangedAction.Add when arg.NewItems!.Count > 1:
 				for (var i = 0; i < arg.NewItems.Count; i++)
 				{
 					countCorrection += 1;
@@ -230,7 +230,7 @@ internal static class CollectionChanged
 				}
 				break;
 
-			case NotifyCollectionChangedAction.Move when arg.NewItems.Count > 1:
+			case NotifyCollectionChangedAction.Move when arg.NewItems!.Count > 1:
 				if (arg.NewStartingIndex > arg.OldStartingIndex)
 				{
 					for (var i = 0; i < arg.NewItems.Count; i++)
@@ -247,8 +247,8 @@ internal static class CollectionChanged
 				}
 				break;
 
-			case NotifyCollectionChangedAction.Replace when arg.OldItems.Count > 1 || arg.NewItems.Count > 1:
-				for (var i = 0; i < Math.Min(arg.NewItems.Count, arg.OldItems.Count); i++)
+			case NotifyCollectionChangedAction.Replace when arg.OldItems!.Count > 1 || arg.NewItems!.Count > 1:
+				for (var i = 0; i < Math.Min(arg.NewItems!.Count, arg.OldItems.Count); i++)
 				{
 					raise(Replace(arg.OldItems[i], arg.NewItems[i], arg.OldStartingIndex + i));
 				}
@@ -269,7 +269,7 @@ internal static class CollectionChanged
 				}
 				break;
 
-			case NotifyCollectionChangedAction.Remove when arg.OldItems.Count > 1:
+			case NotifyCollectionChangedAction.Remove when arg.OldItems!.Count > 1:
 				for (var i = 0; i < arg.OldItems.Count; i++)
 				{
 					countCorrection -= 1;
@@ -296,13 +296,13 @@ internal static class CollectionChanged
 		switch (args.Action)
 		{
 			case NotifyCollectionChangedAction.Add:
-				return args.NewItems.Count;
+				return args.NewItems!.Count;
 
 			case NotifyCollectionChangedAction.Remove:
-				return -args.OldItems.Count;
+				return -args.OldItems!.Count;
 
 			case NotifyCollectionChangedAction.Replace:
-				return args.NewItems.Count - args.OldItems.Count;
+				return args.NewItems!.Count - args.OldItems!.Count;
 
 			case NotifyCollectionChangedAction.Reset when !ignoreReset:
 				throw new ArgumentOutOfRangeException(nameof(args.Action));

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/ImmutableListToUntypedList.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/ImmutableListToUntypedList.cs
@@ -51,7 +51,7 @@ internal class ImmutableListToUntypedList<T> : IList, IList<T>, IImmutableList<T
 	}
 
 	/// <inheritdoc />
-	public bool Contains(object value)
+	public bool Contains(object? value)
 		=> IndexOf(value) >= 0;
 
 	/// <inheritdoc />
@@ -59,7 +59,7 @@ internal class ImmutableListToUntypedList<T> : IList, IList<T>, IImmutableList<T
 		=> IndexOf(item) >= 0;
 
 	/// <inheritdoc />
-	public int IndexOf(object value)
+	public int IndexOf(object? value)
 		=> value is T t ? _inner.IndexOf(t) : -1;
 
 	/// <inheritdoc />
@@ -67,11 +67,11 @@ internal class ImmutableListToUntypedList<T> : IList, IList<T>, IImmutableList<T
 		=> _inner.IndexOf(item);
 
 	/// <inheritdoc />
-	public int IndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
+	public int IndexOf(T item, int index, int count, IEqualityComparer<T>? equalityComparer)
 		=> _inner.IndexOf(item, index, count, equalityComparer);
 
 	/// <inheritdoc />
-	public int LastIndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
+	public int LastIndexOf(T item, int index, int count, IEqualityComparer<T>? equalityComparer)
 		=> _inner.LastIndexOf(item, index, count, equalityComparer);
 
 	/// <inheritdoc />
@@ -91,7 +91,7 @@ internal class ImmutableListToUntypedList<T> : IList, IList<T>, IImmutableList<T
 		=> ((ICollection<T>)_inner).CopyTo(array, arrayIndex);
 
 	/// <inheritdoc />
-	int IList.Add(object value)
+	int IList.Add(object? value)
 		=> throw NotSupported();
 
 	/// <inheritdoc />
@@ -107,7 +107,7 @@ internal class ImmutableListToUntypedList<T> : IList, IList<T>, IImmutableList<T
 		=> _inner.AddRange(items);
 
 	/// <inheritdoc />
-	void IList.Insert(int index, object value)
+	void IList.Insert(int index, object? value)
 		=> throw NotSupported();
 
 	/// <inheritdoc />
@@ -127,11 +127,11 @@ internal class ImmutableListToUntypedList<T> : IList, IList<T>, IImmutableList<T
 		=> _inner.SetItem(index, value);
 
 	/// <inheritdoc />
-	public IImmutableList<T> Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer)
+	public IImmutableList<T> Replace(T oldValue, T newValue, IEqualityComparer<T>? equalityComparer)
 		=> _inner.Replace(oldValue, newValue, equalityComparer);
 
 	/// <inheritdoc />
-	void IList.Remove(object value)
+	void IList.Remove(object? value)
 		=> throw NotSupported();
 
 	/// <inheritdoc />
@@ -139,7 +139,7 @@ internal class ImmutableListToUntypedList<T> : IList, IList<T>, IImmutableList<T
 		=> throw NotSupported();
 
 	/// <inheritdoc />
-	public IImmutableList<T> Remove(T value, IEqualityComparer<T> equalityComparer)
+	public IImmutableList<T> Remove(T value, IEqualityComparer<T>? equalityComparer)
 		=> _inner.Remove(value, equalityComparer);
 
 	/// <inheritdoc />
@@ -147,7 +147,7 @@ internal class ImmutableListToUntypedList<T> : IList, IList<T>, IImmutableList<T
 		=> _inner.RemoveAll(match);
 
 	/// <inheritdoc />
-	public IImmutableList<T> RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer)
+	public IImmutableList<T> RemoveRange(IEnumerable<T> items, IEqualityComparer<T>? equalityComparer)
 		=> _inner.RemoveRange(items, equalityComparer);
 
 	/// <inheritdoc />

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/ListToUntypedList.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/ListToUntypedList.cs
@@ -47,16 +47,16 @@ internal class ListToUntypedList<T> : IList, IList<T>, IReadOnlyList<T>, ICollec
 	}
 
 	/// <inheritdoc />
-	public bool Contains(object value)
-		=> _inner.Contains((T)value);
+	public bool Contains(object? value)
+		=> _inner.Contains((T)value!); // Ignore null check as the T might be a value type or a nullable type
 
 	/// <inheritdoc />
 	public bool Contains(T item)
 		=> _inner.Contains(item);
 
 	/// <inheritdoc />
-	public int IndexOf(object value)
-		=> _inner.IndexOf((T)value);
+	public int IndexOf(object? value)
+		=> _inner.IndexOf((T)value!); // Ignore null check as the T might be a value type or a nullable type
 
 	/// <inheritdoc />
 	public int IndexOf(T item)
@@ -79,9 +79,9 @@ internal class ListToUntypedList<T> : IList, IList<T>, IReadOnlyList<T>, ICollec
 		=> _inner.CopyTo(array, arrayIndex);
 
 	/// <inheritdoc />
-	public int Add(object value)
+	public int Add(object? value)
 	{
-		_inner.Add((T)value);
+		_inner.Add((T)value!); // Ignore null check as the T might be a value type or a nullable type
 		return _inner.Count - 1;
 	}
 
@@ -89,9 +89,21 @@ internal class ListToUntypedList<T> : IList, IList<T>, IReadOnlyList<T>, ICollec
 	public void Add(T item)
 		=> _inner.Add(item);
 
+	
 	/// <inheritdoc />
-	public void Insert(int index, object value)
-		=> _inner.Insert(index, (T)value);
+	public void Insert(int index, object? value)
+	{
+		switch (value)
+		{
+			case null:
+				throw new ArgumentNullException(nameof(value));
+			case T t:
+				_inner.Insert(index, t);
+				break;
+			default:
+				throw new ArgumentOutOfRangeException(nameof(value), $"Value must be of type {typeof(T)}");
+		}
+	}
 
 	/// <inheritdoc />
 	public void Insert(int index, T item)
@@ -102,8 +114,13 @@ internal class ListToUntypedList<T> : IList, IList<T>, IReadOnlyList<T>, ICollec
 		=> _inner.RemoveAt(index);
 
 	/// <inheritdoc />
-	public void Remove(object value)
-		=> _inner.Remove((T)value);
+	public void Remove(object? value)
+	{
+		if (value is T t)
+		{
+			_inner.Remove(t);
+		}
+	}
 
 	/// <inheritdoc />
 	public bool Remove(T item)

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/UntypedListToList.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Adapters/UntypedListToList.cs
@@ -35,19 +35,19 @@ internal class UntypedListToList<T> : IList, IList<T>, IReadOnlyList<T>, ICollec
 	/// <inheritdoc cref="IList{T}" />
 	public T this[int index]
 	{
-		get => (T)_inner[index];
+		get => (T)_inner[index]!;
 		set => _inner[index] = value;
 	}
 
 	/// <inheritdoc />
-	object IList.this[int index]
+	object? IList.this[int index]
 	{
 		get => _inner[index];
 		set => _inner[index] = value;
 	}
 
 	/// <inheritdoc />
-	public bool Contains(object value)
+	public bool Contains(object? value)
 		=> _inner.Contains(value);
 
 	/// <inheritdoc />
@@ -55,7 +55,7 @@ internal class UntypedListToList<T> : IList, IList<T>, IReadOnlyList<T>, ICollec
 		=> _inner.Contains(item);
 
 	/// <inheritdoc />
-	public int IndexOf(object value)
+	public int IndexOf(object? value)
 		=> _inner.IndexOf(value);
 
 	/// <inheritdoc />
@@ -83,11 +83,11 @@ internal class UntypedListToList<T> : IList, IList<T>, IReadOnlyList<T>, ICollec
 		=> _inner.Add(item);
 
 	/// <inheritdoc />
-	public int Add(object value)
+	public int Add(object? value)
 		=> _inner.Add(value);
 
 	/// <inheritdoc />
-	public void Insert(int index, object value)
+	public void Insert(int index, object? value)
 		=> _inner.Insert(index, value);
 
 	/// <inheritdoc />
@@ -99,7 +99,7 @@ internal class UntypedListToList<T> : IList, IList<T>, IReadOnlyList<T>, ICollec
 		=> _inner.RemoveAt(index);
 
 	/// <inheritdoc />
-	public void Remove(object value)
+	public void Remove(object? value)
 		=> _inner.Remove(value);
 
 	/// <inheritdoc />

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Differential/AddNode.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Differential/AddNode.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Linq;
 using Uno.Extensions;
 using Uno.Extensions.Reactive.Utils;
@@ -19,9 +20,11 @@ internal sealed class AddNode : IDifferentialCollectionNode
 
 	public AddNode(IDifferentialCollectionNode previous, NotifyCollectionChangedEventArgs addArg)
 	{
+		Debug.Assert(addArg.Action is NotifyCollectionChangedAction.Add);
+
 		_previous = previous;
-		_added = addArg.NewItems;
-		_addedCount = addArg.NewItems.Count;
+		_added = addArg.NewItems!;
+		_addedCount = addArg.NewItems!.Count;
 
 		_totalCount = previous.Count + _addedCount;
 		_fromIndex = addArg.NewStartingIndex;

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Differential/DifferentialImmutableList.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Differential/DifferentialImmutableList.cs
@@ -34,7 +34,7 @@ internal sealed class DifferentialImmutableList<T> : IImmutableList<T>, IDiffere
 	public bool IsSynchronized => true;
 
 	/// <inheritdoc />
-	public object? SyncRoot => this;
+	public object SyncRoot => this;
 
 	/// <inheritdoc />
 	public bool IsReadOnly => true;
@@ -43,18 +43,18 @@ internal sealed class DifferentialImmutableList<T> : IImmutableList<T>, IDiffere
 	public T this[int index] => (T)Head.ElementAt(index)!;
 
 	/// <inheritdoc />
-	object IList.this[int index]
+	object? IList.this[int index]
 	{
 		get => (T)Head.ElementAt(index)!;
 		set => throw NotSupported();
 	}
 
 	/// <inheritdoc />
-	[Pure] public int IndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
+	[Pure] public int IndexOf(T item, int index, int count, IEqualityComparer<T>? equalityComparer)
 		=> Head.IndexOf(item, index, equalityComparer?.ToEqualityComparer());
 
 	/// <inheritdoc />
-	[Pure] public int LastIndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
+	[Pure] public int LastIndexOf(T item, int index, int count, IEqualityComparer<T>? equalityComparer)
 		=> throw new NotSupportedException();
 
 	/// <inheritdoc cref="IImmutableList{T}" />
@@ -74,12 +74,12 @@ internal sealed class DifferentialImmutableList<T> : IImmutableList<T>, IDiffere
 	[Pure] IImmutableList<T> IImmutableList<T>.InsertRange(int index, IEnumerable<T> items) => InsertRange(index, items.ToImmutableList());
 
 	/// <inheritdoc cref="IImmutableList{T}" />
-	[Pure] public DifferentialImmutableList<T> Remove(T value, IEqualityComparer<T> equalityComparer)
+	[Pure] public DifferentialImmutableList<T> Remove(T value, IEqualityComparer<T>? equalityComparer)
 	{
 		var index = Head.IndexOf(value, 0, equalityComparer?.ToEqualityComparer());
 		return new(new RemoveNode(Head, value, index));
 	}
-	[Pure] IImmutableList<T> IImmutableList<T>.Remove(T value, IEqualityComparer<T> equalityComparer) => Remove(value, equalityComparer);
+	[Pure] IImmutableList<T> IImmutableList<T>.Remove(T value, IEqualityComparer<T>? equalityComparer) => Remove(value, equalityComparer);
 
 	/// <inheritdoc cref="IImmutableList{T}" />
 	[Pure] public DifferentialImmutableList<T> RemoveAll(Predicate<T> match)
@@ -100,7 +100,7 @@ internal sealed class DifferentialImmutableList<T> : IImmutableList<T>, IDiffere
 
 	/// <inheritdoc cref="IImmutableList{T}" />
 	//public DifferentialImmutableList<T> RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer)
-	[Pure] IImmutableList<T> IImmutableList<T>.RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer) => throw new NotSupportedException();
+	[Pure] IImmutableList<T> IImmutableList<T>.RemoveRange(IEnumerable<T> items, IEqualityComparer<T>? equalityComparer) => throw new NotSupportedException();
 
 	/// <inheritdoc cref="IImmutableList{T}" />
 	[Pure] public DifferentialImmutableList<T> RemoveRange(int index, int count) => new(new RemoveNode(Head, index, count));
@@ -121,7 +121,7 @@ internal sealed class DifferentialImmutableList<T> : IImmutableList<T>, IDiffere
 
 	/// <inheritdoc cref="IImmutableList{T}" />
 	//public DifferentialImmutableList<T> Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer) => throw new NotSupportedException();
-	[Pure] IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer) => throw new NotSupportedException();
+	[Pure] IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, IEqualityComparer<T>? equalityComparer) => throw new NotSupportedException();
 
 	/// <summary>
 	/// Moves a range of items within the collection
@@ -141,19 +141,19 @@ internal sealed class DifferentialImmutableList<T> : IImmutableList<T>, IDiffere
 	[Pure] public DifferentialImmutableList<T> ReplaceAt(int index, T newValue) => new(new ReplaceNode(Head, Head.ElementAt(index), newValue, index));
 
 	/// <inheritdoc />
-	bool IList.Contains(object value) => ((IList)this).IndexOf(value) >= 0;
+	bool IList.Contains(object? value) => ((IList)this).IndexOf(value) >= 0;
 
 	/// <inheritdoc />
-	int IList.IndexOf(object value) => Head.IndexOf(value, 0);
+	int IList.IndexOf(object? value) => Head.IndexOf(value, 0);
 
 	/// <inheritdoc />
-	int IList.Add(object value) => throw NotSupported();
+	int IList.Add(object? value) => throw NotSupported();
 
 	/// <inheritdoc />
-	void IList.Insert(int index, object value) => throw NotSupported();
+	void IList.Insert(int index, object? value) => throw NotSupported();
 
 	/// <inheritdoc />
-	void IList.Remove(object value) => throw NotSupported();
+	void IList.Remove(object? value) => throw NotSupported();
 
 	/// <inheritdoc />
 	void IList.RemoveAt(int index) => throw NotSupported();

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Differential/DifferentialReadOnlyList.T.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Differential/DifferentialReadOnlyList.T.cs
@@ -30,11 +30,11 @@ internal class DifferentialReadOnlyList<T> : IList, IList<T>, IReadOnlyList<T>
 	/// <inheritdoc />
 	public int IndexOf(T value) => _head.IndexOf(value!, 0);
 	/// <inheritdoc />
-	public int IndexOf(object value) => _head.IndexOf(value, 0);
+	public int IndexOf(object? value) => _head.IndexOf(value, 0);
 	/// <inheritdoc />
 	public bool Contains(T value) => _head.IndexOf(value!, 0) >= 0;
 	/// <inheritdoc />
-	public bool Contains(object value) => _head.IndexOf(value, 0) >= 0;
+	public bool Contains(object? value) => _head.IndexOf(value, 0) >= 0;
 
 	/// <inheritdoc />
 	public IEnumerator<T> GetEnumerator() => new Enumerator<T>(_head);
@@ -71,13 +71,13 @@ internal class DifferentialReadOnlyList<T> : IList, IList<T>, IReadOnlyList<T>
 
 	/// <summary>Not supported on this collection</summary>
 	/// <exception cref="NotSupportedException">In any cases, this method is not supported on this collection.</exception>
-	public int Add(object value) => throw new NotSupportedException("'Add' not supported on read only collection.");
+	public int Add(object? value) => throw new NotSupportedException("'Add' not supported on read only collection.");
 	/// <summary>Not supported on this collection</summary>
 	/// <exception cref="NotSupportedException">In any cases, this method is not supported on this collection.</exception>
 	public void Add(T value) => throw new NotSupportedException("'Add' not supported on read only collection.");
 	/// <summary>Not supported on this collection</summary>
 	/// <exception cref="NotSupportedException">In any cases, this method is not supported on this collection.</exception>
-	public void Insert(int index, object value) => throw new NotSupportedException("'Insert' not supported on read only collection.");
+	public void Insert(int index, object? value) => throw new NotSupportedException("'Insert' not supported on read only collection.");
 	/// <summary>Not supported on this collection</summary>
 	/// <exception cref="NotSupportedException">In any cases, this method is not supported on this collection.</exception>
 	public void Insert(int index, T value) => throw new NotSupportedException("'Insert' not supported on read only collection.");
@@ -86,7 +86,7 @@ internal class DifferentialReadOnlyList<T> : IList, IList<T>, IReadOnlyList<T>
 	public void RemoveAt(int index) => throw new NotSupportedException("'RemoveAt' not supported on read only collection.");
 	/// <summary>Not supported on this collection</summary>
 	/// <exception cref="NotSupportedException">In any cases, this method is not supported on this collection.</exception>
-	public void Remove(object value) => throw new NotSupportedException("'Remove' not supported on read only collection.");
+	public void Remove(object? value) => throw new NotSupportedException("'Remove' not supported on read only collection.");
 	/// <summary>Not supported on this collection</summary>
 	/// <exception cref="NotSupportedException">In any cases, this method is not supported on this collection.</exception>
 	public bool Remove(T value) => throw new NotSupportedException("'Remove' not supported on read only collection.");

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Differential/DifferentialReadOnlyList.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Differential/DifferentialReadOnlyList.cs
@@ -12,7 +12,7 @@ internal sealed class DifferentialReadOnlyList : IList
 	public DifferentialReadOnlyList(IDifferentialCollectionNode head) => _head = head;
 
 	/// <inheritdoc />
-	public object this[int index]
+	public object? this[int index]
 	{
 		get => index >= 0 && index < Count ? ElementAt(index)! : throw new IndexOutOfRangeException();
 		set => throw new NotSupportedException("'__setItem[]' not supported on read only collection.");
@@ -23,9 +23,9 @@ internal sealed class DifferentialReadOnlyList : IList
 
 	private object? ElementAt(int index) => _head.ElementAt(index);
 	/// <inheritdoc />
-	public int IndexOf(object value) => _head.IndexOf(value, 0);
+	public int IndexOf(object? value) => _head.IndexOf(value, 0);
 	/// <inheritdoc />
-	public bool Contains(object value) => _head.IndexOf(value, 0) >= 0;
+	public bool Contains(object? value) => _head.IndexOf(value, 0) >= 0;
 
 	/// <inheritdoc />
 	public IEnumerator GetEnumerator() => _head.GetEnumerator();
@@ -51,16 +51,16 @@ internal sealed class DifferentialReadOnlyList : IList
 
 	/// <summary>Not supported on this collection</summary>
 	/// <exception cref="NotSupportedException">In any cases, this method is not supported on this collection.</exception>
-	public int Add(object value) => throw new NotSupportedException("'Add' not supported on read only collection.");
+	public int Add(object? value) => throw new NotSupportedException("'Add' not supported on read only collection.");
 	/// <summary>Not supported on this collection</summary>
 	/// <exception cref="NotSupportedException">In any cases, this method is not supported on this collection.</exception>
-	public void Insert(int index, object value) => throw new NotSupportedException("'Insert' not supported on read only collection.");
+	public void Insert(int index, object? value) => throw new NotSupportedException("'Insert' not supported on read only collection.");
 	/// <summary>Not supported on this collection</summary>
 	/// <exception cref="NotSupportedException">In any cases, this method is not supported on this collection.</exception>
 	public void RemoveAt(int index) => throw new NotSupportedException("'RemoveAt' not supported on read only collection.");
 	/// <summary>Not supported on this collection</summary>
 	/// <exception cref="NotSupportedException">In any cases, this method is not supported on this collection.</exception>
-	public void Remove(object value) => throw new NotSupportedException("'Remove' not supported on read only collection.");
+	public void Remove(object? value) => throw new NotSupportedException("'Remove' not supported on read only collection.");
 	/// <summary>Not supported on this collection</summary>
 	/// <exception cref="NotSupportedException">In any cases, this method is not supported on this collection.</exception>
 	public void Clear() => throw new NotSupportedException("'Clear' not supported on read only collection.");

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Differential/MoveNode.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Differential/MoveNode.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Linq;
 using Uno.Extensions.Reactive.Utils;
 
@@ -17,10 +18,12 @@ internal sealed class MoveNode : IDifferentialCollectionNode
 
 	public MoveNode(IDifferentialCollectionNode previous, NotifyCollectionChangedEventArgs arg)
 	{
+		Debug.Assert(arg.Action is NotifyCollectionChangedAction.Move);
+
 		Previous = previous;
 		Count = previous.Count;
 
-		_moved = arg.OldItems;
+		_moved = arg.OldItems!;
 		_movedCount = _moved.Count;
 
 		_oldFromIndex = arg.OldStartingIndex;

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Differential/RemoveNode.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Differential/RemoveNode.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Uno.Extensions.Collections.Facades.Differential;
@@ -12,14 +13,16 @@ internal sealed class RemoveNode : IDifferentialCollectionNode
 {
 	private readonly int _totalCount, _removedCount, _fromIndex, _toIndex;
 
-	public RemoveNode(IDifferentialCollectionNode previous, NotifyCollectionChangedEventArgs addArg)
+	public RemoveNode(IDifferentialCollectionNode previous, NotifyCollectionChangedEventArgs arg)
 	{
+		Debug.Assert(arg.Action is NotifyCollectionChangedAction.Remove);
+
 		Previous = previous;
-		_removedCount = addArg.OldItems.Count;
+		_removedCount = arg.OldItems!.Count;
 
 		_totalCount = previous.Count - _removedCount;
-		_fromIndex = addArg.OldStartingIndex;
-		_toIndex = addArg.OldStartingIndex + _removedCount;
+		_fromIndex = arg.OldStartingIndex;
+		_toIndex = arg.OldStartingIndex + _removedCount;
 	}
 
 	public RemoveNode(IDifferentialCollectionNode previous, int index, int count)

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Differential/ReplaceNode.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Differential/ReplaceNode.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Linq;
 using Uno.Extensions;
 using Uno.Extensions.Reactive.Utils;
@@ -18,12 +19,14 @@ internal sealed class ReplaceNode : IDifferentialCollectionNode
 
 	public ReplaceNode(IDifferentialCollectionNode previous, NotifyCollectionChangedEventArgs arg)
 	{
+		Debug.Assert(arg.Action is NotifyCollectionChangedAction.Replace);
+
 		Previous = previous;
 
-		_added = arg.NewItems;
-		_addedCount = arg.NewItems.Count;
+		_added = arg.NewItems!;
+		_addedCount = arg.NewItems!.Count;
 		//_removed = arg.OldItems; // Useless and prevent reference on removed items (TODO: Deref items in _previous)
-		_removedCount = arg.OldItems.Count;
+		_removedCount = arg.OldItems!.Count;
 
 		_changeCount = _addedCount - _removedCount;
 		_totalCount = previous.Count + _changeCount;

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Differential/ResetNode.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Differential/ResetNode.cs
@@ -25,7 +25,7 @@ internal sealed class ResetNode : IDifferentialCollectionNode
 	public int Count => _items.Count;
 
 	/// <inheritdoc />
-	public object ElementAt(int index)
+	public object? ElementAt(int index)
 		=> _items[index];
 
 	/// <inheritdoc />

--- a/src/Uno.Extensions.Reactive/Collections/Facades/EmptyObservableCollection.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/EmptyObservableCollection.cs
@@ -25,7 +25,7 @@ internal sealed class EmptyObservableCollection<T> : IReadOnlyObservableCollecti
 	}
 
 	/// <inheritdoc />
-	public event NotifyCollectionChangedEventHandler CollectionChanged
+	public event NotifyCollectionChangedEventHandler? CollectionChanged
 	{
 		add { }
 		remove { }
@@ -70,12 +70,12 @@ internal sealed class EmptyObservableCollection<T> : IReadOnlyObservableCollecti
 	public object SyncRoot { get; } = new object();
 
 	/// <inheritdoc />
-	public bool Contains(object value) => false;
+	public bool Contains(object? value) => false;
 	/// <inheritdoc />
 	public bool Contains(T item) => false;
 
 	/// <inheritdoc />
-	public int IndexOf(object value) => -1;
+	public int IndexOf(object? value) => -1;
 	/// <inheritdoc />
 	public int IndexOf(T item) => -1;
 
@@ -89,7 +89,7 @@ internal sealed class EmptyObservableCollection<T> : IReadOnlyObservableCollecti
 	public void CopyTo(Array array, int index) { }
 
 	/// <inheritdoc />
-	object IList.this[int index]
+	object? IList.this[int index]
 	{
 		get => throw OutOfRange();
 		set => throw NotSupported();
@@ -106,7 +106,7 @@ internal sealed class EmptyObservableCollection<T> : IReadOnlyObservableCollecti
 	#region Write (Not Supported / explicit implementations)
 	/// <summary>Not supported on read only collection</summary>
 	/// <exception cref="NotSupportedException">This method is not supported on this collection, a <see cref="NotSupportedException"/> will be thrown.</exception>
-	int IList.Add(object value) => throw NotSupported();
+	int IList.Add(object? value) => throw NotSupported();
 	/// <summary>Not supported on read only collection</summary>
 	/// <exception cref="NotSupportedException">This method is not supported on this collection, a <see cref="NotSupportedException"/> will be thrown.</exception>
 	void ICollection<T>.Add(T item) => throw NotSupported();
@@ -121,7 +121,7 @@ internal sealed class EmptyObservableCollection<T> : IReadOnlyObservableCollecti
 
 	/// <summary>Not supported on read only collection</summary>
 	/// <exception cref="NotSupportedException">This method is not supported on this collection, a <see cref="NotSupportedException"/> will be thrown.</exception>
-	void IList.Insert(int index, object value) => throw NotSupported();
+	void IList.Insert(int index, object? value) => throw NotSupported();
 
 	/// <summary>Not supported on read only collection</summary>
 	/// <exception cref="NotSupportedException">This method is not supported on this collection, a <see cref="NotSupportedException"/> will be thrown.</exception>
@@ -129,11 +129,11 @@ internal sealed class EmptyObservableCollection<T> : IReadOnlyObservableCollecti
 
 	/// <summary>Not supported on read only collection</summary>
 	/// <exception cref="NotSupportedException">This method is not supported on this collection, a <see cref="NotSupportedException"/> will be thrown.</exception>
-	void IList.Remove(object value) => throw NotSupported();
+	void IList.Remove(object? value) => throw NotSupported();
 
 	/// <summary>Not supported on read only collection</summary>
 	/// <exception cref="NotSupportedException">This method is not supported on this collection, a <see cref="NotSupportedException"/> will be thrown.</exception>
-	bool IObservableCollection.Remove(object value) => throw NotSupported();
+	bool IObservableCollection.Remove(object? value) => throw NotSupported();
 
 	/// <summary>Not supported on read only collection</summary>
 	/// <exception cref="NotSupportedException">This method is not supported on this collection, a <see cref="NotSupportedException"/> will be thrown.</exception>

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Map/ConverterEqualityComparer.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Map/ConverterEqualityComparer.cs
@@ -22,10 +22,16 @@ internal class ConverterEqualityComparer<TFrom, TTo> : IEqualityComparer<TTo>
 	}
 
 	/// <inheritdoc />
-	public bool Equals(TTo left, TTo right) 
-		=> _comparer.Equals(_converter.ConvertBack(left), _converter.ConvertBack(right));
+	public bool Equals(TTo? left, TTo? right)
+		=> (left, right) switch
+		{
+			(null, null) => true,
+			(null, _) => false,
+			(_, null) => false,
+			_ => _comparer.Equals(_converter.ConvertBack(left), _converter.ConvertBack(right))
+		};
 
 	/// <inheritdoc />
 	public int GetHashCode(TTo obj)
-		=> _comparer.GetHashCode(_converter.ConvertBack(obj));
+		=> _converter.ConvertBack(obj) is { } back ? _comparer.GetHashCode(back) : -1;
 }

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Map/MapReadOnlyList.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Map/MapReadOnlyList.cs
@@ -50,13 +50,13 @@ internal class MapReadOnlyList<TFrom, TTo> : IList, IList<TTo>, IReadOnlyList<TT
 
 	object? IList.this[int index]
 	{
-		get => _converter.Convert(_source[index]);
+		get => _converter.Convert((TFrom)_source[index]!);
 		set => throw NotSupported();
 	}
 	/// <inheritdoc />
 	public TTo this[int index]
 	{
-		get => _converter.Convert(_source[index]);
+		get => _converter.Convert((TFrom)_source[index]!);
 		set => throw NotSupported();
 	}
 
@@ -66,7 +66,7 @@ internal class MapReadOnlyList<TFrom, TTo> : IList, IList<TTo>, IReadOnlyList<TT
 	public IEnumerator<TTo> GetEnumerator() => new MapEnumerator<TFrom, TTo>(_converter, _source.GetEnumerator());
 
 	/// <inheritdoc />
-	public bool Contains(object value) => Contains((TTo)value);
+	public bool Contains(object? value) => value is TTo t && Contains(t);
 
 	/// <inheritdoc />
 	public bool Contains(TTo item)
@@ -76,7 +76,7 @@ internal class MapReadOnlyList<TFrom, TTo> : IList, IList<TTo>, IReadOnlyList<TT
 	}
 
 	/// <inheritdoc />
-	public int IndexOf(object value) => _source.IndexOf(_converter.ConvertBack(value));
+	public int IndexOf(object? value) => value is TTo t ? _source.IndexOf(_converter.ConvertBack(t)) : -1;
 	/// <inheritdoc />
 	public int IndexOf(TTo item) => _source.IndexOf(_converter.ConvertBack(item));
 
@@ -91,10 +91,10 @@ internal class MapReadOnlyList<TFrom, TTo> : IList, IList<TTo>, IReadOnlyList<TT
 	public void Add(TTo item) => throw NotSupported();
 
 	/// <inheritdoc />
-	public int Add(object value) => throw NotSupported();
+	public int Add(object? value) => throw NotSupported();
 
 	/// <inheritdoc />
-	public void Insert(int index, object value) => throw NotSupported();
+	public void Insert(int index, object? value) => throw NotSupported();
 
 	/// <inheritdoc />
 	public void Insert(int index, TTo item) => throw NotSupported();
@@ -103,7 +103,7 @@ internal class MapReadOnlyList<TFrom, TTo> : IList, IList<TTo>, IReadOnlyList<TT
 	public void RemoveAt(int index) => throw NotSupported();
 
 	/// <inheritdoc />
-	public void Remove(object value) => throw NotSupported();
+	public void Remove(object? value) => throw NotSupported();
 	/// <inheritdoc />
 	public bool Remove(TTo item) => throw NotSupported();
 

--- a/src/Uno.Extensions.Reactive/Collections/Facades/ObservableCollectionSnapshot.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/ObservableCollectionSnapshot.cs
@@ -27,19 +27,19 @@ internal sealed class ObservableCollectionSnapshot<T> : IObservableCollectionSna
 
 	/// <inheritdoc />
 	public T this[int index] => _items[index];
-	object IList.this[int index]
+	object? IList.this[int index]
 	{
 		get => _items[index]!;
 		set => throw NotSupported();
 	}
 
-	bool IList.Contains(object value) => ((IList) _items).Contains(value);
+	bool IList.Contains(object? value) => ((IList) _items).Contains(value);
 
 	/// <inheritdoc />
 	public int IndexOf(T item, int startIndex, IEqualityComparer<T>? comparer = null) => comparer == null 
 		? _items.IndexOf(item, startIndex) 
 		: _items.IndexOf(item, startIndex, _items.Count - startIndex, comparer);
-	int IList.IndexOf(object value) => ((IList)_items).IndexOf(value);
+	int IList.IndexOf(object? value) => ((IList)_items).IndexOf(value);
 	int IObservableCollectionSnapshot.IndexOf(object item, int startIndex, IEqualityComparer? comparer) => comparer is null
 		? _items.IndexOf((T)item, startIndex)
 		: _items.IndexOf((T)item, startIndex, _items.Count - startIndex, comparer.ToEqualityComparer<T>());
@@ -56,10 +56,10 @@ internal sealed class ObservableCollectionSnapshot<T> : IObservableCollectionSna
 
 	void ICollection.CopyTo(Array array, int index) => ((ICollection)_items).CopyTo(array, index);
 
-	int IList.Add(object value) => throw NotSupported();
-	void IList.Insert(int index, object value) => throw NotSupported();
+	int IList.Add(object? value) => throw NotSupported();
+	void IList.Insert(int index, object? value) => throw NotSupported();
 	void IList.RemoveAt(int index) => throw NotSupported();
-	void IList.Remove(object value) => throw NotSupported();
+	void IList.Remove(object? value) => throw NotSupported();
 	void IList.Clear() => throw NotSupported();
 
 	private NotSupportedException NotSupported([CallerMemberName] string? method = null)

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Slice/SliceList.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Slice/SliceList.cs
@@ -34,14 +34,14 @@ internal class SliceList : IList
 	public bool IsReadOnly => true;
 
 	/// <inheritdoc />
-	public object this[int index]
+	public object? this[int index]
 	{
 		get => _source[index];
 		set => throw NotSupported();
 	}
 
 	/// <inheritdoc />
-	public int Add(object value)
+	public int Add(object? value)
 		=> throw NotSupported();
 
 	/// <inheritdoc />
@@ -49,19 +49,19 @@ internal class SliceList : IList
 		=> throw NotSupported();
 
 	/// <inheritdoc />
-	public bool Contains(object value)
+	public bool Contains(object? value)
 		=> IndexOf(value) >= 0;
 
 	/// <inheritdoc />
-	public int IndexOf(object value)
+	public int IndexOf(object? value)
 		=> _source.IndexOf(value, _startIndex, Count, null);
 
 	/// <inheritdoc />
-	public void Insert(int index, object value)
+	public void Insert(int index, object? value)
 		=> throw NotSupported();
 
 	/// <inheritdoc />
-	public void Remove(object value)
+	public void Remove(object? value)
 		=> throw NotSupported();
 
 	/// <inheritdoc />

--- a/src/Uno.Extensions.Reactive/Collections/RichNotifyCollectionChangedEventArgs.cs
+++ b/src/Uno.Extensions.Reactive/Collections/RichNotifyCollectionChangedEventArgs.cs
@@ -155,12 +155,12 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 	{
 	}
 
-	private RichNotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, object changedItem)
+	private RichNotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, object? changedItem)
 		: base(action, changedItem)
 	{
 	}
 
-	private RichNotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, object changedItem, int index)
+	private RichNotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, object? changedItem, int index)
 		: base(action, changedItem, index)
 	{
 	}
@@ -175,12 +175,12 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 	{
 	}
 
-	private RichNotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, object newItem, object oldItem)
+	private RichNotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, object? newItem, object? oldItem)
 		: base(action, newItem, oldItem)
 	{
 	}
 
-	private RichNotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, object newItem, object oldItem, int index)
+	private RichNotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, object? newItem, object? oldItem, int index)
 		: base(action, newItem, oldItem, index)
 	{
 	}
@@ -195,7 +195,7 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 	{
 	}
 
-	private RichNotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, object changedItem, int index, int oldIndex)
+	private RichNotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, object? changedItem, int index, int oldIndex)
 		: base(action, changedItem, index, oldIndex)
 	{
 	}
@@ -239,27 +239,27 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 			case NotifyCollectionChangedAction.Add:
 				return new RichNotifyCollectionChangedEventArgs(
 					NotifyCollectionChangedAction.Add,
-					NewItems,
+					NewItems!,
 					NewStartingIndex + offset);
 
 			case NotifyCollectionChangedAction.Move:
 				return new RichNotifyCollectionChangedEventArgs(
 					NotifyCollectionChangedAction.Move,
-					NewItems,
+					NewItems!,
 					NewStartingIndex + offset,
 					OldStartingIndex + offset);
 
 			case NotifyCollectionChangedAction.Replace:
 				return new RichNotifyCollectionChangedEventArgs(
 					NotifyCollectionChangedAction.Replace,
-					NewItems,
-					OldItems,
+					NewItems!,
+					OldItems!,
 					NewStartingIndex + offset);
 
 			case NotifyCollectionChangedAction.Remove:
 				return new RichNotifyCollectionChangedEventArgs(
 					NotifyCollectionChangedAction.Remove,
-					OldItems,
+					OldItems!,
 					OldStartingIndex + offset);
 
 			case NotifyCollectionChangedAction.Reset:
@@ -325,16 +325,16 @@ internal class RichNotifyCollectionChangedEventArgs : NotifyCollectionChangedEve
 		switch (Action)
 		{
 			case NotifyCollectionChangedAction.Add:
-				return $"Add {NewItems.Count} items at {NewStartingIndex}";
+				return $"Add {NewItems!.Count} items at {NewStartingIndex}";
 
 			case NotifyCollectionChangedAction.Move:
-				return $"Move {NewItems.Count} items from {OldStartingIndex} to {NewStartingIndex}";
+				return $"Move {NewItems!.Count} items from {OldStartingIndex} to {NewStartingIndex}";
 
 			case NotifyCollectionChangedAction.Remove:
-				return $"Remove {OldItems.Count} items at {OldStartingIndex}";
+				return $"Remove {OldItems!.Count} items at {OldStartingIndex}";
 
 			case NotifyCollectionChangedAction.Replace:
-				return $"Replace {OldItems.Count} items at {OldStartingIndex} by {NewItems.Count} items";
+				return $"Replace {OldItems!.Count} items at {OldStartingIndex} by {NewItems!.Count} items";
 
 			case NotifyCollectionChangedAction.Reset:
 				return $"Reset from {ResetOldItems!.Count} items to {ResetNewItems!.Count} items";

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Core.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.Core.cs
@@ -39,7 +39,7 @@ internal partial class CollectionAnalyzer
 
 			// For the replace, we are digging in the collection to determine if we could simplify the change considering the given comparers
 			case NotifyCollectionChangedAction.Replace:
-				return GetChangesCore(getRef(arg.OldItems), getRef(arg.NewItems), versionComparer, arg.OldStartingIndex);
+				return GetChangesCore(getRef(arg.OldItems!), getRef(arg.NewItems!), versionComparer, arg.OldStartingIndex);
 
 			default:
 				throw new ArgumentOutOfRangeException(nameof(arg), arg.Action, $"Action '{arg.Action}' not supported.");

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer.T.cs
@@ -30,7 +30,7 @@ internal class CollectionAnalyzer<T>
 	}
 
 	private ListRef<T> GetRef(IList list)
-		=> new(list, list.Count, i => (T)list[i], list.GetIndexOf(_comparer));
+		=> new(list, list.Count, i => (T)list[i]!, list.GetIndexOf(_comparer));
 
 	private ListRef<T> GetRef(IList<T> list)
 		=> new(list, list.Count, i => list[i], list.GetIndexOf(_comparer));

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Add.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Add.cs
@@ -45,7 +45,7 @@ partial class CollectionAnalyzer
 		internal static CollectionUpdater.Update Visit(RichNotifyCollectionChangedEventArgs args, ICollectionUpdaterVisitor visitor)
 		{
 			var callback = new CollectionUpdater.Update(args);
-			var items = args.NewItems;
+			var items = args.NewItems!;
 
 			for (var i = 0; i < items.Count; i++)
 			{

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Remove.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Remove.cs
@@ -42,7 +42,7 @@ partial class CollectionAnalyzer
 		internal static CollectionUpdater.Update Visit(RichNotifyCollectionChangedEventArgs args, ICollectionUpdaterVisitor visitor)
 		{
 			var callback = new CollectionUpdater.Update(args);
-			var items = args.OldItems;
+			var items = args.OldItems!;
 
 			for (var i = 0; i < items.Count; i++)
 			{

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Replace.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/CollectionAnalyzer._Replace.cs
@@ -87,9 +87,13 @@ partial class CollectionAnalyzer
 		}
 
 		private RichNotifyCollectionChangedEventArgs CreateEvent(int from, int count)
+#if NET8_0_OR_GREATER
+			=> RichNotifyCollectionChangedEventArgs.ReplaceSome<T>(
+#else
 			=> RichNotifyCollectionChangedEventArgs.ReplaceSome(
-				_oldItems.Slice(from, count),
-				_newItems.Slice(from, count),
+#endif
+				_oldItems!.Slice(from, count),
+				_newItems!.Slice(from, count),
 				Starts + _indexOffset + from,
 				_isReplaceOfSameEntities);
 

--- a/src/Uno.Extensions.Reactive/Collections/Tracking/Updater/CollectionUpdateCallbackHelper.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Tracking/Updater/CollectionUpdateCallbackHelper.cs
@@ -14,7 +14,7 @@ internal static class CollectionUpdateCallbackHelper
 			case 1:
 				return uiCallbacks[0];
 			default:
-				return (BeforeCallback)Delegate.Combine(uiCallbacks.ToArray());
+				return (BeforeCallback?)Delegate.Combine(uiCallbacks.ToArray())!;
 		}
 	}
 
@@ -27,7 +27,7 @@ internal static class CollectionUpdateCallbackHelper
 			case 1:
 				return uiCallbacks[0];
 			default:
-				return (BeforeCallback)Delegate.Combine(uiCallbacks);
+				return (BeforeCallback?)Delegate.Combine(uiCallbacks)!;
 		}
 	}
 
@@ -48,7 +48,7 @@ internal static class CollectionUpdateCallbackHelper
 			case 1:
 				return uiCallbacks[0];
 			default:
-				return (AfterCallback)Delegate.Combine(uiCallbacks.ToArray());
+				return (AfterCallback?)Delegate.Combine(uiCallbacks.ToArray());
 		}
 	}
 
@@ -61,7 +61,7 @@ internal static class CollectionUpdateCallbackHelper
 			case 1:
 				return uiCallbacks[0];
 			default:
-				return (AfterCallback)Delegate.Combine(uiCallbacks);
+				return (AfterCallback?)Delegate.Combine(uiCallbacks);
 		}
 	}
 

--- a/src/Uno.Extensions.Reactive/Core/Axes/MessageAxis.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/MessageAxis.cs
@@ -112,12 +112,12 @@ public abstract class MessageAxis : IEquatable<MessageAxis>
 
 	/// <inheritdoc />
 	[Pure]
-	public bool Equals(MessageAxis other)
-		=> Equals(this, other);
+	public bool Equals(MessageAxis? other)
+		=> other is not null && Equals(this, other);
 
 	/// <inheritdoc />
 	[Pure]
-	public override bool Equals(object obj)
+	public override bool Equals(object? obj)
 		=> obj is MessageAxis other && Equals(this, other);
 
 	[Pure]

--- a/src/Uno.Extensions.Reactive/Core/Axes/MessageAxisValue.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/MessageAxisValue.cs
@@ -45,7 +45,7 @@ public readonly record struct MessageAxisValue
 	}
 
 	/// <inheritdoc />
-	public override string ToString()
+	public override string? ToString()
 		=> (IsSet, Value) switch
 		{
 			(false, _) => "--unset--",

--- a/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSource.Composite.cs
+++ b/src/Uno.Extensions.Reactive/Core/ContextRequests/RequestSource.Composite.cs
@@ -21,7 +21,7 @@ internal sealed class CompositeRequestSource : IRequestSource
 		other.RequestRaised += OnRequestReceived;
 		ct.Register(() => other.RequestRaised -= OnRequestReceived);
 
-		void OnRequestReceived(object _, IContextRequest request)
+		void OnRequestReceived(object? _, IContextRequest request)
 		{
 			if (request is not EndRequest)
 			{

--- a/src/Uno.Extensions.Reactive/Core/Internal/ListStateImpl.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/ListStateImpl.cs
@@ -45,7 +45,7 @@ internal class ListStateImpl<T> : FeedToListFeedAdapter<T>, IListState<T>, IStat
 		=> base.GetHashCode() ^ _implementation.GetHashCode();
 
 	/// <inheritdoc />
-	public override bool Equals(object obj)
+	public override bool Equals(object? obj)
 		=> obj is ListStateImpl<T> other && Equals(this, other);
 
 	public static bool operator ==(ListStateImpl<T> left, ListStateImpl<T> right)

--- a/src/Uno.Extensions.Reactive/Core/Internal/SourceContext.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/SourceContext.cs
@@ -382,7 +382,7 @@ public sealed class SourceContext : IAsyncDisposable
 		RequestSource.RequestRaised += OnRequest;
 		ct.Register(() => RequestSource.RequestRaised -= OnRequest);
 
-		void OnRequest(object _, IContextRequest request)
+		void OnRequest(object? _, IContextRequest request)
 		{
 			if (request is EndRequest)
 			{
@@ -436,7 +436,7 @@ public sealed class SourceContext : IAsyncDisposable
 		{
 			_ctx = ctx;
 
-			_previous = _current.Value;
+			_previous = _current.Value ?? SourceContext.None;
 			_current.Value = ctx;
 		}
 

--- a/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
+++ b/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
@@ -114,7 +114,7 @@ internal class FeedToListFeedAdapter<TCollection, TItem> : IListFeed<TItem>
 			^ _itemComparer.GetHashCode();
 
 	/// <inheritdoc />
-	public override bool Equals(object obj)
+	public override bool Equals(object? obj)
 		=> obj is FeedToListFeedAdapter<TCollection, TItem> other && Equals(this, other);
 
 	public static bool operator ==(FeedToListFeedAdapter<TCollection, TItem> left, FeedToListFeedAdapter<TCollection, TItem> right)

--- a/src/Uno.Extensions.Reactive/Operators/HotSwapFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/HotSwapFeed.cs
@@ -22,7 +22,7 @@ namespace Uno.Extensions.Reactive.Operators;
 /// It will instead listen for a new source to enumerate.
 /// </remarks>
 [EditorBrowsable(EditorBrowsableState.Never)]
-public sealed class HotSwapFeed<T> : IFeed<T>
+internal sealed class HotSwapFeed<T> : IFeed<T>
 {
 	private readonly object _gate = new();
 	private ISignal<Message<T>>? _current;
@@ -50,11 +50,6 @@ public sealed class HotSwapFeed<T> : IFeed<T>
 	{
 		lock (_gate)
 		{
-			//if (_parent is IHotSwapAwareFeed aware)
-			//{
-			//	aware.HotSwap(this, updatedParent);
-			//}
-
 			if (_current == feed)
 			{
 				return;
@@ -150,7 +145,7 @@ public sealed class HotSwapFeed<T> : IFeed<T>
 			return await MoveNextAsync().ConfigureAwait(false);
 		}
 
-		private void OnFeedChanged(object sender, ISignal<Message<T>>? parent)
+		private void OnFeedChanged(object? sender, ISignal<Message<T>>? parent)
 		{
 			var next = _next;
 			if (next is not null && Interlocked.CompareExchange(ref _next, new TaskCompletionSource<SessionCurrentEnumerator>(), next) == next)

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.HotReload.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.HotReload.cs
@@ -305,10 +305,10 @@ partial class BindableViewModelBase
 
 
 	private static object CreateErrorFeed(Type valueType, string message)
-		=> Activator.CreateInstance(typeof(ErrorFeed<>).MakeGenericType(valueType), new InvalidOperationException(message));
+		=> Activator.CreateInstance(typeof(ErrorFeed<>).MakeGenericType(valueType), new InvalidOperationException(message))!;
 
 	private static object CreateUndefinedFeed(Type valueType)
-		=> Activator.CreateInstance(typeof(UndefinedFeed<>).MakeGenericType(valueType));
+		=> Activator.CreateInstance(typeof(UndefinedFeed<>).MakeGenericType(valueType))!;
 
 	private class ErrorFeed<T> : IFeed<T>
 	{
@@ -369,7 +369,7 @@ partial class BindableViewModelBase
 		var hotSwapType = typeof(IHotSwapState<>).MakeGenericType(valueType);
 		if (!hotSwapType.IsInstanceOfType(previousState))
 		{
-			if (model.Log().IsEnabled(LogLevel.Information)) model.Log().Info($"The state '{previousState.GetType()}' used for '{property}' does not support hot-swap.");
+			if (model.Log().IsEnabled(LogLevel.Information)) model.Log().Info($"The state '{previousState?.GetType()}' used for '{property}' does not support hot-swap.");
 
 			return;
 		}

--- a/src/Uno.Extensions.Reactive/Presentation/Commands/AsyncCommand.SubCommand.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Commands/AsyncCommand.SubCommand.cs
@@ -128,7 +128,7 @@ partial class AsyncCommand
 			task.ContinueWith(
 				(_, state) =>
 				{
-					((CancellationTokenRegistration)state).Dispose();
+					((CancellationTokenRegistration)state!).Dispose();
 					Complete();
 				},
 				ctReg,

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Feed/FeedDependenciesStore.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Feed/FeedDependenciesStore.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Uno.Extensions.Reactive.Sources;
@@ -60,7 +61,7 @@ internal sealed class FeedDependenciesStore : IDisposable
 		}
 	}
 
-	public bool TryGet(IMessageEntry entry, out FeedDependency dependency)
+	public bool TryGet(IMessageEntry entry, [NotNullWhen(true)] out FeedDependency? dependency)
 	{
 		lock (_dependenciesPerCurrentEntry)
 		{

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/FeedSession.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/FeedSession.cs
@@ -28,7 +28,7 @@ internal abstract class FeedSession : IAsyncDisposable
 		Context = context;
 
 		_ct = CancellationTokenSource.CreateLinkedTokenSource(ct);
-		_ctSub = ct.Register(static session => _ = ((FeedSession)session).DisposeAsync(), this, useSynchronizationContext: false);
+		_ctSub = ct.Register(static session => _ = ((FeedSession)session!).DisposeAsync(), this, useSynchronizationContext: false);
 	}
 
 	/// <summary>

--- a/src/Uno.Extensions.Reactive/Utils/ActivatorHelper.cs
+++ b/src/Uno.Extensions.Reactive/Utils/ActivatorHelper.cs
@@ -78,7 +78,7 @@ internal static class ActivatorHelper
 				else
 				{
 					// Not found, try for get it from DI, or use null.
-					newArguments.Add((false, tryGetMissingArgument?.Invoke(param.ParameterType, param.Name)));
+					newArguments.Add((false, tryGetMissingArgument?.Invoke(param.ParameterType, param.Name!)));
 				}
 			}
 

--- a/src/Uno.Extensions.Reactive/Utils/DictionaryExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/DictionaryExtensions.cs
@@ -7,6 +7,7 @@ namespace Uno.Extensions.Reactive.Utils;
 internal static class DictionaryExtensions
 {
 	public static Dictionary<TKey, TValue> ToDictionaryWhereKey<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> readOnly, Predicate<TKey> predicate)
+		where TKey : notnull
 	{
 		var result = new Dictionary<TKey, TValue>(readOnly.Count);
 		foreach (var kvp in readOnly)
@@ -21,6 +22,7 @@ internal static class DictionaryExtensions
 	}
 
 	public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> readOnly)
+		where TKey : notnull
 	{
 		if (readOnly is IDictionary<TKey, TValue> dic)
 		{
@@ -33,6 +35,7 @@ internal static class DictionaryExtensions
 	}
 
 	public static Dictionary<TKey, TValue> SetItems<TKey, TValue>(this Dictionary<TKey, TValue> target, IReadOnlyDictionary<TKey, TValue> source)
+		where TKey : notnull
 	{
 		foreach (var item in source)
 		{

--- a/src/Uno.Extensions.Reactive/Utils/ListExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/ListExtensions.cs
@@ -105,7 +105,11 @@ internal static class ListExtensions
 					{
 						for (var i = index; i < index + count; i++)
 						{
+#if NET8_0_OR_GREATER
+							if (comparer.Equals((T?)list[i], value))
+#else
 							if (comparer.Equals((T)list[i], value))
+#endif
 							{
 								return i;
 							}

--- a/src/Uno.Extensions.Reactive/Utils/Logging/LogExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/Logging/LogExtensions.cs
@@ -78,6 +78,6 @@ internal static class LogExtensions
 
 	private static class Holder<T>
 	{
-		public static ILogger Logger { get; } = CreateLog(typeof(T).FullName);
+		public static ILogger Logger { get; } = CreateLog(typeof(T).FullName!);
 	}
 }


### PR DESCRIPTION
## Bugfix
fix: Fix lot of nullable annotation issues (appears when updating to newer SDK version)

## What is the current behavior?
Compliant with netstd 2.0

## What is the new behavior?
Compliant with net 8.0

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
