### PR TITLE
feat: Uniformize public async API

### DIFF
--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
@@ -91,12 +91,12 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 	}
 
 	/// <inheritdoc />
-	ValueTask IListState<T>.UpdateMessage(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
-		=> _state.UpdateMessage(updater, ct);
+	ValueTask IListState<T>.UpdateMessageAsync(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
+		=> _state.UpdateMessageAsync(updater, ct);
 
 	/// <inheritdoc />
-	ValueTask IState<IImmutableList<T>>.UpdateMessage(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
-		=> _state.UpdateMessage(updater, ct);
+	ValueTask IState<IImmutableList<T>>.UpdateMessageAsync(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
+		=> _state.UpdateMessageAsync(updater, ct);
 
 
 	private static BindableCollection CreateBindableCollection(IListState<T> state)
@@ -179,10 +179,10 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 		}
 
 		async ValueTask SetSelected(SelectionInfo info, CancellationToken ct)
-			=> await state.UpdateMessage(msg => msg.Selected(info).Set(BindableViewModelBase.BindingSource, collection), ct);
+			=> await state.UpdateMessageAsync(msg => msg.Selected(info).Set(BindableViewModelBase.BindingSource, collection), ct);
 
 		async ValueTask Edit(Func<IDifferentialCollectionNode, IDifferentialCollectionNode> change, CancellationToken ct)
-			=> await state.UpdateMessage(
+			=> await state.UpdateMessageAsync(
 				msg =>
 				{
 					// Note: The change might have been computed on an older version of the collection

--- a/src/Uno.Extensions.Reactive/Core/IListState.cs
+++ b/src/Uno.Extensions.Reactive/Core/IListState.cs
@@ -20,6 +20,6 @@ public interface IListState<T> : IListFeed<T>, IState
 	/// <param name="updater">The update method to apply to the current message.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	/// <remarks>This is the raw way to update a state, you should consider using the <see cref="ListState.Update{T}"/> method instead.</remarks>
-	ValueTask UpdateMessage(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct);
+	/// <remarks>This is the raw way to update a state, you should consider using the <see cref="ListState.UpdateAsync{T}(Uno.Extensions.Reactive.IListState{T},System.Func{System.Collections.Immutable.IImmutableList{T},System.Collections.Immutable.IImmutableList{T}},System.Threading.CancellationToken)"/> method instead.</remarks>
+	ValueTask UpdateMessageAsync(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct = default);
 }

--- a/src/Uno.Extensions.Reactive/Core/IState.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/IState.T.cs
@@ -19,6 +19,6 @@ public interface IState<T> : IFeed<T>, IState
 	/// <param name="updater">The update method to apply to the current message.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	/// <remarks>This is the raw way to update a state, you should consider using the <see cref="State.UpdateAsync{T}(Uno.Extensions.Reactive.IState{T},System.Func{T?,T?},System.Threading.CancellationToken)"/> method instead.</remarks>
+	/// <remarks>This is the raw way to update a state, you should consider using the <see cref="State.UpdateAsync{T}"/> method instead.</remarks>
 	ValueTask UpdateMessageAsync(Action<MessageBuilder<T>> updater, CancellationToken ct = default);
 }

--- a/src/Uno.Extensions.Reactive/Core/IState.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/IState.T.cs
@@ -19,6 +19,6 @@ public interface IState<T> : IFeed<T>, IState
 	/// <param name="updater">The update method to apply to the current message.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	/// <remarks>This is the raw way to update a state, you should consider using the <see cref="State.Update{T}"/> method instead.</remarks>
-	ValueTask UpdateMessage(Action<MessageBuilder<T>> updater, CancellationToken ct);
+	/// <remarks>This is the raw way to update a state, you should consider using the <see cref="State.UpdateAsync{T}(Uno.Extensions.Reactive.IState{T},System.Func{T?,T?},System.Threading.CancellationToken)"/> method instead.</remarks>
+	ValueTask UpdateMessageAsync(Action<MessageBuilder<T>> updater, CancellationToken ct = default);
 }

--- a/src/Uno.Extensions.Reactive/Core/Internal/ListStateImpl.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/ListStateImpl.cs
@@ -33,8 +33,8 @@ internal class ListStateImpl<T> : FeedToListFeedAdapter<T>, IListState<T>, IStat
 	public SourceContext Context => _implementation.Context;
 
 	/// <inheritdoc />
-	public ValueTask UpdateMessage(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
-		=> _implementation.UpdateMessage(updater, ct);
+	public ValueTask UpdateMessageAsync(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
+		=> _implementation.UpdateMessageAsync(updater, ct);
 
 	/// <inheritdoc />
 	public ValueTask DisposeAsync()

--- a/src/Uno.Extensions.Reactive/Core/Internal/StateImpl.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/StateImpl.cs
@@ -111,7 +111,7 @@ internal sealed class StateImpl<T> : IState<T>, IFeed<T>, IAsyncDisposable, ISta
 	}
 
 	/// <inheritdoc />
-	public async ValueTask UpdateMessage(Action<MessageBuilder<T>> updater, CancellationToken ct)
+	public async ValueTask UpdateMessageAsync(Action<MessageBuilder<T>> updater, CancellationToken ct)
 	{
 		// First we make sure that the UpdateFeed is active, so the update will be applied ^^
 		Enable();

--- a/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
@@ -11,6 +11,16 @@ namespace Uno.Extensions.Reactive;
 static partial class ListState
 {
 	/// <summary>
+	/// [DEPRECATED] Use UpdateMessageAsync instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use UpdateMessageAsync")]
+#endif
+	public static ValueTask UpdateMessage<T>(this IListState<T> state, Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
+		=> state.UpdateMessageAsync(updater, ct);
+
+	/// <summary>
 	/// Updates the value of a state
 	/// </summary>
 	/// <typeparam name="T">Type of the value of the state.</typeparam>
@@ -18,8 +28,8 @@ static partial class ListState
 	/// <param name="updater">The update method to apply to the current value.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask Update<T>(this IListState<T> state, Func<IImmutableList<T>, IImmutableList<T>> updater, CancellationToken ct)
-		=> state.UpdateMessage(
+	public static ValueTask UpdateAsync<T>(this IListState<T> state, Func<IImmutableList<T>, IImmutableList<T>> updater, CancellationToken ct = default)
+		=> state.UpdateMessageAsync(
 			m =>
 			{
 				var updatedValue = updater(m.CurrentData.SomeOrDefault() ?? ImmutableList<T>.Empty);
@@ -30,46 +40,76 @@ static partial class ListState
 			ct);
 
 	/// <summary>
-	/// Updates the value of a list state
-	/// </summary>
-	/// <typeparam name="T">Type of the items of the list state.</typeparam>
-	/// <param name="state">The list state to update.</param>
-	/// <param name="updater">The update method to apply to the current list.</param>
-	/// <param name="ct">A cancellation to cancel the async operation.</param>
-	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask UpdateData<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
-		=> state.UpdateMessage(m => m.Data(updater(m.CurrentData)), ct);
-
-	/// <summary>
-	/// Updates the value of a list state
-	/// </summary>
-	/// <typeparam name="T">Type of the items of the list state.</typeparam>
-	/// <param name="state">The list state to update.</param>
-	/// <param name="updater">The update method to apply to the current list.</param>
-	/// <param name="ct">A cancellation to cancel the async operation.</param>
-	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask UpdateData<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, IImmutableList<T>> updater, CancellationToken ct)
-		=> state.UpdateMessage(m => m.Data(updater(m.CurrentData)), ct);
-
-	/// <summary>
-	/// [DEPRECATED] Use UpdateData instead
+	/// [DEPRECATED] Use UpdateAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
-	[Obsolete("Use UpdateData")]
+	[Obsolete("Use UpdateAsync")]
+#endif
+	public static ValueTask Update<T>(this IListState<T> state, Func<IImmutableList<T>, IImmutableList<T>> updater, CancellationToken ct)
+		=> UpdateAsync(state, updater, ct);
+
+	/// <summary>
+	/// Updates the value of a list state
+	/// </summary>
+	/// <typeparam name="T">Type of the items of the list state.</typeparam>
+	/// <param name="state">The list state to update.</param>
+	/// <param name="updater">The update method to apply to the current list.</param>
+	/// <param name="ct">A cancellation to cancel the async operation.</param>
+	/// <returns>A ValueTask to track the async update.</returns>
+	public static ValueTask UpdateDataAsync<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct = default)
+		=> state.UpdateMessageAsync(m => m.Data(updater(m.CurrentData)), ct);
+
+	/// <summary>
+	/// [DEPRECATED] Use UpdateDataAsync instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use UpdateDataAsync")]
+#endif
+	public static ValueTask UpdateData<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
+		=> UpdateDataAsync(state, updater, ct);
+
+	/// <summary>
+	/// Updates the value of a list state
+	/// </summary>
+	/// <typeparam name="T">Type of the items of the list state.</typeparam>
+	/// <param name="state">The list state to update.</param>
+	/// <param name="updater">The update method to apply to the current list.</param>
+	/// <param name="ct">A cancellation to cancel the async operation.</param>
+	/// <returns>A ValueTask to track the async update.</returns>
+	public static ValueTask UpdateDataAsync<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, IImmutableList<T>> updater, CancellationToken ct = default)
+		=> state.UpdateMessageAsync(m => m.Data(updater(m.CurrentData)), ct);
+
+	/// <summary>
+	/// [DEPRECATED] Use UpdateDataAsync instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use UpdateDataAsync")]
+#endif
+	public static ValueTask UpdateData<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, IImmutableList<T>> updater, CancellationToken ct)
+		=> UpdateDataAsync(state, updater, ct);
+
+	/// <summary>
+	/// [DEPRECATED] Use UpdateDataAsync instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use UpdateDataAsync")]
 #endif
 	public static ValueTask UpdateValue<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
-		=> UpdateData(state, updater, ct);
+		=> UpdateDataAsync(state, updater, ct);
 
 	/// <summary>
-	/// [DEPRECATED] Use UpdateData instead
+	/// [DEPRECATED] Use UpdateDataAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
-	[Obsolete("Use UpdateData")]
+	[Obsolete("Use UpdateDataAsync")]
 #endif
 	public static ValueTask UpdateValue<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, IImmutableList<T>> updater, CancellationToken ct)
-		=> UpdateData(state, updater, ct);
+		=> UpdateDataAsync(state, updater, ct);
 
 
 	#region Operators
@@ -81,8 +121,8 @@ static partial class ListState
 	/// <param name="item">The item to add.</param>
 	/// <param name="ct">A token to abort the async add operation.</param>
 	/// <returns></returns>
-	public static ValueTask InsertAsync<T>(this IListState<T> state, T item, CancellationToken ct)
-		=> state.UpdateData(items => items.SomeOrDefault(ImmutableList<T>.Empty).Insert(0, item), ct);
+	public static ValueTask InsertAsync<T>(this IListState<T> state, T item, CancellationToken ct = default)
+		=> state.UpdateDataAsync(items => items.SomeOrDefault(ImmutableList<T>.Empty).Insert(0, item), ct);
 
 	/// <summary>
 	/// Adds an item into a list state
@@ -92,8 +132,8 @@ static partial class ListState
 	/// <param name="item">The item to add.</param>
 	/// <param name="ct">A token to abort the async add operation.</param>
 	/// <returns></returns>
-	public static ValueTask AddAsync<T>(this IListState<T> state, T item, CancellationToken ct)
-		=> state.UpdateData(items => items.SomeOrDefault(ImmutableList<T>.Empty).Add(item), ct);
+	public static ValueTask AddAsync<T>(this IListState<T> state, T item, CancellationToken ct = default)
+		=> state.UpdateDataAsync(items => items.SomeOrDefault(ImmutableList<T>.Empty).Add(item), ct);
 
 	/// <summary>
 	/// Removes all matching items from a list state.
@@ -103,8 +143,8 @@ static partial class ListState
 	/// <param name="match">Predicate to determine which items should be removed.</param>
 	/// <param name="ct">A token to abort the async add operation.</param>
 	/// <returns></returns>
-	public static ValueTask RemoveAllAsync<T>(this IListState<T> state, Predicate<T> match, CancellationToken ct)
-		=> state.UpdateData(itemsOpt => itemsOpt.Map(items => items.RemoveAll(match)), ct);
+	public static ValueTask RemoveAllAsync<T>(this IListState<T> state, Predicate<T> match, CancellationToken ct = default)
+		=> state.UpdateDataAsync(itemsOpt => itemsOpt.Map(items => items.RemoveAll(match)), ct);
 
 	/// <summary>
 	/// Updates all matching items from a list state.
@@ -115,8 +155,8 @@ static partial class ListState
 	/// <param name="updater">How to update items.</param>
 	/// <param name="ct">A token to abort the async add operation.</param>
 	/// <returns></returns>
-	public static ValueTask UpdateAsync<T>(this IListState<T> state, Predicate<T> match, Func<T, T> updater, CancellationToken ct)
-		=> state.UpdateData(
+	public static ValueTask UpdateAllAsync<T>(this IListState<T> state, Predicate<T> match, Func<T, T> updater, CancellationToken ct = default)
+		=> state.UpdateDataAsync(
 			itemsOpt => itemsOpt.Map(items =>
 			{
 				var updated = items;
@@ -132,9 +172,22 @@ static partial class ListState
 			ct);
 
 	/// <summary>
+	/// [DEPRECATED] Use .UpdateAllAsync instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use UpdateAllAsync")]
+#endif
+	public static ValueTask UpdateAsync<T>(this IListState<T> state, Predicate<T> match, Func<T, T> updater, CancellationToken ct)
+		=> UpdateAllAsync(state, match, updater, ct);
+
+	/// <summary>
 	/// [DEPRECATED] Use .ForEachAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use ForEachAsync")]
+#endif
 	public static IDisposable Execute<T>(this IListState<T> state, AsyncAction<IImmutableList<T>> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
 		where T : notnull
 		=> ForEachAsync(state, action, caller, line);
@@ -162,12 +215,12 @@ static partial class ListState
 	/// <param name="selectedItems">The items to flag as selected.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static async ValueTask<bool> TrySelectAsync<T>(this IListState<T> state, IImmutableList<T> selectedItems, CancellationToken ct)
+	public static async ValueTask<bool> TrySelectAsync<T>(this IListState<T> state, IImmutableList<T> selectedItems, CancellationToken ct = default)
 	{
 		var comparer = ListFeed<T>.DefaultComparer.Entity;
 		var success = false;
 
-		await state.UpdateMessage(msg =>
+		await state.UpdateMessageAsync(msg =>
 		{
 			var items = msg.CurrentData.SomeOrDefault(ImmutableList<T>.Empty);
 			if (SelectionInfo.TryCreateMultiple(items, selectedItems, out var selection, comparer))
@@ -188,13 +241,13 @@ static partial class ListState
 	/// <param name="selectedItem">The item to flag as selected.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static async ValueTask<bool> TrySelectAsync<T>(this IListState<T> state, T selectedItem, CancellationToken ct)
+	public static async ValueTask<bool> TrySelectAsync<T>(this IListState<T> state, T selectedItem, CancellationToken ct = default)
 		where T : notnull
 	{
 		var comparer = ListFeed<T>.DefaultComparer.Entity;
 		var success = false;
 
-		await state.UpdateMessage(msg =>
+		await state.UpdateMessageAsync(msg =>
 		{
 			var items = msg.CurrentData.SomeOrDefault(ImmutableList<T>.Empty);
 			if (SelectionInfo.TryCreateSingle(items, selectedItem, out var selection, comparer))
@@ -214,7 +267,18 @@ static partial class ListState
 	/// <param name="state">The state to update.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static async ValueTask ClearSelection<T>(this IListState<T> state, CancellationToken ct)
+	public static async ValueTask ClearSelectionAsync<T>(this IListState<T> state, CancellationToken ct = default)
 		where T : notnull
-		=> await state.UpdateMessage(msg => msg.Selected(SelectionInfo.Empty), ct);
+		=> await state.UpdateMessageAsync(msg => msg.Selected(SelectionInfo.Empty), ct);
+
+	/// <summary>
+	/// [DEPRECATED] Use .ClearSelectionAsync instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use ClearSelectionAsync")]
+#endif
+	public static ValueTask ClearSelection<T>(this IListState<T> state, CancellationToken ct = default)
+		where T : notnull
+		=> ClearSelectionAsync(state, ct);
 }

--- a/src/Uno.Extensions.Reactive/Core/State.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/State.Extensions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -12,6 +10,16 @@ namespace Uno.Extensions.Reactive;
 partial class State
 {
 	/// <summary>
+	/// [DEPRECATED] Use UpdateMessageAsync instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use UpdateMessageAsync")]
+#endif
+	public static ValueTask UpdateMessage<T>(this IState<T> state, Action<MessageBuilder<T>> updater, CancellationToken ct)
+		=> state.UpdateMessageAsync(updater, ct);
+
+	/// <summary>
 	/// Updates the value of a state
 	/// </summary>
 	/// <typeparam name="T">Type of the value of the state.</typeparam>
@@ -19,9 +27,9 @@ partial class State
 	/// <param name="updater">The update method to apply to the current value.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask Update<T>(this IState<T> state, Func<T?, T?> updater, CancellationToken ct)
+	public static ValueTask UpdateAsync<T>(this IState<T> state, Func<T?, T?> updater, CancellationToken ct = default)
 		where T : notnull
-		=> state.UpdateMessage(
+		=> state.UpdateMessageAsync(
 			m =>
 			{
 				var updatedValue = updater(m.CurrentData.SomeOrDefault());
@@ -32,6 +40,17 @@ partial class State
 			ct);
 
 	/// <summary>
+	/// [DEPRECATED] Use UpdateAsync instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use UpdateAsync")]
+#endif
+	public static ValueTask Update<T>(this IState<T> state, Func<T?, T?> updater, CancellationToken ct)
+		where T : notnull
+		=> UpdateAsync(state, updater, ct);
+
+	/// <summary>
 	/// Updates the value of a state
 	/// </summary>
 	/// <typeparam name="T">Type of the value of the state.</typeparam>
@@ -39,18 +58,28 @@ partial class State
 	/// <param name="updater">The update method to apply to the current value.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask UpdateData<T>(this IState<T> state, Func<Option<T>, Option<T>> updater, CancellationToken ct)
-		=> state.UpdateMessage(m => m.Data(updater(m.CurrentData)), ct);
+	public static ValueTask UpdateDataAsync<T>(this IState<T> state, Func<Option<T>, Option<T>> updater, CancellationToken ct = default)
+		=> state.UpdateMessageAsync(m => m.Data(updater(m.CurrentData)), ct);
 
 	/// <summary>
-	/// [DEPRECATED] Use UpdateData instead
+	/// [DEPRECATED] Use UpdateAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
-	[Obsolete("Use UpdateData")]
+	[Obsolete("Use UpdateDataAsync")]
+#endif
+	public static ValueTask UpdateData<T>(this IState<T> state, Func<Option<T>, Option<T>> updater, CancellationToken ct)
+		=> UpdateDataAsync(state, updater, ct);
+
+	/// <summary>
+	/// [DEPRECATED] Use UpdateDataAsync instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use UpdateDataAsync")]
 #endif
 	public static ValueTask UpdateValue<T>(this IState<T> state, Func<Option<T>, Option<T>> updater, CancellationToken ct)
-		=> UpdateData(state, updater, ct);
+		=> UpdateDataAsync(state, updater, ct);
 
 	/// <summary>
 	/// Sets the value of a state
@@ -60,9 +89,9 @@ partial class State
 	/// <param name="value">The value to set.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask Set<T>(this IState<T> state, T? value, CancellationToken ct)
+	public static ValueTask SetAsync<T>(this IState<T> state, T? value, CancellationToken ct = default)
 		where T : struct
-		=> state.UpdateMessage(m => m.Data(Option.SomeOrNone(value)), ct);
+		=> state.UpdateMessageAsync(m => m.Data(Option.SomeOrNone(value)), ct);
 
 	/// <summary>
 	/// Sets the value of a state
@@ -71,19 +100,29 @@ partial class State
 	/// <param name="value">The value to set.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask Set(this IState<string> state, string? value, CancellationToken ct)
-		=> state.UpdateMessage(m => m.Data(value is { Length: > 0 } ? value : Option<string>.None()), ct);
+	public static ValueTask SetAsync(this IState<string> state, string? value, CancellationToken ct = default)
+		=> state.UpdateMessageAsync(m => m.Data(value is { Length: > 0 } ? value : Option<string>.None()), ct);
 
 	/// <summary>
-	/// [DEPRECATED] Use .ForEachAsync instead
+	/// [DEPRECATED] Use SetAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
-	[Obsolete("Use ForEachAsync")]
+	[Obsolete("Use SetAsync")]
 #endif
-	public static IDisposable Execute<T>(this IState<T> state, AsyncAction<T?> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
-		where T : notnull
-		=> ForEachAsync(state, action, caller, line);
+	public static ValueTask Set<T>(this IState<T> state, T? value, CancellationToken ct)
+		where T : struct
+		=> SetAsync(state, value, ct);
+
+	/// <summary>
+	/// [DEPRECATED] Use SetAsync instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use SetAsync")]
+#endif
+	public static ValueTask Set(this IState<string> state, string? value, CancellationToken ct)
+		=> SetAsync(state, value, ct);
 
 	/// <summary>
 	/// Execute an async callback each time the state is being updated.
@@ -97,4 +136,15 @@ partial class State
 	public static IDisposable ForEachAsync<T>(this IState<T> state, AsyncAction<T?> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
 		where T : notnull
 		=> new StateForEach<T>(state, action, $"ForEachAsync defined in {caller} at line {line}.");
+
+	/// <summary>
+	/// [DEPRECATED] Use .ForEachAsync instead
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
+	[Obsolete("Use ForEachAsync")]
+#endif
+	public static IDisposable Execute<T>(this IState<T> state, AsyncAction<T?> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
+		where T : notnull
+		=> ForEachAsync(state, action, caller, line);
 }

--- a/src/Uno.Extensions.Reactive/Operators/ListFeedSelection.cs
+++ b/src/Uno.Extensions.Reactive/Operators/ListFeedSelection.cs
@@ -66,9 +66,9 @@ internal sealed class ListFeedSelection<TSource, TOther> : IListState<TSource>, 
 		=> Enable().GetSource(context, ct);
 
 	/// <inheritdoc />
-	public async ValueTask UpdateMessage(Action<MessageBuilder<IImmutableList<TSource>>> updater, CancellationToken ct)
+	public async ValueTask UpdateMessageAsync(Action<MessageBuilder<IImmutableList<TSource>>> updater, CancellationToken ct)
 		=> await Enable()
-			.UpdateMessage(
+			.UpdateMessageAsync(
 				u =>
 				{
 					var currentData = u.CurrentData;
@@ -148,7 +148,7 @@ internal sealed class ListFeedSelection<TSource, TOther> : IListState<TSource>, 
 			var items = implMsg.Current.Data.SomeOrDefault(ImmutableList<TSource>.Empty);
 
 			await _selectionState
-				.UpdateMessage(
+				.UpdateMessageAsync(
 					otherMsg =>
 					{
 						try

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.cs
@@ -179,7 +179,7 @@ public abstract partial class BindableViewModelBase : IBindable, INotifyProperty
 			// Here we also make sure to leave the UI thread so no matter the implementation of the State,
 			// we won't raise the State updated callbacks on the UI Thread.
 			await Task
-				.Run(async () => await stateImpl.UpdateMessage(DoUpdate, ct).ConfigureAwait(false), ct)
+				.Run(async () => await stateImpl.UpdateMessageAsync(DoUpdate, ct).ConfigureAwait(false), ct)
 				.ConfigureAwait(false);
 
 			void DoUpdate(MessageBuilder<TProperty> msg)

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/Input.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/Input.cs
@@ -27,8 +27,8 @@ internal sealed class Input<T> : IInput<T>
 		=> _state.GetSource(context, ct);
 
 	/// <inheritdoc />
-	public ValueTask UpdateMessage(Action<MessageBuilder<T>> updater, CancellationToken ct)
-		=> _state.UpdateMessage(
+	public ValueTask UpdateMessageAsync(Action<MessageBuilder<T>> updater, CancellationToken ct)
+		=> _state.UpdateMessageAsync(
 			msg =>
 			{
 				updater(msg);


### PR DESCRIPTION
## Feature
Uniformize public async API

## What is the current behavior?
* Rely only on IDE for async handling
* Enforce code quality by forcing usage of `CancellationToken`

## What is the new behavior?
* Suffix all method with `Async`
* Make `CancellationToken` optional

## PR Checklist

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
