### PR TITLE
chore: [MVUX] Enforce code analysis rules

### DIFF
--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
@@ -172,18 +172,18 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 		{
 			var originalCount = currentCount;
 
-			await pageTokens.WaitFor(requests.RequestMoreItems(desiredCount), ct);
+			await pageTokens.WaitFor(requests.RequestMoreItems(desiredCount), ct).ConfigureAwait(false);
 
 			var resultCount = currentCount;
 
 			return (uint)Math.Max(0, resultCount - originalCount);
 		}
 
-		async ValueTask SetSelected(SelectionInfo info, CancellationToken ct)
-			=> await state.UpdateMessageAsync(msg => msg.Selected(info).Set(BindableViewModelBase.BindingSource, collection), ct);
+		ValueTask SetSelected(SelectionInfo info, CancellationToken ct)
+			=> state.UpdateMessageAsync(msg => msg.Selected(info).Set(BindableViewModelBase.BindingSource, collection), ct);
 
-		async ValueTask Edit(Func<IDifferentialCollectionNode, IDifferentialCollectionNode> change, CancellationToken ct)
-			=> await state.UpdateMessageAsync(
+		ValueTask Edit(Func<IDifferentialCollectionNode, IDifferentialCollectionNode> change, CancellationToken ct)
+			=> state.UpdateMessageAsync(
 				msg =>
 				{
 					// Note: The change might have been computed on an older version of the collection
@@ -209,6 +209,6 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 	/// <inheritdoc />
 	public async ValueTask DisposeAsync()
 	{
-		await _state.DisposeAsync();
+		await _state.DisposeAsync().ConfigureAwait(false);
 	}
 }

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
@@ -75,7 +75,8 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 					(current, @params) => current
 						.With(@params.parentMsg)
 						.Data(@params.parentMsg.Current.Data.Map(_ => @params.collectionView)),
-					(parentMsg, collectionView)))
+					(parentMsg, collectionView),
+					ct))
 			{
 				yield return localMsg.Current;
 			}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/LoadMoreItemsRequest.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/LoadMoreItemsRequest.cs
@@ -35,7 +35,7 @@ internal class LoadMoreItemsRequest
 	{
 		try
 		{
-			return (await _result.Task).Count;
+			return (await _result.Task.ConfigureAwait(false)).Count;
 		}
 		catch (OperationCanceledException)
 		{

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/EditionService.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/EditionService.cs
@@ -37,8 +37,8 @@ internal class EditionService : IEditionService, IDisposable
 					var tcs = new TaskCompletionSource<object?>();
 					using var _ = _ct.Token.Register(() => tcs.TrySetCanceled());
 					dispatcher.TryEnqueue(() => tcs.TrySetResult(default));
-					await tcs.Task;
-					await Dequeue();
+					await tcs.Task.ConfigureAwait(false);
+					await Dequeue().ConfigureAwait(false);
 				},
 				_ct.Token);
 		}
@@ -51,12 +51,12 @@ internal class EditionService : IEditionService, IDisposable
 	private async Task Dequeue()
 	{
 		// Make sure we are not running multiple dequeue in //
-		using var _ = await _gate.LockAsync(_ct.Token);
+		using var _ = await _gate.LockAsync(_ct.Token).ConfigureAwait(false);
 
 		var editions = Interlocked.Exchange(ref _editions, ImmutableQueue<Func<IDifferentialCollectionNode, IDifferentialCollectionNode>>.Empty);
 		foreach (var edition in editions)
 		{
-			await _editFromView(edition, _ct.Token);
+			await _editFromView(edition, _ct.Token).ConfigureAwait(false);
 		}
 	}
 

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/PaginationService.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/PaginationService.cs
@@ -67,9 +67,9 @@ internal sealed class PaginationService : IPaginationService, IDisposable
 			throw new ObjectDisposedException(nameof(PaginationService));
 		}
 
-		using (await _gate.LockAsync(ct))
+		using (await _gate.LockAsync(ct).ConfigureAwait(false))
 		{
-			return await new LoadRequest(this, count).GetResult(ct);
+			return await new LoadRequest(this, count).GetResult(ct).ConfigureAwait(false);
 		}
 	}
 

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/SingletonServiceProvider.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Services/SingletonServiceProvider.cs
@@ -26,7 +26,7 @@ internal class SingletonServiceProvider : IServiceProvider, IAsyncDisposable
 			switch (service)
 			{
 				case IAsyncDisposable asyncDisposable:
-					await asyncDisposable.DisposeAsync();
+					await asyncDisposable.DisposeAsync().ConfigureAwait(false);
 					break;
 
 				case IDisposable disposable:

--- a/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispatcherQueueProvider.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispatcherQueueProvider.cs
@@ -47,13 +47,13 @@ public static class DispatcherQueueProvider
 
 			TryEnqueue(Execute);
 
-			return await tcs.Task;
+			return await tcs.Task.ConfigureAwait(false);
 
 			async void Execute()
 			{
 				try
 				{
-					tcs.TrySetResult(await action(ct));
+					tcs.TrySetResult(await action(ct).ConfigureAwait(false));
 				}
 				catch (Exception error)
 				{

--- a/src/Uno.Extensions.Reactive.UI/common.props
+++ b/src/Uno.Extensions.Reactive.UI/common.props
@@ -9,6 +9,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<EditorConfigFiles Include="../Uno.Extensions.Reactive/.editorconfig" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
 	</ItemGroup>
   

--- a/src/Uno.Extensions.Reactive/.editorconfig
+++ b/src/Uno.Extensions.Reactive/.editorconfig
@@ -1,0 +1,5 @@
+root = false
+
+[*.cs]
+dotnet_diagnostic.CA2007.severity = suggestion
+dotnet_diagnostic.CA2016.severity = error

--- a/src/Uno.Extensions.Reactive/.editorconfig
+++ b/src/Uno.Extensions.Reactive/.editorconfig
@@ -1,5 +1,5 @@
 root = false
 
 [*.cs]
-dotnet_diagnostic.CA2007.severity = suggestion
+dotnet_diagnostic.CA2007.severity = error
 dotnet_diagnostic.CA2016.severity = error

--- a/src/Uno.Extensions.Reactive/Core/Feed.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.T.cs
@@ -11,7 +11,7 @@ namespace Uno.Extensions.Reactive;
 /// Provides a set of static methods to create and manipulate <see cref="IFeed{T}"/>.
 /// </summary>
 /// <typeparam name="T">The type of the data.</typeparam>
-public static class Feed<T> // We set the T on the class to it greatly helps type inference of factory delegates
+public static partial class Feed<T> // We set the T on the class to it greatly helps type inference of factory delegates
 {
 	/// <summary>
 	/// Gets or create a custom feed from an async method.

--- a/src/Uno.Extensions.Reactive/Core/Feed.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.cs
@@ -242,10 +242,13 @@ public static partial class Feed
 					return ImmutableList<TResult>.Empty;
 				}
 
-				var items = await FeedExecution.Current!.GetPaginated<TResult>(
-					b => b
-						.ByIndex()
-						.GetPage((req, ct) => gp(value, req, ct)));
+				var items = await FeedExecution
+					.Current
+					!.GetPaginated<TResult>(
+						b => b
+							.ByIndex()
+							.GetPage((req, ct) => gp(value, req, ct)))
+					.ConfigureAwait(false);
 
 				return items;
 			});
@@ -280,10 +283,13 @@ public static partial class Feed
 					return ImmutableList<TResult>.Empty;
 				}
 
-				var items = await FeedExecution.Current!.GetPaginated<TResult>(
-					b => b
-						.ByCursor(args.firstPage)
-						.GetPage((token, count, ct) => args.getPage(value, token, count, ct)));
+				var items = await FeedExecution
+					.Current
+					!.GetPaginated<TResult>(
+						b => b
+							.ByCursor(args.firstPage)
+							.GetPage((token, count, ct) => args.getPage(value, token, count, ct)))
+					.ConfigureAwait(false);
 
 				return items;
 			});

--- a/src/Uno.Extensions.Reactive/Core/IFeed.cs
+++ b/src/Uno.Extensions.Reactive/Core/IFeed.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Uno.Extensions.Reactive;
 
@@ -7,7 +8,7 @@ namespace Uno.Extensions.Reactive;
 /// A **stateless** stream of data.
 /// </summary>
 /// <typeparam name="T">The type of the data.</typeparam>
-public interface IFeed<T> : ISignal<Message<T>>
-	/* where T : record */
+public partial interface IFeed<T> : ISignal<Message<T>>
+	/* where T : record or struct */
 {
 }

--- a/src/Uno.Extensions.Reactive/Core/Internal/FeedSubscription.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/FeedSubscription.cs
@@ -83,8 +83,8 @@ internal class FeedSubscription<T> : IAsyncDisposable, ISourceContextOwner
 	/// <inheritdoc />
 	public async ValueTask DisposeAsync()
 	{
-		await _context.DisposeAsync();
+		await _context.DisposeAsync().ConfigureAwait(false);
 		_requests.Dispose();
-		await _messages.DisposeAsync();
+		await _messages.DisposeAsync().ConfigureAwait(false);
 	}
 }

--- a/src/Uno.Extensions.Reactive/Core/Internal/SourceContext.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/SourceContext.cs
@@ -410,7 +410,7 @@ public sealed class SourceContext : IAsyncDisposable
 
 			// Note: We make sure dispose only the values explicitly defined on this context,
 			//		 but not those that are inherited from the parent context.
-			await (_localStates?.DisposeAsync() ?? default);
+			await (_localStates?.DisposeAsync() ?? default).ConfigureAwait(false);
 			_localRequests?.Dispose();
 		}
 		catch (Exception) { }

--- a/src/Uno.Extensions.Reactive/Core/Internal/StateImpl.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/StateImpl.cs
@@ -118,7 +118,7 @@ internal sealed class StateImpl<T> : IState<T>, IFeed<T>, IAsyncDisposable, ISta
 
 		var update = new Update(updater, _updatesKind);
 		_inner.Add(update);
-		await update.HasBeenApplied; // Makes sure to forward (the first) error to the caller if any.
+		await update.HasBeenApplied.ConfigureAwait(false); // Makes sure to forward (the first) error to the caller if any.
 	}
 
 	private void Enable()
@@ -144,7 +144,7 @@ internal sealed class StateImpl<T> : IState<T>, IFeed<T>, IAsyncDisposable, ISta
 		//		 This is a temporary patch until we support dynamic updates of the subscription mode in FeedSubscription (i.e. the _subscriptionMode).
 		if (_subscription is { } sub)
 		{
-			await sub.DisposeAsync();
+			await sub.DisposeAsync().ConfigureAwait(false);
 		}
 		_subscriptionMode?.Dispose();
 	}

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.Extensions.cs
@@ -80,7 +80,7 @@ public static partial class ListFeed
 		=> await FeedDependency.TryGetCurrentMessage(listFeed).ConfigureAwait(false) switch
 		{
 			{ } message => message.Current.EnsureNoError().Data,
-			null => await listFeed.Options(AsyncFeedValue.Default, ct).FirstOrDefaultAsync(Extensions.Option<IImmutableList<T>>.Undefined(), ct)
+			null => await listFeed.Options(AsyncFeedValue.Default, ct).FirstOrDefaultAsync(Extensions.Option<IImmutableList<T>>.Undefined(), ct).ConfigureAwait(false)
 		};
 
 	/// <summary>
@@ -96,7 +96,7 @@ public static partial class ListFeed
 		{
 			not null when kind is not AsyncFeedValue.Default => throw new NotSupportedException($"Only kind AsyncFeedValue.Default is currently supported by the dynamic feed (requested: {kind})."),
 			{ } message => message.Current.EnsureNoError().Data,
-			null => await listFeed.Options(kind, ct).FirstOrDefaultAsync(Extensions.Option<IImmutableList<T>>.Undefined(), ct)
+			null => await listFeed.Options(kind, ct).FirstOrDefaultAsync(Extensions.Option<IImmutableList<T>>.Undefined(), ct).ConfigureAwait(false)
 		};
 
 	/// <summary>
@@ -234,7 +234,7 @@ public static partial class ListFeed
 	/// <returns>The selected items, or an empty collection if none.</returns>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static async ValueTask<IImmutableList<T>> GetSelectedItems<T>(this IListFeed<T> source, CancellationToken ct)
-		=> (await source.Message(ct)).Current.GetSelectedItems();
+		=> (await source.Message(ct).ConfigureAwait(false)).Current.GetSelectedItems();
 
 	/// <summary>
 	/// Gets the selected item of a list feed, or null if none.
@@ -246,5 +246,5 @@ public static partial class ListFeed
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static async ValueTask<T?> GetSelectedItem<T>(this IListFeed<T> source, CancellationToken ct)
 		where T : notnull
-		=> (await source.Message(ct)).Current.GetSelectedItem();
+		=> (await source.Message(ct).ConfigureAwait(false)).Current.GetSelectedItem();
 }

--- a/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
@@ -228,7 +228,7 @@ static partial class ListState
 				success = true;
 				msg.Selected(selection);
 			}
-		}, ct);
+		}, ct).ConfigureAwait(false);
 
 		return success;
 	}
@@ -255,7 +255,7 @@ static partial class ListState
 				success = true;
 				msg.Selected(selection);
 			}
-		}, ct);
+		}, ct).ConfigureAwait(false);
 
 		return success;
 	}
@@ -267,9 +267,9 @@ static partial class ListState
 	/// <param name="state">The state to update.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static async ValueTask ClearSelectionAsync<T>(this IListState<T> state, CancellationToken ct = default)
+	public static ValueTask ClearSelectionAsync<T>(this IListState<T> state, CancellationToken ct = default)
 		where T : notnull
-		=> await state.UpdateMessageAsync(msg => msg.Selected(SelectionInfo.Empty), ct);
+		=> state.UpdateMessageAsync(msg => msg.Selected(SelectionInfo.Empty), ct);
 
 	/// <summary>
 	/// [DEPRECATED] Use .ClearSelectionAsync instead

--- a/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
+++ b/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
@@ -47,7 +47,7 @@ internal class FeedToListFeedAdapter<TCollection, TItem> : IListFeed<TItem>
 		var localMsg = new MessageManager<TCollection, IImmutableList<TItem>>();
 		await foreach (var parentMsg in context.GetOrCreateSource(_source).WithCancellation(ct).ConfigureAwait(false))
 		{
-			if (localMsg.Update(DoUpdate, parentMsg))
+			if (localMsg.Update(DoUpdate, parentMsg, ct))
 			{
 				yield return localMsg.Current;
 			}

--- a/src/Uno.Extensions.Reactive/Operators/HotSwapFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/HotSwapFeed.cs
@@ -63,7 +63,9 @@ internal sealed class HotSwapFeed<T> : IFeed<T>
 	/// <inheritdoc />
 	public async IAsyncEnumerable<Message<T>> GetSource(SourceContext context, [EnumeratorCancellation] CancellationToken ct = default)
 	{
+#pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task, false positive: it's for the DisposeAsync which cannot be configured here
 		await using var session = new Session(this, context, ct);
+#pragma warning restore CA2007
 		while (await session.MoveNextAsync().ConfigureAwait(false))
 		{
 			yield return session.Current;
@@ -109,7 +111,7 @@ internal sealed class HotSwapFeed<T> : IFeed<T>
 			{
 				var moveNext = enumerator.MoveNextAsync().AsTask();
 				if (await Task.WhenAny(moveNext, next.Task).ConfigureAwait(false) == moveNext
-					&& await moveNext)
+					&& await moveNext.ConfigureAwait(false))
 				{
 					var canSkip = !_isFirstMessage && _isFirstMessageOfCurrentEnumerator;
 

--- a/src/Uno.Extensions.Reactive/Operators/ListFeedSelection.cs
+++ b/src/Uno.Extensions.Reactive/Operators/ListFeedSelection.cs
@@ -199,7 +199,7 @@ internal sealed class ListFeedSelection<TSource, TOther> : IListState<TSource>, 
 		_ct.Cancel();
 		if (_impl is not null)
 		{
-			await _impl.DisposeAsync();
+			await _impl.DisposeAsync().ConfigureAwait(false);
 		}
 	}
 }

--- a/src/Uno.Extensions.Reactive/Operators/SelectAsyncFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/SelectAsyncFeed.cs
@@ -65,7 +65,7 @@ internal sealed class SelectAsyncFeed<TArg, TResult> : IFeed<TResult>
 				if (projection is not null)
 				{
 					// Make sure to await the end of the last projection before completing the subject!
-					await projection;
+					await projection.ConfigureAwait(false);
 				}
 				subject.Complete();
 			}

--- a/src/Uno.Extensions.Reactive/Operators/SelectFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/SelectFeed.cs
@@ -32,7 +32,7 @@ internal sealed class SelectFeed<TArg, TResult> : IFeed<TResult>
 		var localMsg = new MessageManager<TArg, TResult>();
 		await foreach (var parentMsg in context.GetOrCreateSource(_parent).WithCancellation(ct).ConfigureAwait(false))
 		{
-			if (localMsg.Update(DoUpdate, parentMsg))
+			if (localMsg.Update(DoUpdate, parentMsg, ct))
 			{
 				yield return localMsg.Current;
 			}

--- a/src/Uno.Extensions.Reactive/Operators/StateForEach.cs
+++ b/src/Uno.Extensions.Reactive/Operators/StateForEach.cs
@@ -49,7 +49,7 @@ internal sealed class StateForEach<T> : IDisposable
 
 		try
 		{
-			await _action(value, ct);
+			await _action(value, ct).ConfigureAwait(false);
 		}
 		catch (OperationCanceledException) when (ct.IsCancellationRequested)
 		{

--- a/src/Uno.Extensions.Reactive/Operators/WhereFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/WhereFeed.cs
@@ -32,7 +32,7 @@ internal sealed class WhereFeed<T> : IFeed<T>
 		var localMsg = new MessageManager<T, T>();
 		await foreach (var parentMsg in context.GetOrCreateSource(_parent).WithCancellation(ct).ConfigureAwait(false))
 		{
-			if (localMsg.Update(DoUpdate, parentMsg))
+			if (localMsg.Update(DoUpdate, parentMsg, ct))
 			{
 				yield return localMsg.Current;
 			}

--- a/src/Uno.Extensions.Reactive/Operators/WhereListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/WhereListFeed.cs
@@ -29,7 +29,7 @@ internal sealed class WhereListFeed<T> : IListFeed<T>
 		var localMsg = new MessageManager<IImmutableList<T>, IImmutableList<T>>();
 		await foreach (var parentMsg in context.GetOrCreateSource(_parent).WithCancellation(ct).ConfigureAwait(false))
 		{
-			if (localMsg.Update(DoUpdate, parentMsg))
+			if (localMsg.Update(DoUpdate, parentMsg, ct))
 			{
 				yield return localMsg.Current;
 			}

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/Bindable.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/Bindable.cs
@@ -209,7 +209,7 @@ public class Bindable<T> : IBindable, INotifyPropertyChanged, IFeed<T>
 			_asyncSetCt?.Cancel();
 			_asyncSetCt = new();
 
-			await _property.Update(_ => value, true, _asyncSetCt.Token);
+			await _property.Update(_ => value, true, _asyncSetCt.Token).ConfigureAwait(false);
 		}
 		catch (OperationCanceledException)
 		{
@@ -247,7 +247,7 @@ public class Bindable<T> : IBindable, INotifyPropertyChanged, IFeed<T>
 
 			// 2. Propagate the update to the parent (i.e. update the backing state)
 			// Note: We re-invoke the 'update' delegate here (instead of using the '_value') to make sure to respect ACID
-			await _property.Update(t => set(t, update(get(t))), false, ct);
+			await _property.Update(t => set(t, update(get(t))), false, ct).ConfigureAwait(false);
 		}
 	}
 

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableEnumerable.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableEnumerable.cs
@@ -172,7 +172,7 @@ public abstract class BindableEnumerable<TCollection, TItem, TBindableItem> : Bi
 					_owner.RaisePropertyChanged($"Item[{CurrentIndex}]");
 				}
 
-				await _owner._listProperty.Update(list => _owner.Replace(list, previous, updated), false, ct);
+				await _owner._listProperty.Update(list => _owner.Replace(list, previous, updated), false, ct).ConfigureAwait(false);
 			}
 		}
 

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindablePropertyInfo.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindablePropertyInfo.cs
@@ -56,7 +56,7 @@ public readonly struct BindablePropertyInfo<T>
 	{
 		if (CanWrite)
 		{
-			await _update!(updater, isLeafPropertyChanged, ct);
+			await _update!(updater, isLeafPropertyChanged, ct).ConfigureAwait(false);
 		}
 	}
 }

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.cs
@@ -133,7 +133,7 @@ public abstract partial class BindableViewModelBase : IBindable, INotifyProperty
 				updated(initialValue);
 				var ct = stateImpl.Context.Token;
 				var source = FeedUIHelper.GetSource(stateImpl, stateImpl.Context);
-				var dispatcher = await _dispatcher.GetFirstResolved(ct);
+				var dispatcher = await _dispatcher.GetFirstResolved(ct).ConfigureAwait(false);
 
 				dispatcher.TryEnqueue(async () =>
 				{
@@ -206,7 +206,7 @@ public abstract partial class BindableViewModelBase : IBindable, INotifyProperty
 	/// <inheritdoc />
 	public async ValueTask DisposeAsync()
 	{
-		await _disposables.DisposeAsync();
+		await _disposables.DisposeAsync().ConfigureAwait(false);
 		_propertyChanged.Dispose();
 		_dispatcher.Dispose();
 	}

--- a/src/Uno.Extensions.Reactive/Presentation/Commands/AsyncCommand.SubCommand.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Commands/AsyncCommand.SubCommand.cs
@@ -114,12 +114,12 @@ partial class AsyncCommand
 
 			var completed = 0;
 			var task = Task.Run(
-					async () =>
-					{
-						using var _ = context.AsCurrent();
-						await _config.Execute(coercedParameter, ct);
-					},
-					ct);
+				async () =>
+				{
+					using var _ = context.AsCurrent();
+					await _config.Execute(coercedParameter, ct).ConfigureAwait(false);
+				},
+				ct);
 
 			// Note: As the CT is cancelled when the command is disposed, we have to use a registration instead of a continuation
 			// to make sure `ReportExecutionEnded` is run synchronously so before the EventManager is being disposed!

--- a/src/Uno.Extensions.Reactive/Sources/AsyncFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/AsyncFeed.cs
@@ -110,7 +110,7 @@ internal sealed class AsyncFeed<T> : IFeed<T>
 				if (load is not null)
 				{
 					// Make sure to await the end of the last projection before completing the subject!
-					await load;
+					await load.ConfigureAwait(false);
 				}
 				subject.Complete();
 			}

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Feed/FeedDependency.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Feed/FeedDependency.cs
@@ -12,12 +12,12 @@ internal abstract class FeedDependency
 
 	public static async ValueTask<Message<T>?> TryGetCurrentMessage<T>(IFeed<T> feed)
 		=> FeedExecution.Current is { } exec
-			? await exec.Session.Feeds.Get(feed, exec).GetCurrentMessage(exec)
+			? await exec.Session.Feeds.Get(feed, exec).GetCurrentMessage(exec).ConfigureAwait(false)
 			: null;
 
 	public static async ValueTask<Message<IImmutableList<T>>?> TryGetCurrentMessage<T>(IListFeed<T> feed)
 		=> FeedExecution.Current is { } exec
-			? await exec.Session.Feeds.Get(feed, exec).GetCurrentMessage(exec)
+			? await exec.Session.Feeds.Get(feed, exec).GetCurrentMessage(exec).ConfigureAwait(false)
 			: null;
 
 	public static void NotifyTouched(IMessageEntry entry, MessageAxis axis)

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Pagination/PaginationDependency.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/Dependencies/Pagination/PaginationDependency.cs
@@ -101,7 +101,7 @@ internal class PaginationDependency<TItem> : IDependency
 
 		_gotItems = true;
 
-		using (await _gate.LockAsync(_ct.Token))
+		using (await _gate.LockAsync(_ct.Token).ConfigureAwait(false))
 		{
 			var (isPagination, req) = FindPaginationRequest(exec);
 			if (_pages is null // Initial load (req is then expected to be an InitialLoadRequest)
@@ -118,7 +118,7 @@ internal class PaginationDependency<TItem> : IDependency
 				return _items;
 			}
 
-			if (await _pages.MoveNextAsync(req?.DesiredPageSize))
+			if (await _pages.MoveNextAsync(req?.DesiredPageSize).ConfigureAwait(false))
 			{
 				// No needs to configure the _pageInfo, it has been done in the OnLoading method.
 				_items = _items.AddRange(_pages.Current);

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/FeedExecution.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/FeedExecution.cs
@@ -12,6 +12,11 @@ namespace Uno.Extensions.Reactive.Sources;
 internal abstract class FeedExecution : IAsyncDisposable
 {
 	private static readonly AsyncLocal<FeedExecution?> _current = new();
+
+	/// <summary>
+	/// Gets the current execution if any.
+	/// This is not null when used within a <see cref="DynamicFeed{T}"/> method, and null otherwise.
+	/// </summary>
 	public static FeedExecution? Current => _current.Value;
 
 	internal static CurrentSubscription SetCurrent(FeedExecution execution)

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/FeedSession.T.Execution.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/FeedSession.T.Execution.cs
@@ -101,13 +101,13 @@ internal sealed partial class FeedSession<TResult>
 			ValueTask<Option<TResult>> task = default;
 			try
 			{
-				await NotifyBegin();
+				await NotifyBegin().ConfigureAwait(false);
 
 				task = _session._mainAsyncAction(Token);
 			}
 			catch (OperationCanceledException) when (Token.IsCancellationRequested)
 			{
-				await NotifyEnd(FeedExecutionResult.Cancelled);
+				await NotifyEnd(FeedExecutionResult.Cancelled).ConfigureAwait(false);
 
 				lock (StateGate)
 				{
@@ -131,7 +131,7 @@ internal sealed partial class FeedSession<TResult>
 			}
 			catch (Exception error)
 			{
-				await NotifyEnd(FeedExecutionResult.Failed);
+				await NotifyEnd(FeedExecutionResult.Failed).ConfigureAwait(false);
 
 				lock (StateGate)
 				{
@@ -173,7 +173,7 @@ internal sealed partial class FeedSession<TResult>
 
 				if (Token.IsCancellationRequested)
 				{
-					await NotifyEnd(FeedExecutionResult.Cancelled);
+					await NotifyEnd(FeedExecutionResult.Cancelled).ConfigureAwait(false);
 					lock (StateGate)
 					{
 						// Even if we have been cancelled (because a new execution request has been queued),
@@ -224,7 +224,7 @@ internal sealed partial class FeedSession<TResult>
 			{
 				var data = await task.ConfigureAwait(false);
 
-				await NotifyEnd(FeedExecutionResult.Success);
+				await NotifyEnd(FeedExecutionResult.Success).ConfigureAwait(false);
 
 				lock (StateGate)
 				{
@@ -244,7 +244,7 @@ internal sealed partial class FeedSession<TResult>
 			}
 			catch (OperationCanceledException) when (Token.IsCancellationRequested)
 			{
-				await NotifyEnd(FeedExecutionResult.Cancelled);
+				await NotifyEnd(FeedExecutionResult.Cancelled).ConfigureAwait(false);
 
 				lock (StateGate)
 				{
@@ -256,7 +256,7 @@ internal sealed partial class FeedSession<TResult>
 			}
 			catch (Exception error)
 			{
-				await NotifyEnd(FeedExecutionResult.Failed);
+				await NotifyEnd(FeedExecutionResult.Failed).ConfigureAwait(false);
 
 				lock (StateGate)
 				{
@@ -292,7 +292,7 @@ internal sealed partial class FeedSession<TResult>
 			{
 				try
 				{
-					await dependency.OnExecuting(this, Token);
+					await dependency.OnExecuting(this, Token).ConfigureAwait(false);
 				}
 				catch (Exception e)
 				{
@@ -308,7 +308,7 @@ internal sealed partial class FeedSession<TResult>
 				try
 				{
 					// Note: No CT for the end notification (the current Token might already be cancelled).
-					await dependency.OnExecuted(this, result, default);
+					await dependency.OnExecuted(this, result, default).ConfigureAwait(false);
 				}
 				catch (Exception e)
 				{

--- a/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/ForEachRunner.cs
+++ b/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/ForEachRunner.cs
@@ -42,7 +42,7 @@ internal sealed class ForEachRunner<T> : IForEachRunner
 
 		try
 		{
-			await _enumeratorProvider().ForEachAwaitAsync(async item => await _asyncAction(item, _enumerationToken.Token), _enumerationToken.Token);
+			await _enumeratorProvider().ForEachAwaitAsync(async item => await _asyncAction(item, _enumerationToken.Token).ConfigureAwait(false), _enumerationToken.Token).ConfigureAwait(false);
 		}
 		catch (OperationCanceledException)
 		{

--- a/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/RefCountedForEachRunner.cs
+++ b/src/Uno.Extensions.Reactive/Utils/AsyncEnumerables/RefCountedForEachRunner.cs
@@ -112,7 +112,7 @@ internal sealed class RefCountedForEachRunner<T> : IForEachRunner
 
 		try
 		{
-			await _enumeratorProvider().ForEachAwaitAsync(async item => await _asyncAction(item, ct), ct);
+			await _enumeratorProvider().ForEachAwaitAsync(async item => await _asyncAction(item, ct).ConfigureAwait(false), ct).ConfigureAwait(false);
 		}
 		catch (OperationCanceledException)
 		{

--- a/src/Uno.Extensions.Reactive/Utils/AsyncOperationManager/LastWinsAsyncOperationManager.cs
+++ b/src/Uno.Extensions.Reactive/Utils/AsyncOperationManager/LastWinsAsyncOperationManager.cs
@@ -76,7 +76,7 @@ internal sealed class LastWinsAsyncOperationManager : IAsyncOperationsManager
 	{
 		try
 		{
-			await operation(ct);
+			await operation(ct).ConfigureAwait(false);
 		}
 		catch (OperationCanceledException) when (ct.IsCancellationRequested)
 		{

--- a/src/Uno.Extensions.Reactive/Utils/AsyncOperationManager/SequentialAsyncOperationsManager.cs
+++ b/src/Uno.Extensions.Reactive/Utils/AsyncOperationManager/SequentialAsyncOperationsManager.cs
@@ -116,7 +116,7 @@ internal sealed class SequentialAsyncOperationsManager : IAsyncOperationsManager
 
 			try
 			{
-				await operation(_ct.Token);
+				await operation(_ct.Token).ConfigureAwait(false);
 			}
 			catch (OperationCanceledException) when (_ct.IsCancellationRequested)
 			{

--- a/src/Uno.Extensions.Reactive/Utils/Disposables/CompositeAsyncDisposable.cs
+++ b/src/Uno.Extensions.Reactive/Utils/Disposables/CompositeAsyncDisposable.cs
@@ -52,7 +52,7 @@ internal sealed class CompositeAsyncDisposable : ICollection<IAsyncDisposable>, 
 		var (isRemoved, asyncDispose) = RemoveCore(item);
 		if (isRemoved)
 		{
-			await asyncDispose;
+			await asyncDispose.ConfigureAwait(false);
 			return true;
 		}
 		else

--- a/src/Uno.Extensions.Reactive/Utils/OptionExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/OptionExtensions.cs
@@ -40,16 +40,16 @@ internal static class OptionExtensions
 	#region AsyncFunc
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static AsyncFunc<Option<T>> SomeOrNoneWhenNotNull<T>(this AsyncFunc<T> func)
-		=> async ct => Option.SomeOrNone(await func(ct));
+		=> async ct => Option.SomeOrNone(await func(ct).ConfigureAwait(false));
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static AsyncFunc<Option<T>> SomeOrNone<T>(this AsyncFunc<T?> func)
-		=> async ct => Option.SomeOrNone(await func(ct));
+		=> async ct => Option.SomeOrNone(await func(ct).ConfigureAwait(false));
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static AsyncFunc<Option<T>> SomeOrNone<T>(this AsyncFunc<T?> func)
 		where T : struct
-		=> async ct => Option.SomeOrNone(await func(ct));
+		=> async ct => Option.SomeOrNone(await func(ct).ConfigureAwait(false));
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static AsyncFunc<Option<T>, Option<TResult>> SomeOrNoneWhenNotNull<T, TResult>(this AsyncFunc<T, TResult> func)


### PR DESCRIPTION
Based on https://github.com/unoplatform/uno.extensions/pull/2080 which needs to be merged first

## Other
Make MVUX compliant with CA2007 and CA2016

## What is the current behavior?
* CA2007: Possible irrelevant thread swicthing
* CA2016: Might forget CT propagation

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
