### PR TITLE
fix: free viewmodel and prevent caching of page on back

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
@@ -28,6 +28,7 @@ public class FrameNavigator : ControlNavigator<Frame>, IStackNavigator
 
 		if (Control is not null)
 		{
+			Control.Navigating += Frame_Navigating;
 			Control.Navigated += Frame_Navigated;
 		}
 	}
@@ -248,6 +249,22 @@ public class FrameNavigator : ControlNavigator<Frame>, IStackNavigator
 
 		return responseRoute;
 	}
+
+	private void Frame_Navigating(object sender, NavigatingCancelEventArgs e)
+	{
+		if( e.NavigationMode==NavigationMode.Back &&
+			!e.Cancel &&
+			Control?.Content is Page currentPage)
+		{
+			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Frame has navigating to previous page");
+
+			// Force ViewModel to be unset
+			currentPage.DataContext = null;
+			// Force page to be disposed
+			currentPage.NavigationCacheMode = NavigationCacheMode.Disabled;
+		}
+	}
+
 
 	private void Frame_Navigated(object sender, NavigationEventArgs e)
 	{

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOneViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveOneViewModel.cs
@@ -11,7 +11,7 @@ public partial record ReactiveOneViewModel (INavigator Navigator)
 
 	public async Task GoToTwoData()
 	{
-		await Navigator.NavigateDataAsync(this, data:new TwoModel(new ReactiveWidget("From Two",56)));
+		await Navigator.NavigateDataAsync(this, data:new TwoModel(new ReactiveWidget("From One",56)));
 	}
 
 	public async Task GoToThree()
@@ -21,7 +21,7 @@ public partial record ReactiveOneViewModel (INavigator Navigator)
 
 	public async Task GoToThreeData()
 	{
-		await Navigator.NavigateDataAsync(this, data: new ThreeModel(new ReactiveWidget("From Three", 56)));
+		await Navigator.NavigateDataAsync(this, data: new ThreeModel(new ReactiveWidget("From One", 56)));
 	}
 
 	public async Task ShowDialog()

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveThreePage.xaml
@@ -7,6 +7,7 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	NavigationCacheMode="Required"
 	mc:Ignorable="d">
 
 	<Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveTwoPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Reactive/ReactiveTwoPage.xaml
@@ -7,6 +7,7 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:uen="using:Uno.Extensions.Navigation.UI"
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	NavigationCacheMode="Required"
 	mc:Ignorable="d">
 	<Grid>
 		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Reactive/Given_Reactive.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Reactive/Given_Reactive.cs
@@ -91,10 +91,21 @@ public class Given_Reactive : NavigationTestBase
 
 		App.WaitElement("OnePageToTwoPageViewModelButton");
 		var screenBefore = TakeScreenshot("When_PageNavigationViewModel_Before");
+
+		// Iterate through pages 1 to 3 - this caused an issue
+		// where NavigationCacheMode is set to required
+		// see https://github.com/unoplatform/uno.extensions/issues/2097
+		App.WaitThenTap("OnePageToTwoPageViewModelButton");
+		App.WaitThenTap("TwoPageToThreePageViewModelButton");
+		App.WaitThenTap("ThreePageBackViewModelButton");
+		App.WaitThenTap("TwoPageBackViewModelButton");
+		App.WaitElement("OnePageToTwoPageViewModelButton");
+
+
 		App.WaitThenTap("OnePageToThreePageDataButton");
 		App.WaitElement("ThreePageWidgetNameTextBlock");
 		var text = App.GetText("ThreePageWidgetNameTextBlock");
-		Assert.AreEqual("From Three", text);
+		Assert.AreEqual("From One", text);
 
 		App.WaitThenTap("ThreePageBackViewModelButton");
 		text = App.GetText("TwoPageWidgetNameTextBlock");


### PR DESCRIPTION
GitHub Issue (If applicable): fixes: https://github.com/unoplatform/uno.extensions/issues/2097

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

When navigating back both page instance and attached viewmodel are cached, and are used when navigating back to the same page

## What is the new behavior?

Page and viewmodel are disposed, so the next back operation will cause new instance of page and viewmodel to be created

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
