### PR TITLE
Only provide extensions for the Source type

### DIFF
--- a/src/Uno.Extensions.Maui.WinUI.Markup/AssemblyInfo.cs
+++ b/src/Uno.Extensions.Maui.WinUI.Markup/AssemblyInfo.cs
@@ -1,4 +1,0 @@
-﻿using Uno.Extensions.Markup.Generator;
-using Uno.Extensions.Maui;
-
-[assembly: GenerateMarkupForAssembly(typeof(MauiHost))]

--- a/src/Uno.Extensions.Maui.WinUI.Markup/MauiHostMarkupExtensions.cs
+++ b/src/Uno.Extensions.Maui.WinUI.Markup/MauiHostMarkupExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System.Runtime.CompilerServices;
+using Uno.Extensions.Markup.Internals;
+
+namespace Uno.Extensions.Maui;
+
+public static class MauiHostMarkupExtensions
+{
+	[MarkupExtension]
+	public static MauiHost Source(this MauiHost host, Type type)
+	{
+		if (!type.IsSubclassOf(typeof(VisualElement)))
+			throw new InvalidOperationException("The source Type must be of type VisualElement");
+
+		host.Source = type;
+		return host;
+	}
+
+	[MarkupExtension]
+	public static MauiHost Source<TView>(this MauiHost host)
+		where TView : VisualElement =>
+		Source(host, typeof(TView));
+
+	[MarkupExtension]
+	public static MauiHost Source(this MauiHost host, Action<IDependencyPropertyBuilder<Type>> configureProperty)
+	{
+		DependencyPropertyBuilder<Type> instance = DependencyPropertyBuilder<Type>.Instance;
+		configureProperty(instance);
+		instance.SetBinding(host, MauiHost.SourceProperty, "Source");
+		return host;
+	}
+
+	[MarkupExtension]
+	public static MauiHost Source<TSource>(this MauiHost host, Func<TSource> propertyBinding, [CallerArgumentExpression("propertyBinding")]string? propertyBindingExpression = null) =>
+		host.Source(x => x.Bind(propertyBinding, propertyBindingExpression));
+
+	[MarkupExtension]
+	public static MauiHost Source<TSource>(this MauiHost host, Func<TSource> propertyBinding, Func<TSource, Type> convertDelegate, [CallerArgumentExpression("propertyBinding")] string? propertyBindingExpression = null) =>
+		host.Source(x => x.Bind(propertyBinding, propertyBindingExpression).Convert(convertDelegate));
+}

--- a/src/Uno.Extensions.Maui.WinUI.Markup/Uno.Extensions.Maui.WinUI.Markup.csproj
+++ b/src/Uno.Extensions.Maui.WinUI.Markup/Uno.Extensions.Maui.WinUI.Markup.csproj
@@ -3,7 +3,6 @@
 
 	<PropertyGroup>
 		<UseMaui>true</UseMaui>
-		<RootNamespace>Uno.Extensions.Maui</RootNamespace>
 		<NoWarn>$(NoWarn);NU5104;NU5048;NU1009;NU1504;CS0436</NoWarn>
 		<Description>Extensions to embed .NET MAUI controls within your Uno app using C# Markup.</Description>
 		<!--Temporary disable missing XML doc until fixed in the whole package-->
@@ -18,7 +17,6 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" />
 		<PackageReference Include="Uno.WinUI.Markup" />
-		<PackageReference Include="Uno.Extensions.Markup.Generators" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- Build error when using Uno.Extensions.Maui.Markup

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Building with the Markup library results in errors like:
```
2>C:\samples\reference\TubePlayer\TubePlayer\Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\GlobalStaticResources.cs(49,5,49,54): error CS0433: The type 'GlobalStaticResources' exists in both 'Uno.Extensions.Maui.WinUI.Markup, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null' and 'Uno.Extensions.Maui.WinUI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null'
2>C:\samples\reference\TubePlayer\TubePlayer\Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\GlobalStaticResources.cs(50,5,50,54): error CS0433: The type 'GlobalStaticResources' exists in both 'Uno.Extensions.Maui.WinUI.Markup, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null' and 'Uno.Extensions.Maui.WinUI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null'
2>C:\samples\reference\TubePlayer\TubePlayer\Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\GlobalStaticResources.cs(72,5,72,54): error CS0433: The type 'GlobalStaticResources' exists in both 'Uno.Extensions.Maui.WinUI.Markup, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null' and 'Uno.Extensions.Maui.WinUI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null'
2>C:\samples\reference\TubePlayer\TubePlayer\Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\GlobalStaticResources.cs(73,5,73,54): error CS0433: The type 'GlobalStaticResources' exists in both 'Uno.Extensions.Maui.WinUI.Markup, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null' and 'Uno.Extensions.Maui.WinUI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null'
2>C:\samples\reference\TubePlayer\TubePlayer\Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\GlobalStaticResources.cs(95,5,95,54): error CS0433: The type 'GlobalStaticResources' exists in both 'Uno.Extensions.Maui.WinUI.Markup, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null' and 'Uno.Extensions.Maui.WinUI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null'
2>C:\samples\reference\TubePlayer\TubePlayer\Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\GlobalStaticResources.cs(96,5,96,54): error CS0433: The type 'GlobalStaticResources' exists in both 'Uno.Extensions.Maui.WinUI.Markup, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null' and 'Uno.Extensions.Maui.WinUI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null'
2>Done building project "TubePlayer.csproj" -- FAILED.
```

## What is the new behavior?

This should be fixed now. We also are removing the generator as we only really want to be providing extensions around the Source Property. This also allows us to provide an extension for the Source with a Generic Type.

```cs
// Provide a type
new MauiHost().Source(typeof(MyControl));

// Provide a type using Generics
new MauiHost().Source<MyControl>();

// Provide a type from a binding (for the love of god don't do this...)
new MauiHost().Source(() => vm.MyType);

// Provide a type from a binding with a converter
new MauiHost().Source(() => vm.MyProp, prop => prop.SomeCondition() ? typeof(MyControl) : typeof(MyOtherControl));
```
```
