### PR TITLE
fix: Add AdditionalFiles metadata to ensure proper deduplication

### DIFF
--- a/src/Uno.Extensions.Navigation/build/Package.targets
+++ b/src/Uno.Extensions.Navigation/build/Package.targets
@@ -1,6 +1,6 @@
 <Project>
 	<ItemGroup>
-		<AdditionalFiles Include="@(Page)" />
+		<AdditionalFiles Include="@(Page)" SourceItemGroup="Page" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(ImplicitUsings)' == 'true' OR '$(ImplicitUsings)' == 'enable' ">
 		<Using Include="Uno.Extensions.Navigation" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change aligns `AdditionalFiles` with `_InjectAdditionalFiles` from Uno source generators, which may duplicate content based on the absence of `SourceItemGroup`.

This would cause hot reload to fail silently because of duplicate `AdditionalFiles` entries.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
