### PR TITLE
fix: restrict AdditionalFiles to wasdk only

### DIFF
--- a/src/Uno.Extensions.Navigation/build/Package.targets
+++ b/src/Uno.Extensions.Navigation/build/Package.targets
@@ -1,5 +1,5 @@
 <Project>
-	<ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.Contains('windows10'))">
 		<AdditionalFiles Include="@(Page)" SourceItemGroup="Page" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(ImplicitUsings)' == 'true' OR '$(ImplicitUsings)' == 'enable' ">


### PR DESCRIPTION
This change avoids a de-deduplication issue in uno sourcegen tasks, and allows for hot reload to work until uno deduplication is fixed.