### PR TITLE
feat: Adding ClosableNavigator to close dialog/flyout when attempting to navigate to unsupported route

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -201,6 +201,13 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 		request = request with { Route = route };
 
 		if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Building fully qualified route for unhandled request. New request: {request.Route}");
+
+		if(Region.Navigator() is ClosableNavigator closable)
+		{
+			if (Logger.IsEnabled(LogLevel.Trace)) Logger.LogTraceMessage($"Closing navigator and redirecting request");
+			return closable.CloseAndNavigateAsync(request);
+		}
+
 		return Region.NavigateAsync(request);
 
 	}

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ClosableNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ClosableNavigator.cs
@@ -1,0 +1,55 @@
+﻿namespace Uno.Extensions.Navigation.Navigators;
+
+/// <summary>
+/// Defines a Navigator that can be closed, with requests being
+/// routed to the Navigator that was used to create/launch the Navigator
+/// </summary>
+public abstract class ClosableNavigator : ControlNavigator
+{
+	private INavigator? Source { get; set; }
+
+	/// <summary>
+	/// Creates new instance of ClosableNavigator
+	/// </summary>
+	/// <param name="logger">Logger for logging output</param>
+	/// <param name="dispatcher">Dispatcher for thread access</param>
+	/// <param name="region">The corresponding Region</param>
+	/// <param name="resolver">The route resolver</param>
+	protected ClosableNavigator(ILogger logger, IDispatcher dispatcher, IRegion region, IRouteResolver resolver) : base(logger, dispatcher, region, resolver)
+	{
+	}
+
+	/// <inheritdoc/>
+	protected override async Task<Route?> ExecuteRequestAsync(NavigationRequest request)
+	{
+		// Capture the source from the initial navigation, which will open the dialog/flyout
+		// so that it can be used to forward navigation requests to.
+		Source ??= request.Source;
+
+		return default;
+	}
+
+	/// <summary>
+	/// Closes the current dialog or flyout and then navigates using the Navigator
+	/// that originally opened the dialog/flyout
+	/// </summary>
+	/// <param name="request">The request to direct to the source Navigator</param>
+	/// <returns>The navigation response</returns>
+	public async Task<NavigationResponse?> CloseAndNavigateAsync(NavigationRequest request)
+	{
+		await CloseNavigator();
+
+		if (Source is null)
+		{
+			return default;
+		}
+
+		return await Source.NavigateAsync(request);
+	}
+
+	/// <summary>
+	/// Closes the current navigator (for use in CloseAndNavigate
+	/// </summary>
+	/// <returns>Task that can be awaited</returns>
+	protected abstract Task CloseNavigator();
+}

--- a/src/Uno.Extensions.Navigation.UI/Navigators/DialogNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/DialogNavigator.cs
@@ -1,6 +1,6 @@
 ﻿namespace Uno.Extensions.Navigation.Navigators;
 
-public abstract class DialogNavigator : ControlNavigator
+public abstract class DialogNavigator : ClosableNavigator
 {
 	public override bool CanGoBack => ShowTask is not null;
 
@@ -21,6 +21,9 @@ public abstract class DialogNavigator : ControlNavigator
 
 	protected override async Task<Route?> ExecuteRequestAsync(NavigationRequest request)
 	{
+		// Capture the Source - return value can be ignored
+		_ = await base.ExecuteRequestAsync(request);
+
 		var route = request.Route;
 
 		// Make sure any existing dialogs are closed
@@ -59,4 +62,6 @@ public abstract class DialogNavigator : ControlNavigator
 	}
 
 	protected abstract Task<IAsyncInfo?> DisplayDialog(NavigationRequest request, Type? viewType, object? viewModel);
+	protected override async Task CloseNavigator() => CloseDialog();
+
 }

--- a/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FlyoutNavigator.cs
@@ -1,6 +1,6 @@
 ﻿namespace Uno.Extensions.Navigation.Navigators;
 
-public class FlyoutNavigator : ControlNavigator
+public class FlyoutNavigator : ClosableNavigator
 {
 	public override bool CanGoBack => _flyout is not null;
 
@@ -35,6 +35,9 @@ public class FlyoutNavigator : ControlNavigator
 
 	protected override async Task<Route?> ExecuteRequestAsync(NavigationRequest request)
 	{
+		// Capture the Source - return value can be ignored
+		_ = await base.ExecuteRequestAsync(request);
+
 		if (Region.Services is null)
 		{
 			return default;
@@ -194,5 +197,7 @@ public class FlyoutNavigator : ControlNavigator
 	}
 
 	protected override Task CheckLoadedAsync() => _flyout is not null && _content is not null ? _content.EnsureLoaded() : Task.CompletedTask;
+
+	protected override async Task CloseNavigator() => CloseFlyout();
 
 }

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsPage.xaml
@@ -39,6 +39,10 @@
 						uen:Navigation.Request="!DialogsComplex/DialogsComplexDialogSecond"
 						Content="Complex Dialog Nav Request - Second Page" />
 
+
+				<Button AutomationProperties.AutomationId="ComplexDialogSecondPageButton"
+					uen:Navigation.Request="ContentDialogsSecond"
+					Content="Complex Dialog - Second Page" />
 			</StackPanel>
 		</ScrollViewer>
 	</Grid>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsPage.xaml.cs
@@ -1,5 +1,5 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
+
 public sealed partial class ContentDialogsPage : Page
 {
 	public ContentDialogsPage()

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsSecondPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsSecondPage.xaml
@@ -1,0 +1,34 @@
+﻿<Page x:Class="TestHarness.Ext.Navigation.Dialogs.ContentDialogsSecondPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.Dialogs"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  xmlns:utu="using:Uno.Toolkit.UI"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<utu:NavigationBar Content="Content Dialogs - Second Page"
+						   AutomationProperties.AutomationId="DialogsContentDialogsSecondPage" >
+			<utu:NavigationBar.MainCommand>
+				<AppBarButton>
+					<AppBarButton.Icon>
+						<BitmapIcon UriSource="ms-appx:///Assets/Icons/back.png" />
+					</AppBarButton.Icon>
+				</AppBarButton>
+			</utu:NavigationBar.MainCommand>
+		</utu:NavigationBar>
+
+		<ScrollViewer Grid.Row="1">
+			<StackPanel>
+
+			</StackPanel>
+		</ScrollViewer>
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsSecondPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsSecondPage.xaml
@@ -15,9 +15,9 @@
 			<RowDefinition />
 		</Grid.RowDefinitions>
 		<utu:NavigationBar Content="Content Dialogs - Second Page"
-						   AutomationProperties.AutomationId="DialogsContentDialogsSecondPage" >
+						   AutomationProperties.AutomationId="DialogsContentDialogsSecondPageNavigationBar" >
 			<utu:NavigationBar.MainCommand>
-				<AppBarButton>
+				<AppBarButton AutomationProperties.AutomationId="DialogsContentDialogsSecondPageBackButton">
 					<AppBarButton.Icon>
 						<BitmapIcon UriSource="ms-appx:///Assets/Icons/back.png" />
 					</AppBarButton.Icon>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsSecondPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsSecondPage.xaml.cs
@@ -1,5 +1,5 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
+
 public sealed partial class ContentDialogsSecondPage : Page
 {
 	public ContentDialogsSecondPage()

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsSecondPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/ContentDialogsSecondPage.xaml.cs
@@ -1,0 +1,9 @@
+﻿
+namespace TestHarness.Ext.Navigation.Dialogs;
+public sealed partial class ContentDialogsSecondPage : Page
+{
+	public ContentDialogsSecondPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsBasicFlyout.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsBasicFlyout.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 public sealed partial class DialogsBasicFlyout : Page
 {

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexDialog.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexDialog.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 public sealed partial class DialogsComplexDialog : ContentDialog
 {

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexDialogFirstPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexDialogFirstPage.xaml
@@ -24,6 +24,10 @@
 			<Button AutomationProperties.AutomationId="ComplexDialogFirstPageCloseButton"
 					Content="Close dialog"
 					Command="{Binding CloseCommand}" />
+			<Button AutomationProperties.AutomationId="ComplexDialogFirstPageCloseAndSecondButton"
+				uen:Navigation.Request="ContentDialogsSecond"
+				Content="Close dialog and then Second page" />
+			
 		</StackPanel>
 	</Grid>
 </Page>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyout.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyout.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 public sealed partial class DialogsComplexFlyout : Flyout
 {

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOnePage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutOnePage.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 public sealed partial class DialogsComplexFlyoutOnePage : Page
 {

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutTwoPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsComplexFlyoutTwoPage.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 public sealed partial class DialogsComplexFlyoutTwoPage : Page
 {

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsPage.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 public sealed partial class DialogsFlyoutsPage : Page
 {

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsFlyoutsViewModel.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 public partial class DialogsFlyoutsViewModel
 {

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsHostInit.cs
@@ -37,6 +37,8 @@ public class DialogsHostInit : BaseHostInitialization
 			);
 
 		views.Register(
+			new ViewMap<ContentDialogsPage>(),
+			new ViewMap<ContentDialogsSecondPage>(),
 			new ViewMap<DialogsFlyoutsPage, DialogsFlyoutsViewModel>(),
 			new ViewMap<DialogsComplexDialog>(),
 			new ViewMap<DialogsComplexDialogFirstPage, DialogsComplexDialogFirstViewModel>(),
@@ -54,11 +56,13 @@ public class DialogsHostInit : BaseHostInitialization
 			new RouteMap("",
 			Nested: new[]
 			{
+				new RouteMap("ContentDialogs", View: views.FindByView<ContentDialogsPage>()),
+				new RouteMap("ContentDialogsSecond", View: views.FindByView<ContentDialogsSecondPage>(), DependsOn:"ContentDialogs"),
 				new RouteMap("DialogsFlyouts", View: views.FindByViewModel<DialogsFlyoutsViewModel>()),
 				new RouteMap("DialogsComplex", View: views.FindByView<DialogsComplexDialog>(), Nested: new[]
 				{
 					new RouteMap("DialogsComplexDialogFirst", View: views.FindByViewModel<DialogsComplexDialogFirstViewModel>(), IsDefault:true),
-					new RouteMap("DialogsComplexDialogSecond", View: views.FindByViewModel<DialogsComplexDialogSecondViewModel>())
+					new RouteMap("DialogsComplexDialogSecond", View: views.FindByViewModel<DialogsComplexDialogSecondViewModel>(), DependsOn: "DialogsComplexDialogFirst")
 				}),
 				new RouteMap("DialogsComplexFlyout", View: views.FindByView<DialogsComplexFlyout>(), Nested: new[]
 				{

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsHostInit.cs
@@ -1,6 +1,4 @@
-﻿
-
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 public class DialogsHostInit : BaseHostInitialization
 {

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsMainPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsMainPage.xaml.cs
@@ -1,6 +1,4 @@
-﻿
-
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 [TestSectionRoot("Dialogs", TestSections.Navigation_Dialogs, typeof(DialogsHostInit))]
 public sealed partial class DialogsMainPage : BaseTestSectionPage

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsSimpleDialog.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsSimpleDialog.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 public sealed partial class DialogsSimpleDialog : ContentDialog
 {

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsSimpleViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/DialogsSimpleViewModel.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 public class DialogsSimpleViewModel
 {

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/LocalizedDialogsPage.xaml.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/Dialogs/LocalizedDialogsPage.xaml.cs
@@ -1,5 +1,4 @@
-﻿
-namespace TestHarness.Ext.Navigation.Dialogs;
+﻿namespace TestHarness.Ext.Navigation.Dialogs;
 
 public sealed partial class LocalizedDialogsPage : Page
 {

--- a/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
+++ b/testing/TestHarness/TestHarness.Shared/TestHarness.Shared.projitems
@@ -210,6 +210,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\ContentDialogsPage.xaml.cs">
       <DependentUpon>ContentDialogsPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\ContentDialogsSecondPage.xaml.cs">
+      <DependentUpon>ContentDialogsSecondPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsBasicFlyout.xaml.cs">
       <DependentUpon>DialogsBasicFlyout.xaml</DependentUpon>
     </Compile>
@@ -548,6 +551,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\ContentDialogsSecondPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Ext\Navigation\Dialogs\DialogsBasicFlyout.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -746,7 +753,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </_Globbled_Page>
-<Page Include="@(_Globbled_Page)">
+    <Page Include="@(_Globbled_Page)">
       <SubType>Designer</SubType>
     </Page>
     <_Globbed_Compile Include="$(MSBuildThisFileDirectory)**/*.xaml.cs" Exclude="@(Compile)">

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Dialogs/Given_ContentDialog.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Dialogs/Given_ContentDialog.cs
@@ -69,4 +69,33 @@ public class Given_ContentDialog : NavigationTestBase
 		ImageAssert.AreEqual(screenBefore, screenClosed, tolerance: PixelTolerance.Exclusive(Constants.DefaultPixelTolerance));
 	}
 
+
+	[Test]
+	public async Task When_ComplexContentDialogNavigateSecondPage()
+	{
+		InitTestSection(TestSections.Navigation_Dialogs);
+
+		App.WaitThenTap("ContentDialogsButton");
+
+		App.WaitElement("DialogsContentDialogsPage");
+
+		var screenBefore = TakeScreenshot("When_Dialog_Before");
+		App.Tap("ComplexDialogNavRequestButton");
+		var screenAfter = TakeScreenshot("When_Dialog_After");
+		ImageAssert.AreNotEqual(screenBefore, screenAfter);
+
+		App.WaitElement("ComplexDialogFirstPageNavigationBar");
+
+		App.Tap("ComplexDialogFirstPageCloseAndSecondButton");
+
+		App.WaitElement("DialogsContentDialogsSecondPageNavigationBar");
+
+		App.Tap("DialogsContentDialogsSecondPageBackButton");
+
+		await Task.Delay(AppExtensions.UIWaitTimeInMilliseconds);
+
+		var screenClosed = TakeScreenshot("When_Dialog_Closed");
+		ImageAssert.AreEqual(screenBefore, screenClosed, tolerance: PixelTolerance.Exclusive(Constants.DefaultPixelTolerance));
+	}
+
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1394

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

No easy way to navigate from inside a dialog/flyout to a route in the main window of the application. This should close the dialog/flyout

## What is the new behavior?

If the route can't be navigated to within the dialog (eg the route isn't part of the routemap for the route already open in the dialog/route), the navigation request is forwarded to the navigator that initially opened the dialog/flyout. The Dialog/Flyout is also closed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

