### PR TITLE
fix: Adding caching for generated route maps

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/RouteInfoExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteInfoExtensions.cs
@@ -1,0 +1,53 @@
+﻿namespace Uno.Extensions.Navigation;
+
+internal static class RouteInfoExtensions
+{
+	internal static RouteInfo[] Ancestors(this RouteInfo routeInfo, IRouteResolver resolver)
+	{
+		var routes = new List<RouteInfo>();
+		routeInfo.NavigatorAncestors(resolver, routes);
+		return routes.ToArray();
+	}
+
+	private static void NavigatorAncestors(this RouteInfo routeInfo, IRouteResolver resolver, IList<RouteInfo> routes)
+	{
+		routes.Insert(0, routeInfo);
+
+		while (routeInfo?.DependsOnRoute is { } dependee)
+		{
+			routes.Insert(0, dependee);
+			routeInfo = dependee;
+		}
+
+		if (routeInfo?.Parent is { } parent)
+		{
+			parent.NavigatorAncestors(resolver, routes);
+		}
+	}
+
+	internal static RouteInfo[] Ancestors(this INavigator navigator, IRouteResolver resolver)
+	{
+		var routes = new List<RouteInfo>();
+		navigator.NavigatorAncestors(resolver, routes);
+		return routes.ToArray();
+	}
+
+	private static void NavigatorAncestors(this INavigator navigator, IRouteResolver resolver, IList<RouteInfo> routes)
+	{
+		var route = (navigator is IStackNavigator deepNav) ? deepNav.FullRoute : navigator?.Route;
+		while (!(route?.IsEmpty() ?? true))
+		{
+			var info = resolver.FindByPath(route.Base);
+			if (info is not null)
+			{
+				routes.Insert(0, info);
+			}
+			route = route.Next();
+		}
+
+		if (navigator?.GetParent() is { } parent)
+		{
+			parent.NavigatorAncestors(resolver, routes);
+		}
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
@@ -136,7 +136,7 @@ public class RouteResolver : IRouteResolver
 	{
 		if (viewType is null)
 		{
-			return false; ;
+			return false;
 		}
 
 		return viewType == typeof(MessageDialog) ||
@@ -147,9 +147,7 @@ public class RouteResolver : IRouteResolver
 	}
 
 	public RouteInfo? FindByPath(string? path)
-	{
-		return InternalFindByPath(path);
-	}
+		=> InternalFindByPath(path);
 
 	protected virtual RouteInfo? InternalFindByPath(string? path)
 	{
@@ -175,7 +173,8 @@ public class RouteResolver : IRouteResolver
 		{
 			return default;
 		}
-		else if (maps.Length == 1 ||
+
+		if (maps.Length == 1 ||
 			navigator is null)
 		{
 			return maps[0];
@@ -205,9 +204,7 @@ public class RouteResolver : IRouteResolver
 	}
 
 	protected virtual RouteInfo[] InternalFindByViewModel(Type? viewModelType)
-	{
-		return FindRouteByType(viewModelType, map => map.ViewModel);
-	}
+		=> FindRouteByType(viewModelType, map => map.ViewModel);
 
 	public RouteInfo? FindByView(Type? viewType, INavigator? navigator)
 	{
@@ -216,9 +213,7 @@ public class RouteResolver : IRouteResolver
 	}
 
 	protected virtual RouteInfo[] InternalFindByView(Type? viewType)
-	{
-		return FindRouteByType(viewType, map => map.RenderView);
-	}
+		=>FindRouteByType(viewType, map => map.RenderView);
 
 	public RouteInfo? FindByData(Type? dataType, INavigator? navigator)
 	{
@@ -233,65 +228,8 @@ public class RouteResolver : IRouteResolver
 	}
 
 	private RouteInfo[] FindRouteByType(Type? typeToFind, Func<RouteInfo, Type?> mapType)
-	{
-		return FindByInheritedTypes(Mappings, typeToFind, mapType);
-	}
+		=> FindByInheritedTypes(Mappings, typeToFind, mapType);
 
 	private TMap[] FindByInheritedTypes<TMap>(IList<TMap> mappings, Type? typeToFind, Func<TMap, Type?> mapType)
-	{
-		return mappings.FindByInheritedTypes(typeToFind, mapType);
-	}
-}
-
-public static class TempHelpers
-{
-	internal static RouteInfo[] Ancestors(this RouteInfo routeInfo, IRouteResolver resolver)
-	{
-		var routes = new List<RouteInfo>();
-		routeInfo.NavigatorAncestors(resolver, routes);
-		return routes.ToArray();
-	}
-
-	private static void NavigatorAncestors(this RouteInfo routeInfo, IRouteResolver resolver, IList<RouteInfo> routes)
-	{
-		routes.Insert(0, routeInfo);
-
-		while (routeInfo?.DependsOnRoute is { } dependee)
-		{
-			routes.Insert(0, dependee);
-			routeInfo = dependee;
-		}
-
-		if (routeInfo?.Parent is { } parent)
-		{
-			parent.NavigatorAncestors(resolver, routes);
-		}
-	}
-
-
-	internal static RouteInfo[] Ancestors(this INavigator navigator, IRouteResolver resolver)
-	{
-		var routes = new List<RouteInfo>();
-		navigator.NavigatorAncestors(resolver, routes);
-		return routes.ToArray();
-	}
-
-	private static void NavigatorAncestors(this INavigator navigator, IRouteResolver resolver, IList<RouteInfo> routes)
-	{
-		var route = (navigator is IStackNavigator deepNav) ? deepNav.FullRoute : navigator?.Route;
-		while (!(route?.IsEmpty() ?? true))
-		{
-			var info = resolver.FindByPath(route.Base);
-			if (info is not null)
-			{
-				routes.Insert(0, info);
-			}
-			route = route.Next();
-		}
-
-		if (navigator?.GetParent() is { } parent)
-		{
-			parent.NavigatorAncestors(resolver, routes);
-		}
-	}
+		=> mappings.FindByInheritedTypes(typeToFind, mapType);
 }

--- a/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
@@ -213,7 +213,7 @@ public class RouteResolver : IRouteResolver
 	}
 
 	protected virtual RouteInfo[] InternalFindByView(Type? viewType)
-		=>FindRouteByType(viewType, map => map.RenderView);
+		=> FindRouteByType(viewType, map => map.RenderView);
 
 	public RouteInfo? FindByData(Type? dataType, INavigator? navigator)
 	{

--- a/src/Uno.Extensions.Navigation.UI/RouteResolverDefault.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteResolverDefault.cs
@@ -110,6 +110,7 @@ public class RouteResolverDefault : RouteResolver
 												});
 			Mappings.Add(defaultMapFromViewMap);
 			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Created default mapping from viewmap - Path '{defaultMapFromViewMap.Path}'");
+			return defaultMapFromViewMap;
 		}
 
 		if (Logger.IsEnabled(LogLevel.Information)) Logger.LogInformationMessage($"For better performance (avoid reflection), create mapping for for path '{path}', view '{view?.Name}', view model '{viewModel?.Name}'");
@@ -134,6 +135,7 @@ public class RouteResolverDefault : RouteResolver
 				return IsDialogViewType(view);
 			});
 			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($"Created default mapping - Path '{defaultMap.Path}'");
+			Mappings.Add(defaultMap);
 			return defaultMap;
 		}
 

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarHomePage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarHomePage.xaml
@@ -21,6 +21,7 @@
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
 			<RowDefinition />
 		</Grid.RowDefinitions>
 		<utu:NavigationBar Content="TabBar Home"
@@ -29,8 +30,9 @@
 				   Grid.Row="1"
 				   x:Name="CurrentTabBarItemText"
 				   AutomationProperties.AutomationId="CurrentTabBarItemTextBlock" />
+		<ToggleButton Grid.Row="2" Content="ImplicitMapping" IsChecked="{Binding ImplicitMappingEnabled}" Command="{Binding ToggleIsCheckedCommand}" />
 		<Grid uen:Region.Attached="true"
-							 Grid.Row="2" >
+							 Grid.Row="3" >
 			<Grid.RowDefinitions>
 				<RowDefinition />
 				<RowDefinition Height="Auto" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarHomeViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Navigation/TabBar/TabBarHomeViewModel.cs
@@ -1,6 +1,22 @@
 ﻿namespace TestHarness.Ext.Navigation.TabBar;
 
-public record TabBarHomeViewModel(INavigator Navigator)
+public partial class TabBarHomeViewModel : ObservableObject
 {
+	private RouteResolverDefault routeResolver;
+	public TabBarHomeViewModel(IServiceProvider services)
+	{
+		routeResolver = services.GetRequiredService<RouteResolverDefault>();
+		ImplicitMappingEnabled = routeResolver.ReturnImplicitMapping;
+	}
+
+	[ObservableProperty]
+	private bool _implicitMappingEnabled;
+
+	[RelayCommand]
+	public void ToggleIsChecked()
+	{
+		routeResolver.ReturnImplicitMapping = !routeResolver.ReturnImplicitMapping;
+		ImplicitMappingEnabled = routeResolver.ReturnImplicitMapping;
+	}
 }
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2129

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Generated route maps aren't always being added to the Mappings in memory cache

## What is the new behavior?

Generated route maps are added to cache

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
