### PR TITLE
chore: allow loading Uno.Extensions.sln into VS Code / DevKit

### DIFF
--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Skia.Wpf/Uno.Extensions.RuntimeTests.Skia.Wpf.csproj
@@ -6,6 +6,7 @@
 		<UseWPF>true</UseWPF>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 		<DefineConstants>$(DefineConstants);WINDOWS_WINUI</DefineConstants>
+		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 
 		<!--Avoids conflicts with Uno namespace-->
 		<RootNamespace>RuntimeTests</RootNamespace>

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Windows/Uno.Extensions.RuntimeTests.Windows.csproj
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests.Windows/Uno.Extensions.RuntimeTests.Windows.csproj
@@ -12,6 +12,7 @@
 		<EnableMsixTooling>true</EnableMsixTooling>
 		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 		<DefineConstants>$(DefineConstants);WINDOWS_WINUI;WINUI</DefineConstants>
+		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 
 		<!-- Comment this out if you want to handle distributing the WinAppSdk -->
 		<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

VS Code w/Dev Kit **cannot** load Uno.Extension.sln successfully outside of Windows

## What is the new behavior?

VS Code w/Dev Kit can load Uno.Extension.sln successfully


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
