### PR TITLE
docs: Add required entitlements for iOS and Catalyst

### DIFF
--- a/doc/Learn/Authentication/HowTo-Authentication.md
+++ b/doc/Learn/Authentication/HowTo-Authentication.md
@@ -39,7 +39,10 @@ uid: Uno.Extensions.Authentication.HowToAuthentication
     }
     ```
 
-- Update `MainPage` to accept input via `TextBox` with a binding expression to connect to the `Username` property on the view model. The `Button` is also bound to the `Authenticate` method.
+> [!TIP]
+> On Apple platforms (iOS, Mac Catalyst) the Uno storage extension, used by the authentication extension, use the OS Key Chain service to store secrets. This requires your application to have the [proper entitlements](xref:Uno.Extensions.Storage.HowToRequiredEntitlements) to work properly.
+
+- Update `MainPage` to accept input via `TextBox` with a binding expression to connect to the `Username` property on the view model. The `Button` is also bound to the `Authenticate` method. 
 
     ```xml
     <TextBox Text="{Binding Username, Mode=TwoWay}" />

--- a/doc/Learn/Storage/HowTo-RequiredEntitlements.md
+++ b/doc/Learn/Storage/HowTo-RequiredEntitlements.md
@@ -40,6 +40,9 @@ Adding the `Entitlements.plist` to your project is not enough. You must also add
 * [Microsoft iOS](https://learn.microsoft.com/en-us/dotnet/maui/ios/capabilities?#add-capabilities-in-your-apple-developer-account)
 * [Microsoft Mac Catalyst](https://learn.microsoft.com/en-us/dotnet/maui/mac-catalyst/capabilities?#add-capabilities-in-your-apple-developer-account)
 
+> [!CHEAT]
+> You can use XCode to create a project, go to the **Signing and Capabilities**, use the same bundle identifier, add the **Keychain Sharing** capacity (again using the same bundle identifier) then ask Xcode to _fix_ your `Xcode Managed Profile`.
+
 ### 3. Modifying the `*.Mobile.csproj`
 
 A new property group should be added to your `*.csproj` project file. The example below will work for both iOS and Mac Catalyst targets.
@@ -54,6 +57,9 @@ A new property group should be added to your `*.csproj` project file. The exampl
 ```
 
 The values for the `CodesignKey` and `CodesignProvision` **must** match the values from the [Apple Developer Portal](https://developer.apple.com/account).
+
+> [!CHEAT]
+> If you used Xcode earlier then build the application and get both values from the build logs.
 
 ### 4. Rebuilding your application
 

--- a/doc/Learn/Storage/HowTo-RequiredEntitlements.md
+++ b/doc/Learn/Storage/HowTo-RequiredEntitlements.md
@@ -1,0 +1,64 @@
+---
+uid: Uno.Extensions.Storage.HowToRequiredEntitlements
+---
+# How-To: Adding Required Entitlements
+
+On Apple platforms (iOS, Mac Catalyst) the Uno storage extension use the OS Key Chain service to store secrets. This requires your application to have the [`keychain-access-groups`](https://developer.apple.com/documentation/bundleresources/entitlements/keychain-access-groups) entitlement to work properly.
+
+## Step-by-steps
+
+> [!IMPORTANT]
+> This guide assumes you used the template wizard or `dotnet new unoapp` to create your solution. If not, it is recommended that you follow the [instructions](xref:Uno.Extensions.HowToGettingStarted) for creating an application from the template.
+
+### 1. Adding the Entitlements.plist file
+
+The default location, inside your project, for the new file(s) should be:
+
+* iOS: `iOS/Entitlements.plist`
+* Mac Catalyst: `MacCatalyst/Entitlements.plist`
+
+The content of the file(s) should be:
+
+```xml
+<key>keychain-access-groups</key> 
+ <array> 
+ 	<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string> 
+ </array>
+```
+
+For more information see Apple's documentation related to the [Key Chain](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps?language=objc).
+
+The variables `$(AppIdentifierPrefix)` and `$(CFBundleIdentifier)` will be replaced with the correct values at build time. For more information about how the Microsoft .NET SDK works with entitlements you can consult:
+
+* [Microsoft iOS](https://learn.microsoft.com/en-us/dotnet/maui/ios/entitlements)
+* [Microsoft Mac Catalyst](https://learn.microsoft.com/en-us/dotnet/maui/mac-catalyst/entitlements)
+
+### 2. Add capabilities in your Apple Developer Account
+
+Adding the `Entitlements.plist` to your project is not enough. You must also add the capability inside your Apple Developer Account and create a provisioning profile specific for your application. You can follow Microsoft's instruction for both steps:
+
+* [Microsoft iOS](https://learn.microsoft.com/en-us/dotnet/maui/ios/capabilities?#add-capabilities-in-your-apple-developer-account)
+* [Microsoft Mac Catalyst](https://learn.microsoft.com/en-us/dotnet/maui/mac-catalyst/capabilities?#add-capabilities-in-your-apple-developer-account)
+
+### 3. Modifying the `*.Mobile.csproj`
+
+A new property group should be added to your `*.csproj` project file. The example below will work for both iOS and Mac Catalyst targets.
+
+```xml
+<PropertyGroup>
+    <CodesignEntitlements Condition="$(IsIOS)">iOS\Entitlements.plist</CodesignEntitlements>
+    <CodesignEntitlements Condition="$(IsMacCatalyst)">MacCatalyst\Entitlements.plist</CodesignEntitlements>
+    <CodesignKey>Apple Development: Some User (XXXXXXXXXX)</CodesignKey>
+    <CodesignProvision>Mac Catalyst Team Provisioning Profile: com.companyname.maccatalyst</CodesignProvision>
+</PropertyGroup>
+```
+
+The values for the `CodesignKey` and `CodesignProvision` **must** match the values from the [Apple Developer Portal](https://developer.apple.com/account).
+
+### 4. Rebuilding your application
+
+Finally rebuilding the application for your target(s) will now code sign your application. This makes the entitlements valid and allow the Key Chain API to work properly at runtime.
+
+### 5. Troubleshooting
+
+Code signing issues can be difficult to diagnose as the application won't start (or hang) if misconfigured. The operating systems (both iOS or macOS) will log code signing failures. You can see the logs by using Apple's [Console.app](https://support.apple.com/en-ca/guide/console/welcome/mac).

--- a/doc/Learn/Storage/StorageOverview.md
+++ b/doc/Learn/Storage/StorageOverview.md
@@ -1,0 +1,8 @@
+---
+uid: Uno.Extensions.Storage.Overview
+---
+
+# Storage
+
+> [!IMPORTANT]
+> On Apple platforms (iOS, Mac Catalyst) the Uno storage extension, used by the authentication extension, use the OS Key Chain service to store secrets. This requires your application to have the [proper entitlements](xref:Uno.Extensions.Storage.HowToRequiredEntitlements) to work properly.

--- a/doc/Learn/Storage/toc.yml
+++ b/doc/Learn/Storage/toc.yml
@@ -1,0 +1,4 @@
+- name: Overview
+  href: xref:Uno.Extensions.Serialization.Overview
+- name: "How-To: Get started with serialization"
+  href: xref:Uno.Extensions.Serialization.HowToSerialization

--- a/doc/toc.yml
+++ b/doc/toc.yml
@@ -32,6 +32,9 @@
     - name: Serialization
       href: Learn/Serialization/toc.yml
       topicHref: xref:Uno.Extensions.Serialization.Overview
+    - name: Storage
+      href: Learn/Storage/toc.yml
+      topicHref: xref:Uno.Extensions.Storage.Overview
     - name: Validation
       href: Learn/Validation/toc.yml
       topicHref: xref:Uno.Extensions.Validation.Overview

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyChainKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyChainKeyValueStorage.cs
@@ -216,11 +216,11 @@ internal record KeyChainKeyValueStorage(
 		}
 	}
 
-	static internal void LogEntitlementsError()
+	internal void LogEntitlementsError()
 	{
-		if (typeof(KeyChainKeyValueStorage).Log().IsEnabled(LogLevel.Error))
+		if (Logger.IsEnabled(LogLevel.Error))
 		{
-			typeof(KeyChainKeyValueStorage).Log().Error(
+			Logger.LogErrorMessage(
 				"Failed to save to the KeyChain. " +
 				"See https://aka.platform.uno/missing-keychain-entitlement for more details."
 			);
@@ -429,7 +429,7 @@ internal record KeyChainKeyValueStorage(
 				// -34018 -> A required entitlement isn't present.
 				if (status == (SecStatusCode)(-34018))
 				{
-					KeyChainKeyValueStorage.LogEntitlementsError();
+					_parent.LogEntitlementsError();
 				}
 
 				throw new SecurityException(status);

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyChainKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/KeyChainKeyValueStorage.cs
@@ -200,13 +200,7 @@ internal record KeyChainKeyValueStorage(
 				{
 					if (status == SecStatusCode.Param)
 					{
-						if (Logger.IsEnabled(LogLevel.Error))
-						{
-							this.Log().Error(
-							   "Failed to save to the iOS KeyChain. " +
-							   "Make sure an Entitlements.plist file has been provided in the Bundle Signing properties of your project."
-						   );
-						}
+						LogEntitlementsError();
 					}
 
 					throw new SecurityException(status);
@@ -219,6 +213,17 @@ internal record KeyChainKeyValueStorage(
 		if (Logger.IsEnabled(LogLevel.Information))
 		{
 			Logger.LogInformationMessage($"Value for key '{name}' set.");
+		}
+	}
+
+	static internal void LogEntitlementsError()
+	{
+		if (typeof(KeyChainKeyValueStorage).Log().IsEnabled(LogLevel.Error))
+		{
+			typeof(KeyChainKeyValueStorage).Log().Error(
+				"Failed to save to the KeyChain. " +
+				"See https://aka.platform.uno/missing-keychain-entitlement for more details."
+			);
 		}
 	}
 
@@ -421,6 +426,12 @@ internal record KeyChainKeyValueStorage(
 			var status = SecKeyChain.Update(_record, newRecord);
 			if (status != SecStatusCode.Success)
 			{
+				// -34018 -> A required entitlement isn't present.
+				if (status == (SecStatusCode)(-34018))
+				{
+					KeyChainKeyValueStorage.LogEntitlementsError();
+				}
+
 				throw new SecurityException(status);
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2126

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

On Apple platforms authentication can fail if the required entitlements are not present for the app. However there's no useful logs nor any documentation about what's required to make it work.

## What is the new behavior?

At runtime logs will include an URL to the related documentation using https://aka.platform.uno/missing-keychain-entitlement

This document explains what is needed and how to set this up for the application.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
