### PR TITLE
feat: Add ability to refresh an IState

### DIFF
--- a/src/Uno.Extensions.Core.Generators/Compat/CompatibilityTypesGenerationContext.cs
+++ b/src/Uno.Extensions.Core.Generators/Compat/CompatibilityTypesGenerationContext.cs
@@ -10,6 +10,7 @@ internal record CompatibilityTypesGenerationContext(
 	[ContextType("System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute?")] INamedTypeSymbol? DynamicallyAccessedMembersAttribute,
 	[ContextType("System.Diagnostics.CodeAnalysis.MaybeNullAttribute?")] INamedTypeSymbol? MaybeNullAttribute, // .net std 2.1 and above
 	[ContextType("System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute?")] INamedTypeSymbol? MaybeNullWhenAttribute, // .net std 2.1 and above
+	[ContextType("System.Diagnostics.CodeAnalysis.MemberNotNullAttribute?")] INamedTypeSymbol? MemberNotNullAttribute, // .net std 2.1 and above
 	[ContextType("System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute?")] INamedTypeSymbol? MemberNotNullWhenAttribute, // .net std 2.1 and above
 	[ContextType("System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute?")] INamedTypeSymbol? NotNullIfNotNullAttribute, // .net std 2.1 and above
 	[ContextType("System.Diagnostics.CodeAnalysis.NotNullWhenAttribute?")] INamedTypeSymbol? NotNullWhenAttribute, // .net std 2.1 and above

--- a/src/Uno.Extensions.Core.Generators/Compat/CompatibilityTypesGenerationTool.cs
+++ b/src/Uno.Extensions.Core.Generators/Compat/CompatibilityTypesGenerationTool.cs
@@ -33,6 +33,10 @@ internal class CompatibilityTypesGenerationTool : ICodeGenTool
 		{
 			yield return (nameof(_context.MaybeNullWhenAttribute), GetMaybeNullWhenAttribute());
 		}
+		if (!(_context.MemberNotNullWhenAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableMemberNotNullAttribute"))
+		{
+			yield return (nameof(_context.MemberNotNullAttribute), GetMemberNotNullAttribute());
+		}
 		if (!(_context.MemberNotNullWhenAttribute?.IsAccessibleTo(assembly) ?? false) && !GetIsDisabled("UnoExtensionsGeneration_DisableMemberNotNullWhenAttribute"))
 		{
 			yield return (nameof(_context.MemberNotNullWhenAttribute), GetMemberNotNullWhenAttribute());
@@ -238,6 +242,40 @@ internal class CompatibilityTypesGenerationTool : ICodeGenTool
 					{{
 						ParameterName = parameterName;
 					}}
+				}}
+			}}
+			".Align(0);
+
+	private string GetMemberNotNullAttribute()
+		=> $@"{this.GetFileHeader(3)}
+
+			// Note: You can disable the generation of this file by setting in your project the property
+			//		 <UnoExtensionsGeneration_DisableMemberNotNullAttribute>true</UnoExtensionsGeneration_DisableMemberNotNullAttribute>
+
+			using global::System;
+
+			namespace System.Diagnostics.CodeAnalysis
+			{{
+				/// <summary>Specifies that the method or property will ensure that the listed field and property members have values that aren't <see langword=""null"" />.</summary>
+				[global::System.AttributeUsage(global::System.AttributeTargets.Method | global::System.AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+				internal sealed class MemberNotNullAttribute : global::System.Attribute
+				{{
+					/// <summary>Initializes the attribute with a field or property member.</summary>
+					/// <param name=""member"">The field or property member that is promised to be non-null.</param>
+					public MemberNotNullAttribute(string member)
+					{{
+						Members = new string[1] {{ member }};
+					}}
+
+					/// <summary>Initializes the attribute with the list of field and property members.</summary>
+					/// <param name=""members"">The list of field and property members that are promised to be non-null.</param>
+					public MemberNotNullAttribute(params string[] members)
+					{{
+						Members = members;
+					}}
+
+					/// <summary>Gets field or property member names.</summary>
+					public string[] Members {{ get; }}
 				}}
 			}}
 			".Align(0);

--- a/src/Uno.Extensions.Core.Generators/buildTransitive/Uno.Extensions.Core.props
+++ b/src/Uno.Extensions.Core.Generators/buildTransitive/Uno.Extensions.Core.props
@@ -4,6 +4,7 @@
 		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableDynamicallyAccessedMembersAttribute" />
 		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableMaybeNullAttribute" />
 		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableMaybeNullWhenAttribute" />
+		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableMemberNotNullAttribute" />
 		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableMemberNotNullWhenAttribute" />
 		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableNotNullIfNotNullAttribute" />
 		<CompilerVisibleProperty Include="UnoExtensionsGeneration_DisableNotNullWhenAttribute" />

--- a/src/Uno.Extensions.Reactive.Messaging/StateExtensions.cs
+++ b/src/Uno.Extensions.Reactive.Messaging/StateExtensions.cs
@@ -129,11 +129,11 @@ public static class StateExtensions
 	/// </summary>
 	/// <typeparam name="T">Type of the value of the state.</typeparam>
 	/// <param name="listState">The list state to refresh.</param>
-	/// <param name="ct">An cancellation to abort the asynchronous operation, cf. remarks for details.</param>
+	/// <param name="ct"> A cancellation to abort the asynchronous operation, cf. remarks for details.</param>
 	/// <returns>An asynchronous boolean indicating if the source has been refreshed or not.</returns>
 	/// <remarks>
 	/// Cancelling the <paramref name="ct"/> will only cancel the wait for the refreshed message on state, but it won't cancel the refresh itself.
-	/// Once refreshed has been requested, it cannot be cancelled.
+	/// Once refreshed has been requested, it cannot be canceled.
 	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
 	public static async ValueTask<bool> TryRefreshAsync<T>(this IListState<T> listState, CancellationToken ct = default)

--- a/src/Uno.Extensions.Reactive.Messaging/StateExtensions.cs
+++ b/src/Uno.Extensions.Reactive.Messaging/StateExtensions.cs
@@ -116,7 +116,10 @@ public static class StateExtensions
 
 		var awaiter = new TokenSetAwaiter<RefreshToken>();
 		var refreshed = awaiter.WaitFor(req, ct);
-		var messageListener = state.GetSource(state.Context, ct).ForEachAsync(msg => awaiter.Received(msg.Current.Get(MessageAxis.Refresh)), ct);
+		var messageListener = state
+			.GetSource(state.Context, ct)
+			.Where(msg => !msg.Current.IsTransient)
+			.ForEachAsync(msg => awaiter.Received(msg.Current.Get(MessageAxis.Refresh)), ct);
 
 		return await Task.WhenAny(refreshed, messageListener) == refreshed;
 	}
@@ -143,7 +146,10 @@ public static class StateExtensions
 
 		var awaiter = new TokenSetAwaiter<RefreshToken>();
 		var refreshed = awaiter.WaitFor(req, ct);
-		var messageListener = listState.GetSource(listState.Context, ct).ForEachAsync(msg => awaiter.Received(msg.Current.Get(MessageAxis.Refresh)), ct);
+		var messageListener = listState
+			.GetSource(listState.Context, ct)
+			.Where(msg => !msg.Current.IsTransient)
+			.ForEachAsync(msg => awaiter.Received(msg.Current.Get(MessageAxis.Refresh)), ct);
 
 		return await Task.WhenAny(refreshed, messageListener) == refreshed;
 	}

--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_StateRefresh.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_StateRefresh.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Messaging;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Operators;
+
+[TestClass]
+public class Given_StateRefresh : FeedTests
+{
+	[TestMethod]
+	public async Task When_RequestRefreshRefreshableFeed_Then_ReturnsTrueAndGetUpdatedValue()
+	{
+		var src = Feed.Async(async _ => 42);
+		var sut = new StateImpl<int>(Context, src);
+		var result = sut.Record();
+
+		await result.Should().BeAsync(m => m
+			.Message(42, Error.No, Progress.Final));
+
+		sut.RequestRefresh().Should().BeTrue();
+
+		await result.Should().BeAsync(m => m
+			.Message(42, Error.No, Progress.Final)
+			.Message(42, Error.No, Progress.Final, Refreshed.Is(1)));
+	}
+
+	[TestMethod]
+	public async Task When_RequestRefreshNonRefreshableFeed_Then_ReturnsFalseAndNoUpdate()
+	{
+		static async IAsyncEnumerable<Message<int>> GetMessages([EnumeratorCancellation] CancellationToken ct)
+		{
+			yield return Message<int>.Initial.With().Data(42);
+		}
+
+		var src = Feed.Create(GetMessages);
+		var sut = new StateImpl<int>(Context, src);
+		var result = sut.Record();
+
+		await result.Should().BeAsync(m => m
+			.Message(42, Error.No, Progress.Final));
+
+		sut.RequestRefresh().Should().BeFalse();
+
+		await result.Should().BeAsync(m => m
+			.Message(42, Error.No, Progress.Final));
+	}
+
+	[TestMethod]
+	public async Task When_TryRefreshAsyncRefreshableFeed_Then_ReturnsTrueAndTaskCompleteWhenGetValue()
+	{
+		var value = new TaskCompletionSource<int>(CT);
+		var src = Feed.Async(async _ => await value.Task.ConfigureAwait(false));
+		var sut = new StateImpl<int>(Context, src);
+		var result = sut.Record();
+
+		await result.Should().BeAsync(m => m
+			.Message(Data.Undefined, Error.No, Progress.Transient)
+		);
+
+		value.SetResult(42);
+
+		await result.Should().BeAsync(m => m
+			.Message(Data.Undefined, Error.No, Progress.Transient)
+			.Message(42, Error.No, Progress.Final)
+		);
+
+		value = new TaskCompletionSource<int>(CT);
+		var request = sut.TryRefreshAsync();
+
+		await result.Should().BeAsync(m => m
+			.Message(Data.Undefined, Error.No, Progress.Transient)
+			.Message(42, Error.No, Progress.Final)
+			.Message(42, Error.No, Progress.Transient)
+		);
+		request.IsCompleted.Should().BeFalse();
+
+		value.SetResult(43);
+
+		await result.Should().BeAsync(m => m
+			.Message(Data.Undefined, Error.No, Progress.Transient)
+			.Message(42, Error.No, Progress.Final)
+			.Message(42, Error.No, Progress.Transient)
+			.Message(43, Error.No, Progress.Final)
+		);
+		(await request).Should().BeTrue(); // Check async as completion is ran from another thread.
+	}
+
+	[TestMethod]
+	public async Task When_TryRefreshAsyncNonRefreshableFeed_Then_ReturnsFalseSyncAndNoUpdate()
+	{
+		static async IAsyncEnumerable<Message<int>> GetMessages([EnumeratorCancellation] CancellationToken ct)
+		{
+			yield return Message<int>.Initial.With().Data(42);
+		}
+
+		var src = Feed.Create(GetMessages);
+		var sut = new StateImpl<int>(Context, src);
+		var result = sut.Record();
+
+		await result.Should().BeAsync(m => m
+			.Message(42, Error.No, Progress.Final)
+		);
+
+		var request = sut.TryRefreshAsync();
+		request.IsCompleted.Should().BeTrue();
+		request.Result.Should().BeFalse();
+
+		await result.Should().BeAsync(m => m
+			.Message(42, Error.No, Progress.Final));
+	}
+}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
@@ -55,6 +55,9 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 	SourceContext IState.Context => _state.Context;
 
 	/// <inheritdoc />
+	IRequestSource IState.Requests => _state.Requests;
+
+	/// <inheritdoc />
 	public string PropertyName { get; }
 
 	/// <inheritdoc />

--- a/src/Uno.Extensions.Reactive/Core/IState.cs
+++ b/src/Uno.Extensions.Reactive/Core/IState.cs
@@ -13,8 +13,20 @@ namespace Uno.Extensions.Reactive;
 public interface IState : IAsyncDisposable
 {
 	/// <summary>
-	/// The context to which this state belong
+	/// The context to which this state belongs.
 	/// </summary>
+	/// <remarks>This context is expected to be a "root" context.</remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	SourceContext Context { get; }
+
+	// Note: Should a State always be only a wrapper over a feed (i.e. no interface, only concrete type!) and expose (internally?) it's FeedSubscription?
+	/// <summary>
+	/// The request source to use to manipulate that state.
+	/// </summary>
+	/// <remarks>
+	/// This is expected to be the request source of the context used to subscribe to the underlying feed if any.
+	/// If the state implementation is not wrapping a feed (uncommon), requests sent to this should be handled by the state itself.
+	/// </remarks>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	internal IRequestSource Requests { get; }
 }

--- a/src/Uno.Extensions.Reactive/Core/IState.cs
+++ b/src/Uno.Extensions.Reactive/Core/IState.cs
@@ -19,7 +19,7 @@ public interface IState : IAsyncDisposable
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	SourceContext Context { get; }
 
-	// Note: Should a State always be only a wrapper over a feed (i.e. no interface, only concrete type!) and expose (internally?) it's FeedSubscription?
+	// Note: Should a State always be only a wrapper over a feed (i.e. no interface, only concrete type!) and expose (internally?) its FeedSubscription?
 	/// <summary>
 	/// The request source to use to manipulate that state.
 	/// </summary>

--- a/src/Uno.Extensions.Reactive/Core/Internal/FeedSubscription.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/FeedSubscription.cs
@@ -41,6 +41,8 @@ internal class FeedSubscription<T> : IAsyncDisposable, ISourceContextOwner
 
 	internal Message<T> Current => _messages.TryGetCurrent(out var value) ? value : Message<T>.Initial;
 
+	internal IRequestSource Requests => _requests;
+
 	public IDisposable UpdateMode(SubscriptionMode mode)
 	{
 		// Not supported yet.

--- a/src/Uno.Extensions.Reactive/Core/Internal/ListStateImpl.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/ListStateImpl.cs
@@ -31,6 +31,8 @@ internal class ListStateImpl<T> : FeedToListFeedAdapter<T>, IListState<T>, IStat
 
 	/// <inheritdoc />
 	public SourceContext Context => _implementation.Context;
+	/// <inheritdoc />
+	public IRequestSource Requests => _implementation.Requests;
 
 	/// <inheritdoc />
 	public ValueTask UpdateMessageAsync(Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)

--- a/src/Uno.Extensions.Reactive/Core/Internal/StateImpl.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/StateImpl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,6 +28,16 @@ internal sealed class StateImpl<T> : IState<T>, IFeed<T>, IAsyncDisposable, ISta
 	/// </summary>
 	public SourceContext Context { get; }
 	SourceContext IStateImpl.Context => Context;
+
+	/// <inheritdoc cref="IState{T}"/>
+	public IRequestSource Requests
+	{
+		get
+		{
+			Enable();
+			return _subscription.Requests;
+		}
+	}
 
 	internal Message<T> Current => _subscription?.Current ?? Message<T>.Initial;
 
@@ -107,7 +118,7 @@ internal sealed class StateImpl<T> : IState<T>, IFeed<T>, IAsyncDisposable, ISta
 		Enable();
 
 		// Note: The subscription has been created using our own Context, and we forward the subscriber context only for requests propagation.
-		return _subscription!.GetMessages(context, ct);
+		return _subscription.GetMessages(context, ct);
 	}
 
 	/// <inheritdoc />
@@ -121,6 +132,7 @@ internal sealed class StateImpl<T> : IState<T>, IFeed<T>, IAsyncDisposable, ISta
 		await update.HasBeenApplied; // Makes sure to forward (the first) error to the caller if any.
 	}
 
+	[MemberNotNull(nameof(_subscription))]
 	private void Enable()
 	{
 		if (_subscription is not null)

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/Input.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/Input.cs
@@ -14,6 +14,9 @@ internal sealed class Input<T> : IInput<T>
 	/// <inheritdoc />
 	SourceContext IState.Context => _state.Context;
 
+	/// <inheritdoc />
+	IRequestSource IState.Requests => _state.Requests;
+
 	public string PropertyName { get; }
 
 	public Input(string propertyName, IState<T> state)


### PR DESCRIPTION
## Feature
Add ability to refresh an IState

## What is the current behavior?
No way to programmatically refresh an IState

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
