### PR TITLE
fix: Correcting gitversion

### DIFF
--- a/build/ci/.azure-pipelines.Packages.yml
+++ b/build/ci/.azure-pipelines.Packages.yml
@@ -44,7 +44,7 @@ jobs:
       msbuildLocationMethod: location
       msbuildLocation: $(MSBUILDPATH)
       msbuildArchitecture: x86
-      msbuildArguments: /r /m /v:m /p:Configuration=Release "/p:PackageOutputPath=$(build.artifactstagingdirectory)\nuget" "/p:PackageVersion=$(GitVersion.FullSemVer)" "/p:InformationalVersion=%GITVERSION_InformationalVersion%" /detailedsummary /bl:$(build.artifactstagingdirectory)/uno-extensions.binlog
+      msbuildArguments: /r /m /v:m /p:Configuration=Release "/p:PackageOutputPath=$(build.artifactstagingdirectory)\nuget" "/p:PackageVersion=$(GitVersion.FullSemVer)" "/p:InformationalVersion=$(GITVERSION_InformationalVersion)"  /detailedsummary /bl:$(build.artifactstagingdirectory)/uno-extensions.binlog
       clean: false
       maximumCpuCount: true
       restoreNugetPackages: false

--- a/build/ci/.azure-pipelines.Wasm.yml
+++ b/build/ci/.azure-pipelines.Wasm.yml
@@ -25,7 +25,7 @@ jobs:
     displayName: Use GitVersion
 
   - script: |
-      dotnet build testing/TestHarness/TestHarness.Wasm/TestHarness.Wasm.csproj /p:Configuration=Release "/p:InformationalVersion=%GITVERSION_InformationalVersion%" /p:UnoExtensionsDisableNet7=true /p:GeneratePackageOnBuild=false /detailedsummary /bl:$(build.artifactstagingdirectory)/testharness-wasm.binlog
+      dotnet build testing/TestHarness/TestHarness.Wasm/TestHarness.Wasm.csproj /p:Configuration=Release "/p:InformationalVersion=$(GITVERSION_InformationalVersion)" /p:UnoExtensionsDisableNet7=true /p:GeneratePackageOnBuild=false /detailedsummary /bl:$(build.artifactstagingdirectory)/testharness-wasm.binlog
 
   - task: CopyFiles@2
     displayName: 'Publish Wasm Binaries'

--- a/build/ci/.azure-pipelines.Windows.yml
+++ b/build/ci/.azure-pipelines.Windows.yml
@@ -49,7 +49,7 @@ jobs:
       msbuildLocationMethod: location
       msbuildLocation: $(MSBUILDPATH)
       msbuildArchitecture: x86
-      msbuildArguments: /m /v:m /r /p:Configuration=Release "/p:InformationalVersion=%GITVERSION_InformationalVersion%" /p:GeneratePackageOnBuild=false /p:AotAssemblies=false /p:UseWebAssemblyAOT=false /detailedsummary /bl:$(build.artifactstagingdirectory)/samples-windows-${{parameters.solutionName}}.binlog
+      msbuildArguments: /m /v:m /r /p:Configuration=Release "/p:InformationalVersion=$(GITVERSION_InformationalVersion)" /p:GeneratePackageOnBuild=false /p:AotAssemblies=false /p:UseWebAssemblyAOT=false /detailedsummary /bl:$(build.artifactstagingdirectory)/samples-windows-${{parameters.solutionName}}.binlog
       clean: false
       maximumCpuCount: true
       restoreNugetPackages: false


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.extensions/issues/2172 also closes https://github.com/unoplatform/Uno.Figma/issues/2385

## PR Type

What kind of change does this PR introduce?
- Bugfix


## What is the current behavior?

Incorrect usage of gitversion value

## What is the new behavior?

Correcting gitversion variable

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
