### PR TITLE
feat: Adding support for unpackaged Windows applications 

### DIFF
--- a/samples/Playground/Playground/Playground.csproj
+++ b/samples/Playground/Playground/Playground.csproj
@@ -67,13 +67,13 @@
   <ItemGroup>
     <EmbeddedResource Include="appsettings.development.json" />
     <EmbeddedResource Include="appsettings.json" />
-    <EmbeddedResource Include="data.json" />
+    <Content Include="data.json" />
   </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Configuration\Uno.Extensions.Configuration.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Core\Uno.Extensions.Core.csproj" />
-		<ProjectReference Include="..\..\..\src\Uno.Extensions.Hosting.UI\Uno.Extensions.Hosting.WinUI.csproj"  ExcludeAssets="all"  />
+		<ProjectReference Include="..\..\..\src\Uno.Extensions.Hosting.UI\Uno.Extensions.Hosting.WinUI.csproj" ExcludeAssets="all" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Hosting\Uno.Extensions.Hosting.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Http.Refit\Uno.Extensions.Http.Refit.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Http.UI\Uno.Extensions.Http.WinUI.csproj" />

--- a/samples/Playground/Playground/ViewModels/AdHocViewModel.cs
+++ b/samples/Playground/Playground/ViewModels/AdHocViewModel.cs
@@ -2,10 +2,12 @@
 
 
 using System.Diagnostics;
+using Uno.Extensions.Reactive;
 using Uno.Extensions.Storage;
 
 namespace Playground.ViewModels;
 
+[ReactiveBindable(false)]
 public partial class AdHocViewModel:ObservableObject
 {
 	private readonly IDispatcher _dispatcher;

--- a/samples/Playground/Playground/ViewModels/AdHocViewModel.cs
+++ b/samples/Playground/Playground/ViewModels/AdHocViewModel.cs
@@ -86,7 +86,9 @@ public partial class AdHocViewModel:ObservableObject
 
 	public async Task LoadWidgets()
 	{
-		var widgets = await _dataService.ReadPackageFileAsync<Widget[]>(_serializer, "data.json");
+		var widgetsAsText = await _dataService.ReadPackageFileAsync(@"Playground\data.json");
+
+		var widgets = await _dataService.ReadPackageFileAsync<Widget[]>(_serializer, @"Playground\data.json");
 	}
 
 	public async Task RunBackgroundTask()

--- a/src/Uno.Extensions.Core.UI/ApplicationDataExtensions.cs
+++ b/src/Uno.Extensions.Core.UI/ApplicationDataExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System.Reflection;
+
+namespace Uno.Extensions;
+
+internal static class ApplicationDataExtensions
+{
+	private const string DefaultUnoAppName = "unoapp";
+
+	public static string DataFolder()
+	{
+		var dataFolder = string.Empty;
+		if (
+#if !__WINDOWS__
+			true
+#else
+					PlatformHelper.IsAppPackaged
+#endif
+		)
+		{
+			try
+			{
+				dataFolder = Windows.Storage.ApplicationData.Current?.LocalFolder?.Path ?? string.Empty;
+			}
+			catch
+			{
+				// This will throw an exception on WinUI if unpackaged, so dataFolder will be null
+				// Can also be null on Linux FrameBuffer
+			}
+		}
+
+		if (string.IsNullOrWhiteSpace(dataFolder))
+		{
+			var appName = Assembly.GetEntryAssembly()?.GetName().Name ?? DefaultUnoAppName;
+			dataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), appName);
+		}
+
+		if (!string.IsNullOrWhiteSpace(dataFolder) &&
+			!Directory.Exists(dataFolder))
+		{
+			Directory.CreateDirectory(dataFolder);
+		}
+
+		return dataFolder;
+	}
+}

--- a/src/Uno.Extensions.Core.UI/Settings.cs
+++ b/src/Uno.Extensions.Core.UI/Settings.cs
@@ -1,0 +1,85 @@
+﻿using System.Text.Json;
+
+namespace Uno.Extensions;
+
+internal record Settings(ILogger<Settings>? Logger = default) : ISettings
+{
+#if __WINDOWS__
+	private const string SettingsFileName = "__settings__.";
+#endif
+	private bool _initialized;
+	private bool _useFileSettings;
+	private Dictionary<string, string> settings = new Dictionary<string, string>();
+
+#if __WINDOWS__
+	private string SettingsFile
+	{
+		get
+		{
+			var dataFolder = ApplicationDataExtensions.DataFolder();
+			var settingsFile = Path.Combine(dataFolder, SettingsFileName);
+			return settingsFile;
+		}
+	}
+#endif
+
+	private void Initialize()
+	{
+		if (_initialized)
+		{
+			return;
+		}
+
+		_initialized = true;
+
+#if __WINDOWS__
+		if (!PlatformHelper.IsAppPackaged)
+		{
+			_useFileSettings = true;
+			var settingsFile = SettingsFile;
+			if (File.Exists(settingsFile))
+			{
+				var json = File.ReadAllText(settingsFile);
+				settings = JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new Dictionary<string, string>();
+			}
+		}
+#else
+		_useFileSettings = false;
+#endif
+	}
+
+	public string? Get(string key)
+	{
+		Initialize();
+		if (!_useFileSettings)
+		{
+			return ApplicationData.Current.LocalSettings.Values[key] is string t ? t : default;
+		}
+		else
+		{
+			return settings.TryGetValue(key, out var value) ? value : default;
+		}
+	}
+	public void Set(string key, string value)
+	{
+		Initialize();
+		if (!_useFileSettings)
+		{
+			ApplicationData.Current.LocalSettings.Values[key] = value;
+		}
+		else
+		{
+			if (value is null)
+			{
+				settings.Remove(key);
+			}
+			else
+			{
+				settings[key] = value;
+			}
+#if __WINDOWS__
+			File.WriteAllText(SettingsFile, JsonSerializer.Serialize(settings));
+#endif
+		}
+	}
+}

--- a/src/Uno.Extensions.Core.UI/Toolkit/ScopedThemeService.cs
+++ b/src/Uno.Extensions.Core.UI/Toolkit/ScopedThemeService.cs
@@ -5,7 +5,8 @@ internal class ScopedThemeService : ThemeService
 	public ScopedThemeService(
 		ILogger<ScopedThemeService> logger,
 		Window window,
-		IDispatcher dispatcher) : base(window, dispatcher, logger)
+		IDispatcher dispatcher,
+		ISettings settings) : base(window, dispatcher, settings, logger)
 	{
 	}
 }

--- a/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
@@ -6,6 +6,7 @@ internal class ThemeService : IThemeService, IDisposable
 	private UIElement? _rootAccessorElement;
 	private readonly IDispatcher _dispatcher;
 	private readonly ILogger? _logger;
+	private readonly ISettings _settings;
 	private TaskCompletionSource<bool>? _initialization;
 
 	/// <inheritdoc/>
@@ -14,10 +15,12 @@ internal class ThemeService : IThemeService, IDisposable
 	internal ThemeService(
 		Window window,
 		IDispatcher dispatcher,
+		ISettings settings,
 		ILogger? logger = default)
 	{
 		_dispatcher = dispatcher;
 		_logger = logger;
+		_settings = settings;
 
 		if (!_dispatcher.HasThreadAccess && PlatformHelper.IsThreadingEnabled)
 		{
@@ -39,11 +42,13 @@ internal class ThemeService : IThemeService, IDisposable
 	internal ThemeService(
 		UIElement rootAccessorElement,
 		IDispatcher dispatcher,
+		ISettings settings,
 		ILogger? logger = default)
 	{
 		RootElement = rootAccessorElement;
 		_dispatcher = dispatcher;
 		_logger = logger;
+		_settings = settings;
 
 		_ = InitializeAsync();
 	}
@@ -143,7 +148,7 @@ internal class ThemeService : IThemeService, IDisposable
 	{
 		try
 		{
-			ApplicationData.Current.LocalSettings.Values[CurrentThemeSettingsKey] = theme.ToString();
+			_settings.Set(CurrentThemeSettingsKey, theme.ToString());
 		}
 		catch (Exception ex)
 		{
@@ -155,7 +160,7 @@ internal class ThemeService : IThemeService, IDisposable
 	{
 		try
 		{
-			return Enum.TryParse<AppTheme>(ApplicationData.Current.LocalSettings.Values[CurrentThemeSettingsKey] + string.Empty, out var theme) ? theme : AppTheme.System;
+			return Enum.TryParse<AppTheme>(_settings.Get(CurrentThemeSettingsKey) + string.Empty, out var theme) ? theme : AppTheme.System;
 		}
 		catch (Exception ex)
 		{

--- a/src/Uno.Extensions.Core.UI/UIElementExtensions.cs
+++ b/src/Uno.Extensions.Core.UI/UIElementExtensions.cs
@@ -12,5 +12,5 @@ public static class UIElementExtensions
 	/// <param name="logger">[Optional] logger for logging</param>
 	/// <returns>Theme service for controlling application theme</returns>
 	public static IThemeService GetThemeService(this UIElement element, ILogger? logger = default) =>
-		new ThemeService(element, new Dispatcher(element), logger);
+		new ThemeService(element, new Dispatcher(element), new Settings(), logger);
 }

--- a/src/Uno.Extensions.Core.UI/WindowExtensions.cs
+++ b/src/Uno.Extensions.Core.UI/WindowExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions;
+﻿using System.Reflection;
+
+namespace Uno.Extensions;
 
 /// <summary>
 /// Extensions for <see cref="Window"/>
@@ -12,5 +14,5 @@ public static class WindowExtensions
 	/// <param name="logger">[Optional]The logger for log output</param>
 	/// <returns>The theme service for controlling application theme</returns>
 	public static IThemeService GetThemeService(this Window window, ILogger? logger = default) =>
-		new ThemeService(window, new Dispatcher(window), logger);
+		new ThemeService(window, new Dispatcher(window), new Settings(), logger);
 }

--- a/src/Uno.Extensions.Core/ISettings.cs
+++ b/src/Uno.Extensions.Core/ISettings.cs
@@ -1,0 +1,7 @@
+﻿namespace Uno.Extensions;
+
+internal interface ISettings
+{
+	string? Get(string key);
+	void Set(string key, string value);
+}

--- a/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
+++ b/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
@@ -54,7 +54,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="Uno.Extensions.Core.UI" />
+		<InternalsVisibleTo Include="Uno.Extensions.Core.WinUI" />
 		<InternalsVisibleTo Include="Uno.Extensions.Hosting" />
+		<InternalsVisibleTo Include="Uno.Extensions.Hosting.UWP" />
+		<InternalsVisibleTo Include="Uno.Extensions.Hosting.WinUI" />
 		<InternalsVisibleTo Include="Uno.Extensions.Storage" />
 		<InternalsVisibleTo Include="Uno.Extensions.Storage.UI" />
 		<InternalsVisibleTo Include="Uno.Extensions.Storage.WinUI" />

--- a/src/Uno.Extensions.Hosting.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Hosting.UI/HostBuilderExtensions.cs
@@ -31,6 +31,7 @@ public static class HostBuilderExtensions
 			.ConfigureServices((ctx, services) =>
 			{
 				_ = services
+				.AddSingleton<ISettings, Settings>()
 				.AddScoped<IThemeService, ScopedThemeService>();
 			});
 	}

--- a/src/Uno.Extensions.Hosting.UI/UnoHost.cs
+++ b/src/Uno.Extensions.Hosting.UI/UnoHost.cs
@@ -5,7 +5,6 @@
 /// </summary>
 public static class UnoHost
 {
-	private const string DefaultUnoAppName = "unoapp";
 
 	/// <summary>
 	/// Initializes a new instance of the HostBuilder class that is pre-configured 
@@ -29,28 +28,7 @@ public static class UnoHost
 			.ConfigureCustomDefaults(args)
 			.ConfigureAppConfiguration((ctx, appConfig) =>
 			{
-				string dataFolder = string.Empty;
-				try
-				{
-					dataFolder = Windows.Storage.ApplicationData.Current?.LocalFolder?.Path ?? string.Empty;
-				}
-				catch
-				{
-					// This will throw an exception on WinUI if unpackaged, so dataFolder will be null
-					// Can also be null on Linux FrameBuffer
-				}
-
-				if (string.IsNullOrWhiteSpace(dataFolder))
-				{
-					var appName = Assembly.GetEntryAssembly()?.GetName().Name ?? DefaultUnoAppName;
-					dataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), appName);
-				}
-
-				if (!string.IsNullOrWhiteSpace(dataFolder) &&
-					!Directory.Exists(dataFolder))
-				{
-					Directory.CreateDirectory(dataFolder);
-				}
+				var dataFolder = ApplicationDataExtensions.DataFolder();
 
 				var appHost = ctx.HostingEnvironment.FromHostEnvironment(dataFolder, applicationAssembly);
 				ctx.HostingEnvironment = appHost;

--- a/src/Uno.Extensions.Localization.UI/LocalizationService.cs
+++ b/src/Uno.Extensions.Localization.UI/LocalizationService.cs
@@ -59,7 +59,12 @@ internal class LocalizationService : IServiceInitialize, ILocalizationService, I
 		}
 	}
 
-	private static bool overrideSupported = true;
+	private static bool overrideSupported =
+#if !__WINDOWS__
+		true;
+#else
+		PlatformHelper.IsAppPackaged;
+#endif
 	private string? PrimaryLanguageOverride
 	{
 		get

--- a/src/Uno.Extensions.Storage.UI/FileStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/FileStorage.cs
@@ -34,6 +34,16 @@ internal record FileStorage(ILogger<FileStorage> Logger, IDataFolderProvider Dat
 				return default;
 			}
 
+#if __WINDOWS__
+			if (!PlatformHelper.IsAppPackaged)
+			{
+				var file = System.IO.Path.Combine(
+								 System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly()?.Location ?? string.Empty) ?? string.Empty,
+								 filename);
+				return File.ReadAllText(file);
+			}
+#endif
+
 			var fileUri = new Uri($"ms-appx:///{filename}");
 			if (Logger.IsEnabled(LogLevel.Trace))
 			{
@@ -79,6 +89,16 @@ internal record FileStorage(ILogger<FileStorage> Logger, IDataFolderProvider Dat
 				}
 				return default;
 			}
+
+#if __WINDOWS__
+			if (!PlatformHelper.IsAppPackaged)
+			{
+				var file = System.IO.Path.Combine(
+								 System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly()?.Location ?? string.Empty) ?? string.Empty,
+								 filename);
+				return System.IO.File.OpenRead(file);
+			}
+#endif
 
 			var storageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri($"ms-appx:///{filename}"));
 			var stream = await storageFile.OpenStreamForReadAsync();

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -17,9 +17,9 @@
 		<PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
 		<PackageVersion Include="Microsoft.Toolkit.Uwp.UI" Version="7.1.2" />
 		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.8.5" />
-		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.231219000" />
+		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.240211001" />
 		<PackageVersion Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
-		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
 		<PackageVersion Include="Refit" Version="6.3.2" />
 		<PackageVersion Include="Refit.HttpClientFactory" Version="6.3.2" />
 		<PackageVersion Include="SkiaSharp" Version="2.88.3" />
@@ -75,4 +75,7 @@
 		<PackageVersion Include="Xamarin.Google.Android.Material" Version="1.4.0.4" />
 		<PackageVersion Include="Xamarin.UITest" Version="4.1.2" />
 	</ItemGroup>
+
+
+	<Import Project="../../src/winappsdk-workaround.targets" Condition="exists('../../src/winappsdk-workaround.targets')" />
 </Project>

--- a/testing/TestHarness/TestHarness.Windows/TestHarness.Windows.csproj
+++ b/testing/TestHarness/TestHarness.Windows/TestHarness.Windows.csproj
@@ -11,13 +11,13 @@
 		<UseWinUI>true</UseWinUI>
 		<DefineConstants>$(DefineConstants);WINUI;UNO_EXT_TIMERS</DefineConstants>
 		<DefaultLanguage>en</DefaultLanguage>
-		<!--<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>-->
+		<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
 		<!--<WindowsPackageType>None</WindowsPackageType>-->
-		<EnableMsixTooling>true</EnableMsixTooling>
+		<EnableMsixTooling>false</EnableMsixTooling>
 	</PropertyGroup>
 
 	<PropertyGroup><!-- Bundles the WinAppSDK binaries (Uncomment for unpackaged builds) -->
-		<!-- <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained> -->
+		 <!--<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>--> 
 		<!-- This bundles the .NET Core libraries (Uncomment for packaged builds)  -->
 		<!--<SelfContained>true</SelfContained>-->
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2133, #1369, #2055, #1370

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Unpackaged (Windows) applications can't make used of applicationdata, so IStorage and localization services don't work

## What is the new behavior?

For unpackaged applications, the local path to the executing assembly is used for packaged files. A settings implementation has been added to support read/write settings where ApplicationData.LocalSettings doesn't work for unpackaged applications.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
