### PR TITLE
fix: Make sure serialization is registered when registering storage

### DIFF
--- a/src/Uno.Extensions.Storage.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Storage.UI/HostBuilderExtensions.cs
@@ -27,6 +27,7 @@ public static class HostBuilderExtensions
 		Action<HostBuilderContext, IServiceCollection>? configure = default)
 	{
 		return hostBuilder
+			.UseSerialization()
 			.UseConfiguration(
 				configure: configBuilder =>
 				{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #https://github.com/unoplatform/uno.templates/issues/578


## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Serialization should be registered with hostbuilder when storage is registered (since it uses ISerializer). 

## What is the new behavior?

Serialization is now registered prior to registering storage 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
