### PR TITLE
fix: Adding platform check before invoking dllimport method

### DIFF
--- a/src/Uno.Extensions.Core/PlatformHelper.cs
+++ b/src/Uno.Extensions.Core/PlatformHelper.cs
@@ -74,7 +74,7 @@ public static class PlatformHelper
 				|| RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
 
 			// If wasm, then can assume app isn't packaged, so skip this check
-			if (!IsWebAssembly && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
 				_isAppPackaged = IsWindowsAppPackaged();
 			}

--- a/src/Uno.Extensions.Core/PlatformHelper.cs
+++ b/src/Uno.Extensions.Core/PlatformHelper.cs
@@ -74,21 +74,26 @@ public static class PlatformHelper
 				|| RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
 
 			// If wasm, then can assume app isn't packaged, so skip this check
-			if (!IsWebAssembly)
+			if (!IsWebAssembly && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
-				try
-				{
-					// Application is MSIX packaged if it has an identity: https://learn.microsoft.com/en-us/windows/msix/detect-package-identity
-					int length = 0;
-					var sb = new System.Text.StringBuilder(0);
-					int result = GetCurrentPackageFullName(ref length, sb);
-					_isAppPackaged = result != AppModelErrorNoPackage;
-				}
-				catch
-				{
-					_isAppPackaged = false;
-				}
+				_isAppPackaged = IsWindowsAppPackaged();
 			}
+		}
+	}
+
+	private static bool IsWindowsAppPackaged()
+	{
+		try
+		{
+			// Application is MSIX packaged if it has an identity: https://learn.microsoft.com/en-us/windows/msix/detect-package-identity
+			int length = 0;
+			var sb = new System.Text.StringBuilder(0);
+			int result = GetCurrentPackageFullName(ref length, sb);
+			return result != AppModelErrorNoPackage;
+		}
+		catch
+		{
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): related to https://github.com/unoplatform/uno/discussions/15635

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Dllimported method GetCurrentPackageFullName is invoked on all platforms other than WASM. It should only be invoked on Windows

## What is the new behavior?

Platform check ensures GetCurrentPackageFullName is only called on Windows

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
