### PR TITLE
fix: Configuration information not passed to Authentication providers by name

### DIFF
--- a/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
@@ -120,14 +120,11 @@ public static class ConfigBuilderExtensions
 	{
 		if (configSection is null)
 		{
-			if (configurationSection is { Length: > 0 })
+			if (configurationSection is not { Length: > 0 })
 			{
-				configSection = ctx => ctx.Configuration.GetSection(configurationSection);
+				configurationSection = typeof(TSettingsOptions).Name;
 			}
-			else
-			{
-				configSection = ctx => ctx.Configuration.GetSection(typeof(TSettingsOptions).Name);
-			}
+			configSection = ctx => ctx.Configuration.GetSection(configurationSection);
 		}
 
 		static string? FilePath(HostBuilderContext hctx)
@@ -160,7 +157,7 @@ public static class ConfigBuilderExtensions
 					}
 
 					var section = configSection(ctx);
-					services.ConfigureAsWritable<TSettingsOptions>(section, configPath);
+					services.ConfigureAsWritable<TSettingsOptions>(section, configPath, configurationSection);
 				}
 
 			).AsConfigBuilder();

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -17,9 +17,10 @@
 		<PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
 		<PackageVersion Include="Microsoft.Toolkit.Uwp.UI" Version="7.1.2" />
 		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.8.5" />
-		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.240211001" />
+		<PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2365.46" />
+		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
 		<PackageVersion Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
-		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
+		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
 		<PackageVersion Include="Refit" Version="6.3.2" />
 		<PackageVersion Include="Refit.HttpClientFactory" Version="6.3.2" />
 		<PackageVersion Include="SkiaSharp" Version="2.88.3" />

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/WebAuthenticationSettingsHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/WebAuthenticationSettingsHostInit.cs
@@ -11,7 +11,8 @@ public class WebAuthenticationSettingsHostInit : BaseHostInitialization
 		return builder
 			.UseAuthentication(auth =>
 					auth
-					.AddWeb<IWebAuthenticationTestEndpoint>(name: "WebSettings")) // name defines not only the name of the provider but also the section in the appsettings file
+					.AddWeb<IWebAuthenticationTestEndpoint>(name: "WebSettings")
+					.AddWeb<IWebAuthenticationTestEndpoint>(name: "WebSettings2")) // name defines not only the name of the provider but also the section in the appsettings file
 
 				.ConfigureServices(services =>
 					services

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/appsettings.webauthsettings.json
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Web/appsettings.webauthsettings.json
@@ -2,5 +2,9 @@
   "WebSettings": {
     "LoginStartUri": "https://localhost:7193/webauth/Login/Facebook?redirect_uri=oidc-auth://",
     "LogoutStartUri": "https://localhost:7193/webauth/Logout/Facebook"
+  },
+  "WebSettings2": {
+    "LoginStartUri": "https://localhost:7193/webauth/Login/Facebook?redirect_uri=oidc-auth://&setting=2",
+    "LogoutStartUri": "https://localhost:7193/webauth/Logout/Facebook&setting=2"
   }
 }

--- a/testing/TestHarness/TestHarness.Windows/TestHarness.Windows.csproj
+++ b/testing/TestHarness/TestHarness.Windows/TestHarness.Windows.csproj
@@ -13,7 +13,7 @@
 		<DefaultLanguage>en</DefaultLanguage>
 		<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
 		<!--<WindowsPackageType>None</WindowsPackageType>-->
-		<EnableMsixTooling>false</EnableMsixTooling>
+		<EnableMsixTooling>true</EnableMsixTooling>
 	</PropertyGroup>
 
 	<PropertyGroup><!-- Bundles the WinAppSDK binaries (Uncomment for unpackaged builds) -->
@@ -41,6 +41,7 @@
 		<PackageReference Include="IdentityModel.OidcClient" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
 		<PackageReference Include="Microsoft.Identity.Client" />
+		<PackageReference Include="Microsoft.Web.WebView2"/>
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 		<PackageReference Include="Refit" />
@@ -94,4 +95,33 @@
 
 	<Import Project="..\..\..\src\Uno.Extensions.Core.Generators\buildTransitive\Uno.Extensions.Core.props" />
 	<Import Project="..\TestHarness.Shared\TestHarness.Shared.projitems" Label="Shared" Condition="Exists('..\TestHarness.Shared\TestHarness.Shared.projitems')" />
+
+	<!--
+  This is a temporary workaround to avoid error "NETSDK1152: Found multiple publish output files with the same relative path:"
+  for Microsoft.Web.WebView2.Core.dll, with one coming from MsixContent and the other from the Microsoft.Web.Webview2 Nuget package.
+  If both are present, we only keep the one from the NuGet package. See https://github.com/unoplatform/uno/issues/14555.
+-->
+	<Target Name="ResolveWebView2CoreDuplicates1" BeforeTargets="_ComputeResolvedFilesToPublishTypes" AfterTargets="ComputeFilesToPublish">
+		<Message Importance="high" Text ="Applying workaround to resolve Microsoft.Web.WebView2.Core.dll duplication in package (1)" />
+		<ItemGroup>
+			<_WebView2CoreFilesToExclude Include="@(ResolvedFileToPublish)" Condition="'%(Filename)' == 'Microsoft.Web.WebView2.Core'"/>
+		</ItemGroup>
+		<ItemGroup Condition="'@(_WebView2CoreFilesToExclude->Count())' &gt; 1">
+			<_WebView2CoreFilesToExclude Remove="@(_WebView2CoreFilesToExclude)" Condition="$([System.String]::Copy(%(FullPath)).Contains('.nuget'))"/>
+			<ResolvedFileToPublish Remove="@(_WebView2CoreFilesToExclude)" />
+		</ItemGroup>
+		<Message Importance="high" Text ="Removed: @(_WebView2CoreFilesToExclude)" />
+	</Target>
+
+	<Target Name="ResolveWebView2CoreDuplicates2" BeforeTargets="_ComputeAppxPackagePayload" AfterTargets="GetPackagingOutputs">
+		<Message Importance="high" Text ="Applying workaround to resolve Microsoft.Web.WebView2.Core.dll duplication in package (2)" />
+		<ItemGroup >
+			<_WebView2CoreOutputsToExclude Include="@(PackagingOutputs)" Condition="'%(Filename)' == 'Microsoft.Web.WebView2.Core'"/>
+		</ItemGroup>
+		<ItemGroup Condition="'@(_WebView2CoreOutputsToExclude->Count())' &gt; 1">
+			<_WebView2CoreOutputsToExclude Remove="@(_WebView2CoreOutputsToExclude)" Condition="$([System.String]::Copy(%(FullPath)).Contains('.nuget'))"/>
+			<PackagingOutputs Remove="@(_WebView2CoreOutputsToExclude)" />
+		</ItemGroup>
+		<Message Importance="high" Text ="Removed: @(_WebView2CoreOutputsToExclude)" />
+	</Target>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.extensions/discussions/2193

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Where there are multiple configurations for a given type, or they're referenced by name, the configuration doesn't return valid information

## What is the new behavior?

Configuration sections are correctly registered by name

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
