### PR TITLE
Maui Namespaces

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -41,8 +41,8 @@
 		<PackageVersion Include="Uno.Core" Version="4.0.1" />
 		<PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />
 		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
-		<PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.0.13" />
-		<PackageVersion Include="Uno.Extensions.Markup.WinUI" Version="5.0.13" />
+		<PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.2.0-dev.58" />
+		<PackageVersion Include="Uno.Extensions.Markup.WinUI" Version="5.2.0-dev.58" />
 		<PackageVersion Include="Uno.Roslyn" Version="1.3.0-dev.12" />
 		<PackageVersion Include="Uno.Toolkit" Version="5.0.15" />
 		<PackageVersion Include="Uno.Toolkit.UI" Version="5.0.15" />
@@ -53,7 +53,7 @@
 		<PackageVersion Include="Uno.UI.Runtime.WebAssembly" Version="5.0.19" />
 		<PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.24.0-dev.95" />
 		<PackageVersion Include="Uno.WinUI" Version="5.0.19" />
-		<PackageVersion Include="Uno.WinUI.Markup" Version="5.0.13" />
+		<PackageVersion Include="Uno.WinUI.Markup" Version="5.2.0-dev.58" />
 		<PackageVersion Include="Uno.WinUI.MSAL" Version="5.0.19" />
 		<PackageVersion Include="Uno.WinUI.Runtime.WebAssembly" Version="5.0.19" />
 		<PackageVersion Include="coverlet.collector" Version="3.1.2" />

--- a/src/Uno.Extensions.Maui.UI/build/Package.targets
+++ b/src/Uno.Extensions.Maui.UI/build/Package.targets
@@ -7,6 +7,8 @@
 	<ItemGroup Condition=" '$(ImplicitUsings)' == 'true' OR '$(ImplicitUsings)' == 'enable' ">
 		<Using Include="Uno.Extensions.Maui" />
 		<Using Include="Uno.Extensions.Maui.Platform" />
+		<!-- Removes .NET MAUI usings to avoid Ambiguous references -->
+		<Using Remove="@(Using->HasMetadata('Sdk')->WithMetadataValue('Sdk', 'Maui'))"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Maui.WinUI.Markup/MauiHostMarkupExtensions.cs
+++ b/src/Uno.Extensions.Maui.WinUI.Markup/MauiHostMarkupExtensions.cs
@@ -31,9 +31,9 @@ public static class MauiHostMarkupExtensions
 
 	[MarkupExtension]
 	public static MauiHost Source<TSource>(this MauiHost host, Func<TSource> propertyBinding, [CallerArgumentExpression("propertyBinding")]string? propertyBindingExpression = null) =>
-		host.Source(x => x.Bind(propertyBinding, propertyBindingExpression));
+		host.Source(x => x.Binding(propertyBinding, propertyBindingExpression));
 
 	[MarkupExtension]
 	public static MauiHost Source<TSource>(this MauiHost host, Func<TSource> propertyBinding, Func<TSource, Type> convertDelegate, [CallerArgumentExpression("propertyBinding")] string? propertyBindingExpression = null) =>
-		host.Source(x => x.Bind(propertyBinding, propertyBindingExpression).Convert(convertDelegate));
+		host.Source(x => x.Binding(propertyBinding, propertyBindingExpression).Convert(convertDelegate));
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

MAUI namespaces may be implicitly added. C# Markup API's use `.Bind(`


## What is the new behavior?

MAUI namespaces are removed from implicit namespaces. C# Markup has been updated to use new `.Binding(` methods.