### PR TITLE
feat: Adding logging when unable to launch login or logout flows

### DIFF
--- a/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationProvider.cs
@@ -51,6 +51,10 @@ internal record WebAuthenticationProvider
 		if (loginStartUri is null ||
 			string.IsNullOrWhiteSpace(loginStartUri))
 		{
+			if (ProviderLogger.IsEnabled(LogLevel.Warning))
+			{
+				ProviderLogger.LogWarning($"{nameof(InternalSettings.LoginStartUri)} not specified, unable to start login flow");
+			}
 			return default;
 		}
 
@@ -68,6 +72,10 @@ internal record WebAuthenticationProvider
 
 		if (string.IsNullOrWhiteSpace(loginCallbackUri))
 		{
+			if (ProviderLogger.IsEnabled(LogLevel.Warning))
+			{
+				ProviderLogger.LogWarning($"{nameof(InternalSettings.LoginCallbackUri)} not specified and {OAuthRedirectUriParameter} not set in {nameof(InternalSettings.LoginStartUri)}, unable to start login flow");
+			}
 			return default;
 		}
 
@@ -153,7 +161,11 @@ internal record WebAuthenticationProvider
 		if (logoutStartUri is null ||
 			string.IsNullOrWhiteSpace(logoutStartUri))
 		{
-			return true;
+			if (ProviderLogger.IsEnabled(LogLevel.Warning))
+			{
+				ProviderLogger.LogWarning($"{nameof(InternalSettings.LogoutStartUri)} not specified, unable to start logout flow");
+			}
+			return false;
 		}
 
 		var logoutCallbackUri = InternalSettings.LogoutCallbackUri ?? InternalSettings.LoginCallbackUri;
@@ -177,6 +189,10 @@ internal record WebAuthenticationProvider
 
 		if (string.IsNullOrWhiteSpace(logoutCallbackUri))
 		{
+			if (ProviderLogger.IsEnabled(LogLevel.Warning))
+			{
+				ProviderLogger.LogWarning($"{nameof(InternalSettings.LogoutCallbackUri)} not specified and {OAuthRedirectUriParameter} not set in {nameof(InternalSettings.LogoutStartUri)}, unable to start logout flow");
+			}
 			return false;
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): related to https://github.com/unoplatform/uno.extensions/discussions/2193

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

No logging when unable to start login or logout flow for web auth

## What is the new behavior?

Warning logs when unable to start login or logout flow

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
