### PR TITLE
fix: Moving windows/webview2 workaround to auth MSAL library targets

### DIFF
--- a/src/Uno.Extensions.Authentication.MSAL/build/Package.targets
+++ b/src/Uno.Extensions.Authentication.MSAL/build/Package.targets
@@ -1,5 +1,34 @@
 <Project>
-  <ItemGroup Condition=" '$(ImplicitUsings)' == 'true' OR '$(ImplicitUsings)' == 'enable' ">
-    <Using Include="Uno.Extensions.Authentication.MSAL" />
- </ItemGroup>
+	<ItemGroup Condition=" '$(ImplicitUsings)' == 'true' OR '$(ImplicitUsings)' == 'enable' ">
+		<Using Include="Uno.Extensions.Authentication.MSAL" />
+	</ItemGroup>
+
+	<!--
+  This is a temporary workaround to avoid error "NETSDK1152: Found multiple publish output files with the same relative path:"
+  for Microsoft.Web.WebView2.Core.dll, with one coming from MsixContent and the other from the Microsoft.Web.Webview2 Nuget package.
+  If both are present, we only keep the one from the NuGet package. See https://github.com/unoplatform/uno/issues/14555.
+-->
+	<Target Name="ResolveWebView2CoreDuplicates1" BeforeTargets="_ComputeResolvedFilesToPublishTypes" AfterTargets="ComputeFilesToPublish">
+		<Message Importance="high" Text ="Applying workaround to resolve Microsoft.Web.WebView2.Core.dll duplication in package (1)" />
+		<ItemGroup>
+			<_WebView2CoreFilesToExclude Include="@(ResolvedFileToPublish)" Condition="'%(Filename)' == 'Microsoft.Web.WebView2.Core'"/>
+		</ItemGroup>
+		<ItemGroup Condition="'@(_WebView2CoreFilesToExclude->Count())' &gt; 1">
+			<_WebView2CoreFilesToExclude Remove="@(_WebView2CoreFilesToExclude)" Condition="$([System.String]::Copy(%(FullPath)).Contains('.nuget'))"/>
+			<ResolvedFileToPublish Remove="@(_WebView2CoreFilesToExclude)" />
+		</ItemGroup>
+		<Message Importance="high" Text ="Removed: @(_WebView2CoreFilesToExclude)" />
+	</Target>
+
+	<Target Name="ResolveWebView2CoreDuplicates2" BeforeTargets="_ComputeAppxPackagePayload" AfterTargets="GetPackagingOutputs">
+		<Message Importance="high" Text ="Applying workaround to resolve Microsoft.Web.WebView2.Core.dll duplication in package (2)" />
+		<ItemGroup >
+			<_WebView2CoreOutputsToExclude Include="@(PackagingOutputs)" Condition="'%(Filename)' == 'Microsoft.Web.WebView2.Core'"/>
+		</ItemGroup>
+		<ItemGroup Condition="'@(_WebView2CoreOutputsToExclude->Count())' &gt; 1">
+			<_WebView2CoreOutputsToExclude Remove="@(_WebView2CoreOutputsToExclude)" Condition="$([System.String]::Copy(%(FullPath)).Contains('.nuget'))"/>
+			<PackagingOutputs Remove="@(_WebView2CoreOutputsToExclude)" />
+		</ItemGroup>
+		<Message Importance="high" Text ="Removed: @(_WebView2CoreOutputsToExclude)" />
+	</Target>
 </Project>

--- a/testing/TestHarness/TestHarness.Windows/TestHarness.Windows.csproj
+++ b/testing/TestHarness/TestHarness.Windows/TestHarness.Windows.csproj
@@ -94,34 +94,6 @@
 	</ItemGroup>
 
 	<Import Project="..\..\..\src\Uno.Extensions.Core.Generators\buildTransitive\Uno.Extensions.Core.props" />
+	<Import Project="..\..\..\src\Uno.Extensions.Authentication.MSAL\build\Package.targets" />
 	<Import Project="..\TestHarness.Shared\TestHarness.Shared.projitems" Label="Shared" Condition="Exists('..\TestHarness.Shared\TestHarness.Shared.projitems')" />
-
-	<!--
-  This is a temporary workaround to avoid error "NETSDK1152: Found multiple publish output files with the same relative path:"
-  for Microsoft.Web.WebView2.Core.dll, with one coming from MsixContent and the other from the Microsoft.Web.Webview2 Nuget package.
-  If both are present, we only keep the one from the NuGet package. See https://github.com/unoplatform/uno/issues/14555.
--->
-	<Target Name="ResolveWebView2CoreDuplicates1" BeforeTargets="_ComputeResolvedFilesToPublishTypes" AfterTargets="ComputeFilesToPublish">
-		<Message Importance="high" Text ="Applying workaround to resolve Microsoft.Web.WebView2.Core.dll duplication in package (1)" />
-		<ItemGroup>
-			<_WebView2CoreFilesToExclude Include="@(ResolvedFileToPublish)" Condition="'%(Filename)' == 'Microsoft.Web.WebView2.Core'"/>
-		</ItemGroup>
-		<ItemGroup Condition="'@(_WebView2CoreFilesToExclude->Count())' &gt; 1">
-			<_WebView2CoreFilesToExclude Remove="@(_WebView2CoreFilesToExclude)" Condition="$([System.String]::Copy(%(FullPath)).Contains('.nuget'))"/>
-			<ResolvedFileToPublish Remove="@(_WebView2CoreFilesToExclude)" />
-		</ItemGroup>
-		<Message Importance="high" Text ="Removed: @(_WebView2CoreFilesToExclude)" />
-	</Target>
-
-	<Target Name="ResolveWebView2CoreDuplicates2" BeforeTargets="_ComputeAppxPackagePayload" AfterTargets="GetPackagingOutputs">
-		<Message Importance="high" Text ="Applying workaround to resolve Microsoft.Web.WebView2.Core.dll duplication in package (2)" />
-		<ItemGroup >
-			<_WebView2CoreOutputsToExclude Include="@(PackagingOutputs)" Condition="'%(Filename)' == 'Microsoft.Web.WebView2.Core'"/>
-		</ItemGroup>
-		<ItemGroup Condition="'@(_WebView2CoreOutputsToExclude->Count())' &gt; 1">
-			<_WebView2CoreOutputsToExclude Remove="@(_WebView2CoreOutputsToExclude)" Condition="$([System.String]::Copy(%(FullPath)).Contains('.nuget'))"/>
-			<PackagingOutputs Remove="@(_WebView2CoreOutputsToExclude)" />
-		</ItemGroup>
-		<Message Importance="high" Text ="Removed: @(_WebView2CoreOutputsToExclude)" />
-	</Target>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): workaround for #https://github.com/unoplatform/uno/issues/14555

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Referencing Auth.MSAL causes build error (as per https://github.com/unoplatform/uno/issues/14555)

## What is the new behavior?

No exception during build

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
