### PR TITLE
fix: Removing reference to splashscreen as removed from toolkit

### DIFF
--- a/src/Uno.Extensions.Navigation.Toolkit/ExtendedSplashScreenExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/ExtendedSplashScreenExtensions.cs
@@ -11,10 +11,5 @@ public static class ExtendedSplashScreenExtensions
 	public static void Initialize(this ExtendedSplashScreen splash, Window window, LaunchActivatedEventArgs args)
 	{
 		splash.Window = window;
-#if WINDOWS_UWP
-		splash.SplashScreen = args?.SplashScreen;
-#elif WINDOWS
-		splash.SplashScreen = args?.UWPLaunchActivatedEventArgs.SplashScreen;
-#endif
 	}
 }


### PR DESCRIPTION
Related to https://github.com/unoplatform/uno.toolkit.ui/pull/1061

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Reference to removed Splashscreen property on ExtendedSplashScreen

## What is the new behavior?

Reference has been removed in line with toolkit changes

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
