### PR TITLE
Disable WinAppSdk workaround with Uno.Sdk

### DIFF
--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.android.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.android.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui;
 using Uno.Extensions.Maui.Platform;
 
 namespace Uno.Extensions.Maui;

--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.apple.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.apple.cs
@@ -1,5 +1,6 @@
 using UIKit;
 using Uno.Extensions.Maui.Platform;
+using Microsoft.Maui;
 using Windows.UI.Core;
 
 namespace Uno.Extensions.Maui;

--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Maui;
 using Microsoft.Maui.ApplicationModel;
 using Uno.Extensions.Hosting;
 

--- a/src/Uno.Extensions.Maui.UI/MauiEmbedding.windows.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiEmbedding.windows.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Maui;
+﻿using Microsoft.Maui;
+
+namespace Uno.Extensions.Maui;
 
 partial class MauiEmbedding
 {

--- a/src/Uno.Extensions.Maui.UI/MauiHost.cs
+++ b/src/Uno.Extensions.Maui.UI/MauiHost.cs
@@ -1,4 +1,5 @@
 using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui;
 using Uno.Extensions.Maui.Platform;
 
 namespace Uno.Extensions.Maui;

--- a/src/Uno.Extensions.Maui.UI/Uno.Extensions.Maui.WinUI.csproj
+++ b/src/Uno.Extensions.Maui.UI/Uno.Extensions.Maui.WinUI.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Using Remove="Microsoft.Maui.*" />
+		<Using Remove="@(Using->HasMetadata('Sdk')->WithMetadataValue('Sdk', 'Maui'))"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Maui.UI/build/Package.targets
+++ b/src/Uno.Extensions.Maui.UI/build/Package.targets
@@ -66,14 +66,16 @@
 
 
 	<!-- Workaround to avoid including Uno.Toolkit.UI XBFs in the PRI file -->
-	<Target Name="AdjustGetPackagingOutput1" AfterTargets="GetMrtPackagingOutputs">
+	<Target Name="AdjustGetPackagingOutput1" AfterTargets="GetMrtPackagingOutputs"
+		Condition="$(UsingUnoSdk) != 'true'">
 		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
 		<ItemGroup>
 			<_OtherPriFiles Include="@(PackagingOutputs)" Condition="'%(Extension)' == '.pri' and ('%(PackagingOutputs.ReferenceSourceTarget)' == 'ProjectReference' or '%(PackagingOutputs.NugetSourceType)'=='Package')" />
 			<PackagingOutputs Remove="@(_OtherPriFiles)" />
 		</ItemGroup>
 	</Target>
-	<Target Name="AdjustGetPackagingOutput2" BeforeTargets="AddPriPayloadFilesToCopyToOutputDirectoryItems">
+	<Target Name="AdjustGetPackagingOutput2" BeforeTargets="AddPriPayloadFilesToCopyToOutputDirectoryItems"
+		Condition="$(UsingUnoSdk) != 'true'">
 		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
 		<ItemGroup>
 			<_OtherPriFiles1 Include="@(_ReferenceRelatedPaths)" Condition="'%(Extension)' == '.pri' and ('%(_ReferenceRelatedPaths.ReferenceSourceTarget)' == 'ProjectReference' or '%(_ReferenceRelatedPaths.NugetSourceType)'=='Package')" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Workaround conflicts with Uno.Sdk

## What is the new behavior?

Workaround is disabled with Uno.Sdk

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
