### PR TITLE
Add docs for Style<T> where no extension exists

### DIFF
--- a/doc/Learn/Markup/Styles.md
+++ b/doc/Learn/Markup/Styles.md
@@ -10,6 +10,15 @@ new Style<TextBlock>()
     .Setters(s => s.FontSize(14))
 ```
 
+## Using Attached Properties
+
+By default the C# Markup Generators will provide friendly extension methods for properties on the given type for `Style<T>`. This provides an API that is friendly and familiar to the XAML you might be used to as shown in the example above. Sometimes you may need to use Attached DependencyProperties for which there is no generated extension for `Style<T>`, in these cases you can simply call the Add method and pass in both the DependencyProperty and the value:
+
+```cs
+new Style<TextBlock>()
+    .Setters(s => s.Add(HitchhikerGuide.AnswerProperty, 42));
+```
+
 ## Basing a Style on another Style
 
 Sometimes you may want to base a style on another style. This can be done one of two ways. The first is that you can provide the name/key of the style. It is important to remember that this has a limitation of only working for globally accessible styles through the Application and is best used for default styles.


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- unoplatform/uno#14947

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## Description

Adding section to explain how to add Style Setters for properties that do not have a generated Extension