### PR TITLE
fix(mvux): Fix selection not working properly

### DIFF
--- a/samples/Playground/Directory.Build.props
+++ b/samples/Playground/Directory.Build.props
@@ -11,6 +11,7 @@
 	<PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+	<LangVersion>latest</LangVersion>
 
     <DebugType>portable</DebugType>
     <DebugSymbols>True</DebugSymbols>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 		<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
 
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>latest</LangVersion>
 
 		<!-- https://github.com/unoplatform/private/issues/332 -->
 		<!-- <Nullable>annotations</Nullable> -->

--- a/src/Uno.Extensions.Reactive.Tests/Core/Axes/Given_SelectionInfo.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Axes/Given_SelectionInfo.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using FluentAssertions;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Uno.Extensions.Reactive.SelectionInfo;
+
+namespace Uno.Extensions.Reactive.Tests.Core.Axes;
+
+[TestClass]
+public class Given_SelectionInfo
+{
+	[TestMethod]
+	public void When_Contains()
+	{
+		Empty.Contains(42).Should().BeFalse();
+
+		Single(42).Contains(41).Should().BeFalse();
+		Single(42).Contains(42).Should().BeTrue();
+		Single(42).Contains(43).Should().BeFalse();
+
+		Multiple(42, 3).Contains(41).Should().BeFalse();
+		Multiple(42, 3).Contains(42).Should().BeTrue();
+		Multiple(42, 3).Contains(43).Should().BeTrue();
+		Multiple(42, 3).Contains(44).Should().BeTrue();
+		Multiple(42, 3).Contains(45).Should().BeFalse();
+	}
+
+	[TestMethod]
+	[DynamicData(nameof(GetAddCases), DynamicDataSourceType.Method)]
+	public void When_Add(TestCase @case)
+	{
+		var result = @case.Original.Add(@case.Range);
+
+		result.ToString().Should().Be(@case.Result);
+	}
+
+	private static IEnumerable<object[]> GetAddCases()
+	{
+		return GetCases()
+			//.Where(@case => @case.Line == 49)
+			.Select(@case => new object[] { @case with { Op = "+" } });
+
+		IEnumerable<TestCase> GetCases()
+		{
+			yield return new(Empty, new SelectionIndexRange(42, 0), "--Empty--");
+			yield return new(Empty, new SelectionIndexRange(42, 1), "[42, 42]");
+
+			// Overlapping and concomitant ranges
+			yield return new(Single(42), new SelectionIndexRange(40, 2), "[40, 42]");
+
+			yield return new(Single(42), new SelectionIndexRange(41, 0), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(41, 1), "[41, 42]");
+			yield return new(Single(42), new SelectionIndexRange(41, 2), "[41, 42]");
+			yield return new(Single(42), new SelectionIndexRange(41, 3), "[41, 43]");
+
+			yield return new(Single(42), new SelectionIndexRange(42, 0), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(42, 1), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(42, 2), "[42, 43]");
+
+			yield return new(Single(42), new SelectionIndexRange(43, 0), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(43, 1), "[42, 43]");
+			yield return new(Single(42), new SelectionIndexRange(43, 2), "[42, 44]");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(40, 2), "[40, 44]");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(41, 0), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(41, 1), "[41, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(41, 4), "[41, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(41, 5), "[41, 45]");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(42, 0), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(42, 1), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(42, 4), "[42, 45]");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(43, 0), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(43, 1), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(43, 3), "[42, 45]");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(44, 0), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(44, 1), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(44, 2), "[42, 45]");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(45, 0), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(45, 1), "[42, 45]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(45, 2), "[42, 46]");
+
+			// Disjoint ranges
+			yield return new(Single(42), new SelectionIndexRange(5, 0), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(5, 1), "[5, 5] & [42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(5, 2), "[5, 6] & [42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(40, 1), "[40, 40] & [42, 42]");
+
+			yield return new(Single(42), new SelectionIndexRange(50, 0), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(50, 1), "[42, 42] & [50, 50]");
+			yield return new(Single(42), new SelectionIndexRange(50, 2), "[42, 42] & [50, 51]");
+		}
+	}
+
+	[TestMethod]
+	[DynamicData(nameof(GetRemoveCases), DynamicDataSourceType.Method)]
+	public void When_Remove(TestCase @case)
+	{
+		var result = @case.Original.Remove(@case.Range);
+
+		result.ToString().Should().Be(@case.Result);
+	}
+
+	private static IEnumerable<object[]> GetRemoveCases()
+	{
+		return GetCases()
+			//.Where(@case => @case.Line == 141)
+			.Select(@case => new object[] { @case with { Op = "-" } });
+
+		IEnumerable<TestCase> GetCases()
+		{
+			yield return new(Empty, new SelectionIndexRange(42, 0), "--Empty--");
+			yield return new(Empty, new SelectionIndexRange(42, 1), "--Empty--");
+
+			// Overlapping and concomitant ranges
+			yield return new(Single(42), new SelectionIndexRange(40, 2), "[42, 42]");
+
+			yield return new(Single(42), new SelectionIndexRange(41, 0), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(41, 1), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(41, 2), "--Empty--");
+			yield return new(Single(42), new SelectionIndexRange(41, 3), "--Empty--");
+
+			yield return new(Single(42), new SelectionIndexRange(42, 0), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(42, 1), "--Empty--");
+			yield return new(Single(42), new SelectionIndexRange(42, 2), "--Empty--");
+
+			yield return new(Single(42), new SelectionIndexRange(43, 0), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(43, 1), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(43, 2), "[42, 42]");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(40, 2), "[42, 44]");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(41, 0), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(41, 1), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(41, 2), "[43, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(41, 3), "[44, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(41, 5), "--Empty--");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(41, 6), "--Empty--");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(42, 0), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(42, 1), "[43, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(42, 2), "[44, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(42, 3), "--Empty--");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(42, 4), "--Empty--");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(43, 0), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(43, 1), "[42, 42] & [44, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(43, 2), "[42, 42]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(43, 3), "[42, 42]");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(44, 0), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(44, 1), "[42, 43]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(44, 2), "[42, 43]");
+
+			yield return new(Multiple(42, 3), new SelectionIndexRange(45, 0), "[42, 44]");
+			yield return new(Multiple(42, 3), new SelectionIndexRange(45, 1), "[42, 44]");
+
+			// Disjoint ranges
+			yield return new(Single(42), new SelectionIndexRange(5, 0), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(5, 1), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(5, 2), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(40, 1), "[42, 42]");
+
+			yield return new(Single(42), new SelectionIndexRange(50, 0), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(50, 1), "[42, 42]");
+			yield return new(Single(42), new SelectionIndexRange(50, 2), "[42, 42]");
+		}
+	}
+
+	private static SelectionInfo Multiple(uint from, uint length)
+		=> Empty.Add(new SelectionIndexRange(from, length));
+
+	public record struct TestCase(SelectionInfo Original, SelectionIndexRange Range, string Result, [CallerLineNumber] int Line = -1)
+	{
+		public string Op { get; init; } = "with";
+
+		public override string ToString() => $"L{Line}: {Original} {Op} {Range} = {Result}";
+	}
+}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/SelectionFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/SelectionFacet.cs
@@ -274,7 +274,11 @@ internal class SelectionFacet : IDisposable, ISelectionInfo
 #endif
 		_service.SelectRange(itemIndexRange);
 
+#if UAP10_0_19041
+		if (_service.GetSelectedRanges() is { Count: 1 } ranges && ranges[0] is {Length: 1} singleSelection)
+#else
 		if (_service.GetSelectedRanges() is [{ Length: 1 } singleSelection])
+#endif
 		{
 			MoveCurrentToPosition(singleSelection.FirstIndex, isCancelable: false, isSelectionRangeUpdate: true);
 		}
@@ -295,7 +299,11 @@ internal class SelectionFacet : IDisposable, ISelectionInfo
 
 		if (CurrentPosition >= itemIndexRange.FirstIndex
 			&& CurrentPosition <= itemIndexRange.LastIndex
+#if UAP10_0_19041
+			&& _service.GetSelectedRanges() is { Count: 1 } ranges && ranges[0] is { Length: 1 } singleSelection)
+#else
 			&& _service.GetSelectedRanges() is [{ Length: 1 } singleSelection])
+#endif
 		{
 			MoveCurrentToPosition(singleSelection.FirstIndex, isCancelable: false, isSelectionRangeUpdate: true);
 		}
@@ -355,7 +363,7 @@ internal class SelectionFacet : IDisposable, ISelectionInfo
 		=> _service?.GetSelectedRanges() ?? Array.Empty<ItemIndexRange>();
 #endif
 
-	#endregion
+#endregion
 
 	public void Dispose()
 	{

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/SelectionFacet.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Facets/SelectionFacet.cs
@@ -274,9 +274,9 @@ internal class SelectionFacet : IDisposable, ISelectionInfo
 #endif
 		_service.SelectRange(itemIndexRange);
 
-		if (_service.GetSelectedRanges() is { Count: 1 } selection)
+		if (_service.GetSelectedRanges() is [{ Length: 1 } singleSelection])
 		{
-			MoveCurrentToPosition(selection.First().FirstIndex, isCancelable: false, isSelectionRangeUpdate: true);
+			MoveCurrentToPosition(singleSelection.FirstIndex, isCancelable: false, isSelectionRangeUpdate: true);
 		}
 	}
 
@@ -295,9 +295,9 @@ internal class SelectionFacet : IDisposable, ISelectionInfo
 
 		if (CurrentPosition >= itemIndexRange.FirstIndex
 			&& CurrentPosition <= itemIndexRange.LastIndex
-			&& _service.GetSelectedRanges() is { Count: >= 1 } selection)
+			&& _service.GetSelectedRanges() is [{ Length: 1 } singleSelection])
 		{
-			MoveCurrentToPosition(selection.First().FirstIndex, isCancelable: false, isSelectionRangeUpdate: true);
+			MoveCurrentToPosition(singleSelection.FirstIndex, isCancelable: false, isSelectionRangeUpdate: true);
 		}
 	}
 

--- a/src/Uno.Extensions.Reactive/Core/Axes/SelectionIndexRange.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/SelectionIndexRange.cs
@@ -17,5 +17,7 @@ public sealed record SelectionIndexRange(uint FirstIndex, uint Length)
 
 	/// <inheritdoc />
 	public override string ToString()
-		=> $"[{FirstIndex}, {LastIndex}]";
+		=> Length is 0
+			? "--Empty--"
+			: $"[{FirstIndex}, {LastIndex}]";
 }

--- a/src/Uno.Extensions.Reactive/Core/Axes/SelectionInfo.cs
+++ b/src/Uno.Extensions.Reactive/Core/Axes/SelectionInfo.cs
@@ -201,7 +201,7 @@ public sealed record SelectionInfo
 	/// <param name="index">The index to validate.</param>
 	/// <returns>True is the index is present, false otherwise.</returns>
 	public bool Contains(int index)
-		=> Ranges.Any(range => range.FirstIndex >= index && range.LastIndex <= index);
+		=> Ranges.Any(range => range.FirstIndex <= index && index <= range.LastIndex);
 
 	/// <summary>
 	/// Create a new SelectionInfo which contains ranges of this instance among the provided <paramref name="range"/>.

--- a/src/Uno.Extensions.Reactive/Utils/SelectionHelper.cs
+++ b/src/Uno.Extensions.Reactive/Utils/SelectionHelper.cs
@@ -27,7 +27,10 @@ internal static class SelectionHelper
 			var intersect = (long)previous.LastIndex + 1 - current.FirstIndex;
 			if (intersect >= 0)
 			{
-				previous = previous with { Length = previous.Length + current.Length - (uint)intersect };
+				if (intersect < current.Length) // The previous range already contains the current one
+				{
+					previous = previous with { Length = previous.Length + current.Length - (uint)intersect };
+				}
 			}
 			else
 			{
@@ -42,7 +45,12 @@ internal static class SelectionHelper
 
 	public static IReadOnlyList<SelectionIndexRange> Add(IReadOnlyList<SelectionIndexRange> ranges, SelectionIndexRange added)
 	{
-		if (ranges.Count is 0 || added.Length is 0)
+		if (added is null or { Length: 0 })
+		{
+			return ranges;
+		}
+
+		if (ranges.Count is 0)
 		{
 			return new[] { added };
 		}
@@ -55,7 +63,7 @@ internal static class SelectionHelper
 
 	public static IReadOnlyList<SelectionIndexRange> Remove(IReadOnlyList<SelectionIndexRange> ranges, SelectionIndexRange removed)
 	{
-		if (ranges.Count is 0 || removed.Length is 0)
+		if (ranges.Count is 0 || removed is null or { Length: 0 })
 		{
 			return ranges;
 		}
@@ -68,10 +76,17 @@ internal static class SelectionHelper
 				continue;
 			}
 
+			// Determine leading remaining items of the range
 			if (range.FirstIndex < removed.FirstIndex)
 			{
-				var lastIndex = Math.Min(range.LastIndex, removed.FirstIndex);
-				var length = range.FirstIndex - lastIndex + 1;
+				var lastIndex = Math.Min(range.LastIndex, removed.FirstIndex - 1);
+				var length = lastIndex + 1 - range.FirstIndex;
+
+				if (length == 0)
+				{
+					// All items has been removed, continue!
+					continue;
+				}
 
 				if (length == range.Length)
 				{
@@ -83,14 +98,21 @@ internal static class SelectionHelper
 				result.Add(new(range.FirstIndex, length));
 			}
 
-			if (range.LastIndex >= removed.LastIndex)
+			// Then check is there are trailing remaining items
+			if (range.LastIndex > removed.LastIndex)
 			{
-				var firstIndex = Math.Max(range.FirstIndex, removed.LastIndex);
-				var length = range.Length - (firstIndex - range.FirstIndex);
+				var firstIndex = Math.Min(range.LastIndex, Math.Max(range.FirstIndex, removed.LastIndex + 1));
+				var length = range.LastIndex + 1 - firstIndex;
+
+				if (length == 0)
+				{
+					// All items has been removed, continue!
+					continue;
+				}
 
 				if (length == range.Length)
 				{
-					// The whole range is before the exclusion, keep instance and continue!
+					// The whole range is after the exclusion, keep instance and continue!
 					result.Add(range);
 					continue;
 				}

--- a/testing/TestHarness/Directory.Build.props
+++ b/testing/TestHarness/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="15.0">
 	<PropertyGroup>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>latest</LangVersion>
 
 		<!-- https://github.com/unoplatform/private/issues/332 -->
 		<Nullable>annotations</Nullable>


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/discussions/15654

## Bugfix
Fix selection not working properly

## What is the current behavior?
* `ICollectionView.CurrentItem` when selecting item right after the currently selected one, causing circular selection
* Invalid coercing of the item index ranges
* Invalid check to determine if an item is currently selected or not

## What is the new behavior?
🙃

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
