### PR TITLE
feat(mvux): Improve nullable support

### DIFF
--- a/src/Uno.Extensions.Core/Option.T.cs
+++ b/src/Uno.Extensions.Core/Option.T.cs
@@ -166,6 +166,6 @@ public readonly struct Option<T> : IOption, IEquatable<Option<T>>
 		{
 			OptionType.Undefined => $"Undefined<{typeof(T).Name}>",
 			OptionType.None => $"None<{typeof(T).Name}>",
-			_ => $"Some({(_value is IEnumerable enumerable ? string.Join(",", enumerable.Cast<object>()) : _value)})",
+			_ => $"Some({_value switch { string => _value, IEnumerable enumerable => string.Join(",", enumerable.Cast<object>()), _ => _value }})",
 		};
 }

--- a/src/Uno.Extensions.Reactive.Messaging/MessengerExtensions.cs
+++ b/src/Uno.Extensions.Reactive.Messaging/MessengerExtensions.cs
@@ -109,7 +109,7 @@ public static class MessengerExtensions
 		{
 			using var _ = SourceContext.GetOrCreate(other).AsCurrent();
 
-			if ((await other.Option(ct)).IsSome(out var master) && predicate(master, message.Value))
+			if ((await other.Data(ct)).IsSome(out var master) && predicate(master, message.Value))
 			{
 				await update(state, message, keySelector, ct);
 			}

--- a/src/Uno.Extensions.Reactive.Testing/ConstraintParts/ItemsConstraint.cs
+++ b/src/Uno.Extensions.Reactive.Testing/ConstraintParts/ItemsConstraint.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Uno.Extensions.Reactive.Testing;
 
@@ -34,7 +36,19 @@ public sealed class ItemsConstraint<T> : AxisConstraint
 		if (actualItemsOpt.IsSome(out var actualItems))
 		{
 			actualItems.Should().BeAssignableTo<IImmutableList<T>>();
-			((IImmutableList<T>)actualItems).Should().BeEquivalentTo(_items.SomeOrDefault()!);
+
+			var actualImmutableItems = (IImmutableList<T>)actualItems;
+			var expectedImmutableItems = _items.SomeOrDefault()!;
+
+			actualImmutableItems.Count.Should().Be(expectedImmutableItems.Count);
+
+			for (var i = 0; i < expectedImmutableItems.Count; i++)
+			{
+				using (AssertionScope.Current.ForContext($"item [{i}]"))
+				{
+					actualImmutableItems[i].Should().BeEquivalentTo(expectedImmutableItems[i]);
+				}
+			}
 		}
 	}
 

--- a/src/Uno.Extensions.Reactive.Tests/Given_Feed.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Given_Feed.cs
@@ -24,11 +24,11 @@ public class Given_Feed : FeedTests
 		result.Should().Be(42);
 	}
 
-	[TestMethod]
-	public async Task When_Async()
-	{
-		var sut = Feed.Async<int>(async ct => 42);
-		var result = await sut.Option(CT);
+		[TestMethod]
+		public async Task When_Async()
+		{
+			var sut = Feed.Async<int>(async ct => 42);
+			var result = await sut.Data(CT);
 
 		result.IsSome(out var items).Should().BeTrue();
 		items.Should().Be(42);

--- a/src/Uno.Extensions.Reactive.Tests/Given_ListFeed.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Given_ListFeed.cs
@@ -32,7 +32,7 @@ public class Given_ListFeed : FeedTests
 	{
 		var source = new[] { 41, 42, 43 };
 		var sut = ListFeed.Async<int>(async ct => source.ToImmutableList());
-		var result = await sut.Option(CT);
+		var result = await sut.Data(CT);
 
 		result.IsSome(out var items).Should().BeTrue();
 		items.Should().BeEquivalentTo(source);

--- a/src/Uno.Extensions.Reactive.Tests/Messaging/Given_Messaging.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Messaging/Given_Messaging.cs
@@ -26,7 +26,7 @@ public class Given_Messaging : FeedTests
 
 		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Created, new(42)));
 
-		var result = await state.Option(CT);
+		var result = await state.Data(CT);
 		result.Should().Be(Option<MyEntity>.None());
 	}
 
@@ -54,7 +54,7 @@ public class Given_Messaging : FeedTests
 
 		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Deleted, new(42, 1)));
 
-		var result = await state.Option(CT);
+		var result = await state.Data(CT);
 		result.Should().Be(Option<MyEntity>.None());
 	}
 
@@ -111,7 +111,7 @@ public class Given_Messaging : FeedTests
 
 		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Created, new(42)));
 
-		var result = await state.Option(CT);
+		var result = await state.Data(CT);
 		result.Should().Be(Option<MyEntity>.None());
 	}
 
@@ -145,7 +145,7 @@ public class Given_Messaging : FeedTests
 		intermediate.Should().BeEquivalentTo(new MyEntity(42));
 
 		messenger.Send(new EntityMessage<MyEntity>(EntityChange.Deleted, new(42, 2)));
-		var result = await state.Option(CT);
+		var result = await state.Data(CT);
 		result.Should().Be(Option<MyEntity>.None());
 	}
 

--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_CoreFeedOperators.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_CoreFeedOperators.cs
@@ -1,0 +1,303 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Operators;
+
+[TestClass]
+public class Given_CoreFeedOperators
+{
+	#region GetAwaiter
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))]
+	public async Task When_GetAwaiter_Then_AcceptsNotNullAndStruct()
+	{
+		// Note: Those ar compilation tests! Will always throw null ref
+
+		var intValue = await default(IFeed<int>)!;
+		var nullableIntValue = await default(IFeed<int?>)!;
+
+		var stringValue = await default(IFeed<string>)!;
+#nullable disable
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+		var nullableStringValue = await default(IFeed<string?>)!;
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+#nullable restore
+
+		var structValue = await default(IFeed<MyStruct>)!;
+		var nullableStructValue = await default(IFeed<MyStruct?>)!;
+
+		var classValue = await default(IFeed<MyClass>)!;
+#nullable disable
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+		var nullableClassValue = await default(IFeed<MyClass?>)!;
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+#nullable restore
+	}
+
+	[TestMethod]
+	public async Task When_GetAwaiter_Then_GetValue()
+	{
+		(await Feed.Dynamic(async ct => 42)).Should().Be(42);
+	}
+
+	[TestMethod]
+	[DataRow(AsyncFeedValue.Default, 42)]
+	[DataRow(AsyncFeedValue.AllowTransient, 41)]
+	[DataRow(AsyncFeedValue.AllowError, 42)]
+	[DataRow(AsyncFeedValue.All, 41)]
+	public async Task When_ValueWithTransient_Then_GetValue(AsyncFeedValue kind, int expected)
+		=> (await GetFeedWithTransient().Value(kind)).Should().Be(expected);
+
+	[TestMethod]
+	[DataRow(AsyncFeedValue.Default, -1, true)]
+	[DataRow(AsyncFeedValue.AllowTransient, -1, true)]
+	[DataRow(AsyncFeedValue.AllowError, 41, false)]
+	[DataRow(AsyncFeedValue.All, 41, false)]
+	public async Task When_ValueWithError_Then_GetValue(AsyncFeedValue kind, int expected, bool expectError)
+	{
+		var gotException = false;
+		try
+		{
+			(await GetFeedWithError().Value(kind)).Should().Be(expected);
+		}
+		catch (TestException) when (expectError)
+		{
+			gotException = true;
+		}
+
+		if (expectError && !gotException)
+		{
+			Assert.Fail("Didn't get expected exception.");
+		}
+	}
+
+	[TestMethod]
+	[DataRow(AsyncFeedValue.Default, 42, false)]
+	[DataRow(AsyncFeedValue.AllowTransient, -1, true)]
+	[DataRow(AsyncFeedValue.AllowError, 42, false)]
+	[DataRow(AsyncFeedValue.All, 41, false)]
+	public async Task When_ValueWithTransientAndError_Then_GetValue(AsyncFeedValue kind, int expected, bool expectError)
+	{
+		var gotException = false;
+		try
+		{
+			(await GetFeedWithTransientAndError().Value(kind)).Should().Be(expected);
+		}
+		catch (TestException) when (expectError)
+		{
+			gotException = true;
+		}
+
+		if (expectError && !gotException)
+		{
+			Assert.Fail("Didn't get expected exception.");
+		}
+	}
+
+	[TestMethod]
+	[DataRow(AsyncFeedValue.Default, -1, true)]
+	[DataRow(AsyncFeedValue.AllowTransient, -1, true)]
+	[DataRow(AsyncFeedValue.AllowError, 42, false)]
+	[DataRow(AsyncFeedValue.All, 41, false)]
+	public async Task When_ValueWithTransientAndError_2_Then_GetValue(AsyncFeedValue kind, int expected, bool expectError)
+	{
+		var gotException = false;
+		try
+		{
+			(await GetFeedWithTransientAndError(true).Value(kind)).Should().Be(expected);
+		}
+		catch (TestException) when (expectError)
+		{
+			gotException = true;
+		}
+
+		if (expectError && !gotException)
+		{
+			Assert.Fail("Didn't get expected exception.");
+		}
+	}
+	#endregion
+
+	#region Value
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: Those are compilation tests! Will always throw null ref
+	public async Task When_Value_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = await default(IFeed<int>)!.Value();
+		var nullableIntValue = await default(IFeed<int?>)!.Value();
+
+		var stringValue = await default(IFeed<string>)!.Value();
+#nullable disable
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+		var nullableStringValue = await default(IFeed<string?>)!.Value();
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+#nullable restore
+
+		var structValue = await default(IFeed<MyStruct>)!.Value();
+		var nullableStructValue = await default(IFeed<MyStruct?>)!.Value();
+
+		var classValue = await default(IFeed<MyClass>)!.Value();
+#nullable disable
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+		var nullableClassValue = await default(IFeed<MyClass?>)!.Value();
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+#nullable restore
+	}
+
+	[TestMethod]
+	public async Task When_Values_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = default(IFeed<int>)!.Values();
+		var nullableIntValue = default(IFeed<int?>)!.Values();
+
+		var stringValue = default(IFeed<string>)!.Values();
+#nullable disable
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+		var nullableStringValue = default(IFeed<string?>)!.Values();
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+#nullable restore
+
+		var structValue = default(IFeed<MyStruct>)!.Values();
+		var nullableStructValue = default(IFeed<MyStruct?>)!.Values();
+
+		var classValue = default(IFeed<MyClass>)!.Values();
+#nullable disable
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+		var nullableClassValue = default(IFeed<MyClass?>)!.Values();
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+#nullable restore
+	}
+
+	[TestMethod]
+	public async Task When_Value_Then_GetValue()
+	{
+		(await Feed.Dynamic(async ct => 42).Value()).Should().Be(42);
+	}
+	#endregion
+
+	#region Data
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: Those are compilation tests! Will always throw null ref
+	public async Task When_Data_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = await default(IFeed<int>)!.Data();
+		var nullableIntValue = await default(IFeed<int?>)!.Data();
+
+		var stringValue = await default(IFeed<string>)!.Data();
+		var nullableStringValue = await default(IFeed<string?>)!.Data();
+
+		var structValue = await default(IFeed<MyStruct>)!.Data();
+		var nullableStructValue = await default(IFeed<MyStruct?>)!.Data();
+
+		var classValue = await default(IFeed<MyClass>)!.Data();
+		var nullableClassValue = await default(IFeed<MyClass?>)!.Data();
+	}
+
+	[TestMethod]
+	public async Task When_DataSet_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = default(IFeed<int>)!.DataSet();
+		var nullableIntValue = default(IFeed<int?>)!.DataSet();
+
+		var stringValue = default(IFeed<string>)!.DataSet();
+		var nullableStringValue = default(IFeed<string?>)!.DataSet();
+
+		var structValue = default(IFeed<MyStruct>)!.DataSet();
+		var nullableStructValue = default(IFeed<MyStruct?>)!.DataSet();
+
+		var classValue = default(IFeed<MyClass>)!.DataSet();
+		var nullableClassValue = default(IFeed<MyClass?>)!.DataSet();
+	}
+	#endregion
+
+	#region Message
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: Those are compilation tests! Will always throw null ref
+	public async Task When_Message_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = await default(IFeed<int>)!.Message();
+		var nullableIntValue = await default(IFeed<int?>)!.Message();
+
+		var stringValue = await default(IFeed<string>)!.Message();
+		var nullableStringValue = await default(IFeed<string?>)!.Message();
+
+		var structValue = await default(IFeed<MyStruct>)!.Message();
+		var nullableStructValue = await default(IFeed<MyStruct?>)!.Message();
+
+		var classValue = await default(IFeed<MyClass>)!.Message();
+		var nullableClassValue = await default(IFeed<MyClass?>)!.Message();
+	}
+
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: Those are compilation tests! Will always throw null ref
+	public async Task When_Messages_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = default(IFeed<int>)!.Messages();
+		var nullableIntValue = default(IFeed<int?>)!.Messages();
+
+		var stringValue = default(IFeed<string>)!.Messages();
+		var nullableStringValue = default(IFeed<string?>)!.Messages();
+
+		var structValue = default(IFeed<MyStruct>)!.Messages();
+		var nullableStructValue = default(IFeed<MyStruct?>)!.Messages();
+
+		var classValue = default(IFeed<MyClass>)!.Messages();
+		var nullableClassValue = default(IFeed<MyClass?>)!.Messages();
+	}
+	#endregion
+
+	private record class MyClass();
+	private record struct MyStruct();
+
+	private static IFeed<int> GetFeedWithTransient()
+	{
+		async IAsyncEnumerable<Message<int>> GetMessages([EnumeratorCancellation] CancellationToken ct)
+		{
+			var message = Message<int>.Initial;
+			yield return message = message.With().IsTransient(true).Data(41);
+			yield return message = message.With().Data(42);
+			yield return message = message.With().IsTransient(false);
+		}
+
+		return Feed.Create(GetMessages);
+	}
+
+	private static IFeed<int> GetFeedWithError()
+	{
+		async IAsyncEnumerable<Message<int>> GetMessages([EnumeratorCancellation] CancellationToken ct)
+		{
+			var message = Message<int>.Initial;
+			yield return message = message.With().Error(new TestException()).Data(41);
+			yield return message = message.With().Data(42);
+			yield return message = message.With().Error(null);
+		}
+
+		return Feed.Create(GetMessages);
+	}
+
+	private static IFeed<int> GetFeedWithTransientAndError(bool finalBeforeClearError = false)
+	{
+		async IAsyncEnumerable<Message<int>> GetMessages([EnumeratorCancellation] CancellationToken ct)
+		{
+			var message = Message<int>.Initial;
+			yield return message = message.With().IsTransient(true).Error(new TestException()).Data(41);
+			yield return message = message.With().Data(42);
+			if (finalBeforeClearError)
+			{
+				yield return message = message.With().IsTransient(false);
+				yield return message = message.With().Error(null);
+			}
+			else
+			{
+				yield return message = message.With().Error(null);
+				yield return message = message.With().IsTransient(false);
+			}
+		}
+
+		return Feed.Create(GetMessages);
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_CoreListFeedOperators.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_CoreListFeedOperators.cs
@@ -1,0 +1,280 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Operators;
+
+[TestClass]
+public class Given_CoreListFeedOperators
+{
+	#region GetAwaiter
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))]
+	public async Task When_GetAwaiter_Then_AcceptsNotNullAndStruct()
+	{
+		// Note: Those ar compilation tests! Will always throw null ref
+
+		var intValue = await default(IListFeed<int>)!;
+		var nullableIntValue = await default(IListFeed<int?>)!;
+
+		var stringValue = await default(IListFeed<string>)!;
+		var nullableStringValue = await default(IListFeed<string?>)!;
+
+		var structValue = await default(IListFeed<MyStruct>)!;
+		var nullableStructValue = await default(IListFeed<MyStruct?>)!;
+
+		var classValue = await default(IListFeed<MyClass>)!;
+		var nullableClassValue = await default(IListFeed<MyClass?>)!;
+	}
+
+	[TestMethod]
+	public async Task When_GetAwaiter_Then_GetValue()
+	{
+		(await Feed.Dynamic(async ct => ImmutableList.Create(42)).AsListFeed()).Should().BeEquivalentTo(new[] { 42 });
+	}
+
+	[TestMethod]
+	[DataRow(AsyncFeedValue.Default, 42)]
+	[DataRow(AsyncFeedValue.AllowTransient, 41)]
+	[DataRow(AsyncFeedValue.AllowError, 42)]
+	[DataRow(AsyncFeedValue.All, 41)]
+	public async Task When_ValueWithTransient_Then_GetValue(AsyncFeedValue kind, int expected)
+		=> (await GetFeedWithTransient().Value(kind)).Should().BeEquivalentTo(new[] { expected });
+
+	[TestMethod]
+	[DataRow(AsyncFeedValue.Default, -1, true)]
+	[DataRow(AsyncFeedValue.AllowTransient, -1, true)]
+	[DataRow(AsyncFeedValue.AllowError, 41, false)]
+	[DataRow(AsyncFeedValue.All, 41, false)]
+	public async Task When_ValueWithError_Then_GetValue(AsyncFeedValue kind, int expected, bool expectError)
+	{
+		var gotException = false;
+		try
+		{
+			(await GetFeedWithError().Value(kind)).Should().BeEquivalentTo(new[] { expected });
+		}
+		catch (TestException) when (expectError)
+		{
+			gotException = true;
+		}
+
+		if (expectError && !gotException)
+		{
+			Assert.Fail("Didn't get expected exception.");
+		}
+	}
+
+	[TestMethod]
+	[DataRow(AsyncFeedValue.Default, 42, false)]
+	[DataRow(AsyncFeedValue.AllowTransient, -1, true)]
+	[DataRow(AsyncFeedValue.AllowError, 42, false)]
+	[DataRow(AsyncFeedValue.All, 41, false)]
+	public async Task When_ValueWithTransientAndError_Then_GetValue(AsyncFeedValue kind, int expected, bool expectError)
+	{
+		var gotException = false;
+		try
+		{
+			(await GetFeedWithTransientAndError().Value(kind)).Should().BeEquivalentTo(new[] { expected });
+		}
+		catch (TestException) when (expectError)
+		{
+			gotException = true;
+		}
+
+		if (expectError && !gotException)
+		{
+			Assert.Fail("Didn't get expected exception.");
+		}
+	}
+
+	[TestMethod]
+	[DataRow(AsyncFeedValue.Default, -1, true)]
+	[DataRow(AsyncFeedValue.AllowTransient, -1, true)]
+	[DataRow(AsyncFeedValue.AllowError, 42, false)]
+	[DataRow(AsyncFeedValue.All, 41, false)]
+	public async Task When_ValueWithTransientAndError_2_Then_GetValue(AsyncFeedValue kind, int expected, bool expectError)
+	{
+		var gotException = false;
+		try
+		{
+			(await GetFeedWithTransientAndError(true).Value(kind)).Should().BeEquivalentTo(new[] { expected });
+		}
+		catch (TestException) when (expectError)
+		{
+			gotException = true;
+		}
+
+		if (expectError && !gotException)
+		{
+			Assert.Fail("Didn't get expected exception.");
+		}
+	}
+	#endregion
+
+	#region Value
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: Those are compilation tests! Will always throw null ref
+	public async Task When_Value_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = await default(IListFeed<int>)!.Value();
+		var nullableIntValue = await default(IListFeed<int?>)!.Value();
+
+		var stringValue = await default(IListFeed<string>)!.Value();
+		var nullableStringValue = await default(IListFeed<string?>)!.Value();
+
+		var structValue = await default(IListFeed<MyStruct>)!.Value();
+		var nullableStructValue = await default(IListFeed<MyStruct?>)!.Value();
+
+		var classValue = await default(IListFeed<MyClass>)!.Value();
+		var nullableClassValue = await default(IListFeed<MyClass?>)!.Value();
+	}
+
+	[TestMethod]
+	public async Task When_Values_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = default(IListFeed<int>)!.Values();
+		var nullableIntValue = default(IListFeed<int?>)!.Values();
+
+		var stringValue = default(IListFeed<string>)!.Values();
+		var nullableStringValue = default(IListFeed<string?>)!.Values();
+
+		var structValue = default(IListFeed<MyStruct>)!.Values();
+		var nullableStructValue = default(IListFeed<MyStruct?>)!.Values();
+
+		var classValue = default(IListFeed<MyClass>)!.Values();
+		var nullableClassValue = default(IListFeed<MyClass?>)!.Values();
+	}
+
+	[TestMethod]
+	public async Task When_Value_Then_GetValue()
+	{
+		(await Feed.Dynamic(async ct => ImmutableList.Create(42)).AsListFeed().Value()).Should().BeEquivalentTo(new[] { 42 });
+	}
+	#endregion
+
+	#region Data
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: Those are compilation tests! Will always throw null ref
+	public async Task When_Data_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = await default(IListFeed<int>)!.Data();
+		var nullableIntValue = await default(IListFeed<int?>)!.Data();
+
+		var stringValue = await default(IListFeed<string>)!.Data();
+		var nullableStringValue = await default(IListFeed<string?>)!.Data();
+
+		var structValue = await default(IListFeed<MyStruct>)!.Data();
+		var nullableStructValue = await default(IListFeed<MyStruct?>)!.Data();
+
+		var classValue = await default(IListFeed<MyClass>)!.Data();
+		var nullableClassValue = await default(IListFeed<MyClass?>)!.Data();
+	}
+
+	[TestMethod]
+	public async Task When_DataSet_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = default(IListFeed<int>)!.DataSet();
+		var nullableIntValue = default(IListFeed<int?>)!.DataSet();
+
+		var stringValue = default(IListFeed<string>)!.DataSet();
+		var nullableStringValue = default(IListFeed<string?>)!.DataSet();
+
+		var structValue = default(IListFeed<MyStruct>)!.DataSet();
+		var nullableStructValue = default(IListFeed<MyStruct?>)!.DataSet();
+
+		var classValue = default(IListFeed<MyClass>)!.DataSet();
+		var nullableClassValue = default(IListFeed<MyClass?>)!.DataSet();
+	}
+	#endregion
+
+	#region Message
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: Those are compilation tests! Will always throw null ref
+	public async Task When_Message_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = await default(IListFeed<int>)!.Message();
+		var nullableIntValue = await default(IListFeed<int?>)!.Message();
+
+		var stringValue = await default(IListFeed<string>)!.Message();
+		var nullableStringValue = await default(IListFeed<string?>)!.Message();
+
+		var structValue = await default(IListFeed<MyStruct>)!.Message();
+		var nullableStructValue = await default(IListFeed<MyStruct?>)!.Message();
+
+		var classValue = await default(IListFeed<MyClass>)!.Message();
+		var nullableClassValue = await default(IListFeed<MyClass?>)!.Message();
+	}
+
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: Those are compilation tests! Will always throw null ref
+	public async Task When_Messages_Then_AcceptsNotNullAndStruct()
+	{
+		var intValue = default(IListFeed<int>)!.Messages();
+		var nullableIntValue = default(IListFeed<int?>)!.Messages();
+
+		var stringValue = default(IListFeed<string>)!.Messages();
+		var nullableStringValue = default(IListFeed<string?>)!.Messages();
+
+		var structValue = default(IListFeed<MyStruct>)!.Messages();
+		var nullableStructValue = default(IListFeed<MyStruct?>)!.Messages();
+
+		var classValue = default(IListFeed<MyClass>)!.Messages();
+		var nullableClassValue = default(IListFeed<MyClass?>)!.Messages();
+	}
+	#endregion
+
+	private record class MyClass();
+	private record struct MyStruct();
+
+	private static IListFeed<int> GetFeedWithTransient()
+	{
+		async IAsyncEnumerable<Message<IImmutableList<int>>> GetMessages([EnumeratorCancellation] CancellationToken ct)
+		{
+			var message = Message<IImmutableList<int>>.Initial;
+			yield return message = message.With().IsTransient(true).Data(ImmutableList.Create(41));
+			yield return message = message.With().Data(ImmutableList.Create(42));
+			yield return message = message.With().IsTransient(false);
+		}
+
+		return Feed.Create(GetMessages).AsListFeed();
+	}
+
+	private static IListFeed<int> GetFeedWithError()
+	{
+		async IAsyncEnumerable<Message<IImmutableList<int>>> GetMessages([EnumeratorCancellation] CancellationToken ct)
+		{
+			var message = Message<IImmutableList<int>>.Initial;
+			yield return message = message.With().Error(new TestException()).Data(ImmutableList.Create(41));
+			yield return message = message.With().Data(ImmutableList.Create(42));
+			yield return message = message.With().Error(null);
+		}
+
+		return Feed.Create(GetMessages).AsListFeed();
+	}
+
+	private static IListFeed<int> GetFeedWithTransientAndError(bool finalBeforeClearError = false)
+	{
+		async IAsyncEnumerable<Message<IImmutableList<int>>> GetMessages([EnumeratorCancellation] CancellationToken ct)
+		{
+			var message = Message<IImmutableList<int>>.Initial;
+			yield return message = message.With().IsTransient(true).Error(new TestException()).Data(ImmutableList.Create(41));
+			yield return message = message.With().Data(ImmutableList.Create(42));
+			if (finalBeforeClearError)
+			{
+				yield return message = message.With().IsTransient(false);
+				yield return message = message.With().Error(null);
+			}
+			else
+			{
+				yield return message = message.With().Error(null);
+				yield return message = message.With().IsTransient(false);
+			}
+		}
+
+		return Feed.Create(GetMessages).AsListFeed();
+	}
+}

--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_CoreListStateOperators.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_CoreListStateOperators.cs
@@ -1,0 +1,756 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Operators;
+
+[TestClass]
+public partial class Given_CoreListStateOperators : FeedTests
+{
+	#region UpdateAsync
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: This is a compilation tests!
+	public async Task When_UpdateAsync_Then_AcceptsNotNullAndStruct()
+	{
+		await default(IListState<int>)!.UpdateAsync(_ => ImmutableList.Create(42), CT);
+		await default(IListState<int>)!.UpdateAsync(_ => default(IImmutableList<int>), CT);
+		await default(IListState<int?>)!.UpdateAsync(_ => ImmutableList.Create<int?>(42), CT);
+		await default(IListState<int?>)!.UpdateAsync(_ => default(IImmutableList<int?>), CT);
+		await default(IListState<string>)!.UpdateAsync(_ => ImmutableList.Create(""), CT);
+		await default(IListState<string>)!.UpdateAsync(_ => default(IImmutableList<string>), CT);
+		await default(IListState<string?>)!.UpdateAsync(_ => ImmutableList.Create<string?>(""), CT);
+		await default(IListState<string?>)!.UpdateAsync(_ => default(IImmutableList<string?>), CT);
+		await default(IListState<MyStruct>)!.UpdateAsync(_ => ImmutableList.Create<MyStruct>(new MyStruct()), CT);
+		await default(IListState<MyStruct>)!.UpdateAsync(_ => default(IImmutableList<MyStruct>), CT);
+		await default(IListState<MyStruct?>)!.UpdateAsync(_ => ImmutableList.Create<MyStruct?>(new MyStruct()), CT);
+		await default(IListState<MyStruct?>)!.UpdateAsync(_ => default(IImmutableList<MyStruct?>), CT);
+		await default(IListState<MyClass>)!.UpdateAsync(_ => ImmutableList.Create<MyClass>(new MyClass()), CT);
+		await default(IListState<MyClass>)!.UpdateAsync(_ => default(IImmutableList<MyClass>), CT);
+		await default(IListState<MyClass?>)!.UpdateAsync(_ => ImmutableList.Create<MyClass?>(new MyClass()), CT);
+		await default(IListState<MyClass?>)!.UpdateAsync(_ => default(IImmutableList<MyClass?>), CT);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullListStateOfInt_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create(42);
+		var state = ListState<int>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncEmptyListStateOfInt_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create(42);
+		var state = ListState<int>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => ImmutableList<int>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullListStateOfNullableInt_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<int?>(42);
+		var state = ListState<int?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncEmptyListStateOfNullableInt_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<int?>(42);
+		var state = ListState<int?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => ImmutableList<int?>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullListStateOfString_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<string>("42");
+		var state = ListState<string>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncEmptyListStateOfString_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<string>("42");
+		var state = ListState<string>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => ImmutableList<string>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullListStateOfNullableString_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<string?>("42");
+		var state = ListState<string?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncEmptyListStateOfNullableString_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<string?>("42");
+		var state = ListState<string?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => ImmutableList<string?>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullListStateOfStruct_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyStruct>(new MyStruct());
+		var state = ListState<MyStruct>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncEmptyListStateOfStruct_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyStruct>(new MyStruct());
+		var state = ListState<MyStruct>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => ImmutableList<MyStruct>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullListStateOfNullableStruct_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyStruct?>(new MyStruct());
+		var state = ListState<MyStruct?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncEmptyListStateOfNullableStruct_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyStruct?>(new MyStruct());
+		var state = ListState<MyStruct?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => ImmutableList<MyStruct?>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullListStateOfObject_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyClass>(new MyClass());
+		var state = ListState<MyClass>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Data.None));
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncEmptyListStateOfObject_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyClass>(new MyClass());
+		var state = ListState<MyClass>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => ImmutableList<MyClass>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Data.None));
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullListStateOfNullableObject_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyClass?>(new MyClass());
+		var state = ListState<MyClass?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None));
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncEmptyListStateOfNullableObject_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyClass?>(new MyClass());
+		var state = ListState<MyClass?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => ImmutableList<MyClass?>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None));
+	}
+	#endregion
+
+	#region UpdateDataAsync
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: This is a compilation tests!
+	public async Task When_UpdateDataAsync_Then_AcceptsNotNullAndStruct()
+	{
+		await default(IListState<int>)!.UpdateDataAsync(_ => ImmutableList.Create(42), CT);
+		await default(IListState<int>)!.UpdateDataAsync(_ => default(ImmutableList<int>)!, CT);
+		await default(IListState<int?>)!.UpdateDataAsync(_ => ImmutableList.Create<int?>(42), CT);
+		await default(IListState<int?>)!.UpdateDataAsync(_ => default(ImmutableList<int?>)!, CT);
+		await default(IListState<string>)!.UpdateDataAsync(_ => ImmutableList.Create(""), CT);
+		await default(IListState<string>)!.UpdateDataAsync(_ => default(ImmutableList<string>)!, CT);
+		await default(IListState<string?>)!.UpdateDataAsync(_ => ImmutableList.Create<string?>(""), CT);
+		await default(IListState<string?>)!.UpdateDataAsync(_ => default(ImmutableList<string?>)!, CT);
+		await default(IListState<MyStruct>)!.UpdateDataAsync(_ => ImmutableList.Create<MyStruct>(new MyStruct()), CT);
+		await default(IListState<MyStruct>)!.UpdateDataAsync(_ => default(ImmutableList<MyStruct>)!, CT);
+		await default(IListState<MyStruct?>)!.UpdateDataAsync(_ => ImmutableList.Create<MyStruct?>(new MyStruct()), CT);
+		await default(IListState<MyStruct?>)!.UpdateDataAsync(_ => default(ImmutableList<MyStruct?>)!, CT);
+		await default(IListState<MyClass>)!.UpdateDataAsync(_ => ImmutableList.Create<MyClass>(new MyClass()), CT);
+		await default(IListState<MyClass>)!.UpdateDataAsync(_ => default(ImmutableList<MyClass>)!, CT);
+		await default(IListState<MyClass?>)!.UpdateDataAsync(_ => ImmutableList.Create<MyClass?>(new MyClass()), CT);
+		await default(IListState<MyClass?>)!.UpdateDataAsync(_ => default(ImmutableList<MyClass?>)!, CT);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionListStateOfInt_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<int>(42);
+		var state = ListState<int>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<IImmutableList<int>>), CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultValueListStateOfInt_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<int>(42);
+		var state = ListState<int>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(ImmutableList<int>)!, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsEmptyListStateOfInt_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<int>(42);
+		var state = ListState<int>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => ImmutableList<int>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionListStateOfNullableInt_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<int?>(42);
+		var state = ListState<int?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<IImmutableList<int?>>), CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsNullListStateOfNullableInt_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<int?>(42);
+		var state = ListState<int?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(ImmutableList<int?>)!, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsEmptyListStateOfNullableInt_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<int?>(42);
+		var state = ListState<int?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => ImmutableList<int?>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionListStateOfString_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<string>("42");
+		var state = ListState<string>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<IImmutableList<string>>), CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultValueListStateOfString_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<string>("42");
+		var state = ListState<string>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(ImmutableList<string>)!, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsEmptyListStateOfString_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<string>("42");
+		var state = ListState<string>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => ImmutableList<string>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionListStateOfNullableString_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<string?>("42");
+		var state = ListState<string?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<IImmutableList<string?>>), CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsNullListStateOfNullableString_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<string?>("42");
+		var state = ListState<string?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(ImmutableList<string?>)!, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsEmptyListStateOfNullableString_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<string?>("42");
+		var state = ListState<string?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => ImmutableList<string?>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionListStateOfStruct_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyStruct>(new MyStruct());
+		var state = ListState<MyStruct>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<IImmutableList<MyStruct>>), CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultValueListStateOfStruct_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyStruct>(new MyStruct());
+		var state = ListState<MyStruct>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(ImmutableList<MyStruct>)!, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsEmptyListStateOfStruct_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyStruct>(new MyStruct());
+		var state = ListState<MyStruct>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => ImmutableList<MyStruct>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionListStateOfNullableStruct_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyStruct?>(new MyStruct());
+		var state = ListState<MyStruct?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<IImmutableList<MyStruct?>>), CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsNullListStateOfNullableStruct_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyStruct?>(new MyStruct());
+		var state = ListState<MyStruct?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(ImmutableList<MyStruct?>)!, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsEmptyListStateOfNullableStruct_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyStruct?>(new MyStruct());
+		var state = ListState<MyStruct?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => ImmutableList<MyStruct?>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionListStateOfObject_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyClass>(new MyClass());
+		var state = ListState<MyClass>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<IImmutableList<MyClass>>), CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultValueListStateOfObject_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyClass>(new MyClass());
+		var state = ListState<MyClass>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(ImmutableList<MyClass>)!, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsEmptyListStateOfObject_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyClass>(new MyClass());
+		var state = ListState<MyClass>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => ImmutableList<MyClass>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionListStateOfNullableObject_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyClass?>(new MyClass());
+		var state = ListState<MyClass?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<IImmutableList<MyClass?>>), CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsNullListStateOfNullableObject_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyClass?>(new MyClass());
+		var state = ListState<MyClass?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(ImmutableList<MyClass?>)!, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsEmptyListStateOfNullableObject_Then_TreatAsNone()
+	{
+		var value = ImmutableList.Create<MyClass?>(new MyClass());
+		var state = ListState<MyClass?>.Value(this, () => value);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => ImmutableList<MyClass?>.Empty, CT);
+
+		result.Should().Be(m => m
+			.Message(value)
+			.Message(Data.None)
+		);
+	}
+	#endregion
+
+	#region InsertAsync
+	[TestMethod]
+	public async Task WhenInsertAsync_Then_ItemAdded()
+	{
+		var sut = ListState.Value(this, () => ImmutableList.Create(42));
+		var result = sut.Record();
+
+		await sut.InsertAsync(43, CT);
+
+		result.Should().Be(m => m
+			.Message(Items.Some(42))
+			.Message(Items.Some(43, 42))
+		);
+	}
+	#endregion
+
+	#region AddAsync
+	[TestMethod]
+	public async Task WhenAddAsync_Then_ItemAdded()
+	{
+		var sut = ListState.Value(this, () => ImmutableList.Create(42));
+		var result = sut.Record();
+
+		await sut.AddAsync(43, CT);
+
+		result.Should().Be(m => m
+			.Message(Items.Some(42))
+			.Message(Items.Some(42, 43))
+		);
+	}
+	#endregion
+
+	#region RemoveAllAsync
+	[TestMethod]
+	public async Task WhenRemoveAllAsync_Then_ItemAdded()
+	{
+		var sut = ListState.Value(this, () => ImmutableList.Create(41, 42, 43));
+		var result = sut.Record();
+
+		await sut.RemoveAllAsync(i => i == 42, CT);
+
+		result.Should().Be(m => m
+			.Message(Items.Some(41, 42, 43))
+			.Message(Items.Some(41, 43))
+		);
+	}
+
+	[TestMethod]
+	public async Task WhenRemoveAllAsyncRemovesAllItems_Then_ItemAdded()
+	{
+		var sut = ListState.Value(this, () => ImmutableList.Create(41, 42, 43));
+		var result = sut.Record();
+
+		await sut.RemoveAllAsync(i => true, CT);
+
+		result.Should().Be(m => m
+			.Message(Items.Some(41, 42, 43))
+			.Message(Data.None)
+		);
+	}
+	#endregion
+
+	#region UpdateAllAsync
+	[TestMethod]
+	public async Task WhenUpdateAllAsync_Then_ItemAdded()
+	{
+		var sut = ListState.Value(this, () => ImmutableList.Create(41, 42, 43));
+		var result = sut.Record();
+
+		await sut.UpdateAllAsync(i => i == 42, i => i * 2, CT);
+
+		result.Should().Be(m => m
+			.Message(Items.Some(41, 42, 43))
+			.Message(Items.Some(41, 84, 43))
+		);
+	}
+	#endregion
+
+	#region UpdateAsync
+	[TestMethod]
+	public async Task WhenUpdateAsync_Then_ItemAdded()
+	{
+		var sut = ListState.Value(this, () => ImmutableList.Create(new MyItem(42, 0)));
+		var result = sut.Record();
+
+		await sut.UpdateAsync(new MyItem(42, 1), CT);
+
+		result.Should().Be(m => m
+			.Message(Items.Some(new MyItem(42, 0)))
+			.Message(Items.Some(new MyItem(42, 1)))
+		);
+	}
+	#endregion
+
+	private record class MyClass;
+	private record struct MyStruct;
+
+	internal partial record class MyItem(int Id, int Version);
+}

--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_CoreStateOperators.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_CoreStateOperators.cs
@@ -1,0 +1,511 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Operators;
+
+[TestClass]
+public class Given_CoreStateOperators : FeedTests
+{
+	#region UpdateAsync
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: This is a compilation tests!
+	public async Task When_UpdateAsync_Then_AcceptsNotNullAndStruct()
+	{
+		await default(IState<int>)!.UpdateAsync(_ => 42, CT);
+		await default(IState<int?>)!.UpdateAsync(_ => default(int?), CT);
+		await default(IState<string>)!.UpdateAsync(_ => "", CT);
+#nullable disable
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+		await default(IState<string?>)!.UpdateAsync(_ => default(string?), CT);
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+#nullable restore
+		await default(IState<MyStruct>)!.UpdateAsync(_ => new MyStruct(), CT);
+		await default(IState<MyStruct?>)!.UpdateAsync(_ => default(MyStruct?), CT);
+		await default(IState<MyClass>)!.UpdateAsync(_ => new MyClass(), CT);
+#nullable disable
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+		await default(IState<MyClass?>)!.UpdateAsync(_ => default(MyClass?), CT);
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+#nullable restore
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullStateOfInt_Then_TreatAsNone()
+	{
+		var state = State<int>.Value(this, () => 42);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(42)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullStateOfNullableInt_Then_TreatAsNone()
+	{
+		var state = State<int?>.Value(this, () => 42);
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(42)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullStateOfString_Then_TreatAsNone()
+	{
+		var state = State<string>.Value(this, () => "42");
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message("42")
+			.Message(Data.None)
+		);
+	}
+
+	//[TestMethod] // Forbidden, need to use UpdateDataAsync instead
+	//public async Task When_UpdateAsyncNullStateOfNullableString_Then_TreatAsNone()
+	//{
+	//	var state = State<string?>.Value(this, () => "42");
+	//	var result = state.Record();
+
+	//	await state.UpdateAsync(_ => null, CT);
+
+	//	result.Should().Be(m => m
+	//		.Message("42")
+	//		.Message(Data.None)
+	//	);
+	//}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullStateOfStruct_Then_TreatAsNone()
+	{
+		var state = State<MyStruct>.Value(this, () => new MyStruct());
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullStateOfNullableStruct_Then_TreatAsNone()
+	{
+		var state = State<MyStruct?>.Value(this, () => new MyStruct());
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateAsyncNullStateOfObject_Then_TreatAsNone()
+	{
+		var state = State<MyClass>.Value(this, () => new MyClass());
+		var result = state.Record();
+
+		await state.UpdateAsync(_ => null, CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Data.None));
+	}
+
+	//[TestMethod] // Forbidden, need to use UpdateDataAsync instead
+	//public async Task When_UpdateAsyncNullStateOfNullableObject_Then_TreatAsNone()
+	//{
+	//	var state = State<MyClass?>.Value(this, () => new MyClass());
+	//	var result = state.Record();
+
+	//	await state.UpdateAsync(_ => null, CT);
+
+	//	result.Should().Be(m => m
+	//		.Message(Data.Some)
+	//		.Message(Data.None));
+	//} 
+	#endregion
+
+	#region UpdateDataAsync
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: This is a compilation tests!
+	public async Task When_UpdateDataAsync_Then_AcceptsNotNullAndStruct()
+	{
+		await default(IState<int>)!.UpdateDataAsync(_ => 42, CT);
+		await default(IState<int?>)!.UpdateDataAsync(_ => default(int?), CT);
+		await default(IState<string>)!.UpdateDataAsync(_ => "", CT);
+		await default(IState<string?>)!.UpdateDataAsync(_ => default(string?), CT);
+		await default(IState<MyStruct>)!.UpdateDataAsync(_ => new MyStruct(), CT);
+		await default(IState<MyStruct?>)!.UpdateDataAsync(_ => default(MyStruct?), CT);
+		await default(IState<MyClass>)!.UpdateDataAsync(_ => new MyClass(), CT);
+		await default(IState<MyClass?>)!.UpdateDataAsync(_ => default(MyClass?), CT);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionStateOfInt_Then_TreatAsNone()
+	{
+		var state = State<int>.Value(this, () => 42);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<int>), CT);
+
+		result.Should().Be(m => m
+			.Message(42)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultValueStateOfInt_Then_TreatAsSome()
+	{
+		var state = State<int>.Value(this, () => 42);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(int), CT);
+
+		result.Should().Be(m => m
+			.Message(42)
+			.Message(0)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionStateOfNullableInt_Then_TreatAsNone()
+	{
+		var state = State<int?>.Value(this, () => 42);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<int?>), CT);
+
+		result.Should().Be(m => m
+			.Message(42)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsNullStateOfNullableInt_Then_TreatAsSome()
+	{
+		var state = State<int?>.Value(this, () => 42);
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(int?), CT);
+
+		result.Should().Be(m => m
+			.Message(42)
+			.Message(Option.Some(default(int?)))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionStateOfString_Then_TreatAsNone()
+	{
+		var state = State<string>.Value(this, () => "42");
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<string>), CT);
+
+		result.Should().Be(m => m
+			.Message("42")
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultValueStateOfString_Then_TreatAsSome()
+	{
+		var state = State<string>.Value(this, () => "42");
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(string)!, CT);
+
+		result.Should().Be(m => m
+			.Message("42")
+			.Message(default(string)!)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionStateOfNullableString_Then_TreatAsNone()
+	{
+		var state = State<string?>.Value(this, () => "42");
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<string?>), CT);
+
+		result.Should().Be(m => m
+			.Message("42")
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsNullStateOfNullableString_Then_TreatAsSome()
+	{
+		var state = State<string?>.Value(this, () => "42");
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(string?), CT);
+
+		result.Should().Be(m => m
+			.Message("42")
+			.Message(Option.Some(default(string?)))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionStateOfStruct_Then_TreatAsNone()
+	{
+		var state = State<MyStruct>.Value(this, () => new MyStruct());
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<MyStruct>), CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultValueStateOfStruct_Then_TreatAsSome()
+	{
+		var state = State<MyStruct>.Value(this, () => new MyStruct());
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(MyStruct), CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			// .Message(Data.Some) // Nothing changed!
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionStateOfNullableStruct_Then_TreatAsNone()
+	{
+		var state = State<MyStruct?>.Value(this, () => new MyStruct());
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<MyStruct?>), CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsNullStateOfNullableStruct_Then_TreatAsSome()
+	{
+		var state = State<MyStruct?>.Value(this, () => new MyStruct());
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(MyStruct?), CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Option.Some(default(MyStruct?)))
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionStateOfObject_Then_TreatAsNone()
+	{
+		var state = State<MyClass>.Value(this, () => new MyClass());
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<MyClass>), CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_UpdateDataAsyncReturnsDefaultValueStateOfObject_Then_TreatAsSome()
+	{
+		var state = State<MyClass>.Value(this, () => new MyClass());
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(MyClass)!, CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(default(MyClass)!)
+		);
+	}
+
+	[TestMethod] // Forbidden, need to use UpdateDataAsync instead
+	public async Task When_UpdateDataAsyncReturnsDefaultOptionStateOfNullableObject_Then_TreatAsNone()
+	{
+		var state = State<MyClass?>.Value(this, () => new MyClass());
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(Option<MyClass?>), CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod] // Forbidden, need to use UpdateDataAsync instead
+	public async Task When_UpdateDataAsyncReturnsNullStateOfNullableObject_Then_TreatAsSome()
+	{
+		var state = State<MyClass?>.Value(this, () => new MyClass());
+		var result = state.Record();
+
+		await state.UpdateDataAsync(_ => default(MyClass?), CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Option.Some(default(MyClass?)))
+		);
+	}
+	#endregion
+
+	#region SetAsync
+	[TestMethod]
+	[ExpectedException(typeof(NullReferenceException))] // Note: This is a compilation tests!
+	public async Task When_SetAsync_Then_AcceptsNotNullAndStruct()
+	{
+		await default(IState<int>)!.SetAsync(42, CT);
+		await default(IState<int>)!.SetAsync(null, CT);
+
+		await default(IState<int?>)!.SetAsync(42, CT);
+		await default(IState<int?>)!.SetAsync(null, CT);
+
+		await default(IState<string>)!.SetAsync("", CT);
+		await default(IState<string>)!.SetAsync(null, CT);
+
+		await default(IState<string?>)!.SetAsync("", CT);
+		await default(IState<string?>)!.SetAsync(null, CT);
+
+		await default(IState<MyStruct>)!.SetAsync(new MyStruct(), CT);
+		await default(IState<MyStruct?>)!.SetAsync(null, CT);
+
+		// Forbidden for ACID, must use UpdateAsync instead
+		//await default(IState<MyClass>)!.SetAsync(new MyClass(), CT);
+		//await default(IState<MyClass?>)!.SetAsync(default(MyClass?), CT);
+	}
+
+	[TestMethod]
+	public async Task When_SetAsyncNullStateOfInt_Then_TreatAsNone()
+	{
+		var state = State<int>.Value(this, () => 42);
+		var result = state.Record();
+
+		await state.SetAsync(null, CT);
+
+		result.Should().Be(m => m
+			.Message(42)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_SetAsyncNullStateOfNullableInt_Then_TreatAsNone()
+	{
+		var state = State<int?>.Value(this, () => 42);
+		var result = state.Record();
+
+		await state.SetAsync(null, CT);
+
+		result.Should().Be(m => m
+			.Message(42)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_SetAsyncNullStateOfString_Then_TreatAsNone()
+	{
+		var state = State<string>.Value(this, () => "42");
+		var result = state.Record();
+
+		await state.SetAsync(null, CT);
+
+		result.Should().Be(m => m
+			.Message("42")
+			.Message(Data.None)
+		);
+	}
+
+	//[TestMethod] // Forbidden, need to use UpdateDataAsync instead
+	//public async Task When_SetAsyncNullStateOfNullableString_Then_TreatAsNone()
+	//{
+	//	var state = State<string?>.Value(this, () => "42");
+	//	var result = state.Record();
+
+	//	await state.SetAsync(null, CT);
+
+	//	result.Should().Be(m => m
+	//		.Message("42")
+	//		.Message(Data.None)
+	//	);
+	//}
+
+	[TestMethod]
+	public async Task When_SetAsyncNullStateOfStruct_Then_TreatAsNone()
+	{
+		var state = State<MyStruct>.Value(this, () => new MyStruct());
+		var result = state.Record();
+
+		await state.SetAsync(null, CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Data.None)
+		);
+	}
+
+	[TestMethod]
+	public async Task When_SetAsyncNullStateOfNullableStruct_Then_TreatAsNone()
+	{
+		var state = State<MyStruct?>.Value(this, () => new MyStruct());
+		var result = state.Record();
+
+		await state.SetAsync(null, CT);
+
+		result.Should().Be(m => m
+			.Message(Data.Some)
+			.Message(Data.None)
+		);
+	}
+
+	//[TestMethod] // Forbidden, need to use UpdateDataAsync instead
+	//public async Task When_SetAsyncNullStateOf<Nullable>Object_Then_TreatAsNone()
+	//{
+	//	var state = State.Value(this, () => new MyClass());
+	//	var result = state.Record();
+
+	//	await state.SetAsync(null, CT);
+
+	//	result.Should().Be(m => m
+	//		.Message(Data.Some)
+	//		.Message(Data.None));
+	//} 
+	#endregion
+
+	private record class MyClass;
+	private record struct MyStruct;
+}

--- a/src/Uno.Extensions.Reactive.Tests/Operators/Given_StateForEach.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Operators/Given_StateForEach.cs
@@ -15,6 +15,42 @@ namespace Uno.Extensions.Reactive.Tests.Extensions;
 public class Given_StateForEach : FeedTests
 {
 	[TestMethod]
+	[ExpectedException(typeof(InvalidOperationException))] // Note: This is a compilation tests!
+	public async Task When_ForEachAsync_Then_AcceptsNotNullAndStruct()
+	{
+		default(IState<int>)!.ForEachAsync(async (i, ct) => this.ToString());
+		default(IState<int?>)!.ForEachAsync(async (i, ct) => this.ToString());
+		default(IState<string>)!.ForEachAsync(async (i, ct) => this.ToString());
+#nullable disable
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+		default(IState<string?>)!.ForEachAsync(async (i, ct) => this.ToString());
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+#nullable restore
+		default(IState<MyStruct>)!.ForEachAsync(async (i, ct) => this.ToString());
+		default(IState<MyStruct?>)!.ForEachAsync(async (i, ct) => this.ToString());
+		default(IState<MyClass>)!.ForEachAsync(async (i, ct) => this.ToString());
+#nullable disable
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+		default(IState<MyClass?>)!.ForEachAsync(async (i, ct) => this.ToString());
+#pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+#nullable restore
+	}
+
+	[TestMethod]
+	[ExpectedException(typeof(InvalidOperationException))] // Note: This is a compilation tests!
+	public async Task When_ForEachDataAsync_Then_AcceptsNotNullAndStruct()
+	{
+		default(IState<int>)!.ForEachAsync(async (i, ct) => this.ToString());
+		default(IState<int?>)!.ForEachDataAsync(async (i, ct) => this.ToString());
+		default(IState<string>)!.ForEachDataAsync(async (i, ct) => this.ToString());
+		default(IState<string?>)!.ForEachDataAsync(async (i, ct) => this.ToString());
+		default(IState<MyStruct>)!.ForEachDataAsync(async (i, ct) => this.ToString());
+		default(IState<MyStruct?>)!.ForEachDataAsync(async (i, ct) => this.ToString());
+		default(IState<MyClass>)!.ForEachDataAsync(async (i, ct) => this.ToString());
+		default(IState<MyClass?>)!.ForEachDataAsync(async (i, ct) => this.ToString());
+	}
+
+	[TestMethod]
 	public async Task When_UpdateState_Then_CallbackInvokedIgnoringInitialValue()
 	{
 		var state = State.Value(this, () => 1);
@@ -127,4 +163,7 @@ public class Given_StateForEach : FeedTests
 
 		result.Single().Should().NotBeNull().And.BeEquivalentTo(ImmutableList<int>.Empty);
 	}
+
+	private record class MyClass;
+	private record struct MyStruct;
 }

--- a/src/Uno.Extensions.Reactive.Tests/Sources/Given_DynamicFeed.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Sources/Given_DynamicFeed.cs
@@ -17,6 +17,32 @@ namespace Uno.Extensions.Reactive.Tests.Sources;
 public class Given_DynamicFeed : FeedTests
 {
 	[TestMethod]
+	public async Task When_Dynamic_Then_AcceptsNotNullAndStruct()
+	{
+		(Feed.Dynamic(async _ => 42) is IFeed<int>).Should().BeTrue();
+		(Feed.Dynamic(async _ => default(int?)) is IFeed<int>).Should().BeTrue();
+		(Feed.Dynamic(async _ => "") is IFeed<string>).Should().BeTrue();
+		(Feed.Dynamic(async _ => default(string?)) is IFeed<string>).Should().BeTrue();
+		(Feed.Dynamic(async _ => new MyClass()) is IFeed<MyClass>).Should().BeTrue();
+		(Feed.Dynamic(async _ => default(MyClass?)) is IFeed<MyClass>).Should().BeTrue();
+		(Feed.Dynamic(async _ => new MyStruct()) is IFeed<MyStruct>).Should().BeTrue();
+		(Feed.Dynamic(async _ => default(MyStruct?)) is IFeed<MyStruct>).Should().BeTrue();
+	}
+
+	[TestMethod]
+	public async Task When_Dynamic_2_Then_AcceptsNotNullAndStruct()
+	{
+		(Feed<int>.Dynamic(async _ => 42) is IFeed<int>).Should().BeTrue();
+		(Feed<int?>.Dynamic(async _ => default(int?)) is IFeed<int?>).Should().BeTrue();
+		(Feed<string>.Dynamic(async _ => "") is IFeed<string>).Should().BeTrue();
+		(Feed<string?>.Dynamic(async _ => default(string?)) is IFeed<string?>).Should().BeTrue();
+		(Feed<MyClass>.Dynamic(async _ => new MyClass()) is IFeed<MyClass>).Should().BeTrue();
+		(Feed<MyClass?>.Dynamic(async _ => default(MyClass?)) is IFeed<MyClass?>).Should().BeTrue();
+		(Feed<MyStruct>.Dynamic(async _ => new MyStruct()) is IFeed<MyStruct>).Should().BeTrue();
+		(Feed<MyStruct?>.Dynamic(async _ => default(MyStruct?)) is IFeed<MyStruct?>).Should().BeTrue();
+	}
+
+	[TestMethod]
 	public void When_DelegateSync_Then_LoadSync()
 	{
 		var sut = new DynamicFeed<int>(async _ => 42).Record();
@@ -678,4 +704,7 @@ public class Given_DynamicFeed : FeedTests
 		{
 		}
 	}
+
+	private record class MyClass;
+	private record struct MyStruct;
 }

--- a/src/Uno.Extensions.Reactive/Core/Feed.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
@@ -14,33 +15,33 @@ namespace Uno.Extensions.Reactive;
 partial class Feed
 {
 	/// <summary>
-	/// Get an awaiter to asynchronously get the next data produced by a feed.
+	/// Get an awaiter to asynchronously get the next value produced by a feed.
 	/// </summary>
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
-	/// <param name="feed">The feed to get data from.</param>
-	/// <returns>An awaiter to asynchronously get the next data produced by the feed.</returns>
+	/// <param name="feed">The feed to get value from.</param>
+	/// <returns>An awaiter to asynchronously get the next value produced by the feed.</returns>
 	public static ValueTaskAwaiter<T?> GetAwaiter<T>(this IFeed<T> feed)
 		where T : notnull
 		=> feed.Value(SourceContext.Current.Token).GetAwaiter();
 
 	/// <summary>
-	/// Get an awaiter to asynchronously get the next data produced by a feed.
+	/// Get an awaiter to asynchronously get the next value produced by a feed.
 	/// </summary>
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
-	/// <param name="feed">The feed to get data from.</param>
-	/// <returns>An awaiter to asynchronously get the next data produced by the feed.</returns>
+	/// <param name="feed">The feed to get value from.</param>
+	/// <returns>An awaiter to asynchronously get the next value produced by the feed.</returns>
 	public static ValueTaskAwaiter<T?> GetAwaiter<T>(this IFeed<T?> feed)
 		where T : struct
 		=> feed.Value(SourceContext.Current.Token).GetAwaiter();
 
 	/// <summary>
-	/// Asynchronously get the next data produced by a feed.
+	/// Asynchronously get the next value produced by a feed.
 	/// </summary>
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
-	/// <param name="feed">The feed to get data from.</param>
+	/// <param name="feed">The feed to get value from.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
-	/// <returns>A ValueTask to asynchronously get the next data produced by the feed.</returns>
-	public static async ValueTask<T?> Value<T>(this IFeed<T> feed, CancellationToken ct)
+	/// <returns>A ValueTask to asynchronously get the next value produced by the feed.</returns>
+	public static async ValueTask<T?> Value<T>(this IFeed<T> feed, CancellationToken ct = default)
 		where T : notnull
 		=> await FeedDependency.TryGetCurrentMessage(feed).ConfigureAwait(false) switch
 		{
@@ -49,13 +50,13 @@ partial class Feed
 		};
 
 	/// <summary>
-	/// Asynchronously get the next data produced by a feed.
+	/// Asynchronously get the next value produced by a feed.
 	/// </summary>
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
-	/// <param name="feed">The feed to get data from.</param>
+	/// <param name="feed">The feed to get value from.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
-	/// <returns>A ValueTask to asynchronously get the next data produced by the feed.</returns>
-	public static async ValueTask<T?> Value<T>(this IFeed<T?> feed, CancellationToken ct)
+	/// <returns>A ValueTask to asynchronously get the next value produced by the feed.</returns>
+	public static async ValueTask<T?> Value<T>(this IFeed<T?> feed, CancellationToken ct = default)
 		where T : struct
 		=> await FeedDependency.TryGetCurrentMessage(feed).ConfigureAwait(false) switch
 		{
@@ -64,14 +65,14 @@ partial class Feed
 		};
 
 	/// <summary>
-	/// Asynchronously get the next data produced by a feed.
+	/// Asynchronously get the next value produced by a feed.
 	/// </summary>
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
-	/// <param name="feed">The feed to get data from.</param>
-	/// <param name="kind">Specify which data can be returned or not.</param>
+	/// <param name="feed">The feed to get value from.</param>
+	/// <param name="kind">Specify which value can be returned or not.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
-	/// <returns>A ValueTask to asynchronously get the next acceptable data produced by the feed.</returns>
-	public static async ValueTask<T?> Value<T>(this IFeed<T> feed, AsyncFeedValue kind, CancellationToken ct)
+	/// <returns>A ValueTask to asynchronously get the next acceptable value produced by the feed.</returns>
+	public static async ValueTask<T?> Value<T>(this IFeed<T> feed, AsyncFeedValue kind, CancellationToken ct = default)
 		where T : notnull
 		=> await FeedDependency.TryGetCurrentMessage(feed).ConfigureAwait(false) switch
 		{
@@ -81,14 +82,14 @@ partial class Feed
 		};
 
 	/// <summary>
-	/// Asynchronously get the next data produced by a feed.
+	/// Asynchronously get the next value produced by a feed.
 	/// </summary>
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
-	/// <param name="feed">The feed to get data from.</param>
-	/// <param name="kind">Specify which data can be returned or not.</param>
+	/// <param name="feed">The feed to get value from.</param>
+	/// <param name="kind">Specify which value can be returned or not.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
-	/// <returns>A ValueTask to asynchronously get the next acceptable data produced by the feed.</returns>
-	public static async ValueTask<T?> Value<T>(this IFeed<T?> feed, AsyncFeedValue kind, CancellationToken ct)
+	/// <returns>A ValueTask to asynchronously get the next acceptable value produced by the feed.</returns>
+	public static async ValueTask<T?> Value<T>(this IFeed<T?> feed, AsyncFeedValue kind, CancellationToken ct = default)
 		where T : struct
 		=> await FeedDependency.TryGetCurrentMessage(feed).ConfigureAwait(false) switch
 		{
@@ -107,19 +108,19 @@ partial class Feed
 	/// <returns>An async enumeration sequence of all acceptable data produced by a feed.</returns>
 	public static IAsyncEnumerable<T?> Values<T>(this IFeed<T> feed, AsyncFeedValue kind = AsyncFeedValue.AllowError, CancellationToken ct = default)
 		where T : notnull
-		=> feed.Options(kind, ct).Select(opt => opt.SomeOrDefault());
+		=> feed.DataSet(kind, ct).Select(opt => opt.SomeOrDefault());
 
 	/// <summary>
-	/// Gets an asynchronous enumerable sequence of all data produced by a feed.
+	/// Gets an asynchronous enumerable sequence of all values produced by a feed.
 	/// </summary>
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
-	/// <param name="feed">The feed to get data from.</param>
-	/// <param name="kind">Specify which data can be returned or not.</param>
+	/// <param name="feed">The feed to get values from.</param>
+	/// <param name="kind">Specify which values can be returned or not.</param>
 	/// <param name="ct">A cancellation to cancel the async enumeration.</param>
-	/// <returns>An async enumeration sequence of all acceptable data produced by a feed.</returns>
+	/// <returns>An async enumeration sequence of all acceptable values produced by a feed.</returns>
 	public static IAsyncEnumerable<T?> Values<T>(this IFeed<T?> feed, AsyncFeedValue kind = AsyncFeedValue.AllowError, CancellationToken ct = default)
 		where T : struct
-		=> feed.Options(kind, ct).Select(opt => opt.SomeOrDefault());
+		=> feed.DataSet(kind, ct).Select(opt => opt.SomeOrDefault());
 
 	/// <summary>
 	/// Asynchronously get the next data produced by a feed.
@@ -128,11 +129,11 @@ partial class Feed
 	/// <param name="feed">The feed to get data from.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to asynchronously get the next data produced by the feed.</returns>
-	public static async ValueTask<Option<T>> Option<T>(this IFeed<T> feed, CancellationToken ct)
+	public static async ValueTask<Option<T>> Data<T>(this IFeed<T> feed, CancellationToken ct = default)
 		=> await FeedDependency.TryGetCurrentMessage(feed).ConfigureAwait(false) switch
 		{
 			{ } message => message.Current.EnsureNoError().Data,
-			null => await feed.Options(AsyncFeedValue.Default, ct).FirstOrDefaultAsync(Uno.Extensions.Option<T>.Undefined(), ct).ConfigureAwait(false)
+			null => await feed.DataSet(AsyncFeedValue.Default, ct).FirstOrDefaultAsync(Uno.Extensions.Option<T>.Undefined(), ct).ConfigureAwait(false)
 		};
 
 	/// <summary>
@@ -143,12 +144,12 @@ partial class Feed
 	/// <param name="kind">Specify which data can be returned or not.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to asynchronously get the next acceptable data produced by the feed.</returns>
-	public static async ValueTask<Option<T>> Option<T>(this IFeed<T> feed, AsyncFeedValue kind, CancellationToken ct)
+	public static async ValueTask<Option<T>> Data<T>(this IFeed<T> feed, AsyncFeedValue kind, CancellationToken ct = default)
 		=> await FeedDependency.TryGetCurrentMessage(feed).ConfigureAwait(false) switch
 		{
 			not null when kind is not AsyncFeedValue.Default => throw new NotSupportedException($"Only kind AsyncFeedValue.Default is currently supported by the dynamic feed (requested: {kind})."),
 			{ } message => message.Current.EnsureNoError().Data,
-			null => await feed.Options(kind, ct).FirstOrDefaultAsync(Uno.Extensions.Option<T>.Undefined(), ct).ConfigureAwait(false)
+			null => await feed.DataSet(kind, ct).FirstOrDefaultAsync(Uno.Extensions.Option<T>.Undefined(), ct).ConfigureAwait(false)
 		};
 
 	/// <summary>
@@ -159,7 +160,7 @@ partial class Feed
 	/// <param name="kind">Specify which data can be returned or not.</param>
 	/// <param name="ct">A cancellation to cancel the async enumeration.</param>
 	/// <returns>An async enumeration sequence of all acceptable data produced by a feed.</returns>
-	public static async IAsyncEnumerable<Option<T>> Options<T>(this IFeed<T> feed, AsyncFeedValue kind = AsyncFeedValue.AllowError, [EnumeratorCancellation] CancellationToken ct = default)
+	public static async IAsyncEnumerable<Option<T>> DataSet<T>(this IFeed<T> feed, AsyncFeedValue kind = AsyncFeedValue.AllowError, [EnumeratorCancellation] CancellationToken ct = default)
 	{
 		using var enumCt = CancellationTokenSource.CreateLinkedTokenSource(ct);
 		try
@@ -194,6 +195,39 @@ partial class Feed
 			enumCt.Cancel();
 		}
 	}
+
+	/// <summary>
+	/// Obsolete, use Data instead.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if DEBUG
+	[Obsolete("Use Data instead")]
+#endif
+	public static ValueTask<Option<T>> Option<T>(this IFeed<T> feed, CancellationToken ct = default)
+		=> Data(feed, ct);
+
+	/// <summary>
+	/// Obsolete, use Data instead.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if DEBUG
+	[Obsolete("Use Data instead")]
+#endif
+	public static ValueTask<Option<T>> Option<T>(this IFeed<T> feed, AsyncFeedValue kind, CancellationToken ct)
+		=> Data(feed, kind, ct);
+
+	/// <summary>
+	/// Obsolete, use Data instead.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if DEBUG
+	[Obsolete("Use DataSet instead")]
+#endif
+	public static IAsyncEnumerable<Option<T>> Options<T>(this IFeed<T> feed, AsyncFeedValue kind = AsyncFeedValue.AllowError, CancellationToken ct = default)
+		=> feed.DataSet(kind, ct);
 
 	/// <summary>
 	/// Asynchronously get the next message produced by a feed.

--- a/src/Uno.Extensions.Reactive/Core/Feed.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.Extensions.cs
@@ -219,7 +219,7 @@ partial class Feed
 		=> Data(feed, kind, ct);
 
 	/// <summary>
-	/// Obsolete, use Data instead.
+	/// Obsolete, use DataSet instead.
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -234,19 +234,9 @@ partial class Feed
 	/// </summary>
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
 	/// <param name="feed">The feed to get message from.</param>
-	/// <returns>A ValueTask to asynchronously get the next message produced by the feed.</returns>
-	public static async ValueTask<Message<T>> Message<T>(this IFeed<T> feed)
-		=> await FeedDependency.TryGetCurrentMessage(feed).ConfigureAwait(false)
-			?? await feed.Messages().FirstAsync(SourceContext.Current.Token).ConfigureAwait(false);
-
-	/// <summary>
-	/// Asynchronously get the next message produced by a feed.
-	/// </summary>
-	/// <typeparam name="T">The type of the value of the feed.</typeparam>
-	/// <param name="feed">The feed to get message from.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to asynchronously get the next message produced by the feed.</returns>
-	public static async ValueTask<Message<T>> Message<T>(this IFeed<T> feed, CancellationToken ct)
+	public static async ValueTask<Message<T>> Message<T>(this IFeed<T> feed, CancellationToken ct = default)
 		=> await FeedDependency.TryGetCurrentMessage(feed).ConfigureAwait(false)
 			?? await feed.Messages().FirstAsync(ct).ConfigureAwait(false);
 

--- a/src/Uno.Extensions.Reactive/Core/Feed.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.Extensions.cs
@@ -24,6 +24,16 @@ partial class Feed
 		=> feed.Value(SourceContext.Current.Token).GetAwaiter();
 
 	/// <summary>
+	/// Get an awaiter to asynchronously get the next data produced by a feed.
+	/// </summary>
+	/// <typeparam name="T">The type of the value of the feed.</typeparam>
+	/// <param name="feed">The feed to get data from.</param>
+	/// <returns>An awaiter to asynchronously get the next data produced by the feed.</returns>
+	public static ValueTaskAwaiter<T?> GetAwaiter<T>(this IFeed<T?> feed)
+		where T : struct
+		=> feed.Value(SourceContext.Current.Token).GetAwaiter();
+
+	/// <summary>
 	/// Asynchronously get the next data produced by a feed.
 	/// </summary>
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
@@ -32,6 +42,21 @@ partial class Feed
 	/// <returns>A ValueTask to asynchronously get the next data produced by the feed.</returns>
 	public static async ValueTask<T?> Value<T>(this IFeed<T> feed, CancellationToken ct)
 		where T : notnull
+		=> await FeedDependency.TryGetCurrentMessage(feed).ConfigureAwait(false) switch
+		{
+			{ } message => message.Current.EnsureNoError().Data.SomeOrDefault(),
+			null => await feed.Values(AsyncFeedValue.Default, ct).FirstOrDefaultAsync(ct).ConfigureAwait(false)
+		};
+
+	/// <summary>
+	/// Asynchronously get the next data produced by a feed.
+	/// </summary>
+	/// <typeparam name="T">The type of the value of the feed.</typeparam>
+	/// <param name="feed">The feed to get data from.</param>
+	/// <param name="ct">A cancellation to cancel the async operation.</param>
+	/// <returns>A ValueTask to asynchronously get the next data produced by the feed.</returns>
+	public static async ValueTask<T?> Value<T>(this IFeed<T?> feed, CancellationToken ct)
+		where T : struct
 		=> await FeedDependency.TryGetCurrentMessage(feed).ConfigureAwait(false) switch
 		{
 			{ } message => message.Current.EnsureNoError().Data.SomeOrDefault(),
@@ -56,6 +81,23 @@ partial class Feed
 		};
 
 	/// <summary>
+	/// Asynchronously get the next data produced by a feed.
+	/// </summary>
+	/// <typeparam name="T">The type of the value of the feed.</typeparam>
+	/// <param name="feed">The feed to get data from.</param>
+	/// <param name="kind">Specify which data can be returned or not.</param>
+	/// <param name="ct">A cancellation to cancel the async operation.</param>
+	/// <returns>A ValueTask to asynchronously get the next acceptable data produced by the feed.</returns>
+	public static async ValueTask<T?> Value<T>(this IFeed<T?> feed, AsyncFeedValue kind, CancellationToken ct)
+		where T : struct
+		=> await FeedDependency.TryGetCurrentMessage(feed).ConfigureAwait(false) switch
+		{
+			not null when kind is not AsyncFeedValue.Default => throw new NotSupportedException($"Only kind AsyncFeedValue.Default is currently supported by the dynamic feed (requested: {kind})."),
+			{ } message => message.Current.EnsureNoError().Data.SomeOrDefault(),
+			null => await feed.Values(kind, ct).FirstOrDefaultAsync(ct).ConfigureAwait(false)
+		};
+
+	/// <summary>
 	/// Gets an asynchronous enumerable sequence of all data produced by a feed.
 	/// </summary>
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
@@ -65,6 +107,18 @@ partial class Feed
 	/// <returns>An async enumeration sequence of all acceptable data produced by a feed.</returns>
 	public static IAsyncEnumerable<T?> Values<T>(this IFeed<T> feed, AsyncFeedValue kind = AsyncFeedValue.AllowError, CancellationToken ct = default)
 		where T : notnull
+		=> feed.Options(kind, ct).Select(opt => opt.SomeOrDefault());
+
+	/// <summary>
+	/// Gets an asynchronous enumerable sequence of all data produced by a feed.
+	/// </summary>
+	/// <typeparam name="T">The type of the value of the feed.</typeparam>
+	/// <param name="feed">The feed to get data from.</param>
+	/// <param name="kind">Specify which data can be returned or not.</param>
+	/// <param name="ct">A cancellation to cancel the async enumeration.</param>
+	/// <returns>An async enumeration sequence of all acceptable data produced by a feed.</returns>
+	public static IAsyncEnumerable<T?> Values<T>(this IFeed<T?> feed, AsyncFeedValue kind = AsyncFeedValue.AllowError, CancellationToken ct = default)
+		where T : struct
 		=> feed.Options(kind, ct).Select(opt => opt.SomeOrDefault());
 
 	/// <summary>

--- a/src/Uno.Extensions.Reactive/Core/Feed.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.cs
@@ -29,6 +29,15 @@ public static partial class Feed
 		where T : notnull
 		=> AttachedProperty.GetOrCreate(valueProvider, static vp => new DynamicFeed<T>(vp));
 
+	/// <summary>
+	/// Gets or create a custom feed from an async method.
+	/// </summary>
+	/// <param name="valueProvider">The async method to use to load the value of the resulting feed.</param>
+	/// <returns>A feed that encapsulate the source.</returns>
+	internal static IFeed<T> Dynamic<T>(AsyncFunc<T?> valueProvider)
+		where T : struct
+		=> AttachedProperty.GetOrCreate(valueProvider, static vp => new DynamicFeed<T>(vp.SomeOrNone()));
+
 
 	/// <summary>
 	/// Gets or create a custom feed from a raw <see cref="IAsyncEnumerable{T}"/> sequence of <see cref="Uno.Extensions.Reactive.Message{T}"/>.

--- a/src/Uno.Extensions.Reactive/Core/IState.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/IState.T.cs
@@ -13,6 +13,8 @@ namespace Uno.Extensions.Reactive;
 /// <typeparam name="T">The type of the value.</typeparam>
 public interface IState<T> : IFeed<T>, IState
 {
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved : Confusion non resolvable by code between notnull and struct. Can be resolved by user in VS.
+#pragma warning disable CS0419 // Ambiguous reference in cref attribute
 	/// <summary>
 	/// Updates the current internal message.
 	/// </summary>
@@ -20,5 +22,7 @@ public interface IState<T> : IFeed<T>, IState
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
 	/// <remarks>This is the raw way to update a state, you should consider using the <see cref="State.UpdateAsync{T}"/> method instead.</remarks>
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
+#pragma warning restore CS0419 // Ambiguous reference in cref attribute
 	ValueTask UpdateMessageAsync(Action<MessageBuilder<T>> updater, CancellationToken ct = default);
 }

--- a/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
@@ -15,6 +15,7 @@ static partial class ListState
 	/// [DEPRECATED] Use UpdateMessageAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use UpdateMessageAsync")]
 #endif
@@ -29,7 +30,7 @@ static partial class ListState
 	/// <param name="updater">The update method to apply to the current value.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask UpdateAsync<T>(this IListState<T> state, Func<IImmutableList<T>, IImmutableList<T>> updater, CancellationToken ct = default)
+	public static ValueTask UpdateAsync<T>(this IListState<T> state, Func<IImmutableList<T>, IImmutableList<T>?> updater, CancellationToken ct = default)
 		=> state.UpdateMessageAsync(
 			m =>
 			{
@@ -44,6 +45,7 @@ static partial class ListState
 	/// [DEPRECATED] Use UpdateAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use UpdateAsync")]
 #endif
@@ -65,51 +67,23 @@ static partial class ListState
 	/// [DEPRECATED] Use UpdateDataAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use UpdateDataAsync")]
 #endif
 	public static ValueTask UpdateData<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
 		=> UpdateDataAsync(state, updater, ct);
 
-	/// <summary>
-	/// Updates the value of a list state
-	/// </summary>
-	/// <typeparam name="T">Type of the items of the list state.</typeparam>
-	/// <param name="state">The list state to update.</param>
-	/// <param name="updater">The update method to apply to the current list.</param>
-	/// <param name="ct">A cancellation to cancel the async operation.</param>
-	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask UpdateDataAsync<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, IImmutableList<T>> updater, CancellationToken ct = default)
-		=> state.UpdateMessageAsync(m => m.Data(updater(m.CurrentData)), ct);
 
 	/// <summary>
 	/// [DEPRECATED] Use UpdateDataAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
-#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
-	[Obsolete("Use UpdateDataAsync")]
-#endif
-	public static ValueTask UpdateData<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, IImmutableList<T>> updater, CancellationToken ct)
-		=> UpdateDataAsync(state, updater, ct);
-
-	/// <summary>
-	/// [DEPRECATED] Use UpdateDataAsync instead
-	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use UpdateDataAsync")]
 #endif
 	public static ValueTask UpdateValue<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
-		=> UpdateDataAsync(state, updater, ct);
-
-	/// <summary>
-	/// [DEPRECATED] Use UpdateDataAsync instead
-	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
-#if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
-	[Obsolete("Use UpdateDataAsync")]
-#endif
-	public static ValueTask UpdateValue<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, IImmutableList<T>> updater, CancellationToken ct)
 		=> UpdateDataAsync(state, updater, ct);
 
 
@@ -123,7 +97,7 @@ static partial class ListState
 	/// <param name="ct">A token to abort the async add operation.</param>
 	/// <returns></returns>
 	public static ValueTask InsertAsync<T>(this IListState<T> state, T item, CancellationToken ct = default)
-		=> state.UpdateDataAsync(items => items.SomeOrDefault(ImmutableList<T>.Empty).Insert(0, item), ct);
+		=> state.UpdateDataAsync(items => Option.Some((items.SomeOrDefault() ?? ImmutableList<T>.Empty).Insert(0, item)), ct);
 
 	/// <summary>
 	/// Adds an item into a list state
@@ -134,7 +108,7 @@ static partial class ListState
 	/// <param name="ct">A token to abort the async add operation.</param>
 	/// <returns></returns>
 	public static ValueTask AddAsync<T>(this IListState<T> state, T item, CancellationToken ct = default)
-		=> state.UpdateDataAsync(items => items.SomeOrDefault(ImmutableList<T>.Empty).Add(item), ct);
+		=> state.UpdateDataAsync(items => Option.Some((items.SomeOrDefault() ?? ImmutableList<T>.Empty).Add(item)), ct);
 
 	/// <summary>
 	/// Removes all matching items from a list state.
@@ -176,6 +150,7 @@ static partial class ListState
 	/// [DEPRECATED] Use .UpdateAllAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use UpdateAllAsync")]
 #endif
@@ -204,6 +179,7 @@ static partial class ListState
 	/// [DEPRECATED] Use .ForEachAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use ForEachAsync")]
 #endif
@@ -241,7 +217,7 @@ static partial class ListState
 
 		await state.UpdateMessageAsync(msg =>
 		{
-			var items = msg.CurrentData.SomeOrDefault(ImmutableList<T>.Empty);
+			var items = msg.CurrentData.SomeOrDefault() ?? ImmutableList<T>.Empty;
 			if (SelectionInfo.TryCreateMultiple(items, selectedItems, out var selection, comparer))
 			{
 				success = true;
@@ -268,7 +244,7 @@ static partial class ListState
 
 		await state.UpdateMessageAsync(msg =>
 		{
-			var items = msg.CurrentData.SomeOrDefault(ImmutableList<T>.Empty);
+			var items = msg.CurrentData.SomeOrDefault() ?? ImmutableList<T>.Empty;
 			if (SelectionInfo.TryCreateSingle(items, selectedItem, out var selection, comparer))
 			{
 				success = true;
@@ -294,6 +270,7 @@ static partial class ListState
 	/// [DEPRECATED] Use .ClearSelectionAsync instead
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use ClearSelectionAsync")]
 #endif

--- a/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
@@ -223,7 +223,7 @@ static partial class ListState
 	/// <returns>A <see cref="IDisposable"/> that can be used to remove the callback registration.</returns>
 	public static IDisposable ForEachAsync<T>(this IListState<T> state, AsyncAction<IImmutableList<T>> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
 		where T : notnull
-		=> new StateForEach<IImmutableList<T>>(state, (list, ct) => action(list ?? ImmutableList<T>.Empty, ct), $"ForEachAsync defined in {caller} at line {line}.");
+		=> new StateForEach<IImmutableList<T>>(state, (list, ct) => action(list.SomeOrDefault() ?? ImmutableList<T>.Empty, ct), $"ForEachAsync defined in {caller} at line {line}.");
 	#endregion
 
 	/// <summary>

--- a/src/Uno.Extensions.Reactive/Core/State.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/State.Extensions.cs
@@ -48,6 +48,26 @@ partial class State
 	/// <param name="updater">The update method to apply to the current value.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
+	public static ValueTask UpdateAsync<T>(this IState<T> state, Func<T?, T?> updater, CancellationToken ct = default)
+		where T : struct
+		=> state.UpdateMessageAsync(
+			m =>
+			{
+				var updatedValue = updater(m.CurrentData.SomeOrDefault());
+				var updatedData = updatedValue.HasValue ? Option.Some(updatedValue.Value) : Option<T>.None();
+
+				m.Data(updatedData);
+			},
+			ct);
+
+	/// <summary>
+	/// Updates the value of a state
+	/// </summary>
+	/// <typeparam name="T">Type of the value of the state.</typeparam>
+	/// <param name="state">The state to update.</param>
+	/// <param name="updater">The update method to apply to the current value.</param>
+	/// <param name="ct">A cancellation to cancel the async operation.</param>
+	/// <returns>A ValueTask to track the async update.</returns>
 	public static ValueTask UpdateAsync<T>(this IState<T?> state, Func<T?, T?> updater, CancellationToken ct = default)
 		where T : struct
 		=> state.UpdateMessageAsync(
@@ -117,6 +137,18 @@ partial class State
 	/// <summary>
 	/// Sets the value of a state
 	/// </summary>
+	/// <typeparam name="T">Type of the value of the state.</typeparam>
+	/// <param name="state">The state to update.</param>
+	/// <param name="value">The value to set.</param>
+	/// <param name="ct">A cancellation to cancel the async operation.</param>
+	/// <returns>A ValueTask to track the async update.</returns>
+	public static ValueTask SetAsync<T>(this IState<T?> state, T? value, CancellationToken ct = default)
+		where T : struct
+		=> state.UpdateMessageAsync(m => m.Data(Option.SomeOrNone<T?>(value)), ct);
+
+	/// <summary>
+	/// Sets the value of a state
+	/// </summary>
 	/// <param name="state">The state to update.</param>
 	/// <param name="value">The value to set.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
@@ -167,9 +199,22 @@ partial class State
 	/// <param name="caller"> For debug purposes, the name of this subscription. DO NOT provide anything here, let the compiler fulfill this.</param>
 	/// <param name="line">For debug purposes, the name of this subscription. DO NOT provide anything here, let the compiler fulfill this.</param>
 	/// <returns>A <see cref="IDisposable"/> that can be used to remove the callback registration.</returns>
-	public static IDisposable ForEachAsync<T>(this IState<T> state, AsyncAction<T?> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
+	public static IDisposable ForEachAsync<T>(this IState<T?> state, AsyncAction<T?> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
 		where T : struct
-		=> new StateForEach<T>(state, action.SomeOrNone(), $"ForEachAsync defined in {caller} at line {line}.");
+		=> new StateForEach<T?>(state, action.SomeOrNone(), $"ForEachAsync defined in {caller} at line {line}.");
+
+
+	/// <summary>
+	/// Execute an async callback each time the state is being updated.
+	/// </summary>
+	/// <typeparam name="T">The type of the state</typeparam>
+	/// <param name="state">The state to listen.</param>
+	/// <param name="action">The callback to invoke on each update of the state.</param>
+	/// <param name="caller"> For debug purposes, the name of this subscription. DO NOT provide anything here, let the compiler fulfill this.</param>
+	/// <param name="line">For debug purposes, the name of this subscription. DO NOT provide anything here, let the compiler fulfill this.</param>
+	/// <returns>A <see cref="IDisposable"/> that can be used to remove the callback registration.</returns>
+	public static IDisposable ForEachDataAsync<T>(this IState<T> state, AsyncAction<Option<T>> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
+		=> new StateForEach<T>(state, action, $"ForEachDataAsync defined in {caller} at line {line}.");
 
 	/// <summary>
 	/// [DEPRECATED] Use .ForEachAsync instead

--- a/src/Uno.Extensions.Reactive/Operators/StateForEach.cs
+++ b/src/Uno.Extensions.Reactive/Operators/StateForEach.cs
@@ -10,7 +10,6 @@ using Uno.Extensions.Reactive.Utils;
 namespace Uno.Extensions.Reactive;
 
 internal sealed class StateForEach<T> : IDisposable
-	where T : notnull
 {
 	private readonly CancellationTokenSource _ct = new();
 	private readonly AsyncAction<Option<T>> _action;

--- a/src/Uno.Extensions.Reactive/Sources/Dynamic/DynamicFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/Dynamic/DynamicFeed.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Uno.Extensions.Reactive.Config;
 using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Utils;
 
 namespace Uno.Extensions.Reactive.Sources;
 
@@ -14,7 +15,7 @@ internal sealed class DynamicFeed<T> : IFeed<T>
 
 	public DynamicFeed(AsyncFunc<T?> dataProvider)
 	{
-		_dataProvider = async ct => Option.SomeOrNone(await dataProvider(ct).ConfigureAwait(false));
+		_dataProvider = dataProvider.SomeOrNone();
 	}
 
 	public DynamicFeed(AsyncFunc<Option<T>> dataProvider)

--- a/src/Uno.Extensions.Reactive/Utils/OptionExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/OptionExtensions.cs
@@ -37,6 +37,17 @@ internal static class OptionExtensions
 		=> d => d.MapToSomeOrNone(func);
 	#endregion
 
+	#region AsyncAction
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static AsyncAction<Option<T>> SomeOrNone<T>(this AsyncAction<T?> func)
+		=> async (t, ct) => await func(t.SomeOrDefault(), ct).ConfigureAwait(false);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static AsyncAction<Option<T>> SomeOrNone<T>(this AsyncAction<T?> func)
+		where T : struct
+		=> async (t, ct) => await func(t.SomeOrDefault(), ct).ConfigureAwait(false);
+	#endregion
+
 	#region AsyncFunc
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static AsyncFunc<Option<T>> SomeOrNoneWhenNotNull<T>(this AsyncFunc<T> func)

--- a/src/Uno.Extensions.Reactive/Utils/OptionExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/OptionExtensions.cs
@@ -43,7 +43,7 @@ internal static class OptionExtensions
 		=> async (t, ct) => await func(t.SomeOrDefault(), ct).ConfigureAwait(false);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public static AsyncAction<Option<T>> SomeOrNone<T>(this AsyncAction<T?> func)
+	public static AsyncAction<Option<T?>> SomeOrNone<T>(this AsyncAction<T?> func)
 		where T : struct
 		=> async (t, ct) => await func(t.SomeOrDefault(), ct).ConfigureAwait(false);
 	#endregion


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/discussions/2170
linked https://github.com/unoplatform/uno/discussions/15349

## Feature
Improve nullable support

## What is the current behavior?
* We cannot await a `Feed<Nullable<ValueType>>` + `Nullable<ValueType>` is globally not well supported
* Some operator names are confusing

## What is the new behavior?
* All method that is constrained by `where T : notnull` now have an overload for `Nullable<ValueType>`
* We standardized the naming "Value" (`T`); "Data" (`Option<T>`) and "Message" (`Message<T>`) operators on feeds

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
