### PR TITLE
fix: Correct configuration loading for unnamed sections

### DIFF
--- a/src/Uno.Extensions.Configuration/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ServiceCollectionExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.ComponentModel;
-
-namespace Uno.Extensions.Configuration;
+﻿namespace Uno.Extensions.Configuration;
 
 /// <summary>
 /// Extension methods for <see cref="IServiceCollection"/>.
@@ -27,13 +24,14 @@ public static class ServiceCollectionExtensions
 		string? name = "")
 			where T : class, new()
 	{
+		var sectionName = name != typeof(T).Name ? name : default;
 		return services
 			// Note - we've replaced the Configure method call with the three calls subsequent three calls so that
 			// we can use a local copy of ConfigurationBinder that handles ImmutableList
 			//.Configure<T>(section)
 			.AddOptions()
-			.AddSingleton<IOptionsChangeTokenSource<T>>(new ConfigurationChangeTokenSource<T>(name ?? Options.DefaultName, section))
-			.AddSingleton<IConfigureOptions<T>>(new Uno.Extensions.Configuration.Internal.NamedConfigureFromConfigurationOptions<T>(name ?? Options.DefaultName, section, _ => { }))
+			.AddSingleton<IOptionsChangeTokenSource<T>>(new ConfigurationChangeTokenSource<T>(sectionName ?? Options.DefaultName, section))
+			.AddSingleton<IConfigureOptions<T>>(new Uno.Extensions.Configuration.Internal.NamedConfigureFromConfigurationOptions<T>(sectionName ?? Options.DefaultName, section, _ => { }))
 
 			.AddTransient<IWritableOptions<T>>(provider =>
 			{

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Oidc/OidcAuthenticationLoginPage.xaml
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Oidc/OidcAuthenticationLoginPage.xaml
@@ -22,6 +22,10 @@
 		<StackPanel Grid.Row="1"
 					HorizontalAlignment="Center"
 					VerticalAlignment="Center">
+			<TextBlock>
+				<Run Text="Providers: "/>
+				<Run Text="{Binding ProviderCount}" AutomationProperties.AutomationId="LoginProviderCountText" />
+			</TextBlock>
 			<Button Content="Login"
 					Click="{x:Bind ViewModel.Login}" />
 		</StackPanel>

--- a/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Oidc/OidcAuthenticationLoginViewModel.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Authentication/Oidc/OidcAuthenticationLoginViewModel.cs
@@ -2,6 +2,7 @@
 
 internal record class OidcAuthenticationLoginViewModel(INavigator Navigator, IAuthenticationService Authentication, IAuthenticationRouteInfo RouteInfo)
 {
+	public int ProviderCount => Authentication.Providers.Length;
 	public async void Login()
 	{
 		var authenticated = await Authentication.LoginAsync(null);

--- a/testing/TestHarness/TestHarness.UITest/Ext/Authentication/Oidc/Given_Oidc.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Authentication/Oidc/Given_Oidc.cs
@@ -2,7 +2,7 @@
 
 public class Given_Oidc : NavigationTestBase
 {
-	[Test]
+	// [Test]
 	public async Task When_Oidc_Auth()
 	{
 		InitTestSection(TestSections.Authentication_Oidc);

--- a/testing/TestHarness/TestHarness.UITest/Ext/Authentication/Oidc/Given_Oidc.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Authentication/Oidc/Given_Oidc.cs
@@ -1,0 +1,17 @@
+﻿namespace TestHarness.UITest;
+
+public class Given_Oidc : NavigationTestBase
+{
+	[Test]
+	public async Task When_Oidc_Auth()
+	{
+		InitTestSection(TestSections.Authentication_Oidc);
+
+		App.WaitThenTap("ShowAppButton");
+
+		App.WaitElement("LoginNavigationBar");
+		var text = App.GetText("LoginProviderCountText");
+		Assert.AreEqual("4", text);
+	}
+
+}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno.extensions/issues/2224

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Configuration for unnamed sections aren't being loaded

## What is the new behavior?

Configuration works for both named and unnamed sections

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
