### PR TITLE
fix(mvux): Fix possible concurrency issue when changing ListState too fast

### DIFF
--- a/src/Uno.Extensions.Reactive.Testing/FeedUITests.cs
+++ b/src/Uno.Extensions.Reactive.Testing/FeedUITests.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Win32.SafeHandles;
 using Uno.Extensions.Reactive.Bindings;
@@ -37,7 +38,8 @@ public class FeedUITests : FeedTests, ISourceContextOwner
 
 		if (DispatcherHelper.GetForCurrentThread == DispatcherHelper.NotConfigured)
 		{
-			var dispatcher = new TestDispatcher(TestContext?.TestName);
+			var name = TestContext?.TestName is { Length: > 0 } testName ? $"TestDispatcher for '{testName}'" : null;
+			var dispatcher = new TestDispatcher(name);
 			_testDispatcher = new(dispatcher, () => dispatcher.HasThreadAccess ? dispatcher : null);
 			DispatcherHelper.GetForCurrentThread = _testDispatcher.Value.Resolve;
 		}

--- a/src/Uno.Extensions.Reactive.Testing/TestDispatcher.cs
+++ b/src/Uno.Extensions.Reactive.Testing/TestDispatcher.cs
@@ -22,12 +22,15 @@ public sealed class TestDispatcher : IDispatcher, IDisposable
 	/// </summary>
 	public TestDispatcher(string? testName = null)
 	{
-		_thread = new Thread(Run)
-		{
-			Name =  testName is {Length: >0} ? $"TestDispatcher for '{testName}'" : "testDispacther"
-		};
+		Name = testName ?? "testDispatcher";
+		_thread = new Thread(Run) { Name =  Name };
 		_thread.Start();
 	}
+
+	/// <summary>
+	/// Gets the name of the dispatcher thread.
+	/// </summary>
+	public string Name { get; }
 
 	/// <inheritdoc />
 	public bool HasThreadAccess => Thread.CurrentThread == _thread;

--- a/src/Uno.Extensions.Reactive.Tests/Utils/Dispatching/Given_DispatcherLocal.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Utils/Dispatching/Given_DispatcherLocal.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Dispatching;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Utils.Dispatching;
+
+[TestClass]
+public class Given_DispatcherLocal
+{
+	[TestMethod]
+	public async Task When_GetValue_Then_CreatePerThread()
+	{
+		var current = default(IDispatcher?);
+		using var ui1 = new TestDispatcher("ui1");
+		using var ui2 = new TestDispatcher("ui2");
+
+		var sut = new DispatcherLocal<string>(
+			factory: d => d is TestDispatcher ui ? ui.Name : "background",
+			schedulersProvider: () => current);
+
+		CountValues(sut).Should().Be(0);
+
+		current = ui1;
+		sut.Value.Should().Be("ui1");
+		CountValues(sut).Should().Be(1);
+
+		current = ui2;
+		sut.Value.Should().Be("ui2");
+		CountValues(sut).Should().Be(2);
+
+		current = null;
+		sut.Value.Should().Be("background");
+		CountValues(sut).Should().Be(3);
+	}
+
+	[TestMethod]
+	public async Task When_CreateValueWhileEnumerating_Then_Lock()
+	{
+		var current = default(IDispatcher?);
+		using var ui = new TestDispatcher("ui");
+		var gate = new ManualResetEvent(false);
+
+		var sut = new DispatcherLocal<string>(
+			factory: d => d is TestDispatcher td ? td.Name : "background",
+			schedulersProvider: () => current);
+
+		// Start enumeration
+		sut.Value.Should().Be("background"); // init bg value to get something to enumerate on
+		var enumeration = Task.Run(() =>
+		{
+			var count = 0;
+			sut.ForEachValue((d, _) =>
+			{
+				if (count is 0)
+				{
+					gate.WaitOne();
+				}
+				count++;
+			});
+
+			return count;
+		});
+
+		// Confirm that the enumeration is stuck
+		await Task.Delay(100);
+		enumeration.IsCompleted.Should().BeFalse();
+
+		// As we are enumerating, we cannot create a new value
+		var getValue = Task.Run(() =>
+		{
+			current = ui;
+
+			return sut.Value;
+		});
+
+		// Confirm that the enumeration and get value are stuck
+		await Task.Delay(100);
+		enumeration.IsCompleted.Should().BeFalse();
+		getValue.IsCompleted.Should().BeFalse();
+
+		// Release enumeration
+		gate.Set();
+
+		// Confirm both task completed ... and enumeration was effectively run only on first value
+		for (var i = 0; i < 100 && (!enumeration.IsCompleted || !getValue.IsCompleted); i++)
+		{
+			await Task.Delay(10);
+		}
+		enumeration.IsCompleted.Should().BeTrue();
+		getValue.IsCompleted.Should().BeTrue();
+
+		enumeration.Result.Should().Be(1);
+	}
+
+	[TestMethod]
+	public async Task When_EnumerateWhileCreatingValue_Then_Lock()
+	{
+		var current = default(IDispatcher?);
+		using var ui = new TestDispatcher("ui");
+		var gate = new ManualResetEvent(false);
+
+		var sut = new DispatcherLocal<string>(
+			factory: d =>
+			{
+				if (d == ui)
+				{
+					gate.WaitOne();
+				}
+
+				return d is TestDispatcher td ? td.Name : "background";
+			},
+			schedulersProvider: () => current);
+
+		// Begin to create value
+		var getValue = Task.Run(() =>
+		{
+			current = ui;
+
+			return sut.Value;
+		});
+
+		// Confirm that the creation is stuck
+		await Task.Delay(100);
+		getValue.IsCompleted.Should().BeFalse();
+
+		// As we are creating a value, we cannot enumerate
+		var enumeration = Task.Run(() => CountValues(sut));
+
+		// Confirm that the enumeration and get value are stuck
+		await Task.Delay(100);
+		enumeration.IsCompleted.Should().BeFalse();
+		getValue.IsCompleted.Should().BeFalse();
+
+		// Release get value
+		gate.Set();
+
+		// Confirm both task completed ... and enumeration was effectively run only on first value
+		for (var i = 0; i < 100 && (!enumeration.IsCompleted || !getValue.IsCompleted); i++)
+		{
+			await Task.Delay(10);
+		}
+		enumeration.IsCompleted.Should().BeTrue();
+		getValue.IsCompleted.Should().BeTrue();
+
+		enumeration.Result.Should().Be(1, because: "we should have got the value created for UI thread (on which we have waited on)");
+	}
+
+	private int CountValues<T>(DispatcherLocal<T> sut, bool includeBackground = true)
+	{
+		// note : This method MUST use ForEachValue for test When_EnumerateWhileCreatingValue_Then_Lock to be useful!
+		var count = 0;
+		sut.ForEachValue((_, __) => count++, includeBackground);
+		return count;
+	}
+}

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
@@ -152,13 +152,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 				return;
 			}
 
-			lock (_holder)
-			{
-				foreach (var holder in _holder.GetValues())
-				{
-					holder.value.Update(source, changes, mode);
-				}
-			}
+			_holder.ForEachValue((_, value) => value.Update(source, changes, mode)); 
 		}
 
 		/// <summary>

--- a/src/Uno.Extensions.Reactive/Utils/Dispatching/DispatcherLocal.cs
+++ b/src/Uno.Extensions.Reactive/Utils/Dispatching/DispatcherLocal.cs
@@ -260,8 +260,8 @@ internal sealed class DispatcherLocal<T>
 	}
 
 	/// <summary>
-	/// Gets value for all dispatcher, and optionally for the background thread.
-	/// WARNING: This method is only PARTIALLY thread-safe (no exception if value is created while enumerating, but newly created values won't be enumerated).
+	/// Gets a value for all dispatchers, and optionally for the background thread.
+	/// WARNING: This method is only PARTIALLY thread-safe (no exception if the value is created while enumerating, but newly created values won't be enumerated).
 	/// </summary>
 	public IEnumerable<(IDispatcher? scheduler, T value)> GetValues(bool includeBackground = true)
 	{
@@ -285,7 +285,7 @@ internal sealed class DispatcherLocal<T>
 	}
 
 	/// <summary>
-	/// Executes an action for the value each dispatcher, and optionally for the background thread.
+	/// Executes an action for the value of each dispatcher, and optionally for the background thread.
 	/// WARNING: This method is thread-safe, but the action is executed in a lock, so it should be fast.
 	/// </summary>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -293,7 +293,7 @@ internal sealed class DispatcherLocal<T>
 		=> ForEachValue(static (a, d, v) => a(d, v), action, includeBackground);
 
 	/// <summary>
-	/// Executes an action for the value each dispatcher, and optionally for the background thread.
+	/// Executes an action for the value of each dispatcher, and optionally for the background thread.
 	/// WARNING: This method is thread-safe, but the action is executed in a lock, so it should be fast.
 	/// </summary>
 	public void ForEachValue<TState>(Action<TState, IDispatcher?, T> action, TState state, bool includeBackground = true)

--- a/src/Uno.Extensions.Reactive/Utils/Events/EventManager.THandler.cs
+++ b/src/Uno.Extensions.Reactive/Utils/Events/EventManager.THandler.cs
@@ -50,6 +50,8 @@ internal class EventManager<THandler, TArgs>
 	/// <inheritdoc />
 	public void Raise(TArgs args)
 	{
+		// Note: We prefer to use the GetValues instead of the ForEachValueAsync as we don't mind to miss a new handler
+		//		 inserted during enumeration, and the handler might be heavy and would lock the DispatcherLocal for too long.
 		foreach (var list in _invocationLists.GetValues())
 		{
 			list.value.Invoke(args);
@@ -59,6 +61,8 @@ internal class EventManager<THandler, TArgs>
 	/// <inheritdoc />
 	public void Raise(Func<TArgs> args)
 	{
+		// Note: We prefer to use the GetValues instead of the ForEachValueAsync as we don't mind to miss a new handler
+		//		 inserted during enumeration, and the handler might be heavy and would lock the DispatcherLocal for too long.
 		foreach (var list in _invocationLists.GetValues())
 		{
 			list.value.Invoke(args);
@@ -76,10 +80,5 @@ internal class EventManager<THandler, TArgs>
 
 	/// <inheritdoc />
 	public void Dispose()
-	{
-		foreach (var list in _invocationLists.GetValues())
-		{
-			list.value.Dispose();
-		}
-	}
+		=> _invocationLists.ForEachValue(static (_, list) => list.Dispose());
 }


### PR DESCRIPTION


closes https://github.com/unoplatform/uno/discussions/15654

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## Bugfix
 Fix possible concurrency issue when changing ListState values before ui thread get it

## What is the current behavior?
If the source collection of the `BindableCollection` is switch while the UI thread is getting the current collection, then we miss some updates on it. This drives the UI to not get all collection changes events causing possible sync issues between UI and model.

## What is the new behavior?
lock

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
