### PR TITLE
fixing issue with error on WinUI due to Win2D graphics

### DIFF
--- a/samples/MauiEmbedding/Directory.Packages.props
+++ b/samples/MauiEmbedding/Directory.Packages.props
@@ -2,8 +2,8 @@
 	<ItemGroup>
 		<PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.0" />
 		<PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.231219000" />
+		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
+		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
 		<PackageVersion Include="SkiaSharp" Version="2.88.7" />
 		<PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
 		<PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="2.88.7" />

--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -13,8 +13,8 @@
 		<PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13" />
 		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.7.1" />
 		<PackageVersion Include="Microsoft.Windows.Compatibility" Version="7.0.3" />
-		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.231219000" />
+		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
+		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
 		<PackageVersion Include="Refit" Version="6.3.2" />
 		<PackageVersion Include="Refit.HttpClientFactory" Version="6.3.2" />
 		<PackageVersion Include="SkiaSharp.Views" Version="2.88.6" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -47,7 +47,7 @@
 
 	<Choose>
 		<When Condition="$(_IsWinUI)">
-			<ItemGroup>
+			<ItemGroup Condition="$(ExcludeWinAppSdkReference) != 'true'">
 				<PackageReference Include="Microsoft.WindowsAppSDK" Condition="$(WinAppSdkVersion)==''"/>
 				<PackageReference Include="Microsoft.WindowsAppSDK" Condition="$(WinAppSdkVersion)!=''" VersionOverride="$(WinAppSdkVersion)"/>
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
@@ -95,5 +95,5 @@
 			 <!--Prevent projects from duplicating assemblies in every output folder-->
 			<Private Condition="'$(OutputType)' == 'library' and '$(NugetOverrideVersion)'==''">false</Private>
 		</ProjectReference>
-	</ItemDefinitionGroup> 
+	</ItemDefinitionGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -23,7 +23,8 @@
 		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.7.1" />
 		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-	    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.231219000" />
+		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.231219000" />
+		<PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.2.0" />
 		<PackageVersion Include="Moq" Version="4.17.2" />
 		<PackageVersion Include="Refit" Version="6.3.2" />
 		<PackageVersion Include="Refit.HttpClientFactory" Version="6.3.2" />

--- a/src/Uno.Extensions.Authentication.MSAL/Uno.Extensions.Authentication.MSAL.WinUI.csproj
+++ b/src/Uno.Extensions.Authentication.MSAL/Uno.Extensions.Authentication.MSAL.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>
@@ -22,9 +22,9 @@
 		<Platforms>x86;x64;arm64</Platforms>
 		<RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
 	</PropertyGroup>
-	
+
 	<Import Project="common.props" />
-	
+
 	<PropertyGroup>
 		<PackageId>Uno.Extensions.Authentication.MSAL.WinUI</PackageId>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>

--- a/src/Uno.Extensions.Authentication.Oidc/Uno.Extensions.Authentication.Oidc.WinUI.csproj
+++ b/src/Uno.Extensions.Authentication.Oidc/Uno.Extensions.Authentication.Oidc.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<Import Project="common.props" />
-	
+
 	<PropertyGroup>
 		<PackageId>Uno.Extensions.Authentication.Oidc.WinUI</PackageId>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
@@ -18,7 +18,7 @@
 	<ItemGroup >
 		<PackageReference Include="Uno.WinUI" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Extensions.Authentication.UI\Uno.Extensions.Authentication.WinUI.csproj" />
 		<ProjectReference Include="..\Uno.Extensions.Http.UI\Uno.Extensions.Http.WinUI.csproj" />

--- a/src/Uno.Extensions.Authentication.UI/Uno.Extensions.Authentication.WinUI.csproj
+++ b/src/Uno.Extensions.Authentication.UI/Uno.Extensions.Authentication.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<Import Project="common.props" />
-	
+
 	<PropertyGroup>
 		<PackageId>Uno.Extensions.Authentication.WinUI</PackageId>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>

--- a/src/Uno.Extensions.Core.UI/Uno.Extensions.Core.WinUI.csproj
+++ b/src/Uno.Extensions.Core.UI/Uno.Extensions.Core.WinUI.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>
 		<Description>Core Extensions for the Uno Platform (WinUI)</Description>
 	</PropertyGroup>
-	
+
 	<Import Project="common.props" />
 
 	<PropertyGroup>

--- a/src/Uno.Extensions.Hosting.UI/Uno.Extensions.Hosting.WinUI.csproj
+++ b/src/Uno.Extensions.Hosting.UI/Uno.Extensions.Hosting.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 	<ItemGroup>
 	  <Compile Remove="WasmScripts\**" />
@@ -10,7 +10,7 @@
 		<UnoRuntimeProjectReference Include="Uno.Extensions.Hosting.WinUI.Wasm.csproj" />
 		<UnoRuntimeProjectReference Include="Uno.Extensions.Hosting.WinUI.Skia.csproj" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<Content Include="buildTransitive\Uno.Extensions.Hosting.WinUI.props">
 			<PackagePath>buildTransitive</PackagePath>

--- a/src/Uno.Extensions.Http.UI/Uno.Extensions.Http.WinUI.csproj
+++ b/src/Uno.Extensions.Http.UI/Uno.Extensions.Http.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<Import Project="common.props" />

--- a/src/Uno.Extensions.Localization.UI/Uno.Extensions.Localization.WinUI.csproj
+++ b/src/Uno.Extensions.Localization.UI/Uno.Extensions.Localization.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>

--- a/src/Uno.Extensions.Logging/Uno.Extensions.Logging.WinUI.csproj
+++ b/src/Uno.Extensions.Logging/Uno.Extensions.Logging.WinUI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
 	<Import Project="..\tfms-ui-winui.props" />
 

--- a/src/Uno.Extensions.Maui.UI/Uno.Extensions.Maui.WinUI.csproj
+++ b/src/Uno.Extensions.Maui.UI/Uno.Extensions.Maui.WinUI.csproj
@@ -24,6 +24,7 @@
 		<PackageReference Include="Uno.WinUI" />
 		<PackageReference Include="Microsoft.Maui.Controls" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
+		<PackageReference Include="Microsoft.Graphics.Win2D" Condition="$(TargetFramework.Contains('-windows10'))" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Maui.UI/Uno.Extensions.Maui.WinUI.csproj
+++ b/src/Uno.Extensions.Maui.UI/Uno.Extensions.Maui.WinUI.csproj
@@ -12,6 +12,7 @@
 		<IsMauiEmbedding>false</IsMauiEmbedding>
 		<IsMauiEmbedding Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' OR $(TargetFramework.Contains('windows10'))">true</IsMauiEmbedding>
 		<DefineConstants Condition="$(IsMauiEmbedding)">$(DefineConstants);MAUI_EMBEDDING</DefineConstants>
+		<ExcludeWinAppSdkReference>true</ExcludeWinAppSdkReference>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Maui.WinUI.Markup/Uno.Extensions.Maui.WinUI.Markup.csproj
+++ b/src/Uno.Extensions.Maui.WinUI.Markup/Uno.Extensions.Maui.WinUI.Markup.csproj
@@ -11,7 +11,7 @@
 		<IsMauiEmbedding>false</IsMauiEmbedding>
 		<IsMauiEmbedding Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' OR $(TargetFramework.Contains('windows10'))">true</IsMauiEmbedding>
 		<DefineConstants Condition="$(IsMauiEmbedding)">$(DefineConstants);MAUI_EMBEDDING</DefineConstants>
-		<WinAppSdkVersion>1.4.231219000</WinAppSdkVersion>
+		<ExcludeWinAppSdkReference>true</ExcludeWinAppSdkReference>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.WinUI.csproj
+++ b/src/Uno.Extensions.Navigation.Toolkit/Uno.Extensions.Navigation.Toolkit.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>

--- a/src/Uno.Extensions.Navigation.UI.Markup/Uno.Extensions.Navigation.WinUI.Markup.csproj
+++ b/src/Uno.Extensions.Navigation.UI.Markup/Uno.Extensions.Navigation.WinUI.Markup.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>
@@ -7,7 +7,7 @@
 		<!--Temporary disable missing XML doc until fixed in the whole package-->
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
-		<WinAppSdkVersion>1.4.231219000</WinAppSdkVersion>
+		<PackageDescription>A set of C# for Markup helpers for Uno.Extensions.Navigation.WinUI</PackageDescription>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -18,8 +18,4 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Extensions.Navigation.UI\Uno.Extensions.Navigation.WinUI.csproj" />
 	</ItemGroup>
-
-	<PropertyGroup>
-		<PackageDescription>A set of C# for Markup helpers for Uno.Extensions.Navigation.WinUI</PackageDescription>
-	</PropertyGroup>
 </Project>

--- a/src/Uno.Extensions.Navigation.UI/Uno.Extensions.Navigation.WinUI.csproj
+++ b/src/Uno.Extensions.Navigation.UI/Uno.Extensions.Navigation.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<Import Project="common.props" />
-	
+
 	<PropertyGroup>
 		<PackageId>Uno.Extensions.Navigation.WinUI</PackageId>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>

--- a/src/Uno.Extensions.Reactive.UI.Markup/Uno.Extensions.Reactive.WinUI.Markup.csproj
+++ b/src/Uno.Extensions.Reactive.UI.Markup/Uno.Extensions.Reactive.WinUI.Markup.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>
@@ -6,7 +6,7 @@
 		<!--Temporary disable missing XML doc until fixed in the whole package-->
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
-		<WinAppSdkVersion>1.4.231219000</WinAppSdkVersion>
+		<PackageDescription>A set of C# for Markup helpers for Uno.Extensions.Reactive.WinUI</PackageDescription>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -18,8 +18,4 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Extensions.Reactive.UI\Uno.Extensions.Reactive.WinUI.csproj" />
 	</ItemGroup>
-
-	<PropertyGroup>
-		<PackageDescription>A set of C# for Markup helpers for Uno.Extensions.Reactive.WinUI</PackageDescription>
-	</PropertyGroup>
 </Project>

--- a/src/Uno.Extensions.Reactive.UI.Tests/Uno.Extensions.Reactive.WinUI.Tests.csproj
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Uno.Extensions.Reactive.WinUI.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>

--- a/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.WinUI.csproj
+++ b/src/Uno.Extensions.Reactive.UI/Uno.Extensions.Reactive.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<!--
@@ -10,7 +10,7 @@
 		<EnableDefaultPageItems>false</EnableDefaultPageItems>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 		<PackageId>Uno.Extensions.Reactive.WinUI</PackageId>
-		
+
 		<UnoXamlResourcesTrimming Condition="'$(MSBuildRuntimeType)'=='Core' and '$(Configuration)'=='Release'">true</UnoXamlResourcesTrimming>
 	</PropertyGroup>
 

--- a/src/Uno.Extensions.Storage.UI/Uno.Extensions.Storage.WinUI.csproj
+++ b/src/Uno.Extensions.Storage.UI/Uno.Extensions.Storage.WinUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<Import Project="common.props" />
-	
+
 	<PropertyGroup>
 		<PackageId>Uno.Extensions.Storage.WinUI</PackageId>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>

--- a/src/Uno.Extensions.Toolkit.UI/Uno.Extensions.Toolkit.WinUI.csproj
+++ b/src/Uno.Extensions.Toolkit.UI/Uno.Extensions.Toolkit.WinUI.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<Import Project="..\tfms-ui-winui.props" />
 
 	<PropertyGroup>
 		<Description>Toolkit Extensions for the Uno Platform (WinUI)</Description>
 	</PropertyGroup>
-	
+
 	<PropertyGroup>
 		<PackageId>Uno.Extensions.Toolkit.WinUI</PackageId>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #2060

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Windows fails due to the version of Microsoft.Graphics.Win2D getting linked out

## What is the new behavior?

Windows should be fine now as we directly have a dependency on the updated version of Microsoft.Graphics.2D