### PR TITLE
chore: bump MSAL due to security vulnerability

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,7 @@
 		<PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
 		<PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.1" />
 		<PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-		<PackageVersion Include="Microsoft.Identity.Client" Version="4.55.0" />
+		<PackageVersion Include="Microsoft.Identity.Client" Version="4.60.3" />
 		<PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.22.0" />
 		<PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.3" />
 		<PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.3" />

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -11,7 +11,7 @@
 		<PackageVersion Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="6.0.7" />
 		<PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
 		<PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-		<PackageVersion Include="Microsoft.Identity.Client" Version="4.55.0" />
+		<PackageVersion Include="Microsoft.Identity.Client" Version="4.60.3" />
 		<PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.11" />
 		<PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- related #2246 

## PR Type

What kind of change does this PR introduce?

- Other... Please describe: Dependency Security Vulnerability

## What is the current behavior?

Targets MSAL 4.55.0 with security vulnerability
https://github.com/advisories/GHSA-x674-v45j-fwxw

## What is the new behavior?

Updates to latest patched version
