### PR TITLE
fix: Only override the EnableMsixTooling for libraries

### DIFF
--- a/src/Uno.Extensions.Maui.UI/build/Package.props
+++ b/src/Uno.Extensions.Maui.UI/build/Package.props
@@ -20,12 +20,4 @@
 		<IncludeXamlNamespaces Include="not_maui" />
 		<ExcludeXamlNamespaces Include="maui" />
 	</ItemGroup>
-
-	<Choose>
-		<When Condition="$(TargetFramework.Contains('windows10'))">
-			<PropertyGroup Condition=" '$(OutputType)' != 'WinExe' AND '$(OutputType)' != 'Exe' ">
-				<EnableMsixTooling>false</EnableMsixTooling>
-			</PropertyGroup>
-		</When>
-	</Choose>
 </Project>

--- a/src/Uno.Extensions.Maui.UI/build/Package.targets
+++ b/src/Uno.Extensions.Maui.UI/build/Package.targets
@@ -11,6 +11,14 @@
 		<Using Remove="@(Using->HasMetadata('Sdk')->WithMetadataValue('Sdk', 'Maui'))"/>
 	</ItemGroup>
 
+	<Choose>
+		<When Condition="$(TargetFramework.Contains('windows10'))">
+			<PropertyGroup Condition=" '$(UsingUnoSdk)' != 'true' AND '$(OutputType)' != 'WinExe' AND '$(OutputType)' != 'Exe' ">
+				<EnableMsixTooling>false</EnableMsixTooling>
+			</PropertyGroup>
+		</When>
+	</Choose>
+
 	<ItemGroup>
 		<Using Remove="Microsoft.Maui.*" />
 		<Analyzer Remove="Microsoft.Maui.Controls.SourceGen" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/discussions/16645

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change will ensure that the EnableMsixTooling property is modified properly, in the targets file (when OutputType is set) and only when we're not using the Uno.Sdk (which sets this value properly by itself).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
