### PR TITLE
fix: ResourceLoaderStringLocalizer not resolving

### DIFF
--- a/src/Uno.Extensions.Localization.UI/ResourceLoaderStringLocalizer.cs
+++ b/src/Uno.Extensions.Localization.UI/ResourceLoaderStringLocalizer.cs
@@ -64,11 +64,12 @@ public class ResourceLoaderStringLocalizer : IStringLocalizer
 		string? resource = null;
 		try
 		{
+			resource =
 #if WINDOWS
-			resource = _appResourceMap.GetValue(name)?.ValueAsString ??
-							_defaultResourceMap.GetValue(name)?.ValueAsString;
+				_appResourceMap.GetValue(name)?.ValueAsString ??
+				_defaultResourceMap.GetValue(name)?.ValueAsString;
 #else
-			resource = _appResourceLoader?.GetString(name) ??
+				(_appResourceLoader?.GetString(name) is { Length: > 0 } tmp ? tmp : null) ??
 				_defaultResourceLoader.GetString(name);
 #endif
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno#16627

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
`IStringLocalizer` not resolving on non-windows platforms

## What is the new behavior?
^ fixed

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
![image](https://github.com/unoplatform/uno.extensions/assets/2359550/b9569e29-9712-48bf-8215-808ccc4e1f69)
the null-coalesce is working poorly on these two