### PR TITLE
fix(mvux): Fix invalid equality comparision of value types in bindable

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.Immutable.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.Immutable.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions.Collections.Tracking;
 using Uno.Extensions.Reactive.Collections;
 using Uno.Extensions.Reactive.Tests._Utils;
+using Uno.Extensions.Reactive.Utils;
 using static Uno.Extensions.Collections.CollectionChanged;
 
 namespace Uno.Extensions.Reactive.Tests.Collections.Tracking;

--- a/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.ImmutableNonIList.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Collections/Tracking/Given_CollectionAnalyzer.ImmutableNonIList.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions.Collections.Tracking;
 using Uno.Extensions.Reactive.Collections;
 using Uno.Extensions.Reactive.Tests._Utils;
+using Uno.Extensions.Reactive.Utils;
 using static Uno.Extensions.Collections.CollectionChanged;
 
 namespace Uno.Extensions.Reactive.Tests.Collections.Tracking;

--- a/src/Uno.Extensions.Reactive.Tests/Presentation/Bindings/Given_Bindable.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Presentation/Bindings/Given_Bindable.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Bindings;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Presentation.Bindings;
+
+[TestClass]
+public class Given_Bindable : FeedUITests
+{
+	private TestViewModel _provider = default!;
+
+	[TestInitialize]
+	public override void Initialize()
+	{
+		base.Initialize();
+
+		_provider = new TestViewModel(this);
+	}
+
+	[TestMethod]
+	public async Task When_SetDefaultIntDuringSyncInit_Then_NoPropertyChange()
+		=> await When_SetValueDuringSyncInit<int>();
+
+	[TestMethod]
+	public async Task When_SetDefaultEnumDuringSyncInit_Then_NoPropertyChange()
+		=> await When_SetValueDuringSyncInit<TestEnum>();
+
+	[TestMethod]
+	public async Task When_SetDefaultStructDuringSyncInit_Then_NoPropertyChange()
+		=> await When_SetValueDuringSyncInit<MyStruct>();
+
+	[TestMethod]
+	public async Task When_SetDefaultObjectDuringSyncInit_Then_NoPropertyChange()
+		=> await When_SetValueDuringSyncInit<object>();
+
+	[TestMethod]
+	public async Task When_SetIntDuringSyncInit_Then_PropertyChange()
+		=> await When_SetValueDuringSyncInit(0, 42, 1);
+
+	[TestMethod]
+	public async Task When_SetEnumDuringSyncInit_Then_PropertyChange()
+		=> await When_SetValueDuringSyncInit(TestEnum.A, TestEnum.B, 1);
+
+	[TestMethod]
+	public async Task When_SetStructDuringSyncInit_Then_PropertyChange()
+		=> await When_SetValueDuringSyncInit(new MyStruct(0), new MyStruct(42), 1);
+
+	[TestMethod]
+	public async Task When_SetObjectDuringSyncInit_Then_PropertyChange()
+		=> await When_SetValueDuringSyncInit(new object(), new object(), 1); // We use ref-equality for object to avoid deep comparison on the UI thread
+
+
+	[TestMethod]
+	public async Task When_SetSameIntAfterAsyncInit_Then_NoPropertyChange()
+		=> await When_SetValueAfterAsyncInit<int>();
+
+	[TestMethod]
+	public async Task When_SetSameEnumAfterAsyncInit_Then_NoPropertyChange()
+		=> await When_SetValueAfterAsyncInit<TestEnum>();
+
+	[TestMethod]
+	public async Task When_SetSameStructAfterAsyncInit_Then_NoPropertyChange()
+		=> await When_SetValueAfterAsyncInit<MyStruct>();
+
+	[TestMethod]
+	public async Task When_SetSameObjectAfterAsyncInit_Then_NoPropertyChange()
+		=> await When_SetValueAfterAsyncInit<object>();
+
+	[TestMethod]
+	public async Task When_SetIntAfterAsyncInit_Then_PropertyChange()
+		=> await When_SetValueAfterAsyncInit(0, 42, 1);
+
+	[TestMethod]
+	public async Task When_SetEnumAfterAsyncInit_Then_PropertyChange()
+		=> await When_SetValueAfterAsyncInit(TestEnum.A, TestEnum.B, 1);
+
+	[TestMethod]
+	public async Task When_SetStructAfterAsyncInit_Then_PropertyChange()
+		=> await When_SetValueAfterAsyncInit(new MyStruct(0), new MyStruct(42), 1);
+
+	[TestMethod]
+	public async Task When_SetObjectAfterAsyncInit_Then_PropertyChange()
+		=> await When_SetValueAfterAsyncInit(new object(), new object(), 1); // We use ref-equality for object to avoid deep comparison on the UI thread
+
+	private async Task When_SetValueDuringSyncInit<T>(T original = default!, T updated = default!, int expectedCount = 0)
+	{
+		var (property, state) = _provider.GetSync(original);
+		var sut = new Bindable<T>(property);
+		var changes = 0;
+
+		await Dispatcher.ExecuteAsync(() =>
+		{
+			sut.PropertyChanged += (snd, e) => changes++;
+			sut.SetValue(updated);
+		});
+
+		changes.Should().Be(expectedCount);
+	}
+
+	private async Task When_SetValueAfterAsyncInit<T>(T original = default!, T updated = default!, int expectedCount = 0)
+	{
+		var evt = new ManualResetEvent(false);
+		var (property, state) = _provider.GetAsync(async ct =>
+		{
+			if (!evt.WaitOne(FeedRecorder.DefaultTimeout, false))
+			{
+				throw new InvalidOperationException();
+			}
+			return original;
+		});
+		var sut = new Bindable<T>(property);
+		var changes = 0;
+
+		await Dispatcher.ExecuteAsync(async ct =>
+		{
+			sut.PropertyChanged += (snd, e) => changes++; // 1 init subscription to the underling state by subscribing to the PropertyChanged event from the UI thread.
+			evt.Set(); // 2 release the async initialization
+			await sut.GetSource(_provider.Owner.Context).FirstAsync(ct); // 3 Wait for init to reach the UI thread.
+			sut.SetValue(updated); // 4 Finally set the value from the UI thread, just like a property change by a control using 2-way binding
+		});
+
+		changes.Should().Be(expectedCount);
+	}
+
+	private enum TestEnum
+	{
+		A,
+		B,
+		C
+	}
+
+	private record struct MyStruct(int Value);
+
+	private class TestViewModel(Given_Bindable owner) : BindableViewModelBase
+	{
+		public Given_Bindable Owner => owner;
+
+		public (BindablePropertyInfo<T> property, IState<T> state) GetSync<T>(T defaultValue = default(T)!, [CallerMemberName] string name = "")
+		{
+			var backingState = State<T>.Value(owner, () => defaultValue);
+
+			return (base.Property(name, backingState), backingState);
+		}
+
+		public (BindablePropertyInfo<T> property, IState<T> state) GetAsync<T>(AsyncFunc<T> defaultValue, [CallerMemberName] string name = "")
+		{
+			var backingState = State<T>.Async(owner, defaultValue);
+
+			return (base.Property(name, backingState), backingState);
+		}
+
+		/// <inheritdoc />
+		protected override void __Reactive_UpdateModel(object updatedModel)
+			=> throw new NotSupportedException("Hot reload not supported in test!");
+	}
+}

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/Bindable.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/Bindable.cs
@@ -18,6 +18,10 @@ namespace Uno.Extensions.Reactive.Bindings;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public class Bindable<T> : IBindable, INotifyPropertyChanged, IFeed<T>
 {
+	private static readonly IEqualityComparer<T> _comparer = typeof(T).IsValueType
+		? EqualityComparer<T>.Default
+		: ReferenceEqualityComparer<T>.Default; // We use ref-equality for object to avoid deep comparison on the UI thread
+
 	/// <inheritdoc />
 	public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -164,7 +168,7 @@ public class Bindable<T> : IBindable, INotifyPropertyChanged, IFeed<T>
 	/// <remarks>This is not thread safe and is expected to be invoked from the UI thread.</remarks>
 	private bool SetValueCore(T value, IChangeSet? changes)
 	{
-		if (object.ReferenceEquals(_value, value))
+		if (_comparer.Equals(_value, value))
 		{
 			return false;
 		}

--- a/src/Uno.Extensions.Reactive/Utils/ReferenceEqualityComparer.cs
+++ b/src/Uno.Extensions.Reactive/Utils/ReferenceEqualityComparer.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Uno.Extensions.Reactive.Tests._Utils;
+namespace Uno.Extensions.Reactive.Utils;
 
 internal class ReferenceEqualityComparer<T> : IEqualityComparer<T>
 {


### PR DESCRIPTION
closes #https://github.com/unoplatform/uno/discussions/16581#discussioncomment-9531425

## Bugfix
Fix invalid equality comparision of value types in bindable

## What is the current behavior?
`ValueType` are compared using ref-equality of boxed value ...
If this happen during the init of the bindable we might miss some `PropertyChanged` events and don't display the initial value of the backing `State`.

## What is the new behavior?
If `ValueType` we use the `EqualityComparer.Default`.

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
