### PR TITLE
fix: Using simple settings as alternative for key-value store when ApplicationData isn't available

### DIFF
--- a/src/Uno.Extensions.Core.UI/Settings.cs
+++ b/src/Uno.Extensions.Core.UI/Settings.cs
@@ -60,7 +60,7 @@ internal record Settings(ILogger<Settings>? Logger = default) : ISettings
 			return settings.TryGetValue(key, out var value) ? value : default;
 		}
 	}
-	public void Set(string key, string value)
+	public void Set(string key, string? value)
 	{
 		Initialize();
 		if (!_useFileSettings)
@@ -80,6 +80,33 @@ internal record Settings(ILogger<Settings>? Logger = default) : ISettings
 #if __WINDOWS__
 			File.WriteAllText(SettingsFile, JsonSerializer.Serialize(settings));
 #endif
+		}
+	}
+
+	public void Remove(string key) => Set(key, null);
+
+	public void Clear()
+	{
+		Initialize();
+		if (!_useFileSettings)
+		{
+			ApplicationData.Current.LocalSettings.Values.Clear();
+		}
+		else
+		{
+			settings.Clear();
+#if __WINDOWS__
+			File.WriteAllText(SettingsFile, JsonSerializer.Serialize(settings));
+#endif
+		}
+	}
+
+	public IReadOnlyCollection<string> Keys
+	{
+		get
+		{
+			Initialize();
+			return _useFileSettings ? settings.Keys : ApplicationData.Current.LocalSettings.Values.Keys.Select(k => k.ToString()).ToArray();
 		}
 	}
 }

--- a/src/Uno.Extensions.Core.UI/Settings.cs
+++ b/src/Uno.Extensions.Core.UI/Settings.cs
@@ -106,7 +106,7 @@ internal record Settings(ILogger<Settings>? Logger = default) : ISettings
 		get
 		{
 			Initialize();
-			return _useFileSettings ? settings.Keys : ApplicationData.Current.LocalSettings.Values.Keys.Select(k => k.ToString()).ToArray();
+			return _useFileSettings ? settings.Keys : ApplicationData.Current.LocalSettings.Values.Keys.Select(k => k.ToString(CultureInfo.InvariableCulture)).ToArray();
 		}
 	}
 }

--- a/src/Uno.Extensions.Core.UI/Settings.cs
+++ b/src/Uno.Extensions.Core.UI/Settings.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Globalization;
+using System.Text.Json;
 
 namespace Uno.Extensions;
 
@@ -106,7 +107,7 @@ internal record Settings(ILogger<Settings>? Logger = default) : ISettings
 		get
 		{
 			Initialize();
-			return _useFileSettings ? settings.Keys : ApplicationData.Current.LocalSettings.Values.Keys.Select(k => k.ToString(CultureInfo.InvariableCulture)).ToArray();
+			return _useFileSettings ? settings.Keys : ApplicationData.Current.LocalSettings.Values.Keys.Select(k => k.ToString(CultureInfo.InvariantCulture)).ToArray();
 		}
 	}
 }

--- a/src/Uno.Extensions.Core/ISettings.cs
+++ b/src/Uno.Extensions.Core/ISettings.cs
@@ -1,7 +1,37 @@
 ﻿namespace Uno.Extensions;
 
-internal interface ISettings
+/// <summary>
+/// Simple interface for storing key-value pairs.
+/// </summary>
+public interface ISettings
 {
+	/// <summary>
+	/// Gets the value associated with the specified key.
+	/// </summary>
+	/// <param name="key">The key of the value to get.</param>
+	/// <returns>The value associated with the specified key, or null if the key does not exist.</returns>
 	string? Get(string key);
-	void Set(string key, string value);
+
+	/// <summary>
+	/// Sets the value associated with the specified key.
+	/// </summary>
+	/// <param name="key">The key of the value to set.</param>
+	/// <param name="value">The value to set.</param>
+	void Set(string key, string? value);
+
+	/// <summary>
+	/// Removes the value associated with the specified key.
+	/// </summary>
+	/// <param name="key">The key of the value to remove.</param>
+	void Remove(string key);
+
+	/// <summary>
+	/// Removes all key-value pairs from the settings.
+	/// </summary>
+	void Clear();
+
+	/// <summary>
+	/// Gets a collection of all keys in the settings.
+	/// </summary>
+	IReadOnlyCollection<string> Keys { get; }
 }

--- a/src/Uno.Extensions.Storage.UI/KeyValueStorage/EncryptedApplicationDataKeyValueStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/KeyValueStorage/EncryptedApplicationDataKeyValueStorage.cs
@@ -10,8 +10,9 @@ internal record EncryptedApplicationDataKeyValueStorage(
 	ILogger<ApplicationDataKeyValueStorage> EncryptedLogger,
 	InMemoryKeyValueStorage InMemoryStorage,
 	KeyValueStorageSettings Settings,
-	ISerializer Serializer)
-	: ApplicationDataKeyValueStorage(EncryptedLogger, InMemoryStorage, Settings, Serializer)
+	ISerializer Serializer,
+	ISettings UnpackagedSettings)
+	: ApplicationDataKeyValueStorage(EncryptedLogger, InMemoryStorage, Settings, Serializer, UnpackagedSettings)
 {
 	public new const string Name = "EncryptedApplicationData";
 

--- a/src/Uno.Extensions.Storage.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Storage.UI/ServiceCollectionExtensions.cs
@@ -9,14 +9,15 @@ internal static class ServiceCollectionExtensions
 	private static TKeyValueStorage CreateKeyValueStorage<TKeyValueStorage>(
 		this IServiceProvider sp,
 		string name,
-		Func<ILogger<TKeyValueStorage>, InMemoryKeyValueStorage, KeyValueStorageSettings, ISerializer, TKeyValueStorage> creator)
+		Func<ILogger<TKeyValueStorage>, InMemoryKeyValueStorage, KeyValueStorageSettings, ISerializer, ISettings, TKeyValueStorage> creator)
 	{
 		var l = sp.GetRequiredService<ILogger<TKeyValueStorage>>();
 		var s = sp.GetRequiredService<ISerializer>();
 		var inmem = sp.GetRequiredService<InMemoryKeyValueStorage>();
 		var config = sp.GetRequiredService<IOptions<KeyValueStorageConfiguration>>();
 		var settings = config.Value.GetSettingsOrDefault(name);
-		return creator(l, inmem, settings, s);
+		var unpackaged = sp.GetRequiredService<ISettings>();
+		return creator(l, inmem, settings, s, unpackaged);
 	}
 
 	public static IServiceCollection AddKeyedStorage(this IServiceCollection services)
@@ -27,7 +28,7 @@ internal static class ServiceCollectionExtensions
 					ApplicationDataKeyValueStorage.Name,
 					sp => sp.CreateKeyValueStorage<ApplicationDataKeyValueStorage>(
 								ApplicationDataKeyValueStorage.Name,
-								(l,inmem, settings,s)=>new ApplicationDataKeyValueStorage(l, inmem, settings, s)
+								(l, inmem, settings, s, unpackaged) => new ApplicationDataKeyValueStorage(l, inmem, settings, s, unpackaged)
 								)
 					)
 #if __ANDROID__
@@ -35,7 +36,7 @@ internal static class ServiceCollectionExtensions
 					KeyStoreKeyValueStorage.Name,
 					sp => sp.CreateKeyValueStorage<KeyStoreKeyValueStorage>(
 								KeyStoreKeyValueStorage.Name,
-								(l, inmem, settings, s) => new KeyStoreKeyValueStorage(l, inmem, settings, s)
+								(l, inmem, settings, s, unpackaged) => new KeyStoreKeyValueStorage(l, inmem, settings, s)
 								)
 					)
 #endif
@@ -44,7 +45,7 @@ internal static class ServiceCollectionExtensions
 					KeyChainKeyValueStorage.Name,
 					sp => sp.CreateKeyValueStorage<KeyChainKeyValueStorage>(
 								KeyChainKeyValueStorage.Name,
-								(l, inmem, settings, s) => new KeyChainKeyValueStorage(l, inmem, settings, s)
+								(l, inmem, settings, s, unpackaged) => new KeyChainKeyValueStorage(l, inmem, settings, s)
 								)
 					)
 #endif
@@ -57,7 +58,7 @@ internal static class ServiceCollectionExtensions
 					EncryptedApplicationDataKeyValueStorage.Name,
 					sp => sp.CreateKeyValueStorage<EncryptedApplicationDataKeyValueStorage>(
 								EncryptedApplicationDataKeyValueStorage.Name,
-								(l, inmem, settings, s) => new EncryptedApplicationDataKeyValueStorage(l, inmem, settings, s)
+								(l, inmem, settings, s, unpackaged) => new EncryptedApplicationDataKeyValueStorage(l, inmem, settings, s, unpackaged)
 								)
 					)
 #endif

--- a/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/StorageHostInit.cs
+++ b/testing/TestHarness/TestHarness.Shared/Ext/Core/Storage/StorageHostInit.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Immutable;
-using Microsoft.Extensions.Options;
-using Uno.Extensions.Storage.KeyValueStorage;
+﻿using Uno.Extensions.Storage.KeyValueStorage;
 
 namespace TestHarness;
 
@@ -22,7 +20,8 @@ public class StorageHostInit : BaseHostInitialization
 						var s = sp.GetRequiredService<ISerializer>();
 						var config = sp.GetRequiredService<IOptions<KeyValueStorageConfiguration>>();
 						var settings = config.Value.GetSettingsOrDefault(NoCacheStorage);
-						return new TestingKeyValueStorage(l,inmem, settings, s);
+						var unpackaged = sp.GetRequiredService<ISettings>();
+						return new TestingKeyValueStorage(l, inmem, settings, s, unpackaged);
 					}));
 	}
 
@@ -39,7 +38,7 @@ public class StorageHostInit : BaseHostInitialization
 	}
 }
 
-internal record  TestingKeyValueStorage
+internal record TestingKeyValueStorage
 #if __ANDROID__
 			: KeyStoreKeyValueStorage
 			{
@@ -47,7 +46,8 @@ internal record  TestingKeyValueStorage
 		ILogger<TestingKeyValueStorage> logger,
 		InMemoryKeyValueStorage inmem,
 		KeyValueStorageSettings settings,
-		ISerializer serializer) : base(logger, inmem, settings, serializer)
+		ISerializer serializer,
+	ISettings UnpackagedSettings) : base(logger, inmem, settings, serializer)
 	{
 
 	}
@@ -55,14 +55,16 @@ internal record  TestingKeyValueStorage
 			(ILogger<TestingKeyValueStorage> TestingLogger,
 	InMemoryKeyValueStorage InMemoryStorage,
 	KeyValueStorageSettings Settings,
-	ISerializer Serializer) : KeyChainKeyValueStorage(TestingLogger, InMemoryStorage, Settings, Serializer)
+	ISerializer Serializer,
+	ISettings UnpackagedSettings) : KeyChainKeyValueStorage(TestingLogger, InMemoryStorage, Settings, Serializer)
 {
 
 #else
 			(ILogger<TestingKeyValueStorage> TestingLogger,
 	InMemoryKeyValueStorage InMemoryStorage,
 	KeyValueStorageSettings Settings,
-	ISerializer Serializer) : ApplicationDataKeyValueStorage(TestingLogger, InMemoryStorage, Settings, Serializer)
+	ISerializer Serializer,
+	ISettings UnpackagedSettings) : ApplicationDataKeyValueStorage(TestingLogger, InMemoryStorage, Settings, Serializer, UnpackagedSettings)
 {
 #endif
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.extensions/issues/2241

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Accessing ApplicationData when running unpackaged on Windows throws an exception

## What is the new behavior?

ISettings is used as a fallback for when ApplicaitonData isn't available

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
