### PR TITLE
feat: Add `doNotActivate` parameter to `NavigateAsync` method from Navigation Extensions

### DIFF
--- a/src/Uno.Extensions.Navigation.Toolkit/ApplicationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/ApplicationBuilderExtensions.cs
@@ -6,9 +6,9 @@ public static class ApplicationBuilderExtensions
 	{
 		public ContentControl CreateDefaultView() => new LoadingView();
 
-		public void InitializeViewHost(Window window, FrameworkElement element, Task loadingTask)
+		public void InitializeViewHost(Window window, FrameworkElement element, Task loadingTask, bool doNotActivate)
 		{
-			window.ApplyLoadingTask(element, loadingTask);
+			window.ApplyLoadingTask(element, loadingTask, doNotActivate);
 		}
 
 		public void PreInitialize(FrameworkElement element, IApplicationBuilder builder)

--- a/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
+++ b/src/Uno.Extensions.Navigation.Toolkit/WindowExtensions.cs
@@ -16,6 +16,7 @@ public static class WindowExtensions
 	/// <param name="initialView">[optional] Initial navigation view</param>
 	/// <param name="initialViewModel">[optional] Initial navigation viewmodel</param>
 	/// <param name="initialNavigate">[optional] Callback to drive initial navigation for app</param>
+	/// <param name="doNotActivate">[optional] Do not activate the window after initializing navigation</param>
 	/// <returns>The created IHost</returns>
 	public static Task<IHost> InitializeNavigationAsync(
 		this Window window,
@@ -24,18 +25,20 @@ public static class WindowExtensions
 		string? initialRoute = "",
 		Type? initialView = null,
 		Type? initialViewModel = null,
-		Func<IServiceProvider, INavigator, Task>? initialNavigate = null)
+		Func<IServiceProvider, INavigator, Task>? initialNavigate = null,
+		bool doNotActivate = false)
 	{
 		return window.InternalInitializeNavigationAsync(
 			buildHost,
 			navigationRoot,
 			initialRoute, initialView, initialViewModel,
 			ApplyLoadingTask,
-			initialNavigate
+			initialNavigate,
+			doNotActivate
 			);
 	}
 
-	internal static void ApplyLoadingTask(this Window window, FrameworkElement root, Task navInit)
+	internal static void ApplyLoadingTask(this Window window, FrameworkElement root, Task navInit, bool doNotActivate)
 	{
 		var activate = true;
 		if (root is LoadingView lv)
@@ -53,7 +56,8 @@ public static class WindowExtensions
 					loadingTask = new Func<Task>(async () =>
 					{
 						await navInit;
-						window.Activate();
+						if (!doNotActivate)
+							window.Activate();
 					})();
 				}
 			}
@@ -61,7 +65,7 @@ public static class WindowExtensions
 			lv.Source = loading;
 		}
 
-		if (activate)
+		if (activate && !doNotActivate)
 		{
 			// Activate immediately to show the splash screen
 			window.Activate();

--- a/src/Uno.Extensions.Navigation.UI/ApplicationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ApplicationBuilderExtensions.cs
@@ -9,9 +9,10 @@ public static class ApplicationBuilderExtensions
 	/// <typeparam name="TShell">The <see cref="UIElement" /> to use for the App Shell.</typeparam>
 	/// <param name="appBuilder">The <see cref="IApplicationBuilder" />.</param>
 	/// <param name="initialNavigate">An optional Navigation Delegate to conditionally control where the app should navigate on launch.</param>
+	/// <param name="doNotActivate">An optional flag to prevent the Window from activating right after initialization but only when host is completely loaded.</param>
 	/// <returns>The <see cref="IHost" />.</returns>
 	public static async Task<IHost> NavigateAsync<TShell>(this IApplicationBuilder appBuilder,
-		Func<IServiceProvider, INavigator, Task>? initialNavigate = null)
+		Func<IServiceProvider, INavigator, Task>? initialNavigate = null, bool doNotActivate = false)
 		where TShell : UIElement, new()
 	{
 		var appRoot = new TShell();
@@ -21,7 +22,7 @@ public static class ApplicationBuilderExtensions
 			navRoot = contentProvider.ContentControl;
 		}
 
-		Action<Window, FrameworkElement, Task> initializeViewHost = (_, _, _) => { };
+		Action<Window, FrameworkElement, Task, bool> initializeViewHost = (_, _, _, _) => { };
 		if (appBuilder.Properties.TryGetValue(typeof(IRootViewInitializer), out var propValue) && propValue is IRootViewInitializer initializer)
 		{
 			navRoot ??= initializer.CreateDefaultView();
@@ -43,7 +44,8 @@ public static class ApplicationBuilderExtensions
 			buildHost: () => Task.FromResult(appBuilder.Build()),
 			navigationRoot: navRoot,
 			initializeViewHost: initializeViewHost,
-			initialNavigate: initialNavigate
+			initialNavigate: initialNavigate,
+			doNotActivate: doNotActivate
 		);
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/IRootViewInitializer.cs
+++ b/src/Uno.Extensions.Navigation.UI/IRootViewInitializer.cs
@@ -22,5 +22,6 @@ internal interface IRootViewInitializer
 	/// <param name="window"></param>
 	/// <param name="element"></param>
 	/// <param name="loadingTask"></param>
-	void InitializeViewHost(Window window, FrameworkElement element, Task loadingTask);
+	/// <param name="doNotActivate"></param>
+	void InitializeViewHost(Window window, FrameworkElement element, Task loadingTask, bool doNotActivate = false);
 }

--- a/src/Uno.Extensions.Navigation.UI/ServiceProviderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ServiceProviderExtensions.cs
@@ -46,7 +46,7 @@ public static class ServiceProviderExtensions
 					.CloneScopedInstance<IDispatcher>(services);
 	}
 
-	
+
 
 	/// <summary>
 	/// Initializes navigation for an application using a ContentControl
@@ -91,8 +91,9 @@ public static class ServiceProviderExtensions
 		string? initialRoute = "",
 		Type? initialView = null,
 		Type? initialViewModel = null,
-		Action<Window, FrameworkElement, Task>? initializeViewHost = null,
-		Func<IServiceProvider, INavigator, Task>? initialNavigate = null)
+		Action<Window, FrameworkElement, Task, bool>? initializeViewHost = null,
+		Func<IServiceProvider, INavigator, Task>? initialNavigate = null,
+		bool doNotActivate = false)
 	{
 		if (window.Content is null)
 		{
@@ -100,7 +101,7 @@ public static class ServiceProviderExtensions
 		}
 
 		var buildTask = window.BuildAndInitializeHostAsync(navigationRoot, buildHost, initialRoute, initialView, initialViewModel, initialNavigate);
-		initializeViewHost?.Invoke(window, navigationRoot, buildTask);
+		initializeViewHost?.Invoke(window, navigationRoot, buildTask, doNotActivate);
 		return buildTask;
 	}
 
@@ -124,8 +125,9 @@ public static class ServiceProviderExtensions
 
 		await startup;
 
-		// Fallback to make sure the window is activated
-		window.Activate();
+		var hostLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+		// Activate the window after the application has started
+		hostLifetime.ApplicationStarted.Register(() => window.Activate());
 
 		return host;
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2381

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Window is always activated as soon as possible

## What is the new behavior?

Window is activated either as soon as possible or right after the host is started (all hosted services completed)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
