### PR TITLE
chore: Adjusting warning

### DIFF
--- a/src/Uno.Extensions.Storage.UI/FileStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/FileStorage.cs
@@ -27,9 +27,9 @@ internal record FileStorage(ILogger<FileStorage> Logger, IDataFolderProvider Dat
 		{
 			if (!await FileExistsInPackage(filename))
 			{
-				if (Logger.IsEnabled(LogLevel.Warning))
+				if (Logger.IsEnabled(LogLevel.Information))
 				{
-					Logger.LogWarningMessage($"File '{filename}' does not exist in package");
+					Logger.LogInformationMessage($"File '{filename}' does not exist in package");
 				}
 				return default;
 			}
@@ -68,9 +68,9 @@ internal record FileStorage(ILogger<FileStorage> Logger, IDataFolderProvider Dat
 		}
 		catch (Exception ex)
 		{
-			if (Logger.IsEnabled(LogLevel.Warning))
+			if (Logger.IsEnabled(LogLevel.Information))
 			{
-				Logger.LogWarningMessage($"Unable to read file '{filename}' due to exception {ex.Message}");
+				Logger.LogInformationMessage($"Unable to read file '{filename}' due to exception {ex.Message}");
 			}
 			return default;
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2423

## PR Type
- Bugfix

## What is the current behavior?

Warnings generated from initial template due to missing files

## What is the new behavior?

Downgraded warnings to information

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
