### PR TITLE
fix(mvux): Fix possible cross threading exception in refresh command

### DIFF
--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.Refresh.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.Refresh.cs
@@ -61,7 +61,7 @@ public partial class FeedView
 				{
 					try
 					{
-						subscription.RequestRefresh(() => IsExecuting = false);
+						subscription.RequestRefresh(EndExecution);
 					}
 					catch (Exception error)
 					{
@@ -69,9 +69,16 @@ public partial class FeedView
 						{
 							this.Log().Warn(error, "Failed to send a refresh request");
 						}
-						IsExecuting = false;
+						EndExecution();
 					}
 				});
+
+				void EndExecution()
+#if WINUI
+					=> _view.DispatcherQueue.TryEnqueue(() => IsExecuting = false);
+#else
+					=> _view.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () => IsExecuting = false);
+#endif
 			}
 		}
 	}

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.Refresh.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.Refresh.cs
@@ -75,9 +75,9 @@ public partial class FeedView
 
 				void EndExecution()
 #if WINUI
-					=> _view.DispatcherQueue.TryEnqueue(() => IsExecuting = false);
+					=> _ = _view.DispatcherQueue.TryEnqueue(() => IsExecuting = false);
 #else
-					=> _view.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () => IsExecuting = false);
+					=> _ = _view.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () => IsExecuting = false);
 #endif
 			}
 		}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/2444

## Bugfix
Fix possible cross threading exception in refresh command

## What is the current behavior?
Refresh command may remain `CanExecute = false` after a first execution

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
