### PR TITLE
fix: Prevent FrameView DataContext propagation

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Controls/FrameView.xaml.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/FrameView.xaml.cs
@@ -12,6 +12,9 @@ public sealed partial class FrameView : UserControl
 	public FrameView()
 	{
 		InitializeComponent();
+
+		// Prevent inheritance of DataContext from Parent to avoid propagation to Children
+		DataContext = null;
 	}
 
 	/// <summary>

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/PageNavigation/Given_PageNavigation.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/PageNavigation/Given_PageNavigation.cs
@@ -168,6 +168,19 @@ public class Given_PageNavigation : NavigationTestBase
 
 	}
 
+	[Test]
+	public void When_PageNavigationDataContextDidntChange()
+	{
+		InitTestSection(TestSections.Navigation_PageNavigation);
+
+		App.WaitThenTap("ShowOnePageButton");
+		App.WaitThenTap("OnePageGetUrlFromBrowser");
+
+		// If DataContext is ever changed to anything other than the expected
+		// the text will be "DataContext is not correct"
+		App.WaitForText("OnePageTxtDataContext", "DataContext is ok");
+	}
+
 	private void OnePageToFivePage()
 	{
 		App.WaitThenTap("OnePageToTwoPageButton");

--- a/testing/TestHarness/TestHarness/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml
@@ -36,6 +36,9 @@
 					Click="{x:Bind ViewModel.SettingsWriteTest}"
 					Content="Settings Write Test" />
 			<TextBlock x:Name="TxtUrl" AutomationProperties.AutomationId="OnePageTxtUrlFromBrowser" />
+			<TextBlock x:Name="TxtDataContext"
+					   Text="DataContext is ok"
+					   AutomationProperties.AutomationId="OnePageTxtDataContext" />
 			<Button AutomationProperties.AutomationId="OnePageGetUrlFromBrowser"
 					Click="GetUrlFromBrowser"
 					Content="Get URL" />

--- a/testing/TestHarness/TestHarness/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/PageNavigation/PageNavigationOnePage.xaml.cs
@@ -4,16 +4,31 @@ namespace TestHarness.Ext.Navigation.PageNavigation;
 public sealed partial class PageNavigationOnePage : Page
 {
 	public PageNavigationOneViewModel? ViewModel => DataContext as PageNavigationOneViewModel;
+
+	private Type expectedDataContext = typeof(PageNavigationOneViewModel);
+
 	public PageNavigationOnePage()
 	{
 		this.InitializeComponent();
+
+		this.DataContextChanged += PageNavigationOnePage_DataContextChanged;
+	}
+
+	private void PageNavigationOnePage_DataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+	{
+		// For the test `When_PageNavigationDataContextDidntChange`
+		// If DataContext is ever changed to anything other than the expected the text will be "DataContext is not correct"
+		// So that we can validade on the test
+		if (sender.DataContext is { } dataContext && dataContext.GetType() != expectedDataContext)
+		{
+			TxtDataContext.Text = "DataContext is not correct";
+		}
 	}
 
 	public async void OnePageToTwoPageCodebehindClick(object sender, RoutedEventArgs e)
 	{
 		await this.Navigator()!.NavigateViewAsync<PageNavigationTwoPage>(this);
 	}
-
 
 	public async void GetUrlFromBrowser(object sender, RoutedEventArgs e)
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2522

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

`FrameView` would inherit DataContext from parents and propagate it to child pages.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Set `FrameView.DataContext` to `null` to avoid DataContext inheritance and propagation.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
