### PR TITLE
fix(hr): Fix MVUX command executed on old model when hot-reloading

### DIFF
--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/CommandFromMethod.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/CommandFromMethod.cs
@@ -217,7 +217,7 @@ internal partial record CommandFromMethod : IMappedMember
 			return result.ToString();
 		};
 
-		return @$"{Name} ??= new {NS.Commands}.AsyncCommand(
+		return @$"{Name} = new {NS.Commands}.AsyncCommand(
 					nameof({Name}),
 					new {NS.Commands}.CommandConfig[]
 					{{


### PR DESCRIPTION
## Bugfix
MVUX command executed on old model when hot-reloading

## What is the current behavior?
On HR we are keeping the previous instance of the command that captures the previous model instance

## What is the new behavior?
We always update the instance of the command

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
