### PR TITLE
docs: Dropping uwp and referencing uno.sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Uno.Extensions is a series of NuGet packages designed to encapsulate common developer tasks associated with building multi-platform mobile, desktop, and web applications using Uno Platform.
 
+> [!NOTE]
+> Uno.Extensions has dropped support for UWP and has been updated to use the Uno.Sdk for packages that reference Uno.WinUI.
+
 ## Getting Started
 
 See the complete [documentation](xref:Uno.Extensions.Overview) for getting started with Uno.Extensions.

--- a/samples/Playground/Playground/App.xaml.cs
+++ b/samples/Playground/Playground/App.xaml.cs
@@ -1,6 +1,8 @@
 namespace Playground;
 public partial class App : Application
 {
+    private IHost? _host;
+    
     /// <summary>
     /// Initializes the singleton application object. This is the first line of authored code
     /// executed, and as such is the logical equivalent of main() or WinMain().

--- a/samples/Playground/Playground/DebugHttpHandler.cs
+++ b/samples/Playground/Playground/DebugHttpHandler.cs
@@ -1,10 +1,5 @@
 namespace Playground;
 
-public partial class App : Application
-{
-	private IHost? _host;
-}
-
 public class DebugHttpHandler : DelegatingHandler
 {
 	public DebugHttpHandler(HttpMessageHandler? innerHandler = null)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2485

## PR Type

What kind of change does this PR introduce?
- Documentation content changes


## What is the new behavior?

Document dropping support for UWP and migration to uno.sdk


Note: The actual breaking changes were in https://github.com/unoplatform/uno.extensions/pull/2437
