### PR TITLE
Repositories should be registered by the HostBuilder

### DIFF
--- a/src/Uno.Extensions.Hosting.UI/HostBuilder.cs
+++ b/src/Uno.Extensions.Hosting.UI/HostBuilder.cs
@@ -224,6 +224,10 @@ public class HostBuilder : IHostBuilder
 		// register configuration as factory to make it dispose with the service provider
 		services.AddSingleton(_ => _appConfiguration!);
 		services.AddSingleton<IHostApplicationLifetime, ApplicationLifetime>();
+
+		services.AddSingleton<ISingletonInstanceRepository, InstanceRepository>();
+		services.AddScoped<IScopedInstanceRepository, InstanceRepository>();
+
 		services.AddSingleton((Func<IServiceProvider, IHost>)(_ =>
 		{
 			return (IHost)new Internal.Host(_appServices,

--- a/src/Uno.Extensions.Maui.UI/UnoServiceProviderFactory.cs
+++ b/src/Uno.Extensions.Maui.UI/UnoServiceProviderFactory.cs
@@ -43,6 +43,7 @@ internal class UnoServiceProviderFactory : IServiceProviderFactory<IServiceProvi
 		var serviceProvider = _mauiAppBuilder.Services.BuildServiceProvider();
 
 		// Register the singleton instances captured earlier with the mutable instance container
+		// TODO: Revisit this and ensure that we shouldn't refactor this... it's a bit of a hack
 		singletons.ForEach(sreg => serviceProvider.AddSingletonInstance(sreg.ServiceType, sreg.Implementation));
 
 		_mauiAppBuilder.ConfigureContainer(new MauiServiceProviderFactory(serviceProvider));

--- a/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
@@ -41,8 +41,6 @@ public static class ServiceCollectionExtensions
 						};
 						return config;
 					})
-					.AddSingleton<ISingletonInstanceRepository, InstanceRepository>()
-					.AddScoped<IScopedInstanceRepository, InstanceRepository>()
 					.AddSingleton<IResponseNavigatorFactory, ResponseNavigatorFactory>()
 
 					.AddSingleton<RouteNotifier>()


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #2502 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When running an app with MAUI Embedding but not using Extensions Navigation the app will fail when the MAUI and Uno ServiceCollections are combined and a single ServiceProvider is produced due to an extension method used by MAUI Embedding that requires a service that is only registered in Extensions Navigation.

## What is the new behavior?

The Uno HostBuilder now takes responsibility for registering these services as the Hosting package exposes the extensions that require the use of these services.


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
