### PR TITLE
feat: update MVUX naming convention for generated classes

### DIFF
--- a/src/Uno.Extensions.Reactive.Generator/Bindables/Inputs/BindableInput.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/Inputs/BindableInput.cs
@@ -7,7 +7,7 @@ namespace Uno.Extensions.Reactive.Generator;
 
 /// <summary>
 /// A VM parameter that somehow implements IFeed&lt;TValue&gt; and which will be exposed on the BindableVM
-/// as de-normalized properties through a generated BindableTValue class (cf. <see cref="BindableGenerator"/>).
+/// as de-normalized properties through a generated BindableTValue class (cf. <see cref="ViewModelGenerator_2"/>).
 /// </summary>
 internal record BindableInput(IParameterSymbol Parameter, ITypeSymbol _valueType, string _bindableType) : IInputInfo
 {

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_1.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_1.cs
@@ -18,14 +18,14 @@ internal class ViewModelGenTool_1 : ICodeGenTool
 	public string Version => "1";
 
 	private readonly BindableGenerationContext _ctx;
-	private readonly BindableGenerator _bindables;
+	private readonly ViewModelGenerator_1 _bindables;
 	private readonly BindableViewModelMappingGenerator _viewModelsMapping;
 	private readonly IAssemblySymbol _assembly;
 
 	public ViewModelGenTool_1(BindableGenerationContext ctx)
 	{
 		_ctx = ctx;
-		_bindables = new BindableGenerator(ctx);
+		_bindables = new ViewModelGenerator_1(ctx);
 		_viewModelsMapping = new BindableViewModelMappingGenerator(ctx);
 		_assembly = ctx.Context.Compilation.Assembly;
 	}

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_2.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_2.cs
@@ -18,14 +18,14 @@ internal class ViewModelGenTool_2 : ICodeGenTool
 	public string Version => "2";
 
 	private readonly BindableGenerationContext _ctx;
-	private readonly BindableGenerator _bindables;
+	private readonly ViewModelGenerator_1 _bindables;
 	private readonly BindableViewModelMappingGenerator _viewModelsMapping;
 	private readonly IAssemblySymbol _assembly;
 
 	public ViewModelGenTool_2(BindableGenerationContext ctx)
 	{
 		_ctx = ctx;
-		_bindables = new BindableGenerator(ctx);
+		_bindables = new ViewModelGenerator_1(ctx);
 		_viewModelsMapping = new BindableViewModelMappingGenerator(ctx);
 		_assembly = ctx.Context.Compilation.Assembly;
 	}

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_3.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_3.cs
@@ -16,7 +16,7 @@ internal class ViewModelGenTool_3 : ICodeGenTool
 	private const string ViewModelSufix = "ViewModel";
 
 	private readonly BindableGenerationContext _ctx;
-	private readonly ViewModelGenerator _bindables;
+	private readonly ViewModelGenerator_2 _bindables;
 	private readonly BindableViewModelMappingGenerator _viewModelsMapping;
 	private readonly IAssemblySymbol _assembly;
 
@@ -25,7 +25,7 @@ internal class ViewModelGenTool_3 : ICodeGenTool
 	public ViewModelGenTool_3(BindableGenerationContext ctx)
 	{
 		_ctx = ctx;
-		_bindables = new ViewModelGenerator(ctx);
+		_bindables = new ViewModelGenerator_2(ctx);
 		_viewModelsMapping = new BindableViewModelMappingGenerator(ctx);
 		_assembly = ctx.Context.Compilation.Assembly;
 	}

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_3.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_3.cs
@@ -16,7 +16,7 @@ internal class ViewModelGenTool_3 : ICodeGenTool
 	private const string ViewModelSufix = "ViewModel";
 
 	private readonly BindableGenerationContext _ctx;
-	private readonly BindableGenerator _bindables;
+	private readonly ViewModelGenerator _bindables;
 	private readonly BindableViewModelMappingGenerator _viewModelsMapping;
 	private readonly IAssemblySymbol _assembly;
 
@@ -25,7 +25,7 @@ internal class ViewModelGenTool_3 : ICodeGenTool
 	public ViewModelGenTool_3(BindableGenerationContext ctx)
 	{
 		_ctx = ctx;
-		_bindables = new BindableGenerator(ctx);
+		_bindables = new ViewModelGenerator(ctx);
 		_viewModelsMapping = new BindableViewModelMappingGenerator(ctx);
 		_assembly = ctx.Context.Compilation.Assembly;
 	}

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_3.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenTool_3.cs
@@ -1,0 +1,313 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Uno.Extensions.Generators;
+using Uno.Extensions.Reactive.Config;
+using static Microsoft.CodeAnalysis.Accessibility;
+
+
+namespace Uno.Extensions.Reactive.Generator;
+
+internal class ViewModelGenTool_3 : ICodeGenTool
+{
+	private const string ViewModelSufix = "ViewModel";
+
+	private readonly BindableGenerationContext _ctx;
+	private readonly BindableGenerator _bindables;
+	private readonly BindableViewModelMappingGenerator _viewModelsMapping;
+	private readonly IAssemblySymbol _assembly;
+
+	public string Version => "3";
+
+	public ViewModelGenTool_3(BindableGenerationContext ctx)
+	{
+		_ctx = ctx;
+		_bindables = new BindableGenerator(ctx);
+		_viewModelsMapping = new BindableViewModelMappingGenerator(ctx);
+		_assembly = ctx.Context.Compilation.Assembly;
+	}
+
+	public IEnumerable<(string fileName, string code)> Generate()
+	{
+		var models = from module in _assembly.Modules
+					 from type in module.GetNamespaceTypes()
+					 where IsSupported(type)
+					 select type;
+
+		foreach (var model in models)
+		{
+			yield return ($"{model}.Bindable", GenerateViewModel(model));
+			yield return (model.ToString(), GeneratePartialModel(model));
+		}
+
+		foreach (var (type, code) in _bindables.Generate())
+		{
+			yield return (type.ToString(), code);
+		}
+
+		yield return _viewModelsMapping.Generate();
+	}
+
+	private bool IsSupported([NotNullWhen(true)] INamedTypeSymbol? type)
+	{
+		if (type is null)
+		{
+			return false;
+		}
+
+		if (_ctx.IsGenerationEnabled(type) is { } isEnabled)
+		{
+			// If the attribute is set, we don't check for the `partial`: the build as to fail if not
+			return isEnabled;
+		}
+
+		if (type.IsPartial()
+			&& (type.ContainingAssembly.FindAttribute<ImplicitBindablesAttribute>() ?? new()) is { IsEnabled: true } @implicit // Note: the type might be from another assembly than current
+			&& @implicit.Patterns.Any(pattern => Regex.IsMatch(type.ToString(), pattern)))
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	private static string GetModelName(INamedTypeSymbol type)
+		=> type.Name.TrimEnd("Model", StringComparison.Ordinal);
+
+	private static string GetViewModelName(INamedTypeSymbol model)
+		=> $"{GetModelName(model)}{ViewModelSufix}";
+
+	private static string GetViewModelFullName(INamedTypeSymbol model)
+		=> $"{model.ToFullString().TrimEnd(model.Name, StringComparison.Ordinal)}{GetModelName(model)}{ViewModelSufix}";
+
+	private string GenerateViewModel(INamedTypeSymbol model)
+	{
+		var vmName = GetViewModelName(model);
+		var hasBaseType = IsSupported(model.BaseType);
+
+		var baseType = hasBaseType
+			? GetViewModelFullName(model.BaseType!)
+			: $"{NS.Bindings}.BindableViewModelBase";
+
+		var members = GetMembers(model).ToList();
+
+		var vm = this.InSameNamespaceOf(
+			model,
+			$@"
+				{this.GetCodeGenAttribute()}
+				[{NS.Bindings}.Bindable(typeof({model.ToFullString()}))]
+				{model.DeclaredAccessibility.ToCSharpCodeString()} partial class {vmName} : {baseType}
+				{{
+					{members.Select(member => member.GetBackingField()).Align(5)}
+
+					{model
+						.Constructors
+						.Where(ctor => !ctor.IsCloneCtor(model)
+							// we do not support inheritance of ctor, inheritance always goes through the same BindableVM(vm) ctor.
+							&& ctor.DeclaredAccessibility is not Protected and not ProtectedAndFriend and not ProtectedAndInternal and not Private)
+						.Where(_ctx.IsGenerationNotDisable)
+						.Select(ctor => $@"
+							{GetCtorAccessibility(ctor)} {vmName}({ctor.Parameters.Select(p => p.ToFullString()).JoinBy(", ")})
+								: this(new {model.ToFullString()}({ctor.Parameters.Select(p => p.Name).JoinBy(", ")}))
+							{{
+								if ({NS.Config}.FeedConfiguration.EffectiveHotReload.HasFlag({NS.Config}.HotReloadSupport.State))
+								{{
+									__reactiveModelArgs = new (Type, string, object?)[] {{ {ctor.Parameters.Select(p => $"(typeof({p.Type.ToFullString()}), \"{p.Name}\", {p.Name} as object)").JoinBy(", ")} }};
+								}}
+							}}")
+						.Align(5)}
+
+					protected {vmName}({model.ToFullString()} {N.Ctor.Model}){(hasBaseType ? $" : base({N.Ctor.Model})" : "")}
+					{{
+						var {N.Ctor.Ctx} = {NS.Core}.SourceContext.GetOrCreate({N.Ctor.Model});
+
+						{(hasBaseType ? "" : @$"// Share the context between Model and ViewModel
+							{NS.Core}.SourceContext.Set(this, {N.Ctor.Ctx});
+							base.RegisterDisposable({N.Ctor.Model});
+							{N.Model} = {N.Ctor.Model};").Align(6)}
+
+						{N.Ctor.Model}.__reactiveBindableViewModel = this;
+
+						{members.Select(member => member.GetInitialization()).Align(6)}
+
+						{(hasBaseType ? "" : $@"
+							if ({N.Ctor.Model} is global::System.ComponentModel.INotifyPropertyChanged npc)
+							{{
+								npc.PropertyChanged += __Reactive_OnModelPropertyChanged;
+							}}").Align(6)}
+					}}
+
+					#region Hot-reload support
+					private (Type type, string name, object? value)[]? __reactiveModelArgs;
+
+					protected override (Type type, string name, object? value)[] __Reactive_GetModelArguments()
+						=> __reactiveModelArgs ?? base.__Reactive_GetModelArguments();
+
+					#if {!hasBaseType}
+					protected override void __Reactive_UpdateModel(object updatedModel)
+					{{
+						if ({N.Model} is global::System.ComponentModel.INotifyPropertyChanged npc)
+						{{
+							npc.PropertyChanged -= __Reactive_OnModelPropertyChanged;
+						}}
+
+						var previousModel = (object){N.Model};
+
+						__Reactive_BindableInitializeForUpdatedModel(updatedModel, {NS.Core}.SourceContext.GetOrCreate(updatedModel));
+						__Reactive_TryPatchBindableProperties(previousModel, updatedModel);
+
+						base.RaisePropertyChanged(""""); // 'Model' and any other mapped property.
+					}}
+					#endif
+
+					protected {(hasBaseType ? "override" : "virtual")} void __Reactive_BindableInitializeForUpdatedModel(object updatedModel, {NS.Core}.SourceContext {N.Ctor.Ctx})
+					{{
+						#if {hasBaseType}
+						base.__Reactive_BindableInitializeForUpdatedModel(updatedModel, {N.Ctor.Ctx});
+						#else
+						//{N.Model} = model;
+						#endif
+
+						dynamic {N.Ctor.Model} = updatedModel;
+
+						{N.Ctor.Model}.__reactiveBindableViewModel = this;
+
+						{members.Select(member => $@"try
+							{{
+								{member.GetInitialization()}
+							}}
+							catch (Exception)
+							{{
+								if (__Reactive_Log().IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Warning))
+								{{
+									global::Microsoft.Extensions.Logging.LoggerExtensions.Log(
+										__Reactive_Log(),
+										global::Microsoft.Extensions.Logging.LogLevel.Warning,
+										$""Failed to initialize '{member.Name}' from the updated model, this member is unlikely to work properly."");
+								}}
+							}}").Align(6)}
+
+						{(hasBaseType ? "" : @$"
+							if ({N.Ctor.Model} is global::System.ComponentModel.INotifyPropertyChanged npc)
+							{{
+								npc.PropertyChanged += __Reactive_OnModelPropertyChanged;
+							}}").Align(6)}
+					}}
+					#endregion
+
+					private void __Reactive_OnModelPropertyChanged(object? sender, global::System.ComponentModel.PropertyChangedEventArgs args)
+						=> base.RaisePropertyChanged(args.PropertyName);
+
+					{hasBaseType switch
+						{
+							false => $"public {model.ToFullString()} {N.Model} {{ get; private set; }}",
+							true => $"public new {model.ToFullString()} {N.Model} => ({model.ToFullString()}) base.{N.Model};",
+						}}
+
+					{members.Select(member => member.GetDeclaration()).Align(5)}
+				}}");
+
+
+		// If type is at least internally accessible, add it to a mapping from the VM type to it's bindable counterpart to ease usage in navigation engine.
+		// (Private types are almost only a test case which is not supported by nav anyway)
+		if (model.DeclaredAccessibility is not Accessibility.Private
+			&& model.GetContainingTypes().All(type => type.DeclaredAccessibility is not Accessibility.Private))
+		{
+			_viewModelsMapping.Register(model, GetViewModelFullName(model));
+		}
+
+		return vm.Align(0);
+	}
+
+	/// <summary>
+	/// Gets the instance of the
+	/// </summary>
+	/// <param name="model"></param>
+	/// <returns></returns>
+	private string GeneratePartialModel(INamedTypeSymbol model)
+	{
+		var vm = GetViewModelFullName(model);
+		return this.AsPartialOf(
+			model,
+			attributes: $"[{NS.Bindings}.Model(typeof({vm}))]\r\n[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]",
+			bases: $"global::System.IAsyncDisposable, {NS.Core}.ISourceContextAware, {NS.Bindings}.IModel<{vm}>",
+			code: $@"
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				internal {vm} __reactiveBindableViewModel = default!;
+
+				/// <inheritdoc />
+				{vm} {NS.Bindings}.IModel<{vm}>.ViewModel => __reactiveBindableViewModel;
+
+				/// <inheritdoc />
+				{this.GetCodeGenAttribute()}
+				public global::System.Threading.Tasks.ValueTask DisposeAsync()
+					=> {NS.Core}.SourceContext.Find(this)?.DisposeAsync() ?? default;
+			");
+	}
+
+	private string GetCtorAccessibility(IMethodSymbol ctor)
+		=> ctor.DeclaredAccessibility == Accessibility.Private
+			? "public"
+			: ctor.GetAccessibilityAsCSharpCodeString();
+
+	private IEnumerable<IMappedMember> GetMembers(INamedTypeSymbol type)
+	{
+		foreach (var member in type.GetMembers().Where(member => member.IsAccessible() && !member.IsStatic))
+		{
+			switch (member)
+			{
+				case IFieldSymbol field when _ctx.IsListFeed(field.Type, out var valueType):
+					yield return new BindableListFromListFeedField(field, valueType);
+					break;
+
+				case IFieldSymbol field when _ctx.IsFeedOfList(field.Type, out var collectionType, out var valueType):
+					yield return new BindableListFromFeedOfListField(field, collectionType, valueType);
+					break;
+
+				case IFieldSymbol field when _ctx.IsFeed(field.Type, out var valueType):
+					{
+						yield return _bindables.GetBindableType(valueType) is { } bindableType && !field.HasAttributes(_ctx.ValueAttribute)
+							? new BindableFromFeedField(field, valueType, bindableType)
+							: new PropertyFromFeedField(field, valueType);
+						break;
+					}
+
+				case IFieldSymbol field:
+					yield return new MappedField(field);
+					break;
+
+				case IPropertySymbol property when _ctx.IsListFeed(property.Type, out var valueType):
+					yield return new BindableListFromListFeedProperty(property, valueType);
+					break;
+
+				case IPropertySymbol property when _ctx.IsFeedOfList(property.Type, out var collectionType, out var valueType):
+					yield return new BindableListFromFeedOfListProperty(property, collectionType, valueType);
+					break;
+
+				case IPropertySymbol property when _ctx.IsFeed(property.Type, out var valueType):
+					{
+						yield return _bindables.GetBindableType(valueType) is { } bindableType && !property.HasAttributes(_ctx.ValueAttribute)
+							? new BindableFromFeedProperty(property, valueType, bindableType)
+							: new PropertyFromFeedProperty(property, valueType);
+						break;
+					}
+
+				case IPropertySymbol property:
+					yield return new MappedProperty(property);
+					break;
+
+				case IMethodSymbol method when CommandFromMethod.TryCreate(type, method, _ctx, out var commandGenerator):
+					yield return commandGenerator;
+					break;
+
+				case IMethodSymbol { MethodKind: MethodKind.Ordinary, IsImplicitlyDeclared: false } method:
+					yield return new MappedMethod(method);
+					break;
+			}
+		}
+	}
+
+}

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenerator.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenerator.cs
@@ -7,16 +7,16 @@ using Uno.Extensions.Generators;
 
 namespace Uno.Extensions.Reactive.Generator;
 
-internal class BindableGenerator : ICodeGenTool
+internal class ViewModelGenerator : ICodeGenTool
 {
-	// Version 1 used with ViewModelGenTool Versions 1 and 2
-	public string Version => "1";
+	// To Match with the ViewModelGenTool.Version
+	public string Version => "3";
 
 	private readonly BindableGenerationContext _ctx;
 
-	private List<INamedTypeSymbol> _toGenerate = new();
+	private List<INamedTypeSymbol> _toGenerate = [];
 
-	public BindableGenerator(BindableGenerationContext ctx)
+	public ViewModelGenerator(BindableGenerationContext ctx)
 	{
 		_ctx = ctx;
 	}
@@ -31,7 +31,7 @@ internal class BindableGenerator : ICodeGenTool
 			}
 
 			_toGenerate.Add(named);
-			return $"{symbol.ContainingNamespace}.Bindable{symbol.GetPascalCaseName()}";
+			return $"{symbol.ContainingNamespace}.{GetViewModelName(named)}";
 		}
 
 		return null;
@@ -73,7 +73,7 @@ internal class BindableGenerator : ICodeGenTool
 						prop.Type.Is(_ctx.IImmutableList, allowBaseTypes: false, out var immutableList)
 						|| prop.Type.Is(_ctx.ImmutableList, allowBaseTypes: false, out immutableList)
 					)
-					&& GetBindableType(immutableList.TypeArguments.Single()) is {} itemBindableType)
+					&& GetBindableType(immutableList.TypeArguments.Single()) is { } itemBindableType)
 				{
 					var itemType = immutableList.TypeArguments.Single();
 					var propertyInfo = prop.Type.Is(_ctx.ImmutableList, allowBaseTypes: false, out _)
@@ -84,6 +84,7 @@ internal class BindableGenerator : ICodeGenTool
 					initializer = $@"_{camelName} = new {bindable}(
 						{propertyInfo.Align(6)},
 						p => new {itemBindableType}(p));";
+
 					property = new Property(prop.Type.DeclaredAccessibility, bindable, prop.Name)
 					{
 						Getter = $"_{camelName}"
@@ -100,7 +101,7 @@ internal class BindableGenerator : ICodeGenTool
 				//		Getter = $"_{camelName}"
 				//	};
 				//}
-				else if (GetBindableType(prop.Type) is {} subBindable)
+				else if (GetBindableType(prop.Type) is { } subBindable)
 				{
 					bindable = subBindable;
 					initializer = $@"_{camelName} = new {bindable}({GetPropertyInfo(prop.Type)});";
@@ -150,6 +151,8 @@ internal class BindableGenerator : ICodeGenTool
 				Setter = "base.SetValue(value)"
 			};
 
+		var vm = GetViewModelName(record);
+
 		var code = @$"{this.GetFileHeader()}
 
 using System;
@@ -159,11 +162,11 @@ using System.Threading.Tasks;
 namespace {record.ContainingNamespace}
 {{
 	{this.GetCodeGenAttribute()}
-	{record.GetAccessibilityAsCSharpCodeString()} sealed class Bindable{record.GetPascalCaseName()} : {NS.Bindings}.Bindable<{record}>
+	{record.GetAccessibilityAsCSharpCodeString()} sealed class {vm} : {NS.Bindings}.Bindable<{record}>
 	{{
 		{properties.Select(prop => $"private readonly {prop.bindable} _{prop.symbol.GetCamelCaseName()};").Align(2)}
 
-		public Bindable{record.GetPascalCaseName()}({NS.Bindings}.BindablePropertyInfo<{record}> property)
+		public {vm}({NS.Bindings}.BindablePropertyInfo<{record}> property)
 			: base(property, hasValueProperty: {(valueProperty is null ? "false" : "true")})
 		{{
 			{properties.Select(prop => prop.initializer).Align(3)}
@@ -179,6 +182,12 @@ namespace {record.ContainingNamespace}
 }}
 ";
 
-return code;
+		return code;
 	}
+
+	private static string GetModelName(INamedTypeSymbol type)
+		=> type.Name.TrimEnd("Model", StringComparison.Ordinal);
+
+	private static string GetViewModelName(INamedTypeSymbol model)
+		=> $"{GetModelName(model)}ViewModel";
 }

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenerator_1.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenerator_1.cs
@@ -7,7 +7,7 @@ using Uno.Extensions.Generators;
 
 namespace Uno.Extensions.Reactive.Generator;
 
-internal class BindableGenerator : ICodeGenTool
+internal class ViewModelGenerator_1 : ICodeGenTool
 {
 	// Version 1 used with ViewModelGenTool Versions 1 and 2
 	public string Version => "1";
@@ -16,7 +16,7 @@ internal class BindableGenerator : ICodeGenTool
 
 	private List<INamedTypeSymbol> _toGenerate = new();
 
-	public BindableGenerator(BindableGenerationContext ctx)
+	public ViewModelGenerator_1(BindableGenerationContext ctx)
 	{
 		_ctx = ctx;
 	}

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenerator_2.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/ViewModelGenerator_2.cs
@@ -7,16 +7,16 @@ using Uno.Extensions.Generators;
 
 namespace Uno.Extensions.Reactive.Generator;
 
-internal class ViewModelGenerator : ICodeGenTool
+internal class ViewModelGenerator_2 : ICodeGenTool
 {
 	// To Match with the ViewModelGenTool.Version
-	public string Version => "3";
+	public string Version => "2";
 
 	private readonly BindableGenerationContext _ctx;
 
 	private List<INamedTypeSymbol> _toGenerate = [];
 
-	public ViewModelGenerator(BindableGenerationContext ctx)
+	public ViewModelGenerator_2(BindableGenerationContext ctx)
 	{
 		_ctx = ctx;
 	}

--- a/src/Uno.Extensions.Reactive.Generator/FeedsGenerator.cs
+++ b/src/Uno.Extensions.Reactive.Generator/FeedsGenerator.cs
@@ -46,6 +46,13 @@ public partial class FeedsGenerator : ISourceGenerator
 						context.AddSource(PathHelper.SanitizeFileName(generated.fileName) + ".g.cs", generated.code);
 					}
 					break;
+
+				case 3:
+					foreach (var (fileName, code) in new ViewModelGenTool_3(bindableContext).Generate())
+					{
+						context.AddSource(PathHelper.SanitizeFileName(fileName) + ".g.cs", code);
+					}
+					break;
 			}
 		}
 		else

--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_BasicViewModel_Then_Generate.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_BasicViewModel_Then_Generate.cs
@@ -17,11 +17,11 @@ public partial class Given_BasicViewModel_Then_Generate : FeedUITests
 	[TestMethod]
 	public async Task Test_Constructors()
 	{
-		await using var bindableCtor1 = new BindableGiven_BasicViewModel_Then_Generate__ViewModel();
+		await using var bindableCtor1 = new Given_BasicViewModel_Then_Generate__ViewViewModel();
 
-		await using var bindableCtor2 = new BindableGiven_BasicViewModel_Then_Generate__ViewModel(aRandomService: "aRandomService");
+		await using var bindableCtor2 = new Given_BasicViewModel_Then_Generate__ViewViewModel(aRandomService: "aRandomService");
 
-		await using var bindableCtor3 = new BindableGiven_BasicViewModel_Then_Generate__ViewModel(
+		await using var bindableCtor3 = new Given_BasicViewModel_Then_Generate__ViewViewModel(
 			anExternalInput: default(IFeed<string>)!,
 			anExternalReadWriteInput: default(IState<string>)!,
 			anExternalRecordInput: default(IFeed<MyRecord>)!,
@@ -31,7 +31,7 @@ public partial class Given_BasicViewModel_Then_Generate : FeedUITests
 	[TestMethod]
 	public async Task When_FeedOfKindOfImmutableList_Then_TreatAsListFeed()
 	{
-		await using var bindable = new BindableWhen_FeedOfKindOfImmutableList_Then_TreatAsListFeed_ViewModel();
+		await using var bindable = new When_FeedOfKindOfImmutableList_Then_TreatAsListFeed_ViewViewModel();
 
 		AssertIsValid(bindable.AFeedOfArray);
 		AssertIsValid(bindable.AFeedOfImmutableList);
@@ -81,7 +81,7 @@ public partial class Given_BasicViewModel_Then_Generate : FeedUITests
 	[TestMethod]
 	public async Task When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed()
 	{
-		await using var bindable = new BindableWhen_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_ViewModel();
+		await using var bindable = new When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_ViewViewModel();
 
 		AssertIsValid(bindable.AFeedOfEnumerable);
 

--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_Methods_Then_GenerateCommands.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_Methods_Then_GenerateCommands.cs
@@ -30,7 +30,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_ParameterLess_Void()
 	{
-		await using var vm = new BindableWhen_ParameterLess_Void_ViewModel();
+		await using var vm = new When_ParameterLess_Void_ViewViewModel();
 
 		vm.MyMethod.Execute(null);
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -54,7 +54,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneParameter_Void()
 	{
-		await using var vm = new BindableWhen_OneParameter_Void_ViewModel();
+		await using var vm = new When_OneParameter_Void_ViewViewModel();
 
 		vm.MyMethod.Execute("42");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -79,7 +79,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneValueTypeParameter_Void()
 	{
-		await using var vm = new BindableWhen_OneValueTypeParameter_Void_ViewModel();
+		await using var vm = new When_OneValueTypeParameter_Void_ViewViewModel();
 
 		vm.MyMethod.Execute(new DateTimeOffset(1983, 9, 9, 15, 00, 00, TimeSpan.FromHours(1)));
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -104,7 +104,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneNullableValueTypeParameter_Void()
 	{
-		await using var vm = new BindableWhen_OneNullableValueTypeParameter_Void_ViewModel();
+		await using var vm = new When_OneNullableValueTypeParameter_Void_ViewViewModel();
 
 		vm.MyMethod.Execute(new DateTimeOffset(1983, 9, 9, 15, 00, 00, TimeSpan.FromHours(1)));
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -129,7 +129,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneParameterAndCT_Void()
 	{
-		await using var vm = new BindableWhen_OneParameterAndCT_Void_ViewModel();
+		await using var vm = new When_OneParameterAndCT_Void_ViewViewModel();
 
 		vm.MyMethod.Execute("42");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -161,7 +161,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_ParameterLess_Task()
 	{
-		await using var vm = new BindableWhen_ParameterLess_Task_ViewModel();
+		await using var vm = new When_ParameterLess_Task_ViewViewModel();
 
 		vm.MyMethod.Execute(null);
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -201,7 +201,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneParameter_Task()
 	{
-		await using var vm = new BindableWhen_OneParameter_Task_ViewModel();
+		await using var vm = new When_OneParameter_Task_ViewViewModel();
 
 		vm.MyMethod.Execute("42");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -239,7 +239,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_ParameterLess_ValueTask()
 	{
-		await using var vm = new BindableWhen_ParameterLess_ValueTask_ViewModel();
+		await using var vm = new When_ParameterLess_ValueTask_ViewViewModel();
 
 		vm.MyMethod.Execute(null);
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -279,7 +279,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneParameter_ValueTask()
 	{
-		await using var vm = new BindableWhen_OneParameter_ValueTask_ViewModel();
+		await using var vm = new When_OneParameter_ValueTask_ViewViewModel();
 
 		vm.MyMethod.Execute("42");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -320,7 +320,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneParameterAndCT_ValueTask()
 	{
-		await using var vm = new BindableWhen_OneParameterAndCT_ValueTask_ViewModel();
+		await using var vm = new When_OneParameterAndCT_ValueTask_ViewViewModel();
 
 		vm.MyMethod.Execute("42");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -357,7 +357,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameter_Void_WithoutCommandParameter()
 	{
-		await using var vm = new BindableWhen_OneFeedParameter_Void_ViewModel();
+		await using var vm = new When_OneFeedParameter_Void_ViewViewModel();
 
 		// We have to wait for the external parameter to be provided by the feed
 		await WaitFor(() => vm.MyMethod.CanExecute(null));
@@ -372,7 +372,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameter_Void_WithCommandParameter()
 	{
-		await using var vm = new BindableWhen_OneFeedParameter_Void_ViewModel();
+		await using var vm = new When_OneFeedParameter_Void_ViewViewModel();
 
 		vm.MyMethod.Execute("43");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -403,7 +403,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameterAndCT_Void_WithoutCommandParameter()
 	{
-		await using var vm = new BindableWhen_OneFeedParameterAndCT_Void_ViewModel();
+		await using var vm = new When_OneFeedParameterAndCT_Void_ViewViewModel();
 
 		// We have to wait for the external parameter to be provided by the feed
 		await WaitFor(() => vm.MyMethod.CanExecute(null));
@@ -418,7 +418,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameterAndCT_Void_WithCommandParameter()
 	{
-		await using var vm = new BindableWhen_OneFeedParameterAndCT_Void_ViewModel();
+		await using var vm = new When_OneFeedParameterAndCT_Void_ViewViewModel();
 
 		vm.MyMethod.Execute("43");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -455,7 +455,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameter_ValueTask_WithoutCommandParameter()
 	{
-		await using var vm = new BindableWhen_OneFeedParameter_ValueTask_ViewModel();
+		await using var vm = new When_OneFeedParameter_ValueTask_ViewViewModel();
 
 		// We have to wait for the external parameter to be provided by the feed
 		await WaitFor(() => vm.MyMethod.CanExecute(null));
@@ -476,7 +476,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameter_ValueTask_WithCommandParameter()
 	{
-		await using var vm = new BindableWhen_OneFeedParameter_ValueTask_ViewModel();
+		await using var vm = new When_OneFeedParameter_ValueTask_ViewViewModel();
 
 		vm.MyMethod.Execute("43");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -519,7 +519,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneListFeedParameter_ValueTask_WithoutCommandParameter()
 	{
-		await using var vm = new BindableWhen_OneListFeedParameter_ValueTask_ViewModel();
+		await using var vm = new When_OneListFeedParameter_ValueTask_ViewViewModel();
 
 		// We have to wait for the external parameter to be provided by the feed
 		await WaitFor(() => vm.MyMethod.CanExecute(null));
@@ -540,7 +540,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneListFeedParameter_ValueTask_WithCommandParameter()
 	{
-		await using var vm = new BindableWhen_OneListFeedParameter_ValueTask_ViewModel();
+		await using var vm = new When_OneListFeedParameter_ValueTask_ViewViewModel();
 
 		vm.MyMethod.Execute(ImmutableList.Create("51", "52", "53"));
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -583,7 +583,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameterAndCT_ValueTask_WithoutCommandParameter()
 	{
-		await using var vm = new BindableWhen_OneFeedParameterAndCT_ValueTask_ViewModel();
+		await using var vm = new When_OneFeedParameterAndCT_ValueTask_ViewViewModel();
 
 		// We have to wait for the external parameter to be provided by the feed
 		await WaitFor(() => vm.MyMethod.CanExecute(null));
@@ -604,7 +604,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_OneFeedParameterAndCT_ValueTask_WithCommandParameter()
 	{
-		await using var vm = new BindableWhen_OneFeedParameterAndCT_ValueTask_ViewModel();
+		await using var vm = new When_OneFeedParameterAndCT_ValueTask_ViewViewModel();
 
 		vm.MyMethod.Execute("43");
 		await WaitFor(() => vm.InvokeCount == 1);
@@ -645,7 +645,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[DataRow(nameof(When_MultipleFeedParameter_ViewModel.MyMethodWithCt))]
 	public async Task When_MultipleFeedParameter_ViewModel_CanExecuteWithoutParameter(string method)
 	{
-		await using var vm = new BindableWhen_MultipleFeedParameter_ViewModel();
+		await using var vm = new When_MultipleFeedParameter_ViewViewModel();
 
 		var commandInfo = vm.GetType().GetMember(method).Single();
 		commandInfo.Should().BeAssignableTo<PropertyInfo>(because: "a command should have been generated for that method");
@@ -664,7 +664,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[DataRow(nameof(When_MultipleFeedParameter_ViewModel.MyMethodWithCt))]
 	public async Task When_MultipleFeedParameter_ViewModel_CanExecuteOnlyWithoutParameter(string method)
 	{
-		await using var vm = new BindableWhen_MultipleFeedParameter_ViewModel();
+		await using var vm = new When_MultipleFeedParameter_ViewViewModel();
 
 		var commandInfo = vm.GetType().GetMember(method).Single();
 		commandInfo.Should().BeAssignableTo<PropertyInfo>(because: "a command should have been generated for that method");
@@ -680,7 +680,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[DataRow(nameof(When_MultipleFeedParameter_ViewModel.MyMethodWithCt), nameof(When_MixedViewAndFeedParameter_ViewModel.MyParameter), _ct)]
 	private async Task When_MultipleFeedParameter_ViewModel_ArgsReDispatchedProperly(string method, params string[] expectedArgs)
 	{
-		await using var vm = new BindableWhen_MultipleFeedParameter_ViewModel();
+		await using var vm = new When_MultipleFeedParameter_ViewViewModel();
 
 		var commandInfo = vm.GetType().GetMember(method).Single();
 		commandInfo.Should().BeAssignableTo<PropertyInfo>(because: "a command should have been generated for that method");
@@ -751,7 +751,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[DataRow(nameof(When_MixedViewAndFeedParameter_ViewModel.MyMethod3WithCt))]
 	public async Task When_MixedViewAndFeedParameter_ViewModel_CanExecuteWithParameter(string method)
 	{
-		await using var vm = new BindableWhen_MixedViewAndFeedParameter_ViewModel();
+		await using var vm = new When_MixedViewAndFeedParameter_ViewViewModel();
 
 		var commandInfo = vm.GetType().GetMember(method).Single();
 		commandInfo.Should().BeAssignableTo<PropertyInfo>(because: "a command should have been generated for that method");
@@ -774,7 +774,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[DataRow(nameof(When_MixedViewAndFeedParameter_ViewModel.MyMethod3WithCt))]
 	public async Task When_MixedViewAndFeedParameter_ViewModel_CanExecuteOnlyWithParameter(string method)
 	{
-		await using var vm = new BindableWhen_MixedViewAndFeedParameter_ViewModel();
+		await using var vm = new When_MixedViewAndFeedParameter_ViewViewModel();
 
 		var commandInfo = vm.GetType().GetMember(method).Single();
 		commandInfo.Should().BeAssignableTo<PropertyInfo>(because: "a command should have been generated for that method");
@@ -797,7 +797,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[DataRow(nameof(When_MixedViewAndFeedParameter_ViewModel.MyMethod3WithCt), _viewParam, nameof(When_MixedViewAndFeedParameter_ViewModel.MyParameter), nameof(When_MixedViewAndFeedParameter_ViewModel.MyParameter2), _ct)]
 	private async Task When_MixedViewAndFeedParameter_ArgsReDispatchedProperly(string method, params string[] expectedArgs)
 	{
-		await using var vm = new BindableWhen_MixedViewAndFeedParameter_ViewModel();
+		await using var vm = new When_MixedViewAndFeedParameter_ViewViewModel();
 
 		var commandInfo = vm.GetType().GetMember(method).Single();
 		commandInfo.Should().BeAssignableTo<PropertyInfo>(because: "a command should have been generated for that method");
@@ -846,7 +846,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 		GetMember(nameof(When_ImplicitCommandDisabled_ViewModel.AsyncWithParameter2)).Should().NotBeNull().And.BeAssignableTo<MethodInfo>();
 
 		MemberInfo GetMember(string name)
-			=> typeof(BindableWhen_ImplicitCommandDisabled_ViewModel).GetMember(name, BindingFlags.Instance | BindingFlags.Public).Single();
+			=> typeof(When_ImplicitCommandDisabled_ViewViewModel).GetMember(name, BindingFlags.Instance | BindingFlags.Public).Single();
 	}
 
 	[TestMethod]
@@ -858,7 +858,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 			.Subject.PropertyType.Should().BeAssignableTo(typeof(ICommand));
 
 		MemberInfo GetMember(string name)
-			=> typeof(BindableWhen_ImplicitCommandDisabled_ViewModel).GetMember(name, BindingFlags.Instance | BindingFlags.Public).Single();
+			=> typeof(When_ImplicitCommandDisabled_ViewViewModel).GetMember(name, BindingFlags.Instance | BindingFlags.Public).Single();
 	}
 
 	[TestMethod]
@@ -867,7 +867,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 		GetMember(nameof(When_ImplicitCommandEnabled_ViewModel.WithExplicitAttribute)).Should().NotBeNull().And.BeAssignableTo<MethodInfo>();
 
 		MemberInfo GetMember(string name)
-			=> typeof(BindableWhen_ImplicitCommandEnabled_ViewModel).GetMember(name, BindingFlags.Instance | BindingFlags.Public).Single();
+			=> typeof(When_ImplicitCommandEnabled_ViewViewModel).GetMember(name, BindingFlags.Instance | BindingFlags.Public).Single();
 	}
 
 	[ImplicitFeedCommandParameters(false)]
@@ -885,7 +885,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_ImplicitFeedCommandDisabled_ViewModel_Then_ParameterNotUsed()
 	{
-		await using var vm = new BindableWhen_ImplicitFeedCommandDisabled_ViewModel();
+		await using var vm = new When_ImplicitFeedCommandDisabled_ViewViewModel();
 
 		var subs = GetSubCommands(vm.SyncWithParameter);
 		subs.Should().HaveCount(1);
@@ -903,7 +903,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_ImplicitFeedCommandDisabledWithExplicitAttribute_ViewModel_Then_ParameterUsed()
 	{
-		await using var vm = new BindableWhen_ImplicitFeedCommandDisabled_ViewModel();
+		await using var vm = new When_ImplicitFeedCommandDisabled_ViewViewModel();
 
 		// We wait for the feed parameter to be full-filed
 		await WaitFor(() => vm.WithExplicitAttribute.CanExecute(null));
@@ -923,7 +923,7 @@ public partial class Given_Methods_Then_GenerateCommands : FeedUITests
 	[TestMethod]
 	public async Task When_When_UsingConflictingTypesParameter_Then_Compiles()
 	{
-		await using var vm = new BindableWhen_UsingConflictingTypesParameter_ViewModel();
+		await using var vm = new When_UsingConflictingTypesParameter_ViewViewModel();
 
 		vm.ConflictWhenNotPrefixedByGlobal1.CanExecute(new Uno.System.DateTime()).Should().BeTrue();
 		vm.ConflictWhenNotPrefixedByGlobal1.CanExecute(new global::System.DateTime()).Should().BeFalse();

--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_RecordWithList_Then_GenerateListOfBindable.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_RecordWithList_Then_GenerateListOfBindable.cs
@@ -18,15 +18,15 @@ public partial class Given_RecordWithList_Then_GenerateListOfBindable : FeedUITe
 	[TestMethod]
 	public async Task IsListOfBindable()
 	{
-		await using var sut = new BindableMyViewModel();
+		await using var sut = new MyViewViewModel();
 
-		sut.MyFeed.Items.Should().BeAssignableTo<IEnumerable<BindableMyRecordWithListItem>>();
+		sut.MyFeed.Items.Should().BeAssignableTo<IEnumerable<MyRecordWithListItemViewModel>>();
 	}
 
 	[TestMethod]
 	public async Task SupportsAdd()
 	{
-		await using var sut = new BindableMyViewModel();
+		await using var sut = new MyViewViewModel();
 		var args = new List<NotifyCollectionChangedEventArgs>();
 		var result = sut.Model.MyFeed.Select(r => r.Items).Record();
 
@@ -48,7 +48,7 @@ public partial class Given_RecordWithList_Then_GenerateListOfBindable : FeedUITe
 	[TestMethod]
 	public async Task SupportsRemove()
 	{
-		await using var sut = new BindableMyViewModel();
+		await using var sut = new MyViewViewModel();
 		var args = new List<NotifyCollectionChangedEventArgs>();
 		var result = sut.Model.MyFeed.Select(r => r.Items).Record();
 

--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_ViewModel_Then_GenerateBindable.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_ViewModel_Then_GenerateBindable.cs
@@ -76,11 +76,11 @@ public partial class Given_ViewModel_Then_GenerateBindable
 		=> Assert.IsNotNull(GetBindable(typeof(Given_ViewModel_Then_GenerateBindable_FlaggedCodeGen_NotSuffixed)));
 
 	[TestMethod]
-	public void NestedFlaggedCodeGen_NotSuffixedViewModel()
+	public void NestedFlaggedCodeGen_NotSuffixedTest()
 		=> Assert.IsNotNull(GetBindable(typeof(NestedFlaggedCodeGen_NotSuffixed)));
 
 	[TestMethod]
-	public void NestedInternalFlaggedCodeGen_NotSuffixedViewModel()
+	public void NestedInternalFlaggedCodeGen_NotSuffixedTest()
 		=> Assert.IsNotNull(GetBindable(typeof(NestedInternalFlaggedCodeGen_NotSuffixed)));
 
 	[TestMethod]

--- a/src/Uno.Extensions.Reactive.Tests/Generator/Given_ViewModel_Then_GenerateBindable.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Generator/Given_ViewModel_Then_GenerateBindable.cs
@@ -98,22 +98,30 @@ public partial class Given_ViewModel_Then_GenerateBindable
 	private Type? GetBindable(Type vmType)
 		=> GetBindable(vmType.FullName!);
 
+
 	private Type? GetBindable(string vmType)
 	{
+		vmType = TrimEnd(vmType, "Model", StringComparison.Ordinal);
+
 		var index = vmType.LastIndexOf('+');
 		if (index >= 0)
 		{
-			return GetType().Assembly.GetType($"{vmType.Substring(0, index)}+Bindable{vmType.Substring(index + 1)}");
+			return GetType().Assembly.GetType($"{vmType.Substring(0, index)}+{vmType.Substring(index + 1)}ViewModel");
 		}
 
 		index = vmType.LastIndexOf('.');
 		if (index >= 0)
 		{
-			return GetType().Assembly.GetType($"{vmType.Substring(0, index)}.Bindable{vmType.Substring(index + 1)}");
+			return GetType().Assembly.GetType($"{vmType.Substring(0, index)}.{vmType.Substring(index + 1)}ViewModel");
 		}
 
-		return GetType().Assembly.GetType("Bindable" + vmType);
+		return GetType().Assembly.GetType($"{vmType}ViewModel");
 	}
+
+	private string TrimEnd(string text, string value, StringComparison comparison)
+		=> text.EndsWith(value, comparison)
+			? text.Substring(0, text.Length - value.Length)
+			: text;
 
 	public partial class Nested_ViewModel { }
 

--- a/src/Uno.Extensions.Reactive.Tests/IntegrationTests/Given_HotReload.cs
+++ b/src/Uno.Extensions.Reactive.Tests/IntegrationTests/Given_HotReload.cs
@@ -65,11 +65,11 @@ public partial class Given_HotReload : FeedUITests
 	}
 
 	[ReactiveBindable(false)]
-	[Model(bindable: typeof(BindableWhen_UpdateValueTypeFeedInModel_Then_BindableUpdated_MyModel))]
+	[Model(bindable: typeof(When_UpdateValueTypeFeedInModel_Then_BindableUpdated_MyViewModel))]
 	[MetadataUpdateOriginalType(typeof(When_UpdateValueTypeFeedInModel_Then_BindableUpdated_MyModel))]
 	public partial class When_UpdateValueTypeFeedInModel_Then_BindableUpdated_MyModel_v1
 	{
-		internal BindableWhen_UpdateValueTypeFeedInModel_Then_BindableUpdated_MyModel __reactiveBindableViewModel = default!;
+		internal When_UpdateValueTypeFeedInModel_Then_BindableUpdated_MyViewModel __reactiveBindableViewModel = default!;
 
 		public IFeed<string> MyFeed => Feed.Async(async ct => "Feed value from model v1");
 	}
@@ -101,11 +101,11 @@ public partial class Given_HotReload : FeedUITests
 	}
 
 	[ReactiveBindable(false)]
-	[Model(bindable: typeof(BindableWhen_UpdateRecordFeedInModel_Then_BindableUpdated_MyModel))]
+	[Model(bindable: typeof(When_UpdateRecordFeedInModel_Then_BindableUpdated_MyViewModel))]
 	[MetadataUpdateOriginalType(typeof(When_UpdateRecordFeedInModel_Then_BindableUpdated_MyModel))]
 	public partial class When_UpdateRecordFeedInModel_Then_BindableUpdated_MyModel_v1
 	{
-		internal BindableWhen_UpdateRecordFeedInModel_Then_BindableUpdated_MyModel __reactiveBindableViewModel = default!;
+		internal When_UpdateRecordFeedInModel_Then_BindableUpdated_MyViewModel __reactiveBindableViewModel = default!;
 
 		public IFeed<When_UpdateRecordFeedInModel_Then_BindableUpdated_Record> MyFeed => Feed.Async(async ct => new When_UpdateRecordFeedInModel_Then_BindableUpdated_Record("Feed value from model v1"));
 	}
@@ -115,7 +115,7 @@ public partial class Given_HotReload : FeedUITests
 	[TestMethod]
 	public async Task When_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated()
 	{
-		var bindable = new BindableWhen_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyModel();
+		var bindable = new When_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyViewModel();
 
 		var tcs = new TaskCompletionSource();
 		Dispatcher.TryEnqueue(() => bindable.PropertyChanged += (s, e) => tcs.TrySetResult());
@@ -135,11 +135,11 @@ public partial class Given_HotReload : FeedUITests
 	}
 
 	[ReactiveBindable(false)]
-	[Model(bindable: typeof(BindableWhen_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyModel))]
+	[Model(bindable: typeof(When_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyViewModel))]
 	[MetadataUpdateOriginalType(typeof(When_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyModel))]
 	public partial class When_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyModel_v1
 	{
-		internal BindableWhen_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyModel __reactiveBindableViewModel = default!;
+		internal When_ChangeKindOfValueTypeFeedInModel_Then_BindableUpdated_MyViewModel __reactiveBindableViewModel = default!;
 
 		public IFeed<string> MyFeed => Feed.Dynamic(async ct => "Feed value from model v1");
 	}
@@ -149,7 +149,7 @@ public partial class Given_HotReload : FeedUITests
 	[TestMethod]
 	public async Task When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated()
 	{
-		var bindable = new BindableWhen_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyModel();
+		var bindable = new When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyViewModel();
 
 		var tcs = new TaskCompletionSource();
 		Dispatcher.TryEnqueue(() => bindable.PropertyChanged += (s, e) => tcs.TrySetResult());
@@ -171,11 +171,11 @@ public partial class Given_HotReload : FeedUITests
 	}
 
 	[ReactiveBindable(false)]
-	[Model(bindable: typeof(BindableWhen_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyModel))]
+	[Model(bindable: typeof(When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyViewModel))]
 	[MetadataUpdateOriginalType(typeof(When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyModel))]
 	public partial class When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyModel_v1
 	{
-		internal BindableWhen_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyModel __reactiveBindableViewModel = default!;
+		internal When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_MyViewModel __reactiveBindableViewModel = default!;
 
 		public IFeed<When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_Record> MyFeed => Feed.Dynamic(async ct => new When_ChangeKindOfRecordFeedInModel_Then_BindableUpdated_Record("Feed value from model v1"));
 	}

--- a/src/Uno.Extensions.Reactive.Tests/IntegrationTests/Given_HotReload.cs
+++ b/src/Uno.Extensions.Reactive.Tests/IntegrationTests/Given_HotReload.cs
@@ -45,7 +45,7 @@ public partial class Given_HotReload : FeedUITests
 	[TestMethod]
 	public async Task When_UpdateValueTypeFeedInModel_Then_BindableUpdated()
 	{
-		var bindable = new BindableWhen_UpdateValueTypeFeedInModel_Then_BindableUpdated_MyModel();
+		var bindable = new When_UpdateValueTypeFeedInModel_Then_BindableUpdated_MyViewModel();
 
 		var tcs = new TaskCompletionSource();
 		Dispatcher.TryEnqueue(() => bindable.PropertyChanged += (s, e) => tcs.TrySetResult());
@@ -79,7 +79,7 @@ public partial class Given_HotReload : FeedUITests
 	[TestMethod]
 	public async Task When_UpdateRecordFeedInModel_Then_BindableUpdated()
 	{
-		var bindable = new BindableWhen_UpdateRecordFeedInModel_Then_BindableUpdated_MyModel();
+		var bindable = new When_UpdateRecordFeedInModel_Then_BindableUpdated_MyViewModel();
 
 		var tcs = new TaskCompletionSource();
 		Dispatcher.TryEnqueue(() => bindable.PropertyChanged += (s, e) => tcs.TrySetResult());

--- a/src/Uno.Extensions.Reactive.Tests/Presentation/Bindings/Given_BindableViewModelBase.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Presentation/Bindings/Given_BindableViewModelBase.cs
@@ -15,7 +15,7 @@ public partial class Given_BindableViewModelBase : FeedUITests
 	[TestMethod]
 	public async Task When_UpdateSourceMultipleTimeWhileUIThreadFreeze_Then_LastWin()
 	{
-		var sut = new BindableWhen_UpdateSourceMultipleTimeWhileUIThreadFreeze_Then_LastWin_Model();
+		var sut = new When_UpdateSourceMultipleTimeWhileUIThreadFreeze_Then_LastWin_ViewModel();
 
 		var changes = 0;
 		var uiFrozen = new ManualResetEvent(false);

--- a/src/Uno.Extensions.Reactive/Config/BindableGenerationToolAttribute.cs
+++ b/src/Uno.Extensions.Reactive/Config/BindableGenerationToolAttribute.cs
@@ -13,5 +13,5 @@ public class BindableGenerationToolAttribute : Attribute
 	/// Gets or sets the version of tool that should be used to generate bindables.
 	/// </summary>
 	/// <remarks>Set this to 1 to use code gen used in Uno.Extensions.Reactive versions below 2.3</remarks>
-	public int Version { get; init; } = 2;
+	public int Version { get; init; } = 3;
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2460 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Generated classes for MVUX would follow the pattern of XYZModel -> BIndableXYZModel

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
New generated classes will follow this new pattern XYZModel -> XYZViewModel

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
