### PR TITLE
fix: Add launchSettings.json to TestHarness

### DIFF
--- a/testing/TestHarness/TestHarness/App.xaml
+++ b/testing/TestHarness/TestHarness/App.xaml
@@ -9,15 +9,10 @@
 			<ResourceDictionary.MergedDictionaries>
 				<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
 
-				<!-- Load Uno.UI.Toolkit resources -->
-				<ToolkitResources xmlns="using:Uno.Toolkit.UI" />
-
-				<MaterialResources xmlns="using:Uno.Material" />
-
-				<MaterialToolkitResources xmlns="using:Uno.Toolkit.UI.Material" />
+				<!--  Load Material Toolkit resources  -->
+				<MaterialToolkitTheme xmlns="using:Uno.Toolkit.UI.Material" />
 
 				<ResourceDictionary Source="ms-appx:///Uno.Extensions.Reactive.UI/View/FeedView.xaml" />
-
 
 			</ResourceDictionary.MergedDictionaries>
 
@@ -25,14 +20,10 @@
 
 			<Style TargetType="utu:LoadingView">
 
-				<Setter Property="HorizontalAlignment"
-						Value="Stretch" />
-				<Setter Property="HorizontalContentAlignment"
-						Value="Stretch" />
-				<Setter Property="VerticalAlignment"
-						Value="Stretch" />
-				<Setter Property="VerticalContentAlignment"
-						Value="Stretch" />
+				<Setter Property="HorizontalAlignment" Value="Stretch" />
+				<Setter Property="HorizontalContentAlignment" Value="Stretch" />
+				<Setter Property="VerticalAlignment" Value="Stretch" />
+				<Setter Property="VerticalContentAlignment" Value="Stretch" />
 
 				<Setter Property="Template">
 					<Setter.Value>
@@ -43,15 +34,11 @@
 										<VisualState x:Name="Loading" />
 										<VisualState x:Name="Loaded">
 											<Storyboard>
-												<DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-																			   Storyboard.TargetProperty="Opacity">
-													<LinearDoubleKeyFrame KeyTime="{StaticResource DefaultLoadingViewAnimationDuration}"
-																		  Value="1" />
+												<DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Opacity">
+													<LinearDoubleKeyFrame KeyTime="{StaticResource DefaultLoadingViewAnimationDuration}" Value="1" />
 												</DoubleAnimationUsingKeyFrames>
-												<DoubleAnimationUsingKeyFrames Storyboard.TargetName="LoadingContentPresenter"
-																			   Storyboard.TargetProperty="Opacity">
-													<LinearDoubleKeyFrame KeyTime="{StaticResource DefaultLoadingViewAnimationDuration}"
-																		  Value="0" />
+												<DoubleAnimationUsingKeyFrames Storyboard.TargetName="LoadingContentPresenter" Storyboard.TargetProperty="Opacity">
+													<LinearDoubleKeyFrame KeyTime="{StaticResource DefaultLoadingViewAnimationDuration}" Value="0" />
 												</DoubleAnimationUsingKeyFrames>
 											</Storyboard>
 										</VisualState>
@@ -78,14 +65,11 @@
 				<Setter Property="LoadingContent">
 					<Setter.Value>
 						<Grid>
-							<ProgressBar IsIndeterminate="True"
-										 Width="100" />
+							<ProgressBar IsIndeterminate="True" Width="100" />
 						</Grid>
 					</Setter.Value>
 				</Setter>
 			</Style>
 		</ResourceDictionary>
 	</Application.Resources>
-
-
 </Application>

--- a/testing/TestHarness/TestHarness/Properties/launchSettings.json
+++ b/testing/TestHarness/TestHarness/Properties/launchSettings.json
@@ -1,0 +1,50 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    // This profile is first in order for dotnet run to pick it up by default
+    "TestHarness (WebAssembly)": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5000",
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "TestHarness (WebAssembly IIS Express)": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    // Note: In order to select this profile, you'll need to comment the `Packaged` profile below until this is fixed: https://aka.platform.uno/wasdk-maui-debug-profile-issue
+    "TestHarness (WinAppSDK Unpackaged)": {
+      "commandName": "Project",
+      "compatibleTargetFramework": "windows"
+    },
+    "TestHarness (WinAppSDK Packaged)": {
+      "commandName": "MsixPackage",
+      "compatibleTargetFramework": "windows"
+    },
+    "TestHarness (Desktop)": {
+      "commandName": "Project",
+      "compatibleTargetFramework": "desktop"
+    },
+    "TestHarness (Desktop WSL2)": {
+      "commandName": "WSL2",
+      "commandLineArgs": "{ProjectDir}/bin/Debug/net8.0-desktop/TestHarness.dll",
+      "distributionName": "",
+      "compatibleTargetFramework": "desktop"
+    }
+  }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Other
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation


-->

## What is the new behavior?
1. Add launchSettings.json
2. Use MaterialToolkitTheme to initialize resources
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
