### PR TITLE
chore: Add WindowsSdkPackageVersion workaround

### DIFF
--- a/src/tfms-ui-maui.props
+++ b/src/tfms-ui-maui.props
@@ -10,4 +10,7 @@
 		<TargetFrameworks Condition="'$(Build_Windows)'=='true'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
 		<TargetFrameworks>$(TargetFrameworks);net8.0</TargetFrameworks>
 	</PropertyGroup>
+	<PropertyGroup>
+		<WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
+	</PropertyGroup>
 </Project>

--- a/src/tfms-ui-winui.props
+++ b/src/tfms-ui-winui.props
@@ -12,4 +12,7 @@
 		<TargetFrameworks Condition="'$(Build_Web)'=='true'">$(TargetFrameworks);net8.0-browserwasm</TargetFrameworks>
 		<TargetFrameworks>$(TargetFrameworks);net8.0</TargetFrameworks>
 	</PropertyGroup>
+	<PropertyGroup>
+			<WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
+	</PropertyGroup>
 </Project>

--- a/src/tfms-ui-winui.props
+++ b/src/tfms-ui-winui.props
@@ -13,6 +13,6 @@
 		<TargetFrameworks>$(TargetFrameworks);net8.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup>
-			<WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
+		<WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Avoids error:

> ##[error]C:\Users\VssAdministrator\.nuget\packages\microsoft.windowsappsdk\1.6.240829007\buildTransitive\Microsoft.WindowsAppSDK.targets(76,9): Error : This version of the Windows App SDK requires Microsoft.Windows.SDK.NET.Ref 10.0.19041.38 or later.
>     Please update to .NET SDK 6.0.134, 6.0.426, 8.0.109, 8.0.305 or 8.0.402 (or later).
>     Or add a temporary Microsoft.Windows.SDK.NET.Ref reference which can be added with:

```xml
<PropertyGroup>
    <WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
</PropertyGroup>
```