### PR TITLE
chore: add missing packageversions

### DIFF
--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -21,6 +21,7 @@
 		<PackageVersion Include="NUnit" Version="4.1.0" />
 		<PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageVersion Include="NunitXml.TestLogger" Version="3.0.131" />
+		<PackageVersion Include="Xamarin.Google.Android.Material" Version="1.5.0.13" />
 		<PackageVersion Include="Xamarin.UITest" Version="4.3.4" />
 	</ItemGroup>
 </Project>

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -11,6 +11,7 @@
 		<PackageVersion Include="SkiaSharp" Version="2.88.7" />
 		<PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.7" />
 		<PackageVersion Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
 		<PackageVersion Include="Uno.UITest" Version="1.1.0-dev.70" />
 		<PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.70" />
 		<PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.70" />


### PR DESCRIPTION
canaries are failing due to a missing packageversion