### PR TITLE
[Oidc-Auth] Allow native OidcClientOptions settings + Redirect URI auto-discovery

### DIFF
--- a/Uno.Extensions.sln
+++ b/Uno.Extensions.sln
@@ -76,8 +76,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Extensions.Authenticati
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Extensions.Authentication.MSAL.WinUI", "src\Uno.Extensions.Authentication.MSAL\Uno.Extensions.Authentication.MSAL.WinUI.csproj", "{978A32D5-B542-4E4D-9F2E-AE78752F9633}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BEBE0A7A-DF4F-4250-A50E-6901C936A01B}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solution Items", "{BEBE0A7A-DF4F-4250-A50E-6901C936A01B}"
 	ProjectSection(SolutionItems) = preProject
+		src\crosstargeting_override.props = src\crosstargeting_override.props
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Build.targets = src\Directory.Build.targets
 		src\Directory.Packages.props = src\Directory.Packages.props

--- a/doc/Learn/Authentication/HowTo-OidcAuthentication.md
+++ b/doc/Learn/Authentication/HowTo-OidcAuthentication.md
@@ -7,7 +7,6 @@ uid: Uno.Extensions.Authentication.HowToOidcAuthentication
 
 Under the hood, `OidcAuthenticationProvider` relies on [IdentityModel.OidcClient](https://identitymodel.readthedocs.io/), a widely-used .NET library that handles the core OpenID Connect and OAuth 2.0 protocols. This library manages the complex operations like token handling and user authentication.
 
-
 > [!NOTE]
 > It may be useful to familiarize yourself with the [OpenID Connect](https://openid.net/connect/) protocol before proceeding.
 > You can also explore the [Uno Tutorial for Oidc Authentication](xref:Uno.Tutorials.OpenIDConnect) to learn more about the particularities for different platforms.
@@ -96,6 +95,7 @@ Under the hood, `OidcAuthenticationProvider` relies on [IdentityModel.OidcClient
       }
   }
   ```
+
   > Common scopes include `openid`, `profile`, `email`, and `offline_access`. The `openid` scope is required for OpenID Connect authentication. The `profile` and `email` scopes are used to request additional user information, and the `offline_access` scope is used to request a refresh token. Your identity provider may provide additional scopes, such as `api`, to request access to specific APIs.
 
 - `Authority`: The URL of the identity provider.
@@ -171,6 +171,7 @@ Under the hood, `OidcAuthenticationProvider` relies on [IdentityModel.OidcClient
 ## Advanced Customizations
 
 - You can use your own implementation of `IBrowser` (an interface from the `IdentityModel.OidcClient` library) to customize the browser behavior. This should be done by creating a class that implements the interface and register it using the `.ConfigureServices()` in the `App.xaml.cs` file.
+
   ```csharp
     .ConfigureServices((context, services) =>
     {

--- a/doc/Learn/Authentication/HowTo-OidcAuthentication.md
+++ b/doc/Learn/Authentication/HowTo-OidcAuthentication.md
@@ -3,7 +3,14 @@ uid: Uno.Extensions.Authentication.HowToOidcAuthentication
 ---
 # How-To: Get Started with Oidc Authentication
 
-`OidcAuthenticationProvider` allows your users to sign in using their identities from a participating identity provider. It can wrap support for any [OpenID Connect](https://openid.net/connect/) backend, such as [IdentityServer](https://duendesoftware.com/products/identityserver) into an implementation of `IAuthenticationProvider`. This tutorial will use the OIDC authorization to validate user credentials.
+`OidcAuthenticationProvider` is a specific implementation of `IAuthenticationProvider` that allows your users to sign in using their identities from a participating identity provider. It provides seamless integration with any [OpenID Connect](https://openid.net/connect/) backend, such as [IdentityServer](https://duendesoftware.com/products/identityserver). By acting as an adapter, it integrates OpenID Connect authentication into the Uno.Extensions ecosystem, allowing you to leverage a unified approach across platforms.
+
+Under the hood, `OidcAuthenticationProvider` relies on [IdentityModel.OidcClient](https://identitymodel.readthedocs.io/), a widely-used .NET library that handles the core OpenID Connect and OAuth 2.0 protocols. This library manages the complex operations like token handling and user authentication.
+
+
+> [!NOTE]
+> It may be useful to familiarize yourself with the [OpenID Connect](https://openid.net/connect/) protocol before proceeding.
+> You can also explore the [Uno Tutorial for Oidc Authentication](xref:Uno.Tutorials.OpenIDConnect) to learn more about the particularities for different platforms.
 
 ## Step-by-step
 
@@ -78,17 +85,18 @@ uid: Uno.Extensions.Authentication.HowToOidcAuthentication
 
 - We will use the default section name `Oidc` in this example:
 
-    ```json
-    {
-        "Oidc": {
-            "Authority": "https://demo.duendesoftware.com/",
-            "ClientId": "interactive.confidential",
-            "ClientSecret": "secret",
-            "Scope": "openid profile email api offline_access",
-            "RedirectUri": "oidc-auth://callback",
-        }
-    }
-    ```
+  ```json
+  {
+      "Oidc": {
+          "Authority": "https://demo.duendesoftware.com/",
+          "ClientId": "interactive.confidential",
+          "ClientSecret": "secret",
+          "Scope": "openid profile email api offline_access",
+          "RedirectUri": "oidc-auth://callback",
+      }
+  }
+  ```
+  > Common scopes include `openid`, `profile`, `email`, and `offline_access`. The `openid` scope is required for OpenID Connect authentication. The `profile` and `email` scopes are used to request additional user information, and the `offline_access` scope is used to request a refresh token. Your identity provider may provide additional scopes, such as `api`, to request access to specific APIs.
 
 - `Authority`: The URL of the identity provider.
 
@@ -97,6 +105,23 @@ uid: Uno.Extensions.Authentication.HowToOidcAuthentication
 - `Scope`: The scope of the access token.
 
 - `RedirectUri`: The URL that the identity provider will redirect to after the user has authenticated.
+  > It is also possible to populate this setting automatically from the WebAuthenticationBroker using the `.AutoRedirectUriFromAuthenticationBroker()` extension method, which will set the redirect URI to the value returned by the `WebAuthenticationBroker.GetCurrentApplicationCallbackUri()` method, which should discover the correct redirect URI for the application/platform. More information can be found in the [Web Authentication Broker documentation](xref:Uno.Features.WAB).
+  >
+  > When used, this setting will override the value set in the configuration file for both the redirect URI and the post-logout redirect URI.
+  > **This setting is ON by default on WebAssembly but opt-in on other platforms.**
+
+- **Advanced settings**: some advanced settings may need to access directly the `OidcClientOptions` from `IdentityModel.OidcClient` used by this extension. This can be done by using the `.ConfigureOidcClientOptions()` extension method.
+
+    ```csharp
+    builder.AddOidc()
+        .ConfigureOidcClientOptions(options =>
+        {
+            // Example of advanced settings for the OidcClientOptions
+            options.DisablePushedAuthorization  = false; // Disable the PAR endpoint
+            options.Policy.RequireIdentityTokenOnRefreshTokenResponse = true; // Require an identity token on refresh token response
+            options.Policy.Discovery.ValidateIssuerName = false; // Disable issuer name validation
+        });
+    ```
 
 ### 4. Use the provider in your application
 
@@ -142,3 +167,14 @@ uid: Uno.Extensions.Authentication.HowToOidcAuthentication
 - Finally, we can pass the login credentials to the `LoginAsync()` method and authenticate with the identity provider. The user will be prompted to sign in to their account when they tap the button in the application.
 
 - `OidcAuthenticationProvider` will then store the user's access token in credential storage. The token will be automatically refreshed when it expires.
+
+## Advanced Customizations
+
+- You can use your own implementation of `IBrowser` (an interface from the `IdentityModel.OidcClient` library) to customize the browser behavior. This should be done by creating a class that implements the interface and register it using the `.ConfigureServices()` in the `App.xaml.cs` file.
+  ```csharp
+    .ConfigureServices((context, services) =>
+    {
+        services.AddTransient<IBrowser, CustomBrowser>();
+    })
+
+  ```

--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -11,7 +11,7 @@
 		<PackageVersion Include="SkiaSharp.Views" Version="2.88.7" />
 		<PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
 		<PackageVersion Include="SkiaSharp.Skottie" Version="2.88.7" />
-		<PackageVersion Include="System.Text.Json" Version="8.0.4" />
+		<PackageVersion Include="System.Text.Json" Version="8.0.5" />
 		<PackageVersion Include="Uno.Core" Version="4.1.1" />
 		<PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.1.1" />
 		<PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,80 +1,76 @@
 <Project ToolsVersion="15.0">
-	<!--
+  <!--
 		Due to an issue with duplicate references on output for Windows we need to ensure that when building for MAUI Embedding that we use the same version
 		of both WinUI and Uno.WinUI across Extensions and the MauiEmbedding Sample Project.
 	-->
-	<!-- <PropertyGroup Condition="$(SolutionName) != 'MauiEmbedding'">
+  <!-- <PropertyGroup Condition="$(SolutionName) != 'MauiEmbedding'">
 		<UnoVersion Condition="$(UnoVersion) == '' AND !$(MSBuildProjectName.Contains('Maui'))">5.2.175</UnoVersion>
 		<UnoVersion Condition="$(UnoVersion) == '' AND $(MSBuildProjectName.Contains('Maui'))">5.2.175</UnoVersion>
 		<WinAppSdkVersion Condition="$(WinAppSdkVersion) == ''">1.5.240311000</WinAppSdkVersion>
 	</PropertyGroup> -->
-
-	<!--<PropertyGroup>
+  <!--<PropertyGroup>
 		<UnoToolkitVersion>5.0.15</UnoToolkitVersion>
 	</PropertyGroup>-->
-
-	<ItemGroup>
-		<PackageVersion Include="CommunityToolkit.Mvvm" Version="7.0.1" />
-		<PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.1.1" />
-		<PackageVersion Include="FluentAssertions" Version="6.7.0" />
-		<PackageVersion Include="IdentityModel.OidcClient" Version="5.0.0" />
-		<PackageVersion Include="MSTest.TestAdapter" Version="2.2.9" />
-		<PackageVersion Include="MSTest.TestFramework" Version="2.2.9" />
-		<PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-		<PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0"  />
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-		<PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
-		<PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.1" />
-		<PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-		<PackageVersion Include="Microsoft.Identity.Client" Version="4.61.3" />
-		<PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
-		<PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.3" />
-		<PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.3" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-		<PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.7.1" />
-		<PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.2.0" />
-		<PackageVersion Include="Moq" Version="4.17.2" />
-		<PackageVersion Include="Refit" Version="6.3.2" />
-		<PackageVersion Include="Refit.HttpClientFactory" Version="6.3.2" />
-		<PackageVersion Include="Serilog.Extensions.Hosting" Version="4.2.0" />
-		<PackageVersion Include="Serilog.Settings.Configuration" Version="3.3.0" />
-		<PackageVersion Include="Serilog.Sinks.Console" Version="4.0.1" />
-		<PackageVersion Include="Serilog.Sinks.Debug" Version="2.0.0" />
-		<PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
-		<PackageVersion Include="Serilog.Sinks.Xamarin" Version="1.0.0" />
-		<PackageVersion Include="System.Collections.Immutable" Version="8.0.0" /> 
-		<PackageVersion Include="System.Linq.Async" Version="4.0.0" />
-		<PackageVersion Include="System.Net.Http.WinHttpHandler" Version="6.0.1" />
-		<PackageVersion Include="System.Text.Json" Version="8.0.4" />
-		<PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-		<PackageVersion Include="Uno.Core" Version="4.1.1" />
-		<PackageVersion Include="Uno.Core.Extensions" Version="4.1.1" />
-		<PackageVersion Include="Uno.Core.Extensions.Collections" Version="4.1.1" />
-		<PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.1.1" />		
-		<PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" /> 
-		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
-		<PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.3.12" />
-		<PackageVersion Include="Uno.Extensions.Markup.WinUI" Version="5.3.12" />
-		<PackageVersion Include="Uno.Roslyn" Version="1.3.0-dev.12" />
-		<PackageVersion Include="Uno.Toolkit" Version="6.1.8" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)"/>
-
-		<PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.37.0-dev.126" />
-		<PackageVersion Include="Uno.WinUI" Version="$(UnoVersion)" />
-		<PackageVersion Include="Uno.WinUI.Markup" Version="5.3.12" />
-		<PackageVersion Include="Uno.WinUI.MSAL" Version="$(UnoVersion)" />
-		<PackageVersion Include="coverlet.collector" Version="3.1.2" />
-		<PackageVersion Include="xunit" Version="2.4.1" />
-		<PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
-		<PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-		<PackageVersion Include="FluentValidation" Version="11.4.0" />
-
-		<PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-		<PackageVersion Include="System.Net.Http" Version="4.3.4" />
-		<PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="7.0.1" />
+    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.1.1" />
+    <PackageVersion Include="FluentAssertions" Version="6.7.0" />
+    <PackageVersion Include="IdentityModel.OidcClient" Version="5.0.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="2.2.9" />
+    <PackageVersion Include="MSTest.TestFramework" Version="2.2.9" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.61.3" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.UI.Xaml" Version="2.7.1" />
+    <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.2.0" />
+    <PackageVersion Include="Moq" Version="4.17.2" />
+    <PackageVersion Include="Refit" Version="6.3.2" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="6.3.2" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="4.2.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageVersion Include="Serilog.Sinks.Debug" Version="2.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Xamarin" Version="1.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Linq.Async" Version="4.0.0" />
+    <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="6.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageVersion Include="Uno.Core" Version="4.1.1" />
+    <PackageVersion Include="Uno.Core.Extensions" Version="4.1.1" />
+    <PackageVersion Include="Uno.Core.Extensions.Collections" Version="4.1.1" />
+    <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.1.1" />
+    <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />
+    <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
+    <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.3.12" />
+    <PackageVersion Include="Uno.Extensions.Markup.WinUI" Version="5.3.12" />
+    <PackageVersion Include="Uno.Roslyn" Version="1.3.0-dev.12" />
+    <PackageVersion Include="Uno.Toolkit" Version="6.1.8" />
+    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
+    <PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.37.0-dev.126" />
+    <PackageVersion Include="Uno.WinUI" Version="$(UnoVersion)" />
+    <PackageVersion Include="Uno.WinUI.Markup" Version="5.3.12" />
+    <PackageVersion Include="Uno.WinUI.MSAL" Version="$(UnoVersion)" />
+    <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+    <PackageVersion Include="xunit" Version="2.4.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageVersion Include="FluentValidation" Version="11.4.0" />
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
 </Project>

--- a/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationBuilderExtensions.cs
@@ -104,13 +104,13 @@ public static class OidcAuthenticationBuilderExtensions
 	/// </remarks>
 	public static IOidcAuthenticationBuilder AutoRedirectUriFromWebAuthenticationBroker(
 		this IOidcAuthenticationBuilder builder,
-		bool autoReturnUri = true)
+		bool autoRedirectUri = true)
 	{
 		if (builder is IBuilder<OidcAuthenticationSettings> authBuilder)
 		{
 			authBuilder.Settings = authBuilder.Settings with
 			{
-				AutoRedirectUri = autoReturnUri
+				AutoRedirectUri = autoRedirectUri
 			};
 		}
 

--- a/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Authentication;
+﻿using System.ComponentModel;
+
+namespace Uno.Extensions.Authentication;
 
 /// <summary>
 /// Provides OIDC-related extension methods for <see cref="IOidcAuthenticationBuilder"/>.
@@ -20,7 +22,7 @@ public static class OidcAuthenticationBuilderExtensions
 	public static IOidcAuthenticationBuilder Authority(
 		this IOidcAuthenticationBuilder builder,
 		string authority)
-		=> builder.ChangeOption(options => options.Authority = authority);
+		=> builder.UpdateOidcClientOptions(options => options.Authority = authority);
 
 	/// <summary>
 	/// Configures the OIDC authentication feature to be built with the specified client ID.
@@ -37,7 +39,7 @@ public static class OidcAuthenticationBuilderExtensions
 	public static IOidcAuthenticationBuilder ClientId(
 		this IOidcAuthenticationBuilder builder,
 		string clientId)
-		=> builder.ChangeOption(options => options.ClientId = clientId);
+		=> builder.UpdateOidcClientOptions(options => options.ClientId = clientId);
 
 	/// <summary>
 	/// Configures the OIDC authentication feature to be built with the specified client secret.
@@ -54,7 +56,7 @@ public static class OidcAuthenticationBuilderExtensions
 	public static IOidcAuthenticationBuilder ClientSecret(
 		this IOidcAuthenticationBuilder builder,
 		string clientSecret)
-		=> builder.ChangeOption(options => options.ClientSecret = clientSecret);
+		=> builder.UpdateOidcClientOptions(options => options.ClientSecret = clientSecret);
 
 	/// <summary>
 	/// Configures the OIDC authentication feature to be built with the specified scope.
@@ -69,9 +71,9 @@ public static class OidcAuthenticationBuilderExtensions
 	/// The <see cref="IOidcAuthenticationBuilder"/> that was passed in.
 	/// </returns>
 	public static IOidcAuthenticationBuilder Scope(
-	this IOidcAuthenticationBuilder builder,
-	string scope)
-	=> builder.ChangeOption(options => options.Scope = scope);
+		this IOidcAuthenticationBuilder builder,
+		string scope)
+		=> builder.UpdateOidcClientOptions(options => options.Scope = scope);
 
 	/// <summary>
 	/// Configures the OIDC authentication feature to be built with the specified redirect URI.
@@ -86,9 +88,9 @@ public static class OidcAuthenticationBuilderExtensions
 	/// The <see cref="IOidcAuthenticationBuilder"/> that was passed in.
 	/// </returns>
 	public static IOidcAuthenticationBuilder RedirectUri(
-	this IOidcAuthenticationBuilder builder,
-	string redirectUri)
-	=> builder.ChangeOption(options => options.RedirectUri = redirectUri);
+		this IOidcAuthenticationBuilder builder,
+		string redirectUri)
+		=> builder.UpdateOidcClientOptions(options => options.RedirectUri = redirectUri);
 
 	/// <summary>
 	/// Configures the OIDC authentication feature to be built with the specified post-logout redirect URI.
@@ -103,13 +105,21 @@ public static class OidcAuthenticationBuilderExtensions
 	/// The <see cref="IOidcAuthenticationBuilder"/> that was passed in.
 	/// </returns>
 	public static IOidcAuthenticationBuilder PostLogoutRedirectUri(
-	this IOidcAuthenticationBuilder builder,
-	string postLogoutRedirectUri)
-	=> builder.ChangeOption(options => options.PostLogoutRedirectUri = postLogoutRedirectUri);
-
-	private static IOidcAuthenticationBuilder ChangeOption(
 		this IOidcAuthenticationBuilder builder,
-		Action<OidcClientOptions> change)
+		string postLogoutRedirectUri)
+		=> builder.UpdateOidcClientOptions(options => options.PostLogoutRedirectUri = postLogoutRedirectUri);
+
+	// Add an advanced builder allowing to tweak the options directly
+	/// <summary>
+	/// Configures the OIDC authentication feature by updating directly the <see cref="OidcClientOptions"/> parameter.
+	/// </summary>
+	/// <remarks>
+	/// A 
+	/// </remarks>
+	[EditorBrowsable(EditorBrowsableState.Advanced)]
+	public static IOidcAuthenticationBuilder UpdateOidcClientOptions(
+		this IOidcAuthenticationBuilder builder,
+		Action<OidcClientOptions> updater)
 	{
 		if (builder is IBuilder<OidcAuthenticationSettings> authBuilder)
 		{
@@ -121,10 +131,9 @@ public static class OidcAuthenticationBuilderExtensions
 				};
 
 			}
-			change(authBuilder.Settings.Options);
+			updater(authBuilder.Settings.Options);
 		}
 
 		return builder;
 	}
-
 }

--- a/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationBuilderExtensions.cs
@@ -22,7 +22,7 @@ public static class OidcAuthenticationBuilderExtensions
 	public static IOidcAuthenticationBuilder Authority(
 		this IOidcAuthenticationBuilder builder,
 		string authority)
-		=> builder.UpdateOidcClientOptions(options => options.Authority = authority);
+		=> builder.ConfigureOidcClientOptions(options => options.Authority = authority);
 
 	/// <summary>
 	/// Configures the OIDC authentication feature to be built with the specified client ID.
@@ -39,7 +39,7 @@ public static class OidcAuthenticationBuilderExtensions
 	public static IOidcAuthenticationBuilder ClientId(
 		this IOidcAuthenticationBuilder builder,
 		string clientId)
-		=> builder.UpdateOidcClientOptions(options => options.ClientId = clientId);
+		=> builder.ConfigureOidcClientOptions(options => options.ClientId = clientId);
 
 	/// <summary>
 	/// Configures the OIDC authentication feature to be built with the specified client secret.
@@ -56,7 +56,7 @@ public static class OidcAuthenticationBuilderExtensions
 	public static IOidcAuthenticationBuilder ClientSecret(
 		this IOidcAuthenticationBuilder builder,
 		string clientSecret)
-		=> builder.UpdateOidcClientOptions(options => options.ClientSecret = clientSecret);
+		=> builder.ConfigureOidcClientOptions(options => options.ClientSecret = clientSecret);
 
 	/// <summary>
 	/// Configures the OIDC authentication feature to be built with the specified scope.
@@ -73,7 +73,7 @@ public static class OidcAuthenticationBuilderExtensions
 	public static IOidcAuthenticationBuilder Scope(
 		this IOidcAuthenticationBuilder builder,
 		string scope)
-		=> builder.UpdateOidcClientOptions(options => options.Scope = scope);
+		=> builder.ConfigureOidcClientOptions(options => options.Scope = scope);
 
 	/// <summary>
 	/// Configures the OIDC authentication feature to be built with the specified redirect URI.
@@ -90,7 +90,32 @@ public static class OidcAuthenticationBuilderExtensions
 	public static IOidcAuthenticationBuilder RedirectUri(
 		this IOidcAuthenticationBuilder builder,
 		string redirectUri)
-		=> builder.UpdateOidcClientOptions(options => options.RedirectUri = redirectUri);
+		=> builder.ConfigureOidcClientOptions(options => options.RedirectUri = redirectUri);
+
+	/// <summary>
+	/// Let the OidcAuthenticationProvider automatically set the redirect URI to the automatically discovered one from the WebAuthenticationBroker.
+	/// </summary>
+	/// <remarks>
+	/// This feature will use the <see cref="WebAuthenticationBroker.GetCurrentApplicationCallbackUri"/> to set the redirect URI, which is usually discovered automatically by the implementation of the WebAuthenticationBroker (which can be customized).
+	/// More information: <see href="https://platform.uno/docs/articles/features/web-authentication-broker.html">Uno Web Authentication Broker Documentation</see>.
+	///
+	/// > ![IMPORTANT]
+	/// > When this setting is set, the <see cref="OidcClientOptions.RedirectUri"/> and <see cref="OidcClientOptions.PostLogoutRedirectUri"/> settings will be overridden with the value from the WebAuthenticationBroker.
+	/// </remarks>
+	public static IOidcAuthenticationBuilder AutoRedirectUriFromWebAuthenticationBroker(
+		this IOidcAuthenticationBuilder builder,
+		bool autoReturnUri = true)
+	{
+		if (builder is IBuilder<OidcAuthenticationSettings> authBuilder)
+		{
+			authBuilder.Settings = authBuilder.Settings with
+			{
+				AutoRedirectUri = autoReturnUri
+			};
+		}
+
+		return builder;
+	}
 
 	/// <summary>
 	/// Configures the OIDC authentication feature to be built with the specified post-logout redirect URI.
@@ -107,17 +132,17 @@ public static class OidcAuthenticationBuilderExtensions
 	public static IOidcAuthenticationBuilder PostLogoutRedirectUri(
 		this IOidcAuthenticationBuilder builder,
 		string postLogoutRedirectUri)
-		=> builder.UpdateOidcClientOptions(options => options.PostLogoutRedirectUri = postLogoutRedirectUri);
+		=> builder.ConfigureOidcClientOptions(options => options.PostLogoutRedirectUri = postLogoutRedirectUri);
 
 	// Add an advanced builder allowing to tweak the options directly
 	/// <summary>
 	/// Configures the OIDC authentication feature by updating directly the <see cref="OidcClientOptions"/> parameter.
 	/// </summary>
 	/// <remarks>
-	/// A 
+	/// A
 	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
-	public static IOidcAuthenticationBuilder UpdateOidcClientOptions(
+	public static IOidcAuthenticationBuilder ConfigureOidcClientOptions(
 		this IOidcAuthenticationBuilder builder,
 		Action<OidcClientOptions> updater)
 	{

--- a/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationProvider.cs
@@ -1,4 +1,5 @@
-﻿using IdentityModel.OidcClient.Browser;
+﻿using System.Collections.Frozen;
+using IdentityModel.OidcClient.Browser;
 
 namespace Uno.Extensions.Authentication.Oidc;
 
@@ -17,23 +18,31 @@ internal record OidcAuthenticationProvider(
 	{
 		var config = Settings?.Options ?? Configuration.Get(Name) ?? new OidcClientOptions();
 
-		if (PlatformHelper.IsWebAssembly)
+		if (Settings is { AutoRedirectUri: true })
 		{
 			config.RedirectUri = WebAuthenticationBroker.GetCurrentApplicationCallbackUri().OriginalString;
 			config.PostLogoutRedirectUri = WebAuthenticationBroker.GetCurrentApplicationCallbackUri().OriginalString;
 		}
+
 		config.Browser = Browser;
 		_client = new OidcClient(config);
 	}
 
-	protected async override ValueTask<IDictionary<string, string>?> InternalLoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
+	protected override async ValueTask<IDictionary<string, string>?> InternalLoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken)
 	{
 		if (_client is null)
 		{
+			ProviderLogger.LogError("Client is not initialized.");
 			return default;
 		}
 
-		var authenticationResult = await _client.LoginAsync();
+		var authenticationResult = await _client.LoginAsync(cancellationToken: cancellationToken);
+
+		if(authenticationResult.IsError)
+		{
+			ProviderLogger.LogError("Error logging in: {Error} - {ErrorDescription}", authenticationResult.Error, authenticationResult.ErrorDescription);
+			return default;
+		}
 
 		var token = authenticationResult.AccessToken;
 		var refreshToken = authenticationResult.RefreshToken;

--- a/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationProvider.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Frozen;
-using IdentityModel.OidcClient.Browser;
+﻿using IdentityModel.OidcClient.Browser;
 
 namespace Uno.Extensions.Authentication.Oidc;
 
@@ -20,8 +19,8 @@ internal record OidcAuthenticationProvider(
 
 		if (Settings is { AutoRedirectUri: true })
 		{
-			config.RedirectUri = WebAuthenticationBroker.GetCurrentApplicationCallbackUri().OriginalString;
-			config.PostLogoutRedirectUri = WebAuthenticationBroker.GetCurrentApplicationCallbackUri().OriginalString;
+			config.RedirectUri = config.PostLogoutRedirectUri = WebAuthenticationBroker
+				.GetCurrentApplicationCallbackUri().OriginalString;
 		}
 
 		config.Browser = Browser;

--- a/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationSettings.cs
+++ b/src/Uno.Extensions.Authentication.Oidc/OidcAuthenticationSettings.cs
@@ -6,4 +6,6 @@ namespace Uno.Extensions.Authentication.Oidc;
 internal record OidcAuthenticationSettings
 {
 	public OidcClientOptions? Options { get; init; }
+
+	public bool AutoRedirectUri { get; init; } = PlatformHelper.IsWebAssembly;
 }

--- a/src/Uno.Extensions.Authentication.Oidc/WebAuthenticatorBrowser.cs
+++ b/src/Uno.Extensions.Authentication.Oidc/WebAuthenticatorBrowser.cs
@@ -1,6 +1,6 @@
-﻿
-using IdentityModel.OidcClient.Browser;
+﻿using IdentityModel.OidcClient.Browser;
 using System.Diagnostics;
+using Windows.Foundation;
 
 namespace Uno.Extensions.Authentication.Oidc;
 
@@ -8,17 +8,23 @@ public class WebAuthenticatorBrowser : IBrowser
 {
 	public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)
 	{
+		var cts = new CancellationTokenSource(options.Timeout);
+		var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken);
+
 		try
 		{
 #if WINDOWS
-			var userResult = await WinUIEx.WebAuthenticator.AuthenticateAsync(new Uri(options.StartUrl), new Uri(options.EndUrl));
+			var userResult = await WinUIEx.WebAuthenticator.AuthenticateAsync(new Uri(options.StartUrl), new Uri(options.EndUrl), linkedCts.Token);
 			var callbackurl = $"{options.EndUrl}/?{string.Join("&", userResult.Properties.Select(x => $"{x.Key}={x.Value}"))}";
 			return new BrowserResult
 			{
 				Response = callbackurl
 			};
 #else
-			var userResult = await WebAuthenticationBroker.AuthenticateAsync(WebAuthenticationOptions.None, new Uri(options.StartUrl), new Uri(options.EndUrl));
+
+			var userResult = await WebAuthenticationBroker
+				.AuthenticateAsync(WebAuthenticationOptions.None, new Uri(options.StartUrl), new Uri(options.EndUrl))
+				.AsTask(linkedCts.Token);
 
 			return new BrowserResult
 			{

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -58,7 +58,7 @@
 		<PackageVersion Include="System.Private.Uri" Version="4.3.2" />
 		<PackageVersion Include="System.Net.Http" Version="4.3.4" />
 		<PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-		<PackageVersion Include="System.Text.Json" Version="8.0.4" />
+		<PackageVersion Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno.extensions/issues/2588
Fixes https://github.com/unoplatform/uno.extensions/issues/2590

# Feature - Allow update of native `OidcClientOptions`

This PR will allow the application to update the native `OidcClientOptions` for advanced scenario, like settings which are either advanced or not supported by the version for which Uno Extensions is build (which is the case for `DisablePushedAuthorization` setting).

## What is the new behavior?

A new `UpdateOidcClientOptions()` on the builder let the application interact directly with the setting object.

# Feature - Allow auto-discovery of the Redirect URI from Web Auth Broker

The application can now rely on the auto-discovery of the Redirect URI by the Web Auth Broker. It's opt-in, except for Wasm because it was already using it - to stay backward compatible.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
