### PR TITLE
fix: Reduce winappsdk version dependency

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,76 +1,67 @@
 <Project ToolsVersion="15.0">
-  <!--
-		Due to an issue with duplicate references on output for Windows we need to ensure that when building for MAUI Embedding that we use the same version
-		of both WinUI and Uno.WinUI across Extensions and the MauiEmbedding Sample Project.
-	-->
-  <!-- <PropertyGroup Condition="$(SolutionName) != 'MauiEmbedding'">
-		<UnoVersion Condition="$(UnoVersion) == '' AND !$(MSBuildProjectName.Contains('Maui'))">5.2.175</UnoVersion>
-		<UnoVersion Condition="$(UnoVersion) == '' AND $(MSBuildProjectName.Contains('Maui'))">5.2.175</UnoVersion>
-		<WinAppSdkVersion Condition="$(WinAppSdkVersion) == ''">1.5.240311000</WinAppSdkVersion>
-	</PropertyGroup> -->
-  <!--<PropertyGroup>
-		<UnoToolkitVersion>5.0.15</UnoToolkitVersion>
-	</PropertyGroup>-->
-  <ItemGroup>
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="7.0.1" />
-    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.1.1" />
-    <PackageVersion Include="FluentAssertions" Version="6.7.0" />
-    <PackageVersion Include="IdentityModel.OidcClient" Version="5.0.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="2.2.9" />
-    <PackageVersion Include="MSTest.TestFramework" Version="2.2.9" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.61.3" />
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.3" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.UI.Xaml" Version="2.7.1" />
-    <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.2.0" />
-    <PackageVersion Include="Moq" Version="4.17.2" />
-    <PackageVersion Include="Refit" Version="7.2.22" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="7.2.22" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="4.2.0" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageVersion Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Xamarin" Version="1.0.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Include="System.Linq.Async" Version="4.0.0" />
-    <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="6.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="Uno.Core" Version="4.1.1" />
-    <PackageVersion Include="Uno.Core.Extensions" Version="4.1.1" />
-    <PackageVersion Include="Uno.Core.Extensions.Collections" Version="4.1.1" />
-    <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.1.1" />
-    <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />
-    <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
-    <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.3.12" />
-    <PackageVersion Include="Uno.Extensions.Markup.WinUI" Version="5.3.12" />
-    <PackageVersion Include="Uno.Roslyn" Version="1.3.0-dev.12" />
-    <PackageVersion Include="Uno.Toolkit" Version="6.1.8" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
-    <PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.37.0-dev.126" />
-    <PackageVersion Include="Uno.WinUI" Version="$(UnoVersion)" />
-    <PackageVersion Include="Uno.WinUI.Markup" Version="5.3.12" />
-    <PackageVersion Include="Uno.WinUI.MSAL" Version="$(UnoVersion)" />
-    <PackageVersion Include="coverlet.collector" Version="3.1.2" />
-    <PackageVersion Include="xunit" Version="2.4.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="FluentValidation" Version="11.4.0" />
-    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-  </ItemGroup>
+    <PropertyGroup>
+        <WinAppSdkBuildToolsVersion>10.0.22621.3233</WinAppSdkBuildToolsVersion> <!-- Keep this version until https://github.com/microsoft/WindowsAppSDK/issues/4480 is resolved -->
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="CommunityToolkit.Mvvm" Version="7.0.1" />
+        <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.1.1" />
+        <PackageVersion Include="FluentAssertions" Version="6.7.0" />
+        <PackageVersion Include="IdentityModel.OidcClient" Version="5.0.0" />
+        <PackageVersion Include="MSTest.TestAdapter" Version="2.2.9" />
+        <PackageVersion Include="MSTest.TestFramework" Version="2.2.9" />
+        <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Identity.Client" Version="4.61.3" />
+        <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
+        <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.3" />
+        <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.3" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+        <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+        <PackageVersion Include="Microsoft.UI.Xaml" Version="2.7.1" />
+        <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.2.0" />
+        <PackageVersion Include="Moq" Version="4.17.2" />
+        <PackageVersion Include="Refit" Version="7.2.22" />
+        <PackageVersion Include="Refit.HttpClientFactory" Version="7.2.22" />
+        <PackageVersion Include="Serilog.Extensions.Hosting" Version="4.2.0" />
+        <PackageVersion Include="Serilog.Settings.Configuration" Version="3.3.0" />
+        <PackageVersion Include="Serilog.Sinks.Console" Version="4.0.1" />
+        <PackageVersion Include="Serilog.Sinks.Debug" Version="2.0.0" />
+        <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
+        <PackageVersion Include="Serilog.Sinks.Xamarin" Version="1.0.0" />
+        <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+        <PackageVersion Include="System.Linq.Async" Version="4.0.0" />
+        <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="6.0.1" />
+        <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+        <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+        <PackageVersion Include="Uno.Core" Version="4.1.1" />
+        <PackageVersion Include="Uno.Core.Extensions" Version="4.1.1" />
+        <PackageVersion Include="Uno.Core.Extensions.Collections" Version="4.1.1" />
+        <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.1.1" />
+        <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />
+        <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
+        <PackageVersion Include="Uno.Extensions.Markup.Generators" Version="5.3.12" />
+        <PackageVersion Include="Uno.Extensions.Markup.WinUI" Version="5.3.12" />
+        <PackageVersion Include="Uno.Roslyn" Version="1.3.0-dev.12" />
+        <PackageVersion Include="Uno.Toolkit" Version="6.1.8" />
+        <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
+        <PackageVersion Include="Uno.UI.RuntimeTests.Engine" Version="0.37.0-dev.126" />
+        <PackageVersion Include="Uno.WinUI" Version="$(UnoVersion)" />
+        <PackageVersion Include="Uno.WinUI.Markup" Version="5.3.12" />
+        <PackageVersion Include="Uno.WinUI.MSAL" Version="$(UnoVersion)" />
+        <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+        <PackageVersion Include="xunit" Version="2.4.1" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.1" />
+        <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
+        <PackageVersion Include="FluentValidation" Version="11.4.0" />
+        <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+        <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+        <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
This is required in order to prevent version conflicts with uno.sdk which is rolling back winappsdk version to the latest version currently supported by the Store
See: https://github.com/microsoft/WindowsAppSDK/issues/4480 is resolved 	