### PR TITLE
build: use uno.sdk.private for samples/testing

### DIFF
--- a/SamplePackages.props
+++ b/SamplePackages.props
@@ -1,0 +1,63 @@
+<Project ToolsVersion="15.0">
+	<PropertyGroup>
+		<!-- <UnoVersion>5.5.87</UnoVersion> -->
+		<UnoToolkitVersion>6.3.7</UnoToolkitVersion>
+		<UnoThemesVersion>5.3.1</UnoThemesVersion>
+		<UnoCSharpMarkupVersion>5.5.6</UnoCSharpMarkupVersion>
+		<UnoWasmBootstrapVersion>8.0.21</UnoWasmBootstrapVersion>
+		<UnoLoggingVersion>1.7.0</UnoLoggingVersion>
+		<UnoCoreLoggingSingletonVersion>4.1.1</UnoCoreLoggingSingletonVersion>
+		<UnoUniversalImageLoaderVersion>1.9.37</UnoUniversalImageLoaderVersion>
+		<UnoDspTasksVersion>1.4.0</UnoDspTasksVersion>
+		<UnoResizetizerVersion>1.6.1</UnoResizetizerVersion>
+		<SkiaSharpVersion>2.88.9-preview.2.2</SkiaSharpVersion>
+		<SvgSkiaVersion>2.0.0.4</SvgSkiaVersion>
+		<WinAppSdkVersion>1.6.241114003</WinAppSdkVersion>
+		<WinAppSdkBuildToolsVersion>10.0.26100.1742</WinAppSdkBuildToolsVersion>
+		<MicrosoftLoggingVersion>8.0.1</MicrosoftLoggingVersion>
+		<WindowsCompatibilityVersion>8.0.11</WindowsCompatibilityVersion>
+		<MicrosoftIdentityClientVersion>4.65.0</MicrosoftIdentityClientVersion>
+		<CommunityToolkitMvvmVersion>8.3.2</CommunityToolkitMvvmVersion>
+		<PrismVersion>9.0.537</PrismVersion>
+		<AndroidMaterialVersion>1.11.0.3</AndroidMaterialVersion>
+		<AndroidXLegacySupportV4Version>1.0.0.23</AndroidXLegacySupportV4Version>
+		<AndroidXAppCompatVersion>1.7.0.3</AndroidXAppCompatVersion>
+		<AndroidXRecyclerViewVersion>1.3.2.8</AndroidXRecyclerViewVersion>
+		<AndroidXActivityVersion>1.9.2.1</AndroidXActivityVersion>
+		<AndroidXBrowserVersion>1.8.0.6</AndroidXBrowserVersion>
+		<AndroidXSwipeRefreshLayoutVersion>1.1.0.24</AndroidXSwipeRefreshLayoutVersion>
+		<AndroidXNavigationVersion>2.8.0.1</AndroidXNavigationVersion>
+		<AndroidXCollectionVersion>1.4.4</AndroidXCollectionVersion>
+		<MauiVersion>8.0.91</MauiVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<!-- Microsoft Logging -->
+		<PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftLoggingVersion)" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftLoggingVersion)" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftLoggingVersion)" />
+
+		<!-- SkiaSharp -->
+		<PackageVersion Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
+		<PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="$(SkiaSharpVersion)" />
+		<PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="$(SkiaSharpVersion)" />
+		<PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="$(SkiaSharpVersion)" />
+		<PackageVersion Include="SkiaSharp.Skottie" Version="$(SkiaSharpVersion)" />
+
+		<!-- Maui -->
+		<PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+		<PackageVersion Include="Microsoft.Maui.Graphics" Version="$(MauiVersion)" />
+
+		<PackageVersion Include="Xamarin.AndroidX.Navigation.UI" Version="$(AndroidXNavigationVersion)" />
+		<PackageVersion Include="Xamarin.AndroidX.Navigation.Fragment" Version="$(AndroidXNavigationVersion)" />
+		<PackageVersion Include="Xamarin.AndroidX.Navigation.Runtime" Version="$(AndroidXNavigationVersion)" />
+		<PackageVersion Include="Xamarin.AndroidX.Navigation.Common" Version="$(AndroidXNavigationVersion)" />
+		<PackageVersion Include="Xamarin.AndroidX.Collection" Version="$(AndroidXCollectionVersion)"/>
+		<PackageVersion Include="Xamarin.AndroidX.Collection.Ktx" Version="$(AndroidXCollectionVersion)" />
+		<PackageVersion Include="Xamarin.AndroidX.Collection.Jvm" Version="$(AndroidXCollectionVersion)" />
+
+		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="$(WinAppSdkBuildToolsVersion)" />
+		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="$(WinAppSdkVersion)" />
+	</ItemGroup>
+</Project>

--- a/SamplePackages.props
+++ b/SamplePackages.props
@@ -28,7 +28,7 @@
 		<AndroidXSwipeRefreshLayoutVersion>1.1.0.24</AndroidXSwipeRefreshLayoutVersion>
 		<AndroidXNavigationVersion>2.8.0.1</AndroidXNavigationVersion>
 		<AndroidXCollectionVersion>1.4.4</AndroidXCollectionVersion>
-		<MauiVersion>8.0.91</MauiVersion>
+		<MauiVersion>8.0.3</MauiVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
-    "Uno.Sdk": "5.3.96"
+    "Uno.Sdk": "5.3.112",
+    "Uno.Sdk.Private": "5.5.94"
   }
 }

--- a/samples/MauiEmbedding/Directory.Packages.props
+++ b/samples/MauiEmbedding/Directory.Packages.props
@@ -1,37 +1,13 @@
 <Project ToolsVersion="15.0">
-  <!--
-    To update the version of Uno, you should instead update the Sdk version in the global.json file.
+  <Import Project="$(MSBuildThisFileDirectory)..\..\SamplePackages.props" />
 
-    See https://aka.platform.uno/using-uno-sdk for more information.
-  -->
   <ItemGroup>
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageVersion Include="SkiaSharp" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="2.88.8" />
-    <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.8" />
     <PackageVersion Include="Syncfusion.Maui.Core" Version="22.2.9" />
     <PackageVersion Include="Syncfusion.Maui.Charts" Version="22.2.9" />
     <PackageVersion Include="Syncfusion.Maui.DataGrid" Version="22.2.9" />
-    <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.1.1" />
-    <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />
-    <PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
     <PackageVersion Include="Telerik.UI.for.Maui" Version="5.1.0" Condition="$(_UseTelerik)" />
     <PackageVersion Include="Esri.ArcGISRuntime.Maui" Version="200.1.0" />
     <PackageVersion Include="Microsoft.Windows.Compatibility" Version="7.0.4" />
-    <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
 
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.3" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.3" />
-    <PackageVersion Include="Microsoft.Maui.Graphics" Version="8.0.3"  />
-
-    <PackageVersion Include="Xamarin.AndroidX.Navigation.UI" Version="2.7.7.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Navigation.Fragment" Version="2.7.7.1"/>
-    <PackageVersion Include="Xamarin.AndroidX.Navigation.Runtime" Version="2.7.7.1"/>
-    <PackageVersion Include="Xamarin.AndroidX.Navigation.Common" Version="2.7.7.1"/>
-    <PackageVersion Include="Xamarin.AndroidX.Collection" Version="1.4.0.1"/>
-    <PackageVersion Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Collection.Jvm" Version="1.4.0.1" />
   </ItemGroup>
 </Project>

--- a/samples/MauiEmbedding/MauiEmbedding/MauiEmbedding.csproj
+++ b/samples/MauiEmbedding/MauiEmbedding/MauiEmbedding.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Uno.Sdk">
+﻿<Project Sdk="Uno.Sdk.Private">
 	<Import Project="..\..\..\src\tfms-ui-maui.props" />
 
 	<PropertyGroup>
-
+		<TargetFrameworks>net8.0-windows10.0.19041</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<UnoSingleProject>true</UnoSingleProject>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -35,14 +35,6 @@
 			Mvvm;
 		</UnoFeatures>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton"/>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(IsIOSOrCatalyst)' == 'true'">
-		<PackageReference Include="Uno.Extensions.Logging.OSLog" />
-	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Core.UI\Uno.Extensions.Core.WinUI.csproj" />

--- a/samples/Playground/Directory.Build.props
+++ b/samples/Playground/Directory.Build.props
@@ -14,16 +14,4 @@
     -->
 		<NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton"/>
-	</ItemGroup>
-	
-	<ItemGroup Condition="'$(IsBrowserWasm)'=='true'">
-		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(IsIOSOrCatalyst)' == 'true'">
-		<PackageReference Include="Uno.Extensions.Logging.OSLog" />
-	</ItemGroup>
 </Project>

--- a/samples/Playground/Directory.Packages.props
+++ b/samples/Playground/Directory.Packages.props
@@ -1,21 +1,10 @@
 <Project ToolsVersion="15.0">
+	<Import Project="$(MSBuildThisFileDirectory)..\..\SamplePackages.props" />
+
 	<ItemGroup>
-		<PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.1" />
-		<PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-		<PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-		<PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 		<PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-		<PackageVersion Include="Microsoft.Windows.Compatibility" Version="7.0.3" />
 		<PackageVersion Include="Refit" Version="7.2.22" />
 		<PackageVersion Include="Refit.HttpClientFactory" Version="7.2.22" />
-		<PackageVersion Include="SkiaSharp.Views" Version="2.88.7" />
-		<PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
-		<PackageVersion Include="SkiaSharp.Skottie" Version="2.88.7" />
 		<PackageVersion Include="System.Text.Json" Version="8.0.5" />
-		<PackageVersion Include="Uno.Core" Version="4.1.1" />
-		<PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.1.1" />
-		<PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />
-		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)" />
 	</ItemGroup>
 </Project>

--- a/samples/Playground/Playground/Playground.csproj
+++ b/samples/Playground/Playground/Playground.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Uno.Sdk">
+﻿<Project Sdk="Uno.Sdk.Private">
 	<Import Project="..\..\..\src\tfms-ui-winui.props" />
 
 	<PropertyGroup>

--- a/src/Uno.Extensions.Maui.UI/build/Package.targets
+++ b/src/Uno.Extensions.Maui.UI/build/Package.targets
@@ -73,24 +73,4 @@
 	</UsingTask>
 
 
-	<!-- Workaround to avoid including Uno.Toolkit.UI XBFs in the PRI file -->
-	<Target Name="AdjustGetPackagingOutput1" AfterTargets="GetMrtPackagingOutputs"
-		Condition="$(UsingUnoSdk) != 'true'">
-		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
-		<ItemGroup>
-			<_OtherPriFiles Include="@(PackagingOutputs)" Condition="'%(Extension)' == '.pri' and ('%(PackagingOutputs.ReferenceSourceTarget)' == 'ProjectReference' or '%(PackagingOutputs.NugetSourceType)'=='Package')" />
-			<PackagingOutputs Remove="@(_OtherPriFiles)" />
-		</ItemGroup>
-	</Target>
-	<Target Name="AdjustGetPackagingOutput2" BeforeTargets="AddPriPayloadFilesToCopyToOutputDirectoryItems"
-		Condition="$(UsingUnoSdk) != 'true'">
-		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
-		<ItemGroup>
-			<_OtherPriFiles1 Include="@(_ReferenceRelatedPaths)" Condition="'%(Extension)' == '.pri' and ('%(_ReferenceRelatedPaths.ReferenceSourceTarget)' == 'ProjectReference' or '%(_ReferenceRelatedPaths.NugetSourceType)'=='Package')" />
-			<_ReferenceRelatedPaths Remove="@(_OtherPriFiles1)" />
-			<_OtherPriFiles2 Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.pri' and ('%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' == 'ProjectReference' or '%(ReferenceCopyLocalPaths.NugetSourceType)'=='Package')" />
-			<ReferenceCopyLocalPaths Remove="@(_OtherPriFiles2)" />
-		</ItemGroup>
-	</Target>
-
 </Project>

--- a/src/maui-embedding.props
+++ b/src/maui-embedding.props
@@ -1,6 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <UnoVersion>5.2.22</UnoVersion>
-    <WinAppSdkVersion>1.5.240404000</WinAppSdkVersion>
-  </PropertyGroup>
-</Project>

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="15.0">
+	<Import Project="$(MSBuildThisFileDirectory)..\..\SamplePackages.props" />
 	<ItemGroup>
-		<PackageVersion Include="CommunityToolkit.Mvvm" Version="8.0.0" />
 		<PackageVersion Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
 		<PackageVersion Include="FluentAssertions" Version="6.12.0" />
 		<PackageVersion Include="FluentValidation" Version="11.4.0" />
@@ -20,23 +20,15 @@
 		<!--<PackageVersion Include="Microsoft.Toolkit.Uwp.UI" Version="7.1.2" />
 		<PackageVersion Include="Microsoft.UI.Xaml" Version="2.8.5" />-->
 		<!--<PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2365.46" />-->
-		<PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.5.240311000" />
-		<PackageVersion Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
-		<PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
 		<PackageVersion Include="Refit" Version="7.2.22" />
 		<PackageVersion Include="Refit.HttpClientFactory" Version="7.2.22" />
 		<PackageVersion Include="Swashbuckle.AspNetCore" Version="6.2.3" />
 		<PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
 		<PackageVersion Include="Uno.CommunityToolkit.WinUI.UI" Version="7.1.100" />
-		<PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.1.1" />
-		<PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />
-		<PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />
-		<PackageVersion Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(UnoVersion)"/>
 		<PackageVersion Include="Uno.UITest" Version="1.1.0-dev.70" />
 		<PackageVersion Include="Uno.UITest.Selenium" Version="1.1.0-dev.70" />
 		<PackageVersion Include="Uno.UITest.Xamarin" Version="1.1.0-dev.70" />
 		<PackageVersion Include="Uno.UITest.Helpers" Version="1.1.0-dev.70" />
-		<PackageVersion Include="Uno.WinUI" Version="$(UnoVersion)" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageVersion Include="NUnit" Version="4.1.0" />

--- a/testing/TestHarness/TestHarness/TestHarness.csproj
+++ b/testing/TestHarness/TestHarness/TestHarness.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Uno.Sdk">
+﻿<Project Sdk="Uno.Sdk.Private">
 	<Import Project="..\..\..\src\tfms-ui-winui.props" />
 
 	<PropertyGroup>
@@ -88,21 +88,5 @@
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Validation\Uno.Extensions.Validation.csproj" />
 		<ProjectReference Include="..\..\..\src\Uno.Extensions.Validation.Fluent\Uno.Extensions.Validation.Fluent.csproj" />
 		<ProjectReference Include="..\TestHarness.Core\TestHarness.Core.csproj" />
-
-		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
-		<PackageReference Include="Uno.WinUI" />
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
-		<!--<PackageReference Include="Uno.Wasm.Bootstrap" />
-		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" />
-		<PackageReference Include="Uno.Resizetizer" />-->
 	</ItemGroup>
-
-	<ItemGroup Condition="'$(IsBrowserWasm)'=='true'">
-		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(IsIOSOrCatalyst)' == 'true'">
-		<PackageReference Include="Uno.Extensions.Logging.OSLog" />
-	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
In order to keep the samples apps and testing app dependency versions separate from the Uno.Sdk version used by the Extension library, we have moved to using Uno.Sdk.Private for the SDK of the samples/testing projects.

This PR adds that to the global.json and cleans up the package versions being used across the apps in the solution