### PR TITLE
fix: Navigate once when starting app with same route as navigated

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
@@ -59,7 +59,8 @@ public static class FrameworkElementExtensions
 				var response = await initialNavigation();
 
 				if (launchRoute is null ||
-					!launchRoute.FullPath().Equals(response?.Route?.FullPath()))
+					!launchRoute.FullPath().Equals(response?.Route?.FullPath(), StringComparison.OrdinalIgnoreCase))
+
 				{
 					await start();
 				}

--- a/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-
-namespace Uno.Extensions.Navigation;
+﻿namespace Uno.Extensions.Navigation;
 
 public static class FrameworkElementExtensions
 {
@@ -35,11 +33,12 @@ public static class FrameworkElementExtensions
 		{
 			var initialNavigation = () => nav.NavigateRouteAsync(root, initialRoute ?? string.Empty);
 
+			Route? launchRoute = default;
 			var start = () => Task.CompletedTask;
 			var hostConfigOptions = sp.GetService<IOptions<HostConfiguration>>();
 			if (hostConfigOptions?.Value is { } hostConfig &&
-				hostConfig.LaunchRoute() is { } launchRoute &&
-				launchRoute.IsEmpty() == false)
+				(launchRoute = hostConfig.LaunchRoute()) is { } &&
+				!launchRoute.IsEmpty())
 			{
 				start = () => nav.NavigateRouteAsync(root, launchRoute.FullPath());
 			}
@@ -57,8 +56,13 @@ public static class FrameworkElementExtensions
 			}
 			var fullstart = async () =>
 			{
-				await initialNavigation();
-				await start();
+				var response = await initialNavigation();
+
+				if (launchRoute is null ||
+					!launchRoute.FullPath().Equals(response?.Route?.FullPath()))
+				{
+					await start();
+				}
 			};
 			var startupTask = elementRegion.Services!.Startup(fullstart);
 			return startupTask;

--- a/testing/TestHarness/TestHarness.Core/TestSections.cs
+++ b/testing/TestHarness/TestHarness.Core/TestSections.cs
@@ -13,6 +13,7 @@ public enum TestSections
 	Navigation_NavigationView,
 	Navigation_TabBar,
 	Navigation_Reactive,
+	Navigation_AddressBar,
 	Apps_Chefs,
 	Apps_Commerce,
 	Apps_Commerce_ShellControl,

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/AddressBar/Given_AddressBar.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/AddressBar/Given_AddressBar.cs
@@ -1,0 +1,16 @@
+﻿namespace TestHarness.UITest;
+
+public class Given_AddressBar : NavigationTestBase
+{
+	[Test]
+	public async Task When_AddressBar_HomePage_Wont_Navigate_Twice()
+	{
+		InitTestSection(TestSections.Navigation_AddressBar);
+
+		App.WaitElement("TbInstanceCountProperty");
+
+		var intanceCount = App.GetText("TbInstanceCountProperty");
+
+		Assert.AreEqual("1", intanceCount);
+	}
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomeModel.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomeModel.cs
@@ -1,0 +1,19 @@
+﻿namespace TestHarness.Ext.Navigation.AddressBar;
+
+public partial class AddressBarHomeModel
+{
+	public static int InstanceCount
+	{
+		get => ApplicationData.Current.LocalSettings.Values.TryGetValue(Constants.HomeInstanceCountKey, out var value)
+			? (int)value
+			: 0;
+		private set => ApplicationData.Current.LocalSettings.Values[Constants.HomeInstanceCountKey] = value;
+	}
+
+	public int InstanceCountProperty { get; private set; }
+
+	public AddressBarHomeModel()
+	{
+		InstanceCountProperty = ++InstanceCount;
+	}
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomePage.xaml
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomePage.xaml
@@ -1,0 +1,27 @@
+﻿<Page x:Class="TestHarness.Ext.Navigation.AddressBar.AddressBarHomePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.RoutesNavigation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  mc:Ignorable="d"
+	  d:DesignHeight="300"
+	  d:DesignWidth="400">
+
+	<Grid>
+		<StackPanel Grid.Row="1"
+					HorizontalAlignment="Center"
+					Spacing="16">
+			<TextBlock Text="AddressBar HomePage" />
+			<StackPanel Orientation="Horizontal">
+				<TextBlock Text="This page was created: " />
+				<TextBlock AutomationProperties.AutomationId="TbInstanceCountProperty"
+						   Text="{Binding InstanceCountProperty, Mode=TwoWay}" />
+				<TextBlock Text=" times" />
+			</StackPanel>
+
+		</StackPanel>
+
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomePage.xaml
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomePage.xaml
@@ -17,7 +17,7 @@
 			<StackPanel Orientation="Horizontal">
 				<TextBlock Text="This page was created: " />
 				<TextBlock AutomationProperties.AutomationId="TbInstanceCountProperty"
-						   Text="{Binding InstanceCountProperty, Mode=TwoWay}" />
+						   Text="{Binding InstanceCountProperty}" />
 				<TextBlock Text=" times" />
 			</StackPanel>
 

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomePage.xaml.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomePage.xaml.cs
@@ -1,0 +1,9 @@
+﻿namespace TestHarness.Ext.Navigation.AddressBar;
+
+public sealed partial class AddressBarHomePage : Page
+{
+	public AddressBarHomePage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHostInit.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHostInit.cs
@@ -1,0 +1,30 @@
+﻿namespace TestHarness.Ext.Navigation.AddressBar;
+
+public class AddressBarHostInit : BaseHostInitialization
+{
+	protected override string[] ConfigurationFiles => new string[] { "TestHarness.Ext.Navigation.AddressBar.appsettings.addressbar.json" };
+
+	public AddressBarHostInit()
+	{
+		if (ApplicationData.Current.LocalSettings.Values.TryGetValue(Constants.HomeInstanceCountKey, out var value))
+		{
+			ApplicationData.Current.LocalSettings.Values[Constants.HomeInstanceCountKey] = 0;
+		}
+	}
+	protected override void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+	{
+		views.Register(
+			new ViewMap<AddressBarHomePage, AddressBarHomeModel>(),
+			new ViewMap(ViewModel: typeof(ShellViewModel))
+		);
+
+		routes.Register(
+			new RouteMap("", View: views.FindByViewModel<ShellViewModel>(),
+				Nested:
+				[
+					new RouteMap("AddressBarHome", View: views.FindByViewModel<AddressBarHomeModel>(), IsDefault: true)
+				]
+			)
+		);
+	}
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarMainPage.xaml
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarMainPage.xaml
@@ -1,0 +1,38 @@
+﻿<testharness:BaseTestSectionPage xmlns:testharness="using:TestHarness"
+								 x:Class="TestHarness.Ext.Navigation.AddressBar.AddressBarMainPage"
+								 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+								 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+								 xmlns:local="using:TestHarness.Ext.Navigation.RoutesNavigation"
+								 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+								 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+								 mc:Ignorable="d"
+								 xmlns:uen="using:Uno.Extensions.Navigation.UI"
+								 Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<TextBlock Text="AddressBar Navigation Tests"
+				   Margin="20"
+				   FontSize="30" />
+
+		<ContentControl AutomationProperties.AutomationId="NavigationRoot"
+						x:Name="NavigationRoot"
+						HorizontalAlignment="Stretch"
+						VerticalAlignment="Stretch"
+						HorizontalContentAlignment="Stretch"
+						VerticalContentAlignment="Stretch"
+						Grid.Row="1" />
+
+		<StackPanel Grid.Row="2"
+					Orientation="Horizontal"
+					HorizontalAlignment="Center">
+			<Button AutomationProperties.AutomationId="ShowAppButton"
+					Content="AddressBar App"
+					Click="ShowAppClick" />
+		</StackPanel>
+	</Grid>
+
+</testharness:BaseTestSectionPage>

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarMainPage.xaml.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarMainPage.xaml.cs
@@ -1,0 +1,15 @@
+﻿namespace TestHarness.Ext.Navigation.AddressBar;
+
+[TestSectionRoot("AddressBar Navigation", TestSections.Navigation_AddressBar, typeof(AddressBarHostInit))]
+public sealed partial class AddressBarMainPage : BaseTestSectionPage
+{
+	public AddressBarMainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public async void ShowAppClick(object sender, RoutedEventArgs e)
+	{
+		await Navigator.NavigateRouteAsync(this, "");
+	}
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/Constants.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/Constants.cs
@@ -1,0 +1,6 @@
+﻿namespace TestHarness.Ext.Navigation.AddressBar;
+
+internal class Constants
+{
+	public const string HomeInstanceCountKey = "HomeInstanceCount";
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/ShellViewModel.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/ShellViewModel.cs
@@ -1,0 +1,11 @@
+﻿namespace TestHarness.Ext.Navigation.AddressBar;
+
+public record ShellViewModel
+{
+	public INavigator? Navigator { get; init; }
+
+	public ShellViewModel(INavigator navigator)
+	{
+		Navigator = navigator;
+	}
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/appsettings.addressbar.json
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/appsettings.addressbar.json
@@ -1,0 +1,5 @@
+﻿{
+  "HostConfiguration": {
+    "LaunchUrl": "http://localhost:5000/AddressBarHome"
+  }
+}

--- a/testing/TestHarness/TestHarness/TestHarness.csproj
+++ b/testing/TestHarness/TestHarness/TestHarness.csproj
@@ -56,6 +56,7 @@
 	  <EmbeddedResource Include="Ext\Http\Endpoints\appsettings.httpendpoints.json" />
 	  <EmbeddedResource Include="Ext\Http\Refit\appsettings.httprefit.json" />
 	  <EmbeddedResource Include="Ext\Localization\appsettings.locale.json" />
+	  <EmbeddedResource Include="Ext\Navigation\AddressBar\appsettings.addressbar.json" />
 	  <EmbeddedResource Include="Ext\Navigation\Apps\Commerce\appsettings.logging.json" />
 	</ItemGroup>
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2607

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
When specifying a route on the addressbar (e.g., https://url/Main) the first navigation is triggered in two ways. This behavior can be observed on lines 36 and 44 in the following file: [FrameworkElementExtensions.cs](https://github.com/unoplatform/uno.extensions/blob/main/src/Uno.Extensions.Navigation.UI/FrameworkElementExtensions.cs). This way the `initialNavigation` navigates to `""` which eventually navigates to "Main" because it's the default route and `start` navigates to "Main" because it was the route specified, causing a double navigation.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
We check if the route navigated to is the same to the one provided via addressbar, if so we don't navigate.
<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->