### PR TITLE
fix: Bump msal for fix winappsdk issue

### DIFF
--- a/build/ci/stage-build-packages.yml
+++ b/build/ci/stage-build-packages.yml
@@ -20,9 +20,9 @@ jobs:
       echo MSBUILDPATH: $MSBUILDPATH
     displayName: Setup VS17 Path
 
-  - template: templates/install-windows-sdk.yml
-    parameters:
-      sdkVersion: 19041
+  # - template: templates/install-windows-sdk.yml
+  #   parameters:
+  #     sdkVersion: 19041
 
   - template: templates/update-vs-components.yml
 

--- a/build/ci/stage-build-windows.yml
+++ b/build/ci/stage-build-windows.yml
@@ -25,9 +25,9 @@ jobs:
       echo MSBUILDPATH: $MSBUILDPATH
     displayName: Setup VS17 Path
 
-  - template: templates/install-windows-sdk.yml
-    parameters:
-      sdkVersion: 19041
+  # - template: templates/install-windows-sdk.yml
+  #   parameters:
+  #     sdkVersion: 19041
 
   - template: templates/update-vs-components.yml
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,9 +17,9 @@
         <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
         <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.1" />
         <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Identity.Client" Version="4.61.3" />
-        <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.3" />
-        <PackageVersion Include="Microsoft.Identity.Client.Desktop" Version="4.61.3" />
+        <PackageVersion Include="Microsoft.Identity.Client" Version="4.66.2" />
+        <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.66.2" />
+        <PackageVersion Include="Microsoft.Identity.Client.Desktop" Version="4.66.2" />
         <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.3" />
         <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.3" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />

--- a/testing/TestHarness/Directory.Packages.props
+++ b/testing/TestHarness/Directory.Packages.props
@@ -13,7 +13,7 @@
 		<PackageVersion Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="6.0.7" />
 		<PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
 		<PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-		<PackageVersion Include="Microsoft.Identity.Client" Version="4.64.1" />
+		<PackageVersion Include="Microsoft.Identity.Client" Version="4.66.2" />
 		<PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
 		<PackageVersion Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.11" />
 		<PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />


### PR DESCRIPTION
Fixes a build issue with System.Xaml missing in the XAML pass 1.