### PR TITLE
fix: Include Wasm embedded resources for net8.0

### DIFF
--- a/src/Uno.Extensions.Hosting.UI/Uno.Extensions.Hosting.WinUI.csproj
+++ b/src/Uno.Extensions.Hosting.UI/Uno.Extensions.Hosting.WinUI.csproj
@@ -25,7 +25,7 @@
 		<None Remove="WasmScripts\**" />
 	</ItemGroup>
 	
-	<ItemGroup Condition="'$(IsBrowserWasm)'=='true'">
+	<ItemGroup Condition="'$(IsBrowserWasm)'=='true' or '$(TargetFramework)' == 'net8.0' ">
 		<None Remove="WasmScripts\**" />
 		<EmbeddedResource Include="WasmScripts\**" />
 	</ItemGroup>


### PR DESCRIPTION
This is required to support non-uno.sdk projects