### PR TITLE
Docs(Storage): Improve and add Storage Documentation and Reference

### DIFF
--- a/doc/Learn/Storage/StorageOverview.md
+++ b/doc/Learn/Storage/StorageOverview.md
@@ -28,3 +28,9 @@ Uno.Extensions.Storage facilitate local data storage across multiple platforms, 
 [!include[single-project](../includes/single-project.md)]
 
 For more information about `UnoFeatures` refer to our [Using the Uno.Sdk](xref:Uno.Features.Uno.Sdk) docs.
+
+## See Also
+
+- [Uno.UI.Toolkit.StorageFileHelper](https://platform.uno/docs/articles/features/file-management.html)
+- Uno specifics for [File and Folder Pickers](https://platform.uno/docs/articles/features/windows-storage-pickers.html)
+- Storing and reading [Settings](https://platform.uno/docs/articles/features/settings.html)

--- a/doc/Reference/Storage/Storage.md
+++ b/doc/Reference/Storage/Storage.md
@@ -1,0 +1,16 @@
+---
+uid: Reference.Storage.Overview
+---
+
+# Storage Reference Overview
+
+Welcome to the Storage Reference documentation! This section provides an overview of the `IStorage` interface, which facilitates file and folder management within an application. Below, you will find a structured summary of the available methods and their functionalities.
+
+| **Method**                           | **Description**                                                             |
+|--------------------------------------|-----------------------------------------------------------------------------|
+| [CreateFolderAsync](xref:Reference.Storage.CreateFolderAsync) | Creates a folder relative to the application's data directory.              |
+| [ReadPackageFileAsync](xref:Reference.Storage.ReadPackageFileAsync) | Reads a file from the application package and returns its contents.         |
+| [OpenPackageFileAsync](xref:Reference.Storage.OpenPackageFileAsync) | Opens a file from the application package and returns a stream.            |
+| [WriteFileAsync](xref:Reference.Storage.WriteFileAsync) | Writes text content to a file relative to the application's data directory. |
+
+For detailed explanations and implementation guidance, explore the links above.

--- a/doc/Reference/Storage/StorageExtensions.md
+++ b/doc/Reference/Storage/StorageExtensions.md
@@ -1,0 +1,40 @@
+---
+uid: Reference.Storage.Extensions
+---
+
+# Storage Extensions
+
+This section provides documentation for extension methods that enhance the functionality of the `IStorage` interface.
+
+## ReadPackageFileAsync
+
+```csharp
+public static async Task<TData?> ReadPackageFileAsync<TData>(this IStorage storage, ISerializer serializer, string fileName);
+```
+
+**Description:**
+Reads the contents of a file and deserializes it into the specified type using a provided serializer.
+
+**Type Parameters:**
+
+- `TData`: The type to which the file content should be deserialized.
+
+**Parameters:**
+
+- `storage` *(IStorage)*: The storage instance used to access the file.
+- `serializer` *(ISerializer)*: The serializer responsible for converting the file content.
+- `fileName` *(string)*: The relative path of the file to read.
+
+**Returns:**
+
+- `Task<TData?>`: The deserialized instance read from the file, or `null` if the file is not found.
+
+**Example Usage:**
+
+```csharp
+var data = await storage.ReadPackageFileAsync<MyDataClass>(serializer, "config.json");
+if (data != null)
+{
+    Console.WriteLine("Successfully read and deserialized file.");
+}
+```

--- a/doc/Reference/Storage/StorageMethods.md
+++ b/doc/Reference/Storage/StorageMethods.md
@@ -1,0 +1,126 @@
+---
+uid: Reference.Storage.Methods
+---
+
+# Storage Methods
+
+This section provides detailed documentation for each method available in the `IStorage` interface. Each method is described with its purpose, parameters, return values, and usage examples.
+
+## CreateFolderAsync
+
+```csharp
+Task<string?> CreateFolderAsync(string foldername);
+```
+
+**Description:**
+Creates a folder relative to the application's data directory.
+
+**Parameters:**
+
+- `foldername` *(string)*: The name of the folder to create.
+
+**Returns:**
+
+- `Task<string?>`: The folder path if successfully created; otherwise, `null`.
+
+**Example Usage:**
+
+```csharp
+string? folderPath = await storage.CreateFolderAsync("MyAppData");
+if (folderPath != null)
+{
+    Console.WriteLine($"Folder created at: {folderPath}");
+}
+```
+
+---
+
+## ReadPackageFileAsync
+
+```csharp
+Task<string?> ReadPackageFileAsync(string filename);
+```
+
+**Description:**
+Reads a file from the application package and returns its contents as a string.
+
+**Parameters:**
+
+- `filename` *(string)*: The relative path to the file to read.
+
+**Returns:**
+
+- `Task<string?>`: The text contents of the file if it can be read; otherwise, `null`.
+
+**Example Usage:**
+
+```csharp
+string? content = await storage.ReadPackageFileAsync("config.json");
+if (content != null)
+{
+    Console.WriteLine($"File content: {content}");
+}
+```
+
+---
+
+## OpenPackageFileAsync
+
+```csharp
+Task<Stream?> OpenPackageFileAsync(string filename);
+```
+
+**Description:**
+Opens a file for reading from the application package and returns a stream.
+
+**Parameters:**
+
+- `filename` *(string)*: The relative path to the file to read.
+
+**Returns:**
+
+- `Task<Stream?>`: A stream for the file if it can be opened; otherwise, `null`.
+
+**Example Usage:**
+
+```csharp
+using Stream? fileStream = await storage.OpenPackageFileAsync("data.txt");
+if (fileStream != null)
+{
+    using StreamReader reader = new StreamReader(fileStream);
+    string content = await reader.ReadToEndAsync();
+    Console.WriteLine($"File content: {content}");
+}
+```
+
+---
+
+## WriteFileAsync
+
+```csharp
+Task WriteFileAsync(string filename, string text, bool overwrite);
+```
+
+**Description:**
+Writes the specified text to a file in the application's data directory.
+
+**Parameters:**
+
+- `filename` *(string)*: The relative path to the file to write.
+- `text` *(string)*: The text content to write.
+- `overwrite` *(bool)*: Determines whether an existing file should be overwritten.
+
+**Returns:**
+
+- `Task`: An awaitable task that completes when the operation finishes.
+
+**Example Usage:**
+
+```csharp
+await storage.WriteFileAsync("log.txt", "Application started", true);
+Console.WriteLine("Log file updated.");
+```
+
+---
+
+[!include[getting-help](includes/getting-help.md)]

--- a/doc/toc.yml
+++ b/doc/toc.yml
@@ -87,3 +87,12 @@
           href: xref:Reference.Navigation.Navigator
         - name: Implement IRequestHandler
           href: xref:Reference.Navigation.RequestHandler
+    - name: Storage
+      href: xref:Reference.Storage.Storage
+      items:
+        - name: Overview
+          href: xref:Reference.Storage.Storage
+        - name: Methods
+          href: xref:Reference.Storage.Methods
+        - name: Storage Extensions
+          href: xref:Reference.Storage.Extensions

--- a/doc/toc.yml
+++ b/doc/toc.yml
@@ -77,6 +77,8 @@
     - name: Navigation
       href: xref:Reference.Navigation.Overview
       items:
+        - name: Overview
+          href: xref:Reference.Navigation.Overview
         - name: Design
           href: xref:Reference.Navigation.Design
         - name: Navigation Region


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2630 

**Please do NOT auto close this PR while:**
- tasks of the list are still open, which are telling about content to be added
- any of them has TODO marks to ensure checkup of Links are outstanding

## PR Type

What kind of change does this PR introduce?

- Documentation content added
- Bugfix

<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes

- Project automation
- Other... Please describe:

-->

## What is the current behavior?

1. We are missing almost whole Uno.Extensions.Storage Documentation currently as you can [check here](https://platform.uno/docs/articles/external/uno.extensions/doc/Learn/Storage/StorageOverview.html), so its unclear how the code acts without researching repository src and how it should be implemented just taking the documentation into consideration
2. Bugfix: The Navigation Reference Overview Page has been not shown in the Side navigation and was only reachable throught clicking directly on the parent NavigationItem

## What is the new behavior?

> ### Sidenote
> Tryed to use the notes as suggestion and also as way to request specifyed check-ups, but keep the task list clean

Planned and done Updates of this Documentation as Task List:

- [ ] 1. Add Storage related Links to the Overview Page
    - [x] 1.1. Add links to already existing documentation pages
        - [x] 1.1.1. Research Uno.UI.Tookit: Added `StorageFileHelper` as Link
        - [x] 1.1.2. Research Reference Non-UI: Added links to `File and Folder Pickers` and `Settings`
    - [ ] 1.2. Add Links to the new added Storage Reference
        - [x] 1.2.1. Add Link to the Overview as good starting point for a lookup => TODO: Checks outstanding
        - [x] 1.2.2. Add Link to nested Storage Pages already included in the commits so far => TODO: Checks outstanding
        - [ ] 1.2.3. Add other public Storage topics in the code base 
            - [ ] 1.2.3.1. [KeyValueStorageExtensions](https://github.com/unoplatform/uno.extensions/blob/main/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageExtensions.cs)
            - [ ] 1.2.3.2. [IKeyValueStorage](https://github.com/unoplatform/uno.extensions/blob/main/src/Uno.Extensions.Storage/KeyValueStorage/IKeyValueStorage.cs)
            - [ ] 1.2.3.3. [KeyValueStorageSettings](https://github.com/unoplatform/uno.extensions/blob/main/src/Uno.Extensions.Storage/KeyValueStorage/KeyValueStorageSettings.cs)
- [ ] 2. Add Reference Pages 
    - [ ] 2.1. Add Reference Content Pages
        - [x] 2.1.1 Try to use DocFx common functionallity of using the regular xml documentation of the actual codebase !Failed! 
        - [x] 2.1.2 Fallback: Add them manually similar to Navigation Reference because there is no Reference documentation template available
        - [ ] 2.1.3 Check the markdown to be correctly shown with local serve !Failed! Read Note information for this
    - [ ] 2.2. Add Reference Overview Page for Storage
        - [ ] 2.2.1.  Added Overview and included a table which lists all nested pages
        - [ ] 2.2.2. Check the links in the table to actually work
- [ ] 3. Add Sample(s) WITH Tutorial / How-To

> [!NOTE]
Tryed along [this](https://platform.uno/docs/articles/uno-development/docfx.html?tabs=tabid-1#run-docfx-locally) failing and [the Readme in extensions repo](https://github.com/unoplatform/uno.extensions/blob/main/doc/README.md) but at running the Run of the powershell cmd it seems to not know my branch... hoping this will run and be checkable after adding this PR, but it would be better if it would be able to check the docs before

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported) => Failed, unable to serve locally, is this required for docs?
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Docs have been added/updated which fit documentation template !Missing template for Reference!
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes => Its documentation... so no? just 'big' improvements planned 😄
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes) => would say not needed for docs isnt it? Should I add something for this in Release Notes?
- [x] Associated with an issue (GitHub or internal) #2630 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

> [!WARNING]
We don't have any DocFx.json at the Repository Root or the src folder root which would enable using codebases generated xml, onlyone is at the docs root. So by Generating Reference manually is preset to be not up to date if anything is changed and also incomplete

> [!TIP]
Evaluate this capability to be added refering to https://github.com/unoplatform/uno/blob/master/doc/api/index.md also to the extensions repository?

## Help Welcome!

If any of you out here, maybe also documentation expirienced ones, but that's not a must-have, you want to join this PR?

These tasks, beside the above listed ones, you could actually tackle:

- **Feedback and improvement suggestions** to the created docs Content in general, but also on the Reference markdown styles
- Include/Use the actual src xml documentation output with docfx @nickrandolph Reading the [Commit Message](https://github.com/unoplatform/uno.extensions/commit/978680332c4de2124719cde2b89e9765b5296c0f) on the storage repo files it seems like you did the xml documentation, maybe you could check if you could help out including those for the reference documentation?
- One or more Tutorials would be great to have! @kazo0 send a simple sample app for this topic in [this Discussion](https://github.com/unoplatform/uno/discussions/19088#discussioncomment-11574601) which could be used as starting point and by adding e.g. JsonSerializer with a Record similar to the [Peoples App in Mvux](https://platform.uno/docs/articles/external/uno.extensions/doc/Learn/Mvux/Tutorials/HowTo-ListFeed.html) but with the usage of Configuration and Options setup could be better. Possible that JsonSerializer is not capable of Immutable types, so a setup similar to the wizard created AppConfig Record should maybe prefered for this.
