### PR TITLE
fix: ensure writableoptions uses source gen serialization

### DIFF
--- a/src/Uno.Extensions.Configuration/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/HostBuilderExtensions.cs
@@ -39,7 +39,8 @@ public static class HostBuilderExtensions
 			hostBuilder = hostBuilder.ConfigureAppConfiguration(configureAppConfiguration);
 		}
 
-		hostBuilder = hostBuilder.ConfigureServices((ctx, s) =>
+		hostBuilder = hostBuilder.UseSerialization()
+			.ConfigureServices((ctx, s) =>
 				{
 					// We're doing the IsRegistered check here so that the
 					// other configure delegates still run if required

--- a/src/Uno.Extensions.Configuration/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Configuration;
+﻿using Uno.Extensions.Serialization;
+
+namespace Uno.Extensions.Configuration;
 
 /// <summary>
 /// Extension methods for <see cref="IServiceCollection"/>.
@@ -38,7 +40,8 @@ public static class ServiceCollectionExtensions
 				var logger = provider.GetRequiredService<ILogger<IWritableOptions<T>>>();
 				var root = provider.GetRequiredService<Reloader>();
 				var options = provider.GetRequiredService<IOptionsMonitor<T>>();
-				return new WritableOptions<T>(logger, root, options, section.Key, file);
+				var serializer = provider.GetRequiredService<ISerializer<T>>();
+				return new WritableOptions<T>(logger, root, options, serializer, section.Key, file);
 			});
 	}
 }


### PR DESCRIPTION
closes #2719

Cover cases for serialization in writableoptions to ensure usage of source gen