### PR TITLE
fix: Adjust `Window.Current` usages

### DIFF
--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -147,4 +147,4 @@ MainWindow.Activate();
 ```
 
 > [!IMPORTANT]
-> Be sure to remove any other code that sets `MainWindow` or `Window.Current` to prevent conflicts in your application.
+> Be sure to remove any other code that sets `MainWindow` to prevent conflicts in your application.

--- a/doc/Learn/Markup/HowTo-CustomMarkupProject-Theme.md
+++ b/doc/Learn/Markup/HowTo-CustomMarkupProject-Theme.md
@@ -257,7 +257,7 @@ public class App : Application
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
-#if NET6_0_OR_GREATER && WINDOWS && !HAS_UNO
+#if (NET6_0_OR_GREATER && WINDOWS) || HAS_UNO_WINUI
         MainWindow = new Window();
 #else
         MainWindow = Microsoft.UI.Xaml.Window.Current;

--- a/src/Uno.Extensions.Hosting.UI/ApplicationBuilder.cs
+++ b/src/Uno.Extensions.Hosting.UI/ApplicationBuilder.cs
@@ -7,12 +7,8 @@ internal record ApplicationBuilder(Application App, LaunchActivatedEventArgs Arg
 	public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
 
 	public Window Window { get; } =
-#if NET6_0_OR_GREATER && WINDOWS && !HAS_UNO
+#if (NET6_0_OR_GREATER && WINDOWS) || HAS_UNO_WINUI
 		new Window();
-#elif HAS_UNO_WINUI
-		// Window.Current can be null with Uno.WinUI 5.2+
-		// When updating Hosting to Uno.WinUI 5.2+ we need to remove the compiler directive
-		Window.Current ?? new Window();
 #else
 		Window.Current!;
 #endif

--- a/testing/TestHarness/TestHarness/App.xaml.cs
+++ b/testing/TestHarness/TestHarness/App.xaml.cs
@@ -23,8 +23,8 @@ public partial class App : Application
 #endif
 
 
-#if NET6_0_OR_GREATER && WINDOWS10_0_19041_0_OR_GREATER
-				_window = new Window();
+#if (NET6_0_OR_GREATER && WINDOWS10_0_19041_0_OR_GREATER) || HAS_UNO_WINUI
+		_window = new Window();
 #else
 		_window = Window.Current;
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): part of https://github.com/unoplatform/uno-private/issues/922

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`Window.Current` is used

## What is the new behavior?

`Window.Current` is avoided on Uno.WinUI


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
