### PR TITLE
feat(storage): Added Overload for ReadPackageFileAsync

### DIFF
--- a/doc/Learn/Storage/storage-read-package-files.md
+++ b/doc/Learn/Storage/storage-read-package-files.md
@@ -2,9 +2,9 @@
 uid: Uno.Extensions.Storage.HandlingPackageFiles
 ---
 
-# Usage Examples for Storage
+#  Handling Package Files with Storage
 
-## Create, Read and Write Operations on Package Files
+## Usage Examples for Create, Read and Write Operations on Package Files
 
 The `IStorage` interface provides methods to interact with files in your application's package. Below are some examples to help you understand how to use these methods effectively in your application. All of them have to be nested in a class or record of course.
 

--- a/doc/Learn/Storage/storage-read-package-files.md
+++ b/doc/Learn/Storage/storage-read-package-files.md
@@ -1,0 +1,202 @@
+---
+uid: Uno.Extensions.Storage.HandlingPackageFiles
+---
+
+# Usage Examples for Storage
+
+## Create, Read and Write Operations on Package Files
+
+The `IStorage` interface provides methods to interact with files in your application's package. Below are some examples to help you understand how to use these methods effectively in your application. All of them have to be nested in a class or record of course.
+
+### Example 1: Creating a Folder in the Package
+
+If you need to create a folder in your application's package, you can use the `CreateFolderAsync` method. This is helpful for organizing files into directories.
+
+```csharp
+public async Task CreateFolderExample(IStorage storage)
+{
+    var folderName = "NewFolder";
+
+    var folderPath = await storage.CreateFolderAsync(folderName);
+
+    if (folderPath is not null)
+    {
+        Console.WriteLine($"Successfully created folder at '{folderPath}'.");
+    }
+    else
+    {
+        Console.WriteLine($"Failed to create folder '{folderName}'.");
+    }
+}
+```
+
+---
+
+### Example 2: Reading whole File Content
+
+You can read the contents of a file in your application's package as a string using the `ReadPackageFileAsync` method. This is useful for scenarios like loading configuration files or templates.
+
+```csharp
+public async Task ReadFileExample()
+{
+    var fileName = "example.txt";
+    var fileContent = await storage.ReadPackageFileAsync(fileName);
+
+    if (fileContent is not null)
+    {
+        Console.WriteLine($"File Content: {fileContent}");
+    }
+    else
+    {
+        Console.WriteLine($"File '{fileName}' not found in the package.");
+    }
+}
+```
+
+### Example 3: Reading Specific Lines from a File
+
+If you need to read specific lines from a file, you can use the overload of `ReadPackageFileAsync` that accepts line ranges. This is particularly helpful for processing large files where only certain sections are needed.
+
+```csharp
+public async Task ReadSpecificLinesExample(IStorage storage)
+{
+    var fileName = "example.txt";
+    var lineRanges = new List<(int Start, int End)>
+    {
+        (0, 5), // Read lines 0 to 5
+        (10, 15) // Read lines 10 to 15
+    };
+
+    var selectedLines = await storage.ReadPackageFileAsync(fileName, lineRanges);
+
+    if (selectedLines is not null)
+    {
+        foreach (var line in selectedLines)
+        {
+            Console.WriteLine(line);
+        }
+    }
+    else
+    {
+        Console.WriteLine($"File '{fileName}' not found or empty.");
+    }
+}
+```
+
+---
+
+### Example 4: Reading a File and getting its deserialized Content
+
+You can deserialize the contents of a file into a specific type using the `StorageExtensions.ReadPackageFileAsync<TData>` method. This is ideal for scenarios like loading JSON configuration or data files.
+
+```csharp
+public async Task ReadAndDeserializeFile(ISerializer serializer)
+{
+    var fileName = "data.json";
+
+    var data = await storage.ReadPackageFileAsync<Person>(serializer, fileName);
+
+    if (data is not null)
+    {
+        Console.WriteLine($"Deserialized Data: {data}");
+    }
+    else
+    {
+        Console.WriteLine($"File '{fileName}' not found or could not be deserialized.");
+    }
+}
+
+```
+
+> [!TIP]
+> For example, this could be easily be done using [**`Uno.Extensions.Serialization`**](../Serialization/SerializationOverview.md)
+>
+> ```csharp
+> public record Person(string FirstName, string LastName);
+>
+> [JsonSerializable(typeof(Person))]
+> public partial class PersonContext : JsonSerializerContext
+> ```
+
+---
+
+### Example 5: Opening a File as a Stream
+
+If you need to open a file from your application's package as a stream, you can use the `OpenPackageFileAsync` method. This is useful for scenarios like reading binary data or processing files incrementally.
+
+```csharp
+public async Task OpenFileAsStreamExample()
+{
+    var fileName = "example.bin";
+
+    using var stream = await storage.OpenPackageFileAsync(fileName);
+
+    if (stream is not null)
+    {
+        Console.WriteLine($"Successfully opened file '{fileName}' as a stream.");
+        // Process the stream as needed
+    }
+    else
+    {
+        Console.WriteLine($"File '{fileName}' not found in the package.");
+    }
+}
+```
+
+#### Important Note on Stream Handling
+
+When working with streams, it is essential to ensure they are properly closed after use to prevent resource leaks and potential issues with file or network operations. In C#, this can be achieved by using a `using` statement, which ensures that the stream is disposed of correctly, even if an exception occurs during processing.
+
+For example:
+
+```csharp
+public async Task OpenFileAsStreamExample()
+{
+    var fileName = "example.bin";
+
+    // Ensure the stream is properly disposed of after use
+    using var stream = await storage.OpenPackageFileAsync(fileName);
+
+    if (stream is not null)
+    {
+        Console.WriteLine($"Successfully opened file '{fileName}' as a stream.");
+        // Process the stream as needed
+        
+    }
+    else
+    {
+        Console.WriteLine($"File '{fileName}' not found in the package.");
+    }
+}
+```
+
+By using the `using` statement, you can guarantee that the stream is closed automatically when it goes out of scope, simplifying resource management and improving code reliability.
+
+---
+
+### Example 6: Writing to a File in the Package
+
+To write content to a file in your application's package, use the `WriteFileAsync` method. This method allows you to overwrite an existing file or create a new one.
+
+```csharp
+public async Task WriteFileExample()
+{
+    var fileName = "output.txt";
+    var content = "Hello, Uno Platform!";
+    var overwrite = true;
+
+    try
+    {
+        await storage.WriteFileAsync(fileName, content, overwrite);
+        Console.WriteLine($"Successfully wrote to file '{fileName}'.");
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Failed to write to file '{fileName}': {ex.Message}");
+    }
+}
+```
+
+---
+
+These examples demonstrate how to use the `IStorage` interface and its extensions to read files from your application's package, referring to the [Reference](xref:Reference.Storage).

--- a/doc/Learn/Storage/toc.yml
+++ b/doc/Learn/Storage/toc.yml
@@ -2,3 +2,5 @@
   href: xref:Uno.Extensions.Storage.Overview
 - name: "How-To: Add Required Entitlements"
   href: xref:Uno.Extensions.Storage.HowToRequiredEntitlements
+- name: Handling Package Files with Storage
+  href: xref:Uno.Extensions.Storage.HandlingPackageFiles

--- a/doc/Reference/Storage/storage-reference.md
+++ b/doc/Reference/Storage/storage-reference.md
@@ -1,0 +1,102 @@
+---  
+uid: Reference.Storage  
+---  
+
+# Storage Reference  
+
+This document introduces the storage-related functions provided by the `IStorage` interface. These functions allow you to interact with file storage in your application, including creating folders, reading files, and writing files.  
+
+> [!NOTE]
+> For Usage examples, refer to the [Storage](xref:Uno.Extensions.Storage.HandlingPackageFiles) documentation in Overview.
+
+### 1. CreateFolderAsync  
+
+**Description:**  
+Creates a folder relative to the application data path.  
+
+**Signature:**  
+**Parameters:**  
+- `foldername` (string): The name of the folder to create.  
+
+**Returns:**  
+- The folder path if successfully created, or `null` if the operation fails.  
+
+---  
+
+### ReadPackageFileAsync 
+
+For this function, there are multiple overloads available. The following sections describe each overload in detail.
+
+#### `Task<string?> ReadPackageFileAsync(string filename)`
+
+**Description:**  
+Reads the contents of a file from the application package.  
+
+**Signature:**  
+**Parameters:**  
+- `filename` (string): The relative path to the file to read.  
+
+**Returns:**  
+- The text contents of the file if it can be read, or `null` if the file cannot be read.
+
+---
+
+#### `Task<TData?> ReadPackageFileAsync(ISerializer serializer,string filename)`
+
+**Description:**  
+Reads the contents of a file from the application package and deserializes it to the specified type.  
+
+**Signature:**  
+**Parameters:** 
+- `serializer` (ISerializer): The serializer to use for deserialization.  
+- `fileName` (string): The relative path of the file to read from.  
+
+**Returns:**
+- The deserialized instance of the specified type, or `null` if the file isn't found.  
+
+---  
+
+#### `Task<ImmutableList<string>?> ReadPackageFileAsync(string filename, List<(int Start,int End)> lineRanges)`
+
+**Description:**  
+Reads specific line ranges from a file in the application package.  
+
+**Signature:**  
+**Parameters:**  
+- `filename` (string): The relative path to the file to read.  
+- `lineRanges` (List<(int Start, int End)>): A list of tuples specifying the start and end line numbers to select and return.  
+
+**Returns:**  
+- An `ImmutableList<string>` containing the selected lines, or `null` if the file cannot be read.  
+
+---  
+
+### 5. OpenPackageFileAsync  
+
+**Description:**  
+Opens a file for reading from the application package.  
+
+**Signature:**  
+**Parameters:**  
+- `filename` (string): The relative path to the file to read.  
+
+**Returns:**  
+- A `Stream` for the file if it can be opened, or `null` if the file cannot be opened.  
+
+---  
+
+### 6. WriteFileAsync  
+
+**Description:**  
+Writes text to a file relative to the application data path.  
+
+**Signature:**  
+**Parameters:**  
+- `filename` (string): The relative path to the file to write.  
+- `text` (string): The text to write to the file.  
+- `overwrite` (bool): Whether to overwrite the file if it already exists.  
+
+**Returns:**  
+- An awaitable `Task`.  
+
+---  

--- a/doc/toc.yml
+++ b/doc/toc.yml
@@ -40,17 +40,17 @@
     - name: Validation
       href: Learn/Validation/toc.yml
       topicHref: xref:Uno.Extensions.Validation.Overview
-- name: C# Markup
-  href: Learn/Markup/toc.yml
-  topicHref: xref:Uno.Extensions.Markup.Overview
-- name: MVUX
-  href: Learn/Mvux/toc.yml
-  topicHref: xref:Uno.Extensions.Mvux.Overview
-- name: .NET MAUI Embedding
-  href: Learn/Maui/toc.yml
-  topicHref: xref:Uno.Extensions.Maui.Overview
-- name: Theme Service
-  href: xref:Uno.Extensions.ThemeService.Overview
+    - name: MVUX
+      href: Learn/Mvux/toc.yml
+      topicHref: xref:Uno.Extensions.Mvux.Overview
+    - name: .NET MAUI Embedding
+      href: Learn/Maui/toc.yml
+      topicHref: xref:Uno.Extensions.Maui.Overview
+    - name: Theme Service
+      href: xref:Uno.Extensions.ThemeService.Overview
+    - name: C# Markup
+      href: Learn/Markup/toc.yml
+      topicHref: xref:Uno.Extensions.Markup.Overview
 - name: Reference
   items:
     - name: MVUX
@@ -87,3 +87,5 @@
           href: xref:Reference.Navigation.Navigator
         - name: Implement IRequestHandler
           href: xref:Reference.Navigation.RequestHandler
+    - name: Storage
+      href: xref:Reference.Storage

--- a/src/Uno.Extensions.Storage.UI/FileStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/FileStorage.cs
@@ -80,12 +80,7 @@ internal record FileStorage(ILogger<FileStorage> Logger, IDataFolderProvider Dat
 
 	}
 
-    /// <summary>
-    /// Reads specific line ranges from a file in the application package.
-    /// </summary>
-    /// <param name="filename">The relative path to the file to read.</param>
-    /// <param name="lineRanges">A list of tuples specifying the start and end line numbers to select and return.</param>
-    /// <returns>An immutable list of strings containing the selected lines, or null if the file cannot be read.</returns>
+	/// <inheritdoc/>
 	public async Task<IImmutableList<string>?> ReadPackageFileAsync(string filename,List<(int Start, int End)> lineRanges)
 	{
 		try
@@ -163,7 +158,7 @@ internal record FileStorage(ILogger<FileStorage> Logger, IDataFolderProvider Dat
 
 	}
 
-	private IImmutableList<string> GetSelectedLines(string[] fileContent, List<(int Start, int End)> lineRanges)
+	private ImmutableList<string> GetSelectedLines(string[] fileContent, List<(int Start, int End)> lineRanges)
 	{
 		if (Logger.IsEnabled(LogLevel.Trace))
 		{

--- a/src/Uno.Extensions.Storage.UI/FileStorage.cs
+++ b/src/Uno.Extensions.Storage.UI/FileStorage.cs
@@ -1,4 +1,7 @@
-﻿namespace Uno.Extensions.Storage;
+﻿using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+namespace Uno.Extensions.Storage;
 
 internal record FileStorage(ILogger<FileStorage> Logger, IDataFolderProvider DataFolderProvider) : IStorage
 {
@@ -75,6 +78,118 @@ internal record FileStorage(ILogger<FileStorage> Logger, IDataFolderProvider Dat
 			return default;
 		}
 
+	}
+
+    /// <summary>
+    /// Reads specific line ranges from a file in the application package.
+    /// </summary>
+    /// <param name="filename">The relative path to the file to read.</param>
+    /// <param name="lineRanges">A list of tuples specifying the start and end line numbers to select and return.</param>
+    /// <returns>An immutable list of strings containing the selected lines, or null if the file cannot be read.</returns>
+	public async Task<IImmutableList<string>?> ReadPackageFileAsync(string filename,List<(int Start, int End)> lineRanges)
+	{
+		try
+		{
+			if (!await FileExistsInPackage(filename))
+			{
+				if (Logger.IsEnabled(LogLevel.Information))
+				{
+					Logger.LogInformationMessage($"File '{filename}' does not exist in package");
+				}
+				return default;
+			}
+
+#if __WINDOWS__
+			if (!PlatformHelper.IsAppPackaged)
+			{
+				var file = System.IO.Path.Combine(
+								 System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly()?.Location ?? string.Empty) ?? string.Empty,
+								 filename);
+
+				 string[] fileContent = File.ReadAllLines(file);
+				 if (fileContent.Length == 0)
+		         {
+					 if (Logger.IsEnabled(LogLevel.Warning))
+					 {
+						 Logger.LogWarningMessage($"File '{filename}' is empty");
+					 }
+					 return default;
+				 }
+				 return GetSelectedLines(fileContent, lineRanges);
+			}
+#endif
+
+			var fileUri = new Uri($"ms-appx:///{filename}");
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTraceMessage($"Reading file '{fileUri}'");
+			}
+			var storageFile = await StorageFile.GetFileFromApplicationUriAsync(fileUri);
+			if (File.Exists(storageFile.Path))
+			{
+				if (Logger.IsEnabled(LogLevel.Trace))
+				{
+					Logger.LogTraceMessage($"Reading file with path '{storageFile.Path}' that does exist");
+				}
+				
+				string[] fileContent = File.ReadAllLines(storageFile.Path);
+
+				if (fileContent.Length == 0)
+				{
+					if (Logger.IsEnabled(LogLevel.Warning))
+					{
+						Logger.LogWarningMessage($"File '{filename}' is empty");
+					}
+					return default;
+				}
+
+				return GetSelectedLines(fileContent, lineRanges);
+			}
+
+			if (Logger.IsEnabled(LogLevel.Warning))
+			{
+				Logger.LogWarningMessage($"File doesn't exist with path '{storageFile.Path}'");
+			}
+			return default;
+		}
+		catch (Exception ex)
+		{
+			if (Logger.IsEnabled(LogLevel.Information))
+			{
+				Logger.LogInformationMessage($"Unable to read file '{filename}' due to exception {ex.Message}");
+			}
+			return default;
+		}
+
+	}
+
+	private IImmutableList<string> GetSelectedLines(string[] fileContent, List<(int Start, int End)> lineRanges)
+	{
+		if (Logger.IsEnabled(LogLevel.Trace))
+		{
+			Logger.LogTraceMessage($"Selecting lines '{lineRanges}'");
+		}
+
+		var selectedLines = new List<string>();
+		foreach (var (Start, End) in lineRanges)
+		{
+			var start = Math.Clamp(Start, 0, fileContent.Length);
+			var end = Math.Clamp(End, start, fileContent.Length);
+			selectedLines.AddRange(fileContent[start..end]);
+		}
+		if (Logger.IsEnabled(LogLevel.Trace))
+		{
+			if(selectedLines.Count == 0)
+			{
+				Logger.LogTraceMessage($"No lines matched {lineRanges}");
+			}
+			else
+			{
+				Logger.LogTraceMessage($"Selected lines (Count: {selectedLines.Count}) successfull");
+			}
+			
+		}
+		return selectedLines.ToImmutableList();
 	}
 
 	public async Task<Stream?> OpenPackageFileAsync(string filename)

--- a/src/Uno.Extensions.Storage/IStorage.cs
+++ b/src/Uno.Extensions.Storage/IStorage.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Storage;
+﻿using System.Collections.Immutable;
+
+namespace Uno.Extensions.Storage;
 
 /// <summary>
 /// Wrapper for accessing file storage for application
@@ -18,6 +20,14 @@ public interface IStorage
 	/// <param name="filename">The relative path to the file to read</param>
 	/// <returns>The text contents of the file if the file can be read</returns>
 	Task<string?> ReadPackageFileAsync(string filename);
+
+	/// <summary>
+	/// Reads specific line ranges from a file in the application package.
+	/// </summary>
+	/// <param name="filename">The relative path to the file to read.</param>
+	/// <param name="lineRanges">A list of tuples specifying the start and end line numbers to select and return.</param>
+	/// <returns>An <see cref="ImmutableList{T}"/> of <see langword="string"/> containing the selected lines from <paramref name="lineRanges"/>, or <see langword="null"/> if the file cannot be read.</returns>
+	Task<ImmutableList<string>?> ReadPackageFileAsync(string filename, List<(int Start, int End)> lineRanges);
 
 	/// <summary>
 	/// Opens a file for reading from the application package


### PR DESCRIPTION

GitHub Issue (If applicable): closes #2710 #2630 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Project automation
- Other... Please describe:

-->
- Feature
- Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
only Json or Xml formats are having existing ISerializers, so when it comes to native file formats like txt or similar, the string from the existing function has get looped or a stream return would have to get considered.
Stream would then mean to pay attention to closing this stream again afterwards.

Storage Documentation almoast completly missing

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- Overload allowes providing specific lines for the return, not only all or nothing.
- not requiring Stream usage
- Added reference and Samples in their topics

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
not able to run tests because of runtimetests.csproj having 255.255.255.255 value and only uno.ui tests are documented. the linked readme file above does not even contain the header "supported" maybe to be fixed?
![image](https://github.com/user-attachments/assets/f82a4b78-cafe-425a-a9fe-dae4abc7ee2a)
![image](https://github.com/user-attachments/assets/c4a5cd87-0165-43f0-bdbe-38a23ee955f1)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable) => not possible because of above problem
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results. => not possible because of above problem
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
   Feature Template is not applyable, since its no control feature, but yes, I added Usage Samples for all IStorage Functions available
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes) 
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

please tell how to edit ReleaseNotes suitable, did not found a guide in the docs to this

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
