### PR TITLE
Version bump after 5.3 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "5.3-dev.{height}",
-  "versionHeightOffset": 86,
+  "version": "5.4-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
closes #2719

Cover cases for serialization in writableoptions to ensure usage of source gen
This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/5.3, based on #2727