### PR TITLE
Include PropertyName in MemberNames for ValidationResult in FluentVal…

### DIFF
--- a/src/Uno.Extensions.Validation.Fluent/FluentValidator.cs
+++ b/src/Uno.Extensions.Validation.Fluent/FluentValidator.cs
@@ -27,7 +27,7 @@ internal class FluentValidator<T> : IValidator<T>
 		if (instance is T tInstance)
 		{
 			var validationResult = (await _validator.ValidateAsync(tInstance, cancellationToken));
-			result = validationResult?.Errors.Select(x => new ValidationResult(x.ErrorMessage))?.ToList();
+			result = validationResult?.Errors.Select(x => new ValidationResult(x.ErrorMessage, new[] { x.PropertyName }))?.ToList();
 		}
 
 		return result ?? new List<ValidationResult>();


### PR DESCRIPTION
…idator

GitHub Issue (If applicable): closes #2741 

## PR Type

- Feature

## What is the current behavior?

Only the message is passed to the validation result, discrimination based on property name is not possible when consuming it.

## What is the new behavior?

Property name is passed to the member names array of the ValidationResult

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
