### PR TITLE
fix: Deprecated vmImage

### DIFF
--- a/build/ci/stage-build-uitests-wasm.yml
+++ b/build/ci/stage-build-uitests-wasm.yml
@@ -4,7 +4,7 @@ jobs:
   container: unoplatform/wasm-build:3.0
 
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-24.04'
 
   variables:
     NUGET_PACKAGES: $(build.sourcesdirectory)/.nuget


### PR DESCRIPTION
Related doc - https://devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images/
Since UI Tests - WebAssembly has been failing recently we couldn't merge any PR's
