### PR TITLE
fix: Clear nav query params when navigating

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/FrameNavigator.cs
@@ -235,6 +235,8 @@ public class FrameNavigator : ControlNavigator<Frame>, IStackNavigator
 				if (await FrameGoBack(route.NavigationData(), previousMapping) is { } parameter)
 				{
 					request = request.WithData(parameter);
+					responseRoute = CloneWithData(responseRoute, request.Route.Data);
+					previousRoute = CloneWithData(previousRoute, request.Route.Data);
 				}
 			}
 			else
@@ -263,6 +265,16 @@ public class FrameNavigator : ControlNavigator<Frame>, IStackNavigator
 		}
 
 		return responseRoute;
+	}
+
+	private static Route? CloneWithData(Route? route, IDictionary<string, object>? data)
+	{
+		if (route is { } && data is { Count:> 0})
+		{
+			return route with { Data = data };
+		}
+
+		return route;
 	}
 
 	private void Frame_Navigating(object sender, NavigatingCancelEventArgs e)

--- a/src/Uno.Extensions.Navigation/RouteExtensions.cs
+++ b/src/Uno.Extensions.Navigation/RouteExtensions.cs
@@ -348,20 +348,25 @@ public static class RouteExtensions
 
 	public static IDictionary<string, object> Combine(this IDictionary<string, object>? data, IDictionary<string, object>? childData)
 	{
-		if (data is null)
+		var result = new Dictionary<string, object>();
+
+		if (data is not null)
 		{
-			return childData ?? new Dictionary<string, object>();
+			foreach (var x in data)
+			{
+				result[x.Key] = x.Value;
+			}
 		}
 
 		if (childData is not null)
 		{
 			foreach (var x in childData)
 			{
-				data[x.Key] = x.Value;
+				result[x.Key] = x.Value;
 			}
 		}
 
-		return data;
+		return result;
 	}
 
 	public static Route? Merge(this Route? route, IEnumerable<(string?, Route?)>? childRoutes)

--- a/testing/TestHarness/TestHarness.Core/TestSections.cs
+++ b/testing/TestHarness/TestHarness.Core/TestSections.cs
@@ -14,6 +14,8 @@ public enum TestSections
 	Navigation_TabBar,
 	Navigation_Reactive,
 	Navigation_AddressBar,
+	Navigation_AddressBar_Nested,
+	Navigation_AddressBar_Nested_Default,
 	Apps_Chefs,
 	Apps_Commerce,
 	Apps_Commerce_ShellControl,

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/AddressBar/Given_AddressBar.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/AddressBar/Given_AddressBar.cs
@@ -21,11 +21,76 @@ public class Given_AddressBar : NavigationTestBase
 		InitTestSection(TestSections.Navigation_AddressBar);
 
 		App.WaitThenTap("AddressBarSecondButton");
+		AssertAddressBarUrl("AddressBarSecondPage", "?QueryUser.Id");
 
-		App.WaitThenTap("GetUrlFromBrowser");
+		//Ensure query parameters were cleared
+		App.WaitThenTap("AddressBarSecondPageGoBack");
+		AssertAddressBarUrl("AddressBarHomePage", "?QueryUser.Id", false);
+	}
 
-		var url = App.GetText("TxtUrlFromBrowser");
+	[Test]
+	[ActivePlatforms(Platform.Browser)]
+	public void When_AddressBar_Nested_Navigated_Back_Params_Clear()
+	{
+		//Navigation starts with `Navigator.NavigateViewModelAsync<T>()`
+		InitTestSection(TestSections.Navigation_AddressBar_Nested);
+		When_AddressBar_Navigated_Back_Params_Clear();
+	}
 
-		StringAssert.Contains(url, "QueryUser.Id=8a5c5b2e-ff96-474b-9e4d-65bde598f6bc");
+	[Test]
+	[ActivePlatforms(Platform.Browser)]
+	public void When_AddressBar_Nested_Default_Navigated_Back_Params_Clear()
+	{
+		//Navigation starts with `IsDefault: true` on HostInit
+		InitTestSection(TestSections.Navigation_AddressBar_Nested_Default);
+		When_AddressBar_Navigated_Back_Params_Clear();
+	}
+
+	private void When_AddressBar_Navigated_Back_Params_Clear()
+	{
+		App.WaitElement("AddressBarRootPageNavigationView");
+
+		//Goes to HomePage
+		App.WaitThenTap("AddressBarRootPageHomeNavItem");
+
+		//Goes to SecondPage
+		App.WaitThenTap("AddressBarSecondButton");
+		AssertAddressBarUrl("AddressBarSecondPage", "?QueryUser.Id");
+
+		//Goes back to HomePage
+		App.WaitThenTap("AddressBarSecondPageGoBack");
+		AssertAddressBarUrl("AddressBarHomePage", "?QueryUser.Id", false);
+
+		//Goes to CoffeePage
+		App.WaitThenTap("AddressBarRootPageCoffeeNavItem");
+		AssertAddressBarUrl("AddressBarCoffeePage", "?QueryUser.Id", false);
+
+		//Goes to HomePage one more time
+		App.WaitThenTap("AddressBarRootPageHomeNavItem");
+		AssertAddressBarUrl("AddressBarHomePage", "?QueryUser.Id", false);
+
+		//Goes to SecondPage to ensure params are added
+		App.WaitThenTap("AddressBarSecondButton");
+		AssertAddressBarUrl("AddressBarSecondPage", "?QueryUser.Id");
+
+		//Goes back to HomePage to ensure params are cleared
+		App.WaitThenTap("AddressBarSecondPageGoBack");
+		AssertAddressBarUrl("AddressBarHomePage", "?QueryUser.Id", false);
+	}
+
+	private void AssertAddressBarUrl(string pagePrefix, string contains, bool assertContains = true)
+	{
+		App.WaitThenTap($"{pagePrefix}GetUrlFromBrowser");
+
+		var url = App.GetText($"{pagePrefix}TxtUrlFromBrowser");
+
+		if (assertContains)
+		{
+			StringAssert.Contains(url, contains);
+		}
+		else
+		{
+			Assert.IsFalse(url.Contains(contains));
+		}
 	}
 }

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/AddressBar/Given_AddressBar.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/AddressBar/Given_AddressBar.cs
@@ -34,7 +34,7 @@ public class Given_AddressBar : NavigationTestBase
 	{
 		//Navigation starts with `Navigator.NavigateViewModelAsync<T>()`
 		InitTestSection(TestSections.Navigation_AddressBar_Nested);
-		When_AddressBar_Navigated_Back_Params_Clear();
+		Navigate_And_Clear_Params();
 	}
 
 	[Test]
@@ -43,10 +43,10 @@ public class Given_AddressBar : NavigationTestBase
 	{
 		//Navigation starts with `IsDefault: true` on HostInit
 		InitTestSection(TestSections.Navigation_AddressBar_Nested_Default);
-		When_AddressBar_Navigated_Back_Params_Clear();
+		Navigate_And_Clear_Params();
 	}
 
-	private void When_AddressBar_Navigated_Back_Params_Clear()
+	private void Navigate_And_Clear_Params()
 	{
 		App.WaitElement("AddressBarRootPageNavigationView");
 

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarCoffeeModel.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarCoffeeModel.cs
@@ -1,0 +1,11 @@
+﻿using Uno.Extensions.Navigation.Navigators;
+
+namespace TestHarness.Ext.Navigation.AddressBar;
+
+public partial class AddressBarCoffeModel
+{
+	public AddressBarCoffeModel(INavigator navigator)
+	{
+
+	}
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarCoffeeModel.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarCoffeeModel.cs
@@ -2,9 +2,9 @@
 
 namespace TestHarness.Ext.Navigation.AddressBar;
 
-public partial class AddressBarCoffeModel
+public partial class AddressBarCoffeeModel
 {
-	public AddressBarCoffeModel(INavigator navigator)
+	public AddressBarCoffeeModel(INavigator navigator)
 	{
 
 	}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarCoffeePage.xaml
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarCoffeePage.xaml
@@ -1,0 +1,29 @@
+﻿<Page x:Class="TestHarness.Ext.Navigation.AddressBar.AddressBarCoffeePage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.RoutesNavigation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  mc:Ignorable="d"
+	  d:DesignHeight="300"
+	  d:DesignWidth="400">
+
+	<Grid>
+		<StackPanel Grid.Row="1"
+					VerticalAlignment="Center"
+					HorizontalAlignment="Center"
+					Spacing="16">
+
+			<TextBlock Text="Coffee is nice!" />
+
+			<TextBlock x:Name="TxtUrl"
+					   AutomationProperties.AutomationId="AddressBarCoffeePageTxtUrlFromBrowser" />
+
+			<Button AutomationProperties.AutomationId="AddressBarCoffeePageGetUrlFromBrowser"
+					Click="GetUrlFromBrowser"
+					Content="Get URL" />
+		</StackPanel>
+
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarCoffeePage.xaml.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarCoffeePage.xaml.cs
@@ -1,8 +1,8 @@
 ﻿namespace TestHarness.Ext.Navigation.AddressBar;
 
-public sealed partial class AddressBarHomePage : Page
+public sealed partial class AddressBarCoffeePage : Page
 {
-	public AddressBarHomePage()
+	public AddressBarCoffeePage()
 	{
 		this.InitializeComponent();
 	}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomeModel.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomeModel.cs
@@ -7,6 +7,8 @@ public partial class AddressBarHomeModel
 		{ "QueryUser.Id", new Guid("8a5c5b2e-ff96-474b-9e4d-65bde598f6bc") }
 	};
 
+	public AddressBarUser User => new(new Guid("8a5c5b2e-ff96-474b-9e4d-65bde598f6bc"), "João Rodrigues");
+
 	public static int InstanceCount
 	{
 		get => ApplicationData.Current.LocalSettings.Values.TryGetValue(Constants.HomeInstanceCountKey, out var value)

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomePage.xaml
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarHomePage.xaml
@@ -24,7 +24,14 @@
 				<Button Content="Go To Second"
 						AutomationProperties.AutomationId="AddressBarSecondButton"
 						uen:Navigation.Request="AddressBarSecond"
-						uen:Navigation.Data="{Binding UserId}" />
+						uen:Navigation.Data="{Binding User}" />
+
+				<TextBlock x:Name="TxtUrl"
+						   AutomationProperties.AutomationId="AddressBarHomePageTxtUrlFromBrowser" />
+
+				<Button AutomationProperties.AutomationId="AddressBarHomePageGetUrlFromBrowser"
+						Click="GetUrlFromBrowser"
+						Content="Get URL" />
 			</StackPanel>
 
 		</StackPanel>

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarJSImports.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarJSImports.cs
@@ -1,0 +1,9 @@
+﻿namespace TestHarness.Ext.Navigation.AddressBar;
+
+#if __WASM__
+internal static partial class AddressBarJSImports
+{
+	[System.Runtime.InteropServices.JavaScript.JSImport("globalThis.Uno.Extensions.Hosting.getLocation")]
+	public static partial string GetUrl();
+}
+#endif

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarMainPage.xaml.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarMainPage.xaml.cs
@@ -1,6 +1,8 @@
 ﻿namespace TestHarness.Ext.Navigation.AddressBar;
 
 [TestSectionRoot("AddressBar Navigation", TestSections.Navigation_AddressBar, typeof(AddressBarHostInit))]
+[TestSectionRoot("AddressBar Navigation (Nested)", TestSections.Navigation_AddressBar_Nested, typeof(AddressBarNestedHostInit))]
+[TestSectionRoot("AddressBar Navigation (Nested) (Default Nav)", TestSections.Navigation_AddressBar_Nested_Default, typeof(AddressBarNestedDefaultHostInit))]
 public sealed partial class AddressBarMainPage : BaseTestSectionPage
 {
 	public AddressBarMainPage()

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarNestedDefaultHostInit.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarNestedDefaultHostInit.cs
@@ -14,7 +14,7 @@ public class AddressBarNestedDefaultHostInit : BaseHostInitialization
 		views.Register(
 			new ViewMap(ViewModel: typeof(DefaultShellViewModel)),
 			new ViewMap<AddressBarRootPage, AddressBarRootModel>(),
-			new ViewMap<AddressBarCoffeePage, AddressBarCoffeModel>(),
+			new ViewMap<AddressBarCoffeePage, AddressBarCoffeeModel>(),
 			new ViewMap<AddressBarHomePage, AddressBarHomeModel>(),
 			new DataViewMap<AddressBarSecondPage, AddressBarSecondModel, AddressBarUser>(
 				ToQuery: user => new Dictionary<string, string>

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarNestedDefaultHostInit.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarNestedDefaultHostInit.cs
@@ -1,0 +1,56 @@
+﻿namespace TestHarness.Ext.Navigation.AddressBar;
+
+public class AddressBarNestedDefaultHostInit : BaseHostInitialization
+{
+	public AddressBarNestedDefaultHostInit()
+	{
+		if (ApplicationData.Current.LocalSettings.Values.TryGetValue(Constants.HomeInstanceCountKey, out var value))
+		{
+			ApplicationData.Current.LocalSettings.Values[Constants.HomeInstanceCountKey] = 0;
+		}
+	}
+	protected override void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+	{
+		views.Register(
+			new ViewMap(ViewModel: typeof(DefaultShellViewModel)),
+			new ViewMap<AddressBarRootPage, AddressBarRootModel>(),
+			new ViewMap<AddressBarCoffeePage, AddressBarCoffeModel>(),
+			new ViewMap<AddressBarHomePage, AddressBarHomeModel>(),
+			new DataViewMap<AddressBarSecondPage, AddressBarSecondModel, AddressBarUser>(
+				ToQuery: user => new Dictionary<string, string>
+				{
+					{ "QueryUser.Id", $"{user.UserId}" }
+				},
+				FromQuery: async (sp, query) =>
+				{
+					var userService = new AddressBarUserService();
+
+					if (Guid.TryParse($"{query["QueryUser.Id"]}", out var guid))
+					{
+						var user = userService.GetById(guid);
+						return user ?? new AddressBarUser(guid, "User not found");
+					}
+
+					return new AddressBarUser(guid, "User not found");
+				}
+			)
+		);
+
+		routes.Register(
+			new RouteMap("", View: views.FindByViewModel<DefaultShellViewModel>(),
+				Nested:
+				[
+					new RouteMap("AddressBarRoot", View: views.FindByViewModel<AddressBarRootModel>(), IsDefault: true,
+						Nested:
+						[
+							new RouteMap("AddressBarCoffee", View: views.FindByView<AddressBarCoffeePage>(), IsDefault: true),
+							new RouteMap("AddressBarHome", View: views.FindByViewModel<AddressBarHomeModel>()),
+							new RouteMap("AddressBarSecond", View: views.FindByViewModel<AddressBarSecondModel>())
+						]
+					),
+					
+				]
+			)
+		);
+	}
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarNestedHostInit.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarNestedHostInit.cs
@@ -1,0 +1,56 @@
+﻿namespace TestHarness.Ext.Navigation.AddressBar;
+
+public class AddressBarNestedHostInit : BaseHostInitialization
+{
+	public AddressBarNestedHostInit()
+	{
+		if (ApplicationData.Current.LocalSettings.Values.TryGetValue(Constants.HomeInstanceCountKey, out var value))
+		{
+			ApplicationData.Current.LocalSettings.Values[Constants.HomeInstanceCountKey] = 0;
+		}
+	}
+	protected override void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+	{
+		views.Register(
+			new ViewMap(ViewModel: typeof(ShellViewModel)),
+			new ViewMap<AddressBarRootPage, AddressBarRootModel>(),
+			new ViewMap<AddressBarCoffeePage, AddressBarCoffeModel>(),
+			new ViewMap<AddressBarHomePage, AddressBarHomeModel>(),
+			new DataViewMap<AddressBarSecondPage, AddressBarSecondModel, AddressBarUser>(
+				ToQuery: user => new Dictionary<string, string>
+				{
+					{ "QueryUser.Id", $"{user.UserId}" }
+				},
+				FromQuery: async (sp, query) =>
+				{
+					var userService = new AddressBarUserService();
+
+					if (Guid.TryParse($"{query["QueryUser.Id"]}", out var guid))
+					{
+						var user = userService.GetById(guid);
+						return user ?? new AddressBarUser(guid, "User not found");
+					}
+
+					return new AddressBarUser(guid, "User not found");
+				}
+			)
+		);
+
+		routes.Register(
+			new RouteMap("", View: views.FindByViewModel<ShellViewModel>(),
+				Nested:
+				[
+					new RouteMap("AddressBarRoot", View: views.FindByViewModel<AddressBarRootModel>(),
+						Nested:
+						[
+							new RouteMap("AddressBarCoffee", View: views.FindByView<AddressBarCoffeePage>(), IsDefault: true),
+							new RouteMap("AddressBarHome", View: views.FindByViewModel<AddressBarHomeModel>()),
+							new RouteMap("AddressBarSecond", View: views.FindByViewModel<AddressBarSecondModel>())
+						]
+					),
+					
+				]
+			)
+		);
+	}
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarNestedHostInit.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarNestedHostInit.cs
@@ -14,7 +14,7 @@ public class AddressBarNestedHostInit : BaseHostInitialization
 		views.Register(
 			new ViewMap(ViewModel: typeof(ShellViewModel)),
 			new ViewMap<AddressBarRootPage, AddressBarRootModel>(),
-			new ViewMap<AddressBarCoffeePage, AddressBarCoffeModel>(),
+			new ViewMap<AddressBarCoffeePage, AddressBarCoffeeModel>(),
 			new ViewMap<AddressBarHomePage, AddressBarHomeModel>(),
 			new DataViewMap<AddressBarSecondPage, AddressBarSecondModel, AddressBarUser>(
 				ToQuery: user => new Dictionary<string, string>

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarRootModel.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarRootModel.cs
@@ -1,0 +1,5 @@
+﻿namespace TestHarness.Ext.Navigation.AddressBar;
+
+public class AddressBarRootModel
+{
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarRootPage.xaml
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarRootPage.xaml
@@ -1,0 +1,78 @@
+﻿<Page x:Class="TestHarness.Ext.Navigation.AddressBar.AddressBarRootPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:TestHarness.Ext.Navigation.RoutesNavigation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  mc:Ignorable="d"
+	  d:DesignHeight="300"
+	  d:DesignWidth="400">
+
+	<Grid>
+
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="Auto" />
+		</Grid.ColumnDefinitions>
+
+		<TextBlock Text="AddressBar Navigation (Nested)"
+				   Grid.Row="0"
+				   Grid.Column="1"
+				   HorizontalAlignment="Center"
+				   VerticalAlignment="Center"
+				   FontSize="24"
+				   FontWeight="Bold"
+				   Canvas.ZIndex="10"
+				   Margin="0,0,10,0" />
+
+		<muxc:NavigationView x:Name="NavigationViewControl"
+							 AutomationProperties.AutomationId="AddressBarRootPageNavigationView"
+							 Grid.Row="1"
+							 Grid.ColumnSpan="3"
+							 uen:Region.Attached="True"
+							 IsBackButtonVisible="Collapsed"
+							 IsPaneOpen="True"
+							 IsSettingsVisible="False"
+							 IsPaneToggleButtonVisible="False">
+
+			<muxc:NavigationView.MenuItems>
+
+				<muxc:NavigationViewItem uen:Region.Name="AddressBarCoffee"
+										 AutomationProperties.AutomationId="AddressBarRootPageCoffeeNavItem"
+										 Content="Coffee Page">
+					<muxc:NavigationViewItem.Icon>
+						<SymbolIcon Symbol="Like" />
+					</muxc:NavigationViewItem.Icon>
+				</muxc:NavigationViewItem>
+
+				<muxc:NavigationViewItem uen:Region.Name="AddressBarHome"
+										 AutomationProperties.AutomationId="AddressBarRootPageHomeNavItem"
+										 Content="Home Page">
+					<muxc:NavigationViewItem.Icon>
+						<SymbolIcon Symbol="Page" />
+					</muxc:NavigationViewItem.Icon>
+				</muxc:NavigationViewItem>
+
+				<muxc:NavigationViewItem uen:Region.Name="AddressBarSecond"
+										 AutomationProperties.AutomationId="AddressBarRootPageSecondNavItem"
+										 Content="Second Page">
+					<muxc:NavigationViewItem.Icon>
+						<SymbolIcon Symbol="Remote" />
+					</muxc:NavigationViewItem.Icon>
+				</muxc:NavigationViewItem>
+
+			</muxc:NavigationView.MenuItems>
+
+			<Grid uen:Region.Attached="True"
+				  uen:Region.Navigator="Visibility" />
+		</muxc:NavigationView>
+	</Grid>
+</Page>

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarRootPage.xaml.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarRootPage.xaml.cs
@@ -1,0 +1,9 @@
+﻿namespace TestHarness.Ext.Navigation.AddressBar;
+
+public sealed partial class AddressBarRootPage : Page
+{
+	public AddressBarRootPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarSecondPage.xaml
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarSecondPage.xaml
@@ -26,11 +26,15 @@
 			</TextBlock>
 
 			<TextBlock x:Name="TxtUrl"
-					   AutomationProperties.AutomationId="TxtUrlFromBrowser" />
+					   AutomationProperties.AutomationId="AddressBarSecondPageTxtUrlFromBrowser" />
 
-			<Button AutomationProperties.AutomationId="GetUrlFromBrowser"
+			<Button AutomationProperties.AutomationId="AddressBarSecondPageGetUrlFromBrowser"
 					Click="GetUrlFromBrowser"
 					Content="Get URL" />
+
+			<Button uen:Navigation.Request="-"
+					Content="Go Back"
+					AutomationProperties.AutomationId="AddressBarSecondPageGoBack" />
 		</StackPanel>
 
 	</Grid>

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarSecondPage.xaml.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/AddressBarSecondPage.xaml.cs
@@ -10,7 +10,7 @@ public sealed partial class AddressBarSecondPage : Page
 	public async void GetUrlFromBrowser(object sender, RoutedEventArgs e)
 	{
 #if __WASM__
-		var url = ImportsJS.GetUrl();
+		var url = AddressBarJSImports.GetUrl();
 
 		TxtUrl.Text = url;
 #else
@@ -18,10 +18,3 @@ public sealed partial class AddressBarSecondPage : Page
 #endif
 	}
 }
-#if __WASM__
-internal static partial class ImportsJS
-{
-	[System.Runtime.InteropServices.JavaScript.JSImport("globalThis.Uno.Extensions.Hosting.getLocation")]
-	public static partial string GetUrl();
-}
-#endif

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/DefaultShellViewModel.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/DefaultShellViewModel.cs
@@ -1,0 +1,12 @@
+﻿
+namespace TestHarness.Ext.Navigation.AddressBar;
+
+public record DefaultShellViewModel
+{
+	public INavigator? Navigator { get; init; }
+
+	public DefaultShellViewModel(INavigator navigator)
+	{
+		Navigator = navigator;
+	}
+}

--- a/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/ShellViewModel.cs
+++ b/testing/TestHarness/TestHarness/Ext/Navigation/AddressBar/ShellViewModel.cs
@@ -1,4 +1,5 @@
-﻿namespace TestHarness.Ext.Navigation.AddressBar;
+﻿
+namespace TestHarness.Ext.Navigation.AddressBar;
 
 public record ShellViewModel
 {
@@ -7,5 +8,9 @@ public record ShellViewModel
 	public ShellViewModel(INavigator navigator)
 	{
 		Navigator = navigator;
+
+		_ = Start();
 	}
+
+	private async Task Start() => await Navigator.NavigateViewModelAsync<AddressBarRootModel>(this);
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2772

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## 🐞 Problem

The `Combine` method was modifying the original `Route.Data` dictionary directly.  
Since `Route` is a `record`, using `with` is expected to create a new instance without affecting the original.  
However, because `Combine` updated the internal dictionary by reference, it caused unexpected side effects - the original `Route` was being changed indirectly.

## ✅ Fix

The new `Combine` method creates a new dictionary and copies entries from both `data` and `childData`.  
This way, the original inputs stay untouched, and using `with` actually returns a clean, independent `Route` instance, as expected.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
