### PR TITLE
Version bump after 6.0 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.0-dev.{height}",
+  "version": "6.1-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
BREAKING CHANGE: The Uno SDK Dependency has been updated to 6.0, which includes breaking changes.
This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/6.0, based on #2788