### PR TITLE
docs(kiota): Add few but important details for CLI call arguments and CPM

### DIFF
--- a/doc/Learn/Http/HowTo-Kiota.md
+++ b/doc/Learn/Http/HowTo-Kiota.md
@@ -52,13 +52,27 @@ When working with APIs in your application, having a strongly-typed client can s
 
     ```bash
     # From a static spec file
-    kiota generate --openapi PATH_TO_YOUR_API_SPEC.json --language CSharp --class-name MyApiClient --namespace-name MyApp.Client --output ./Client
+    kiota generate --openapi PATH_TO_YOUR_API_SPEC.json --language CSharp --class-name MyApiClient --namespace-name MyApp.Clients.MyApi --output ./MyApp/Clients/MyApi
 
     # OR directly from the running server’s Swagger endpoint
-    kiota generate --openapi http://localhost:5002/swagger/v1/swagger.json --language CSharp --class-name MyApiClient --namespace-name MyApp.Client --output ./Client
+    kiota generate --openapi http://localhost:5002/swagger/v1/swagger.json --language CSharp --class-name MyApiClient --namespace-name MyApp.Clients.MyApi --output ./MyApp/Clients/MyApi
     ```
 
-    This will create a client named `MyApiClient` in the Client folder.
+    This will create a client named `MyApiClient` in the `Clients` folder.
+
+* If those has not been already included in your `Directory.Packages.props` file, the kiota CLI tool will recommend you to add following NuGet packages via dotnet:
+
+  ```xml
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Kiota.Authentification.Azure" Version="1.17.4"/>
+    <PackageVersion Include="Microsoft.Kiota.Bundle" Version="1.17.4"/>
+  </ItemGroup>
+  ```
+
+  > [!IMPORTANT]
+  > As using `dotnet add package` will result in the error `In "C:\Users\YourName\source\repos\YourAppsGitHubRepo\src\YourApp\" were unable to find a Project.` add them manually into the above mentioned file in your `Solution Items` folder.
+  > [!TIP]
+  > Using the plural for the `Clients` folder name enables you also to get a proper expandable Project structure, in case you might will like to make requests to different API like your Database, a external Client API or just more than one external API. By providing the appropriate namespace part behind the `Clients`, that also automatically separates the generated code for the different API Clients generated.
 
 ### 4. Register the Kiota Client
 


### PR DESCRIPTION
… its prompted "missing packages" the user needs to add from this to his CPM file.

- The Folder "Client" and Namespace should be named with plural as its common for areas of our apps that might get expanded in the development process
- Executing Kiota CLI tool results with already added HttpKiota Feature and UseHttp() in the host builder to tell about now listed packages needed to be added, so the user will already have the note and copy to clipboard for this now.
- Added the Project Named Folder to the CLI Path, since not including it, but with the Uno classic folder structure, this resulted on my side in, the Client folder was one directory above the projects we are seeing, so could only be seen from the folder view in VS 2022. Adjusting this like now results in the setup we can explore in Uno apps from template including kiota out of the box.

> [!IMPORTANT]
> Please check, the UseHttpKiota to be valid, as its not recognized in my right now to 6.0.110 updated uno app following the guide, to add those details! Secondary, please also update the uno extensions docs version which is pulled in to the Uno.UI repo so the updates like "Http" instead of "HttpKiota" and so on which I did see are here already applyed will be also included on the web docs.

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
found none explicitly to this, but mentioned these details here now added (and hopefully working at runtime as I am trying to get some things set up still) on discord, if that counts as issue.

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
missing parts, CLI Command was not working as expected, on the current published docs the cli command is also `--namespace` and not with the `-name` postfix like on the actual md files

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
the kiota cli command and suddenly missing packages should now get a better expirience as we are prepared and know how to fix that quickly
the dotnet add package seems to not work in uno projects?

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->
#2792 is still pending as the authentification config with more than 1 client is still a mystery black box from the docs. if the solution is using the ms docs config:subconfig naming, then please "just" add it as information. right now that would not be clear and should include namedoptions capability also for kiota

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
