### PR TITLE
chore: Add xml documentation onto Extensions.Navigation Route and Qualifiers

### DIFF
--- a/src/Uno.Extensions.Navigation/Route.cs
+++ b/src/Uno.Extensions.Navigation/Route.cs
@@ -19,6 +19,12 @@ public record Route(string Qualifier = Qualifiers.None, string? Base = null, str
 
 	public static Route NestedRoute(string path) => new Route(Qualifiers.Nested, path, null, null);
 
+	/// <summary>
+	/// Returns the current Route as <see langword="string"/> 
+	/// </summary>
+	/// <value>
+	/// The navigated Route with this pattern: <see cref="Qualifier"/> <see cref="Base"/> <see cref="Path"/> Route.Query()<br/>
+	/// or <see cref="string.Empty"/> if this would be null</value>
 	public override string ToString()
 	{
 		try

--- a/src/Uno.Extensions.Navigation/Schemes.cs
+++ b/src/Uno.Extensions.Navigation/Schemes.cs
@@ -1,14 +1,50 @@
 ﻿namespace Uno.Extensions.Navigation;
-
+/// <summary>
+/// Provides constants for various navigation qualifiers.
+/// </summary>
 public static class Qualifiers
 {
+	/// <summary>
+	/// The separator used in navigation paths.
+	/// <value>"/"</value>
+	/// </summary>
 	public const string Separator = "/";
+
+	/// <summary>
+	/// Represents the root of the navigation path.
+	/// <value>"/"</value>
+	/// </summary>
 	public const string Root = "/";
+
+	/// <summary>
+	/// Represents no navigation qualifier.
+	/// <value>""</value>
+	/// </summary>
 	public const string None = "";
+
+	/// <summary>
+	/// Represents a nested navigation path.
+	/// <value>"./"</value>
+	/// </summary>
 	public const string Nested = "./";
 	// Note: Disabling parent routing - leaving this code in case parent routing is required
 	//public const string Parent = "../";
+
+	/// <summary>
+	/// Navigates the specified route and presenting it in form of a Dialog.
+	/// <value>"!"</value>
+	/// </summary>
 	public const string Dialog = "!";
+
+	/// <summary>
+	/// Represents a navigation back action.
+	/// <value>"-"</value>
+	/// </summary>
 	public const string NavigateBack = "-";
+
+	/// <summary>
+	/// Represents a clear back stack action.
+	/// <value>"-/"</value>
+	/// </summary>
 	public const string ClearBackStack = "-/";
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The xml doc on both classes/members are completly missing. Especially on Route.ToString() is Overwritten and its not completly clear how to get which resolution of the current Route. The How to get the Current Route Name has been asked in the past and IRouteNotifier docs suggerating us the IRegion.Name.ToString of the arguments would be that desired one while this is most of the time just returnung a null string.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Route.ToString() and the Qualifier const string representations now having xml documentation comments. 
 can help get a better understandig of users what we will get as return value of this Method call

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) **As what are counting xml doc comments?**
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal) **not listed as issue as this has been "just" questions of users**

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
