### PR TITLE
fix: ShowMessageDialogAsync nullables

### DIFF
--- a/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
@@ -218,7 +218,7 @@ public static class NavigatorExtensions
 		DialogAction[]? buttons = default,
 		CancellationToken cancellation = default)
 	{
-		await navigator.ShowMessageDialogAsync<object>(sender, route, content, title, delayInput, defaultButtonIndex, cancelButtonIndex, buttons, cancellation);
+		await navigator.ShowMessageDialogAsync<object>(sender, route, content ?? "", title ?? "", delayInput, defaultButtonIndex, cancelButtonIndex, buttons, cancellation);
 	}
 
 	public static async Task<TResult?> ShowMessageDialogAsync<TResult>(

--- a/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigatorExtensions.cs
@@ -218,7 +218,7 @@ public static class NavigatorExtensions
 		DialogAction[]? buttons = default,
 		CancellationToken cancellation = default)
 	{
-		await navigator.ShowMessageDialogAsync<object>(sender, route, content ?? "", title ?? "", delayInput, defaultButtonIndex, cancelButtonIndex, buttons, cancellation);
+		await navigator.ShowMessageDialogAsync<object>(sender, route, content ?? string.Empty, title ?? string.Empty, delayInput, defaultButtonIndex, cancelButtonIndex, buttons, cancellation);
 	}
 
 	public static async Task<TResult?> ShowMessageDialogAsync<TResult>(


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/20838

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

ShowMessageDialogAsync() currently allows for `content` and `title` to be null. However, when reaching [the creation of the `MessageDialog` in uno](https://github.com/unoplatform/uno/blob/6884f4b4aeda24d1aada7ca59e3fefc3a23fbe3d/src/Uno.UWP/UI/Popups/MessageDialog.cs#L30-L45) there is a null argument exception.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

In effort to keep allowing the user to leave `content` and `title` null, we can simply resolve them as empty strings in Extensions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
