### PR TITLE
docs: Add MESCIUS to cspell dictionary

### DIFF
--- a/build/ci/cspell.json
+++ b/build/ci/cspell.json
@@ -44,6 +44,7 @@
 		"Listview",
 		"LLRM",
 		"mergeable",
+		"MESCIUS",
 		"MSAL",
 		"msbuild",
 		"MVUX",


### PR DESCRIPTION
Added "MESCIUS" the word list

GitHub Issue (If applicable): (https://github.com/unoplatform/uno.extensions/pull/2730)

## PR Type

- Documentation content changes

## What is the current behavior?

GrapeCity changed its name to MESCIUS and we need to update that name change across docs. Starting with adding MESCIUS to cspell list

## What is the new behavior?
 MESCIUS added to word list

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
