### PR TITLE
feat(WebAuthenticationProvider): Allow providing IWebAuthenticationBrokerProvider via DI parameters

### DIFF
--- a/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationProvider.cs
@@ -108,8 +108,8 @@ internal record WebAuthenticationProvider
 		var query = authData.StartsWith(loginCallbackUri) ?
 			AuthHttpUtility.ExtractArguments(authData) : // authData is a fully qualified url, so need to extract query or fragment
 			AuthHttpUtility.ParseQueryString(authData.TrimStart('#').TrimStart('?')); // authData isn't full url, so just process as query or fragment
-
-
+		// cspell:ignore Pkce
+		// TODO: Add here support for oAuth Authorization Code Flow with Pkce-Challenge, by providing at least a AsyncFunc that could be used just like Login/Logout to exchange the code for tokens. <see href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2"/> of what we would have at this time in code, wich is not enough to get tokens in the following lines.
 		var tokens = new Dictionary<string, string>();
 		if (query is null)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- We could register that Interface in DI conditionally, as the WebAuthenticationProvider is no public type or any of the Web Auth parts, its not using an Interface then a class itself.
- While Uno does have this Broker and Interface definition it would be good to have a chance to use this feature 👍 
- Missing oAuth Code Challenge callback function

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- If we would register an Implementation (e.g. via ApiExtension) of this Interface, the DI constructor would resolve IWebAuthenticationBroker as not null
- Optional Argument so existing Code will not break, while Users of Web Auth could provide ApiExtensions of this to be used.
- Applyed Conditional `#if !WINDOWS` because of otherwhise this Interface gets linted with CS0246. see issue on the unoplatform/uno repo for more information about this:
  - https://github.com/unoplatform/uno/issues/21237

- Should enable also to use any future Implementations of this Interface to be used like I am trying to acomplish right now just with HttpListener or maybe Refit for enabling https instead of just http (tpc Listener seems to not be able to use https?):
  - https://github.com/unoplatform/uno.extensions/issues/2640

- added a comment where the oAuth code challenge function should be made availeble as minimalistic approach/or hopefully solution (?) for adding custom action for this without having to copy and re-write the whole WebAuthentication classes and so on, which uno has already!

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
  - Not possible for me to build it locally, as its having that unknown numeric targetframework error
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

As I am not sure until now how the signature of this function should look like as none of the WebConfiguration Functions does have proper xml docs at least or speaking variable names beside the Name of the function like Login or logout, I only added that comment, but hopefully someone of the more expirienced uno devs could install a little additional available `AsyncFunc` right there, so I could "just" add another delegate like the PrepareLoginUri function and do the missing oAuth code flow between Authorization and the point where the WebAuthProvider could proceed with the Tokens actions.

As you can lookup in the following link, the stage of codeflow at the commented point would not include any parameter with `access_token` or `refresh_token` so that could not work out like right now setup to process login properly.
- [Link to the official oAuth standard document](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2)

if this callback could be added, this could be a usable workaround until a full oauth feature would be added for:
- https://github.com/unoplatform/uno.extensions/issues/2870

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
