### PR TITLE
feat(oAuth): Add OAuth needed Configuration Properties and callback delegate for Code Exchange

### DIFF
--- a/build/ci/cspell.json
+++ b/build/ci/cspell.json
@@ -55,6 +55,8 @@
 		"Omnisharp",
 		"overscroll",
 		"Packt",
+		"Pkce",
+		"PKCE",
 		"parameterless",
 		"pickable",
 		"Pluralsight",

--- a/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationSettings.cs
+++ b/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationSettings.cs
@@ -11,7 +11,9 @@ internal record WebAuthenticationSettings
 	public string? LoginCallbackUri { get; init; }
 
 	public AsyncFunc<IServiceProvider, ITokenCache, IDictionary<string, string>?, string?, string>? PrepareLoginCallbackUri { get; init; }
-
+	public AsyncFunc<IServiceProvider, ITokenCache, IDictionary<string, string>?, string?, string?> ExchangeCode { get; init; }
+	public string? TokenEndpoint { get; init; }
+	public bool UsePkce { get; init; } = false;
 	public string AccessTokenKey { get; init; } = "access_token";
 	public string RefreshTokenKey { get; init; } = "refresh_token";
 

--- a/src/Uno.Extensions.Authentication.UI/Web/WebConfiguration.cs
+++ b/src/Uno.Extensions.Authentication.UI/Web/WebConfiguration.cs
@@ -5,6 +5,9 @@ internal record WebConfiguration
 	public bool PrefersEphemeralWebBrowserSession { get; init; }
 	public string? LoginStartUri { get; init; }
 	public string? LoginCallbackUri { get; init; }
+	public string? TokenEndpoint { get; init; }
+	public string? UserInfoEndpoint { get; init; }
+	public bool UsePkce { get; init; } = false;
 	public string? AccessTokenKey { get; init; }
 	public string? RefreshTokenKey { get; init; }
 	public string? IdTokenKey { get; init; }


### PR DESCRIPTION
TODO: Missing integration in WebAuthenticationProvider and the Delegate should get checked which of the parameters are required and which return Type this should have

GitHub Issue (If applicable): closes #2874 
(possibly also more)

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Feature
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- The e.g. TokenEndpoint is missing, but required if the api does not support a discovery Endpoint and we want the WebAuth to integrate this oAuth flow
- no Authorization Code Exchange Delegate

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- Added the Properties I think this will need in the end (refering to asp net core oAuth Properties) so we not need to load multiple Settings/Options just because the main ones are incomplete
- Added an Delegate for Code Exchange (Help needed here)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported) *not possible, I could not build extensions locally even if this would be ready up to this state*
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes 🤔 *not sure?*
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->
I would need somone helping on finishing the Code Exchange callback up please.
Along the guide for oAuth of the Api I need to request, this Service of mine should work with oAuth generally.
I used Refit and put the Delegates all in one class to get the DI options for it [In my Project](https://github.com/DevTKSS/DevTKSS.MyManufacturerERP/blob/master/src/DevTKSS.MyManufacturerERP/Infrastructure/Services/EtsyOAuthAuthenticationService.cs)

Telling you about this to allow you checking if you migth find some things like the defaults and oAuth2Utility (would defintly make sense in my opinion) that could be added as resource to be used from all that might need those functionallities in the future like me. this is so far NOT part of this PR contents dont worry ;) but let me know if you would like some of this to be added 👍 

- [this here are my oAuthOptions it is reffering to](https://github.com/DevTKSS/DevTKSS.MyManufacturerERP/blob/master/src/DevTKSS.MyManufacturerERP/Models/OAuthOptions.cs)
- [and here you can see what hell of a mess its doing to be needed to create multiple settings for one api](https://github.com/DevTKSS/DevTKSS.MyManufacturerERP/blob/master/src/DevTKSS.MyManufacturerERP/appsettings.development.json) so thats also one of the reasons it would make sense to feed Auth and Http from the same Instance by just adding the minimum...
- [Defined constant Defaults like the asp net core oAuth so this takes over faults by typos](https://github.com/DevTKSS/DevTKSS.MyManufacturerERP/tree/master/src/DevTKSS.MyManufacturerERP/Infrastructure/Defaults)
- [oAuth2Utilities](https://github.com/DevTKSS/DevTKSS.MyManufacturerERP/blob/master/src/DevTKSS.MyManufacturerERP/Infrastructure/OAuth2Utilitys.cs)

Thanks in advance for checking on this!

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
