### PR TITLE
chore: Cleanup provisioning of "Compat" custom attributes

### DIFF
--- a/src/Uno.Extensions.Core/_Compat/IsExternalInit.cs
+++ b/src/Uno.Extensions.Core/_Compat/IsExternalInit.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-#if !NET50
+#if !NET5_0_OR_GREATER
 namespace System.Runtime.CompilerServices;
 
 /// <summary>

--- a/src/Uno.Extensions.Core/_Compat/MemberNotNullWhenAttribute.cs
+++ b/src/Uno.Extensions.Core/_Compat/MemberNotNullWhenAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NETSTANDARD2_0 || WINDOWS_UWP || NET461
+using System;
 
 namespace System.Diagnostics.CodeAnalysis
 {
@@ -31,3 +32,4 @@ namespace System.Diagnostics.CodeAnalysis
 		public string[] Members { get; }
 	}
 }
+#endif  // NETSTANDARD2_0 || WINDOWS_UWP || NET461


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno.extensions/pull/2907
Context: https://github.com/unoplatform/uno.extensions/pull/2907#discussion_r2417520359
Context: https://github.com/dotnet/roslyn/issues/45162

Part of the discussion within #2907 suggested that Uno.Extensions.Reactive should be able to access internal members of Uno.Extensions.Core.  This wasn't previously possible, because it would error out:

	src/Uno.Extensions.Core.Generators/KeyEquality/KeyEqualityGenerationTool.cs(382,14): error CS0122: 'MemberNotNullWhenAttribute' is inaccessible due to its protection level

    
While subsequently we *don't* want allow Uno.Extensions.Reactive to have internal access to Uno.Extensions.Core, we *do* want to fix the underlying cause of the CS0122 error: the fact that `Uno.Extensions.Core.dll`, when built for .NET 8, contains `MemberNotNullWhenAttribute`.

@dr1rrb suggested:

> BTW I think there is also an option 4: since we updated all projects
> to at least net8 (9?), we can probably remove all those classes which
> was for earlier versions.

Unfortunately, this is not correct: all projects have *not* been updated to use .NET 8+, as some projects are still on `netstandard2.0`, in particular:

  * `Uno.Extensions.Core.Generators.csproj`
  * `Uno.Extensions.Navigation.Generators.csproj`
  * `Uno.Extensions.Reactive.Generator.csproj`

i.e. source generators, which are loaded by Roslyn, and Roslyn runs under both .NET *and* .NET Framework, and thus source generators are restricted to `netstandard2.0`; see also dotnet/roslyn#45162.

This in turn means we *cannot **remove*** files such as `MemberNotNullWhenAttribute.cs`.

What we can instead do is consistently "condition" the presence of such types.  The problem with `MemberNotNullWhenAttribute.cs` is that the types were *always* present, as compared to e.g. `NotNullIfNotNullAttribute.cs`, which wraps the defined types within a `#if NETSTANDARD2_0 || WINDOWS_UWP || NET461` block.

Update `MemberNotNullWhenAttribute.cs` to likewise use `#if NETSTANDARD2_0 || WINDOWS_UWP || NET461`.

Additionally, `IsExternalInit.cs` was using the `#if` around the type definition for `IsExternalInit`; the `NET50` define is not currently defined, and thus `IsExternalInit` is *always* present, even in a .NET 8 assembly:

	% monodis --typedef src/Uno.Extensions.Core/bin/Uno.Extensions.Core/Debug/net8.0/Uno.Extensions.Core.dll | grep System
	2: System.Runtime.CompilerServices.IsExternalInit (flist=1, mlist=1, flags=0x100180, extends=0x49)

Update `IsExternalInit.cs` to use `NET5_0_OR_GREATER`, which *is* now present, ensuring that the type isn't present:

	% monodis --typedef src/Uno.Extensions.Core/bin/Uno.Extensions.Core/Debug/net8.0/Uno.Extensions.Core.dll | grep System
	# no output

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
