### PR TITLE
chore: improve concurrent project build safety

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,8 @@
 		<ShouldWriteErrorOnInvalidXaml>True</ShouldWriteErrorOnInvalidXaml>
 		<!-- Required by uno 6.0 (WinRT.Runtime.dll >= 2.2.0) -->
 		<WindowsSdkPackageVersion>10.0.19041.57</WindowsSdkPackageVersion>
+
+		<UnoIconUrl>https://uno-assets.platform.uno/logos/uno.png</UnoIconUrl>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/before.Uno.Extensions.sln.targets
+++ b/before.Uno.Extensions.sln.targets
@@ -1,0 +1,12 @@
+<Project>
+	<Import Project="Directory.Build.props" />
+
+	<Target Name="DownloadPackageIcon"
+			Inputs="$(MSBuildThisFile)"
+			Outputs="$(MSBuildThisFileDirectory)\.icons\uno.png">
+
+		<DownloadFile SourceUrl="$(UnoIconUrl)" DestinationFolder="$(MSBuildThisFileDirectory)\.icons">
+			<Output TaskParameter="DownloadedFile" PropertyName="UnoPackageDownloadedIcon" />
+		</DownloadFile>
+	</Target>
+</Project>

--- a/build/ci/stage-build-packages.yml
+++ b/build/ci/stage-build-packages.yml
@@ -29,6 +29,13 @@ jobs:
 
   - template: templates/update-vs-components.yml
 
+  - task: DotNetCoreCLI@2
+    displayName: Download uno.png
+    inputs:
+      command: 'build'
+      projects: Uno.Extensions.sln
+      arguments: '--no-restore -t:DownloadPackageIcon'
+
   - task: MSBuild@1
     displayName: Build Extensions Packages
     inputs:

--- a/src/Directory.UnoMetadata.targets
+++ b/src/Directory.UnoMetadata.targets
@@ -6,23 +6,17 @@
 		<Product  Condition="'$(Product)'==''">$(AssemblyName) ($(TargetFramework))</Product>
 		<PackageLicenseExpression  Condition="'$(PackageLicenseExpression)'==''">Apache-2.0</PackageLicenseExpression>
 		<DefaultLanguage Condition="'$(DefaultLanguage)'==''">en-US</DefaultLanguage>
+		<_LocalUnoPngPath>$(MSBuildThisFileDirectory)..\.icons\uno.png</_LocalUnoPngPath>
+		<PackageIcon Condition=" '$(PackageIcon)' == '' And Exists($(_LocalUnoPngPath)) ">uno.png</PackageIcon>
 	</PropertyGroup>
 
-	<Target Name="DownloadAndSetPackageIcon" AfterTargets="Build"  Condition="'$(PackageIcon)'==''">
-		<PropertyGroup>
-			<IconUrl>https://uno-assets.platform.uno/logos/uno.png</IconUrl>
-		</PropertyGroup>
-
-		<DownloadFile SourceUrl="$(IconUrl)" DestinationFolder="$(MSBuildThisFileDirectory)\.icons">
-			<Output TaskParameter="DownloadedFile" PropertyName="UnoPackageDownloadedIcon" />
-		</DownloadFile>
-
-		<PropertyGroup>
-			<PackageIcon>$([System.IO.Path]::GetFileName($(UnoPackageDownloadedIcon)))</PackageIcon>
-		</PropertyGroup>
-
-		<ItemGroup>
-			<None Include="$(UnoPackageDownloadedIcon)" Pack="true" PackagePath="\" Visible="false" />
-		</ItemGroup>
-	</Target>
+	<ItemGroup>
+		<None
+				Condition=" Exists($(_LocalUnoPngPath)) "
+				Include="$(_LocalUnoPngPath)"
+				Pack="true"
+				PackagePath="\"
+				Visible="false"
+		/>
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Sometimes the **Packages > Build Extensions Packages** job fails:

	  Downloading from "https://uno-assets.platform.uno/logos/uno.png" to "D:\a\1\s\src\.icons\uno.png" (10901 bytes).
	##[error]src\Directory.UnoMetadata.targets(16,3): Error MSB3923: Failed to download file "https://uno-assets.platform.uno/logos/uno.png".
	The process cannot access the file 'D:\a\1\s\src\.icons\uno.png' because it is being used by another process.

The MSB3923 occurs because:

 1. The `DownloadAndSetPackageIcon` target runs as a post-`Build` target for *every* project in the solution, and

 2. Every invocation of `DownloadAndSetPackageIcon` uses the same `DownloadFile.DestinationFolder` location (`$(MSBuildThisFileDirectory)\.icons`), and

 3. Projects are built in parallel: the [`MSBuild@1`][0] `maximumCpuCount` input value is true ("Build in Parallel") *and also* `msbuildArguments` includes `/m` with no value [^0].

therefore the `DownloadAndSetPackageIcon` target can also be run in parallel, which explains the MSB3923 file share errors.

Fix this by updating the `DownloadAndSetPackageIcon` target to instead download files into `$(IntermediateOutputPath).icons`. This should be a per-project directory, and thus should prevent parallel project builds from stepping on each other's toes.

[0]: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/msbuild-v1?view=azure-pipelines
[1]: https://learn.microsoft.com/en-us/visualstudio/msbuild/building-multiple-projects-in-parallel-with-msbuild?view=vs-2022

[^0]: From the docs:

      > If you include this switch without specifying a value, MSBuild
      > uses up to the number of processors in the computer.
      > For more information, see [Building multiple projects in parallel][1].

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
