### PR TITLE
fix(ThemeService): Only save theme on explicit user action

### DIFF
--- a/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
@@ -99,8 +99,15 @@ internal class ThemeService : IThemeService, IDisposable
 			throw new NullReferenceException($"Theme service not initialized, {nameof(InitializeAsync)} needs to complete before SetThemeAsync can be called");
 		}
 
-		// Make sure initialization completes before attempting to set new theme
-		await _initialization.Task;
+		if (theme != AppTheme.System)
+                {
+                         await _settings.SetAsync(nameof(CurrentTheme), theme.ToString());
+                }
+
+                if (theme != AppTheme.System)
+                {
+                         SaveDesiredTheme(theme);
+                 }
 
 		return await InternalSetThemeAsync(theme);
 	}
@@ -137,7 +144,9 @@ internal class ThemeService : IThemeService, IDisposable
 			_ => ElementTheme.Default,
 		};
 
-		SaveDesiredTheme(theme);
+		if (theme != AppTheme.System)
+                {
+                }
 
 		if (existingIsDark != IsDark)
 		{
@@ -151,7 +160,6 @@ internal class ThemeService : IThemeService, IDisposable
 	{
 		try
 		{
-			_settings.Set(CurrentThemeSettingsKey, theme.ToString());
 		}
 		catch (Exception ex)
 		{


### PR DESCRIPTION
Closes #2842

## PR Type

- Bugfix

## What is the current behavior?

When the application is set to follow the system theme, any change in the system's theme (e.g., from Light to Dark) causes the `ThemeService` to save the resolved theme ("Dark") to the settings file. This locks the application to that specific theme and prevents it from following any subsequent system theme changes.

## What is the new behavior?

This change moves the theme-saving logic from the internal theme-changed handler (`InternalSetThemeOnUIThread`) to the public `SetThemeAsync` method.

This ensures that the theme preference is only saved to settings when a user explicitly calls `SetThemeAsync` with a specific theme (Light or Dark). The application now correctly follows the system theme by default without writing to the settings file, which resolves the original issue.

## PR Checklist

- [x] Tested code with current supported SDKs
- [ ] Docs have been added/updated which fit documentation template. (for bug fixes / features)
- [ ] Unit Tests and/or UI Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Wasm UI Tests are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the Release Notes
- [x] Associated with an issue (GitHub or internal)