### PR TITLE
docs: fix cspell detection for docs only changes

### DIFF
--- a/build/ci/stage-determine-changes.yml
+++ b/build/ci/stage-determine-changes.yml
@@ -38,7 +38,7 @@ jobs:
           $isDoc = $file.StartsWith("doc/") -or               # Files in the 'doc/' directory
             ($file -match "^[^/]+\.md$") -or                  # Markdown files at the root level (with no subdirectories involved)
             ($file -match "^\.github/.*\.md$") -or            # Markdown files within the .github folder (including its subdirectories)
-            ($file -match "^\.(markdownlint|cspell)\.json$")  # Specific JSON files: .markdownlint.json and cspell.json
+            ($file -match '(^|[\\/])(markdownlint|cspell)\.json$') # Specific JSON files: .markdownlint.json and cspell.json
   
           if ($isDoc) {
               $docFiles++


### PR DESCRIPTION
This pull request updates the logic for detecting documentation-related files in the CI build stage configuration. The main change is a more robust pattern for matching specific JSON files, ensuring that `.markdownlint.json` and `cspell.json` are correctly identified as documentation files regardless of their location in the repository.

Documentation file detection improvements:

* Updated the regex pattern in `build/ci/stage-determine-changes.yml` to match `.markdownlint.json` and `cspell.json` files in any directory, not just the repository root.