### PR TITLE
chore: bump major version

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.3-dev.{height}",
+  "version": "7.0-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
This pull request updates the project version in preparation for the next major release.

Versioning update:

* Bumped the version number from `6.3-dev.{height}` to `7.0-dev.{height}` in `version.json` to begin development on the 7.0 release series.


Breaking change from: https://github.com/unoplatform/uno.extensions/pull/2733

