### PR TITLE
fix(ThemeService): preserve 'System' theme preference on OS theme changes

### DIFF
--- a/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
@@ -82,16 +82,10 @@ internal class ThemeService : IThemeService, IDisposable
 
 	private void ElementThemeChanged(FrameworkElement sender, object args)
 	{
-		var currentActualTheme = sender.ActualTheme switch
-		{
-			ElementTheme.Dark => AppTheme.Dark,
-			ElementTheme.Light => AppTheme.Light,
-			_ => AppTheme.System,
-		};
-
 		var savedThemePreference = GetSavedTheme();
 
 		// Only respond to system-driven changes if the user's preference is explicitly 'System'.
+		// If the user has set an explicit Dark or Light preference, ignore system theme changes.
 		if (savedThemePreference == AppTheme.System)
 		{
 			ThemeChanged?.Invoke(this, savedThemePreference);

--- a/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
@@ -82,13 +82,20 @@ internal class ThemeService : IThemeService, IDisposable
 
 	private void ElementThemeChanged(FrameworkElement sender, object args)
 	{
-		_ = InternalSetThemeAsync(sender.ActualTheme switch
+		var currentActualTheme = sender.ActualTheme switch
 		{
-			ElementTheme.Default => AppTheme.System,
 			ElementTheme.Dark => AppTheme.Dark,
 			ElementTheme.Light => AppTheme.Light,
 			_ => AppTheme.System,
-		});
+		};
+
+		var savedThemePreference = GetSavedTheme();
+
+		// Only respond to system-driven changes if the user's preference is explicitly 'System'.
+		if (savedThemePreference == AppTheme.System)
+		{
+			ThemeChanged?.Invoke(this, currentActualTheme);
+		}
 	}
 
 	/// <inheritdoc/>

--- a/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
@@ -94,7 +94,7 @@ internal class ThemeService : IThemeService, IDisposable
 		// Only respond to system-driven changes if the user's preference is explicitly 'System'.
 		if (savedThemePreference == AppTheme.System)
 		{
-			ThemeChanged?.Invoke(this, currentActualTheme);
+			ThemeChanged?.Invoke(this, savedThemePreference);
 		}
 	}
 


### PR DESCRIPTION
Closes #2914

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When the user set the application theme to `AppTheme.System`, the service would correctly apply `ElementTheme.Default` to follow the operating system's theme.

However, the first time the system theme changed (e.g., from light to dark), the `ElementThemeChanged` event handler would re-apply the new theme (`AppTheme.Dark`) as a permanent setting. This had two negative effects:

- It overwrote the user's preference: The saved setting was changed from `AppTheme.System` to `AppTheme.Dark`.
- It changed the active theme request: The `RequestedTheme` property was updated from `ElementTheme.Default` to the fixed `ElementTheme.Dark`.

As a result, the application would no longer respond to any future system theme changes, effectively "locking" the theme to whatever it first switched to.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

With the corrected logic, the ElementThemeChanged event handler behaves differently:

- It first checks if the user's saved preference is indeed AppTheme.System.
- If it is, the handler only fires a notification (ThemeChanged event) to inform other parts of the app that the visual theme has changed.
- Crucially, it does not call any methods to set or save the theme.

This ensures that the RequestedTheme property remains ElementTheme.Default and the user's AppTheme.System preference is preserved. The application now correctly follows all subsequent system theme changes without getting locked.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

Tested on the `stable` branch with Uno.SDK 6.3.28 + Uno.Extensions 6.2.3, and it works correctly.
