### PR TITLE
chore: Fix trimmer warnings

### DIFF
--- a/src/Uno.Extensions.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions;
 
 public static class ServiceCollectionExtensions
 {
@@ -15,7 +17,10 @@ public static class ServiceCollectionExtensions
 
 	}
 
-	public static IServiceCollection AddNamedSingleton<TService, TImplementation>(this IServiceCollection services, string Name)
+	public static IServiceCollection AddNamedSingleton<
+		TService,
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation
+	>(this IServiceCollection services, string Name)
 		where TService : class where TImplementation : class, TService
 	{
 		// Register the concrete type (the NamedInstance will use this
@@ -43,7 +48,10 @@ public static class ServiceCollectionExtensions
 				.AddSingleton<INamedInstance<TService>>(sp => new NamedInstanceReference<TService>(sp, OriginalName, Name));
 	}
 
-	public static IServiceCollection SetDefaultInstance<TService, TImplementation>(this IServiceCollection services)
+	public static IServiceCollection SetDefaultInstance<
+		TService,
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation
+	>(this IServiceCollection services)
 		where TService : class where TImplementation : class, TService
 	{
 		return services.AddNamedSingleton<TService, TImplementation>(DefaultInstanceKey);

--- a/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
+++ b/src/Uno.Extensions.Core/Uno.Extensions.Core.csproj
@@ -8,6 +8,7 @@
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 		<CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" />

--- a/src/Uno.Extensions.Http/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Http/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions;
 
 /// <summary>
 /// Extensions for <see cref="IServiceCollection"/>
@@ -49,7 +51,14 @@ public static class ServiceCollectionExtensions
 	/// <param name="name">[optional] Name of the endpoint (used to load from appsettings)</param>
 	/// <param name="configure">[optional] Callback to configure the endpoint</param>
 	/// <returns>Updated service collection</returns>
-	public static IServiceCollection AddClientWithEndpoint<TClient, TImplementation, TEndpoint>(
+	public static IServiceCollection AddClientWithEndpoint<
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+		TClient,
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+		TImplementation,
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+		TEndpoint
+	>(
 		 this IServiceCollection services,
 		 HostBuilderContext context,
 		 TEndpoint? options = null,
@@ -102,7 +111,13 @@ public static class ServiceCollectionExtensions
 	/// <param name="httpClientFactory">[optional] Callback to configure the HttpClient</param>
 	/// <param name="configure">[optional] Callback to configure the endpoint</param>
 	/// <returns>Updated service collection</returns>
-	public static IServiceCollection AddClientWithEndpoint<TInterface, TEndpoint>(
+	[RequiresUnreferencedCode("From `ConfigurationBinder.Get<T>(IConfiguration)`.")]
+	public static IServiceCollection AddClientWithEndpoint<
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+		TInterface,
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+		TEndpoint
+	>(
 		  this IServiceCollection services,
 		  HostBuilderContext context,
 		  TEndpoint? options = null,

--- a/src/Uno.Extensions.Navigation/MappedViewMap.cs
+++ b/src/Uno.Extensions.Navigation/MappedViewMap.cs
@@ -5,6 +5,7 @@ namespace Uno.Extensions.Navigation;
 internal record MappedViewMap(
 		Type? View = null,
 		Func<Type?>? ViewSelector = null,
+		[param:   DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicConstructors)]
 		Type? ViewModel = null,
 		DataMap? Data = null,
 		Type? ResultData = null,

--- a/src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs
+++ b/src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Navigation;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions.Navigation;
 
 public static class NavigationRequestExtensions
 {
@@ -107,16 +109,40 @@ public static class NavigationRequestExtensions
 			var request = new NavigationRequest(sender, hint.ToRoute(navigator, resolver, data), cancellation);
 			return request;
 		}
-		var navMethods = typeof(NavigationRequestExtensions)
-					.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-					.Where(m => m.Name == nameof(ToRequest) &&
-								m.IsGenericMethodDefinition).ToArray();
-		var navMethod = navMethods.First();
-		var constructedNavMethod = navMethod.MakeGenericMethod(hint.Result);
-		var nav = (NavigationRequest)constructedNavMethod.Invoke(null, new object?[] { hint, navigator, resolver, sender, data, cancellation })!;
-		return nav;
-
+		return InvokeToRequest(hint, hint.Result, navigator, resolver, sender, data, cancellation);
 	}
+
+	[UnconditionalSuppressMessage("Trimming", "IL2060", Justification = "hide until proper solution can be determined")]
+	[UnconditionalSuppressMessage("Trimming", "IL3050", Justification = "hide until proper solution can be determined")]
+	private static NavigationRequest InvokeToRequest(
+		RouteHint hint,
+		Type resultType,
+		INavigator navigator,
+		IRouteResolver resolver,
+		object sender,
+		object? data,
+		CancellationToken cancellation)
+	{
+		try
+		{
+			var navMethods = typeof(NavigationRequestExtensions)
+						.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+						.Where(m => m.Name == nameof(ToRequest) &&
+									m.IsGenericMethodDefinition).ToArray();
+			var navMethod = navMethods.First();
+			var constructedNavMethod = navMethod.MakeGenericMethod(resultType);
+			var nav = (NavigationRequest)constructedNavMethod.Invoke(null, new object?[] { hint, navigator, resolver, sender, data, cancellation })!;
+			return nav;
+		}
+		catch (Exception e)
+		{
+			// TODO: how to get an ILogger?
+			Console.Error.WriteLine($"Could not invoke ToRequest<{resultType.FullName}>(…): {e.Message}");
+			Console.Error.WriteLine(e);
+			throw;
+		}
+    }
+
 
 	internal static NavigationRequest<TResult> ToRequest<TResult>(
 		this RouteHint hint,

--- a/src/Uno.Extensions.Navigation/RouteInfo.cs
+++ b/src/Uno.Extensions.Navigation/RouteInfo.cs
@@ -24,6 +24,7 @@ public record RouteInfo(
 	public RouteInfo? DependsOnRoute { get; set; }
 
 	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+	[UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "Cannot 'forward' `[DynamicallyAccessedMembers]` to Func<T>; would need to use a new type, which would be an ABI break.")]
 	public Type? RenderView => View?.Invoke();
 	public bool IsDependent = !string.IsNullOrWhiteSpace(DependsOn);
 }

--- a/src/Uno.Extensions.Navigation/Uno.Extensions.Navigation.csproj
+++ b/src/Uno.Extensions.Navigation/Uno.Extensions.Navigation.csproj
@@ -9,6 +9,8 @@
 
 		<!-- As we are InternalsVisibleTo, we disable some compatibility types that are not used by package itself. -->
 		<UnoExtensionsGeneration_DisableModuleInitializerAttribute>True</UnoExtensionsGeneration_DisableModuleInitializerAttribute>
+
+		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Navigation/ViewMap.cs
+++ b/src/Uno.Extensions.Navigation/ViewMap.cs
@@ -37,11 +37,19 @@ public record ViewMap(
 }
 
 public record ViewMap<TView>(
+	[param:   DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicConstructors)]
 	Type? ViewModel = null,
 	DataMap? Data = null,
 	Type? ResultData = null,
 	object? ViewAttributes = null
-) : ViewMap(View: typeof(TView), ViewModel: ViewModel, Data: Data, ResultData: ResultData, ViewAttributes: ViewAttributes)
+) : ViewMap(
+	View: typeof(TView),
+	ViewSelector: null,
+	ViewModel: ViewModel,
+	Data: Data,
+	ResultData: ResultData,
+	ViewAttributes: ViewAttributes
+)
 	where TView: class, new()
 {
 	public override void RegisterTypes(IServiceCollection services)
@@ -51,7 +59,11 @@ public record ViewMap<TView>(
 	}
 }
 
-public record ViewMap<TView, TViewModel>(
+public record ViewMap<
+	TView,
+	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+	TViewModel
+>(
 	DataMap? Data = null,
 	Type? ResultData = null,
 	object? ViewAttributes = null
@@ -60,7 +72,12 @@ public record ViewMap<TView, TViewModel>(
 {
 }
 
-public record DataViewMap<TView, TViewModel, TData>(
+public record DataViewMap<
+	TView,
+	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+	TViewModel,
+	TData
+>(
 	Func<TData, IDictionary<string, string>>? ToQuery = null,
 	Func<IServiceProvider, IDictionary<string, object>, Task<TData?>>? FromQuery = null,
 	Type? ResultData = null,
@@ -71,7 +88,12 @@ public record DataViewMap<TView, TViewModel, TData>(
 {
 }
 
-public record ResultDataViewMap<TView, TViewModel, TResultData>(
+public record ResultDataViewMap<
+	TView,
+	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+	TViewModel,
+	TResultData
+>(
 	DataMap? Data = null,
 	object? ViewAttributes = null
 ) : ViewMap<TView,TViewModel>(Data: Data, ResultData: typeof(TResultData), ViewAttributes: ViewAttributes)

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Map/LockedMemoizedConverter.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Map/LockedMemoizedConverter.cs
@@ -11,7 +11,12 @@ namespace Uno.Extensions.Conversion;
 /// </summary>
 /// <typeparam name="TFrom">The source value type</typeparam>
 /// <typeparam name="TTo">The target value type</typeparam>
-internal class LockedMemoizedConverter<TFrom, TTo> : ICachedConverter<TFrom, TTo>, IConverter<TFrom, TTo>
+internal class LockedMemoizedConverter<
+	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+	TFrom,
+	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+	TTo
+> : ICachedConverter<TFrom, TTo>, IConverter<TFrom, TTo>
 	where TFrom : class
 	where TTo : class
 {

--- a/src/Uno.Extensions.Reactive/Collections/Facades/Map/OneWayMemoizedConverter.cs
+++ b/src/Uno.Extensions.Reactive/Collections/Facades/Map/OneWayMemoizedConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -11,7 +12,12 @@ namespace Uno.Extensions.Conversion;
 /// </summary>
 /// <typeparam name="TFrom">The source value type</typeparam>
 /// <typeparam name="TTo">The target value type</typeparam>
-internal class OneWayMemoizedConverter<TFrom, TTo> : ICachedConverter<TFrom, TTo>, IConverter<TFrom, TTo>
+internal class OneWayMemoizedConverter<
+	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+	TFrom,
+	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+	TTo
+> : ICachedConverter<TFrom, TTo>, IConverter<TFrom, TTo>
 	where TFrom : class
 	where TTo : class
 {

--- a/src/Uno.Extensions.Reactive/Core/HotReload/HotReloadService.cs
+++ b/src/Uno.Extensions.Reactive/Core/HotReload/HotReloadService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -7,7 +8,9 @@ using Microsoft.Extensions.Logging;
 using Uno.Extensions.Reactive.Bindings;
 using Uno.Extensions.Reactive.Logging;
 
+#pragma warning disable IL2026  // 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
 [assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(Uno.Extensions.Reactive.Core.HotReload.HotReloadService))]
+#pragma warning restore IL2026
 
 namespace Uno.Extensions.Reactive.Core.HotReload;
 
@@ -25,6 +28,7 @@ internal static class HotReloadService
 	{
 	}
 
+	[RequiresUnreferencedCode("`MetadataUpdateOriginalTypeAttribute` may be a per-assembly type, so it cannot be statically known.")]
 	internal static void UpdateApplication(Type[]? types)
 	{
 		if (_trace) _log.Trace($"Received metadata updates for {types?.Length} types to be processed by MVUX hot-patch engine.");
@@ -59,6 +63,7 @@ internal static class HotReloadService
 
 	// As the MetadataUpdateOriginalTypeAttribute might have been generated in the project, we have to use reflection instead of cannot use this:
 	//&& type.GetCustomAttribute<MetadataUpdateOriginalTypeAttribute>() is { OriginalType : not null } typeUpdate)
+	[RequiresUnreferencedCode("`MetadataUpdateOriginalTypeAttribute` may be a per-assembly type, so it cannot be statically known.")]
 	private static Type? GetOriginalType(Type type)
 		=> type
 			.GetCustomAttributes()

--- a/src/Uno.Extensions.Reactive/Uno.Extensions.Reactive.csproj
+++ b/src/Uno.Extensions.Reactive/Uno.Extensions.Reactive.csproj
@@ -5,6 +5,8 @@
 		<Description>Reactive Extensions for the Uno Platform, UWP and WinUI</Description>
 		<ImplicitUsings>false</ImplicitUsings>
 
+		<IsAotCompatible>true</IsAotCompatible>
+
 		<!--
 			As we are InternalsVisibleTo(Uno.Extensions.Reactive.Tests), we disable some compatibility types that are not used by Reactive package itself.
 		-->

--- a/src/Uno.Extensions.Reactive/Utils/ActivatorHelper.cs
+++ b/src/Uno.Extensions.Reactive/Utils/ActivatorHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -9,7 +10,11 @@ namespace Uno.Extensions.Reactive.Utils;
 
 internal static class ActivatorHelper
 {
-	internal static object CreateInstance(Type type, (Type type, string name, object? value)[] arguments, Func<Type, string, object?>? tryGetMissingArgument = null)
+	internal static object CreateInstance(
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+		Type type,
+		(Type type, string name, object? value)[] arguments,
+		Func<Type, string, object?>? tryGetMissingArgument = null)
 	{
 		var ctors = type
 			.GetConstructors(BindingFlags.Instance | BindingFlags.Public)

--- a/src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs
+++ b/src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Serialization;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions.Serialization;
 
 /// <summary>
 /// A reflection-based serializer implementation for System.Text.Json.
@@ -37,6 +39,7 @@ public class SystemTextJsonSerializer : ISerializer
 	/// <returns>
 	/// The instance of targetType deserialized from the source.
 	/// </returns>
+	[RequiresUnreferencedCode("From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 	public object? FromStream(Stream source, Type targetType)
 	{
 		var typedSerializer = TypedSerializer(targetType);
@@ -55,6 +58,7 @@ public class SystemTextJsonSerializer : ISerializer
 	/// <param name="valueType">
 	/// The type to use to serialize the object. value must be convertible to this type.
 	/// </param>
+	[RequiresUnreferencedCode("From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 	public void ToStream(Stream stream, object value, Type valueType)
 	{
 		var typedSerializer = TypedSerializer(valueType);
@@ -80,6 +84,7 @@ public class SystemTextJsonSerializer : ISerializer
 	/// <returns>
 	/// The serialized representation of value.
 	/// </returns>
+	[RequiresUnreferencedCode("From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 	public string ToString(object value, Type valueType)
 	{
 		var typedSerializer = TypedSerializer(valueType);
@@ -98,6 +103,7 @@ public class SystemTextJsonSerializer : ISerializer
 	/// <returns>
 	/// The instance of targetType deserialized from the source.
 	/// </returns>
+	[RequiresUnreferencedCode("From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
 	public object? FromString(string source, Type targetType)
 	{
 		var typedSerializer = TypedSerializer(targetType);


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/121629
Context: dea3b57078be96e4d6e345ebf18486cfa2e8e3a5 / 56a003bab6834a77edcb7d727b8e35315059c06a [may not exist]
Context: c3c4c7862a911b903f1cefc4d20bc3f029ea4b26

Enable `$(IsAotCompatible)`=true for the following projects:

  * `src/Uno.Extensions.Core/Uno.Extensions.Core.csproj`
  * `src/Uno.Extensions.Navigation/Uno.Extensions.Navigation.csproj`
  * `src/Uno.Extensions.Reactive/Uno.Extensions.Reactive.csproj`

Fix the following warnings-as-errors:

	src/Uno.Extensions.Core/DependencyInjection/ServiceCollectionExtensions.cs(24,3): error IL2091:
	  'TService' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in 'Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddTransient<TService>(IServiceCollection)'.
	  The generic parameter 'TImplementation' of 'Uno.Extensions.ServiceCollectionExtensions.AddNamedSingleton<TService, TImplementation>(IServiceCollection, String)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Navigation/MappedViewMap.cs(14,6): error IL2067:
	  'ViewModel' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Uno.Extensions.Navigation.ViewMap.ViewMap(Type, Func<Type>, Type, DataMap, Type, Object)'.
	  The parameter 'ViewModel' of method 'Uno.Extensions.Navigation.MappedViewMap.MappedViewMap(Type, Func<Type>, Type, DataMap, Type, Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Navigation/ViewMap.cs(66,5): error IL2087:
	  'ViewModel' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Uno.Extensions.Navigation.ViewMap<TView>.ViewMap(Type, DataMap, Type, Object)'.
	  The generic parameter 'TViewModel' of 'Uno.Extensions.Navigation.ViewMap<TView, TViewModel>' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Navigation/ViewMap.cs(86,15): error IL2091:
	  'TViewModel' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in 'Uno.Extensions.Navigation.ViewMap<TView, TViewModel>'.
	  The generic parameter 'TViewModel' of 'Uno.Extensions.Navigation.ResultDataViewMap<TView, TViewModel, TResultData>' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.HotReload.cs(102,15): error IL2067:
	  'updatedModelType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Uno.Extensions.Reactive.Bindings.BindableViewModelBase.__Reactive_CreateModelInstance(Type)'.
	  The parameter 'updatedModelType' of method 'Uno.Extensions.Reactive.Bindings.BindableViewModelBase.HotPatch(Type, Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Reactive/Collections/Facades/Map/LockedMemoizedConverter.cs(20,75): error IL2091:
	  'TValue' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in 'System.Runtime.CompilerServices.ConditionalWeakTable<TKey, TValue>'.
	  The generic parameter 'TFrom' of 'Uno.Extensions.Conversion.LockedMemoizedConverter<TFrom, TTo>' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	…
	src/Uno.Extensions.Reactive/Collections/Facades/Map/OneWayMemoizedConverter.cs(19,75): error IL2091:
	  'TValue' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in 'System.Runtime.CompilerServices.ConditionalWeakTable<TKey, TValue>'.
	  The generic parameter 'TFrom' of 'Uno.Extensions.Conversion.OneWayMemoizedConverter<TFrom, TTo>' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	…
	src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.HotReload.cs(405,41): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'.
	  The parameter 'type' of method 'Uno.Extensions.Reactive.Bindings.BindableViewModelBase.IsFeed(Type, out Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Add the missing `[DynamicallyAccessedMembers]`.

Address the following warnings-as-errors:

	src/Uno.Extensions.Navigation/ViewMap.cs(44,5): error IL2067:
	  'ViewModel' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Uno.Extensions.Navigation.ViewMap.ViewMap(Type, Func<Type>, Type, DataMap, Type, Object)'.
	  The parameter 'Data' of method 'Uno.Extensions.Navigation.ViewMap<TView>.ViewMap(Type, DataMap, Type, Object)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

This is dotnet/runtime#121629.  Work around it by providing the
`ViewSelector: null` parameter.

Address the following warning-as-errors:

	src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.HotReload.cs(353,31): error IL3050:
	  Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The native code for this instantiation might not be available at runtime.
	src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.HotReload.cs(357,31): error IL3050:
	  Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The native code for this instantiation might not be available at runtime.
	src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.HotReload.cs(349,31): error IL3050:
	  Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The native code for this instantiation might not be available at runtime.

Add `[RequiresDynamicCode]` to "forward" the IL3050 to callers.

Suppress the following warning-as-error:

	src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.HotReload.cs(394,30): error IL2072:
	  'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'Uno.Extensions.Reactive.Bindings.BindableViewModelBase.IsFeed(Type, out Type)'.
	  The return value of method 'System.Reflection.PropertyInfo.PropertyType.get' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

This IL2072 is "forwarded" from an above change to `IsFeed()`, and I
don't know how to properly forward or address at this callsite.

Suppress the following warning-as-error:

	src/Uno.Extensions.Reactive/Core/HotReload/HotReloadService.cs(11,12): error IL2026:
	  Using member 'Uno.Extensions.Reactive.Core.HotReload.HotReloadService.UpdateApplication(Type[])' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  `MetadataUpdateOriginalTypeAttribute` may be a per-assembly type, so it cannot be statically known.

This is on an `[assembly:]`-level attribute.  I can think of only
using `#pragma warning disable` to remove the error.

Suppress the following warning-as-error:

	src/Uno.Extensions.Navigation/RouteInfo.cs(27,29): error IL2073:
	  'Uno.Extensions.Navigation.RouteInfo.RenderView.get' method return value does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' requirements.
	  The return value of method 'System.Func<TResult>.Invoke()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Remember 56a003ba (which has the comment, merged into dea3b570)?

> Add `[DynamicallyAccessedMembers]` to `RouteInfo.RenderView`.  This
> is a bit of a lie, as `RenderView` invokes `View`…:
> …
> and there is no way to update the `View` parameter to assert that the
> returned `Type` fulfills the requirements.  Oddly, this doesn't require
> suppressing anything…

*Now* it needs suppressing.  We can't change the parameter type without
incurring an ABI break.

TODO: use constructor overloading?
Look into `System.Runtime.CompilerServices.OverloadResolutionPriority`.

For the following warning-as-errors:

	src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs(115,30): error IL2060:
	  Call to 'System.Reflection.MethodInfo.MakeGenericMethod(params Type[])' can not be statically analyzed.
	  It's not possible to guarantee the availability of requirements of the generic method.
	src/Uno.Extensions.Navigation/NavigationRequestExtensions.cs(115,30): error IL3050:
	  Using member 'System.Reflection.MethodInfo.MakeGenericMethod(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The native code for this instantiation might not be available at runtime.

This was apparently added in c3c4c786.

For now, "suppress and wrap" the warning: the warning is suppressed,
and we "wrap" in `[RequiresDynamicCode]`.

Address the following warning-as-error:

	src/Uno.Extensions.Http/ServiceCollectionExtensions.cs(117,15): error IL3050:
	  Using member 'Microsoft.Extensions.Configuration.ConfigurationBinder.Get<T>(IConfiguration)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Binding strongly typed objects to configuration values requires generating dynamic code at runtime, for example instantiating generic types.

TODO: understand why generics were added to this codepath, and
possibly *remove* them?  At a glance, the generics don't appear to be
publicly visible…

For now, Add `[RequiresUnreferencedCode]` to `AddClientWithEndpoint()`.

Address the following warnings-as-errors:

	src/Uno.Extensions.Reactive/Core/HotReload/HotReloadService.cs(69,8): error IL2075:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperty(String)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

The reflection use is required, and this is part of the
HotReload codepath, so annotate with `[RequiresUnreferencedCode]`.

Address the following warnings-as-errors:

	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(86,85): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Serialize(Object, Type, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(104,89): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Deserialize(String, Type, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Reactive/Presentation/Bindings/BindableViewModelBase.HotReload.cs(403,41): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'.
	  The parameter 'type' of method 'Uno.Extensions.Reactive.Bindings.BindableViewModelBase.IsFeed(Type, out Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Add `[RequiresDynamicCodeAttribute]` or `[RequiresUnreferencedCode]`,
depending on the warning message.