### PR TITLE
chore: preserve properties on generated ViewModels

### DIFF
--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableFromFeedProperty.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableFromFeedProperty.cs
@@ -19,8 +19,15 @@ internal record BindableFromFeedProperty(IPropertySymbol _property, ITypeSymbol 
 		=> null;
 
 	/// <inheritdoc />
-	public string GetDeclaration()
-		=> $"{_property.GetAccessibilityAsCSharpCodeString()} {_bindableValueType} {_property.Name} {{ get; private set; }}";
+	public string GetDeclaration() =>
+		$$"""
+		{{_property.GetAccessibilityAsCSharpCodeString()}} {{_bindableValueType}} {{_property.Name}}
+		{
+			[global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof({{_bindableValueType}}))]
+			get;
+			private set;
+		}
+		""";
 
 	/// <inheritdoc />
 	public string? GetInitialization()

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/Bindable.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/Bindable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,8 +17,13 @@ namespace Uno.Extensions.Reactive.Bindings;
 /// <typeparam name="T">The type of the value</typeparam>
 /// <remarks>This type is not thread safe and is expected to be manipulated only from the UI thread.</remarks>
 [EditorBrowsable(EditorBrowsableState.Never)]
-public class Bindable<T> : IBindable, INotifyPropertyChanged, IFeed<T>
+public class Bindable<
+	[DynamicallyAccessedMembers(TRequirements)]
+	T
+> : IBindable, INotifyPropertyChanged, IFeed<T>
 {
+	internal const DynamicallyAccessedMemberTypes TRequirements = DynamicallyAccessedMemberTypes.PublicProperties;
+
 	private static readonly IEqualityComparer<T> _comparer = typeof(T).IsValueType
 		? EqualityComparer<T>.Default
 		: ReferenceEqualityComparer<T>.Default; // We use ref-equality for object to avoid deep comparison on the UI thread

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableEnumerable.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableEnumerable.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -19,7 +20,12 @@ namespace Uno.Extensions.Reactive.Bindings;
 /// <typeparam name="TItem">The type of the items.</typeparam>
 /// <typeparam name="TBindableItem">The type of the bindable of the item.</typeparam>
 [EditorBrowsable(EditorBrowsableState.Never)]
-public abstract class BindableEnumerable<TCollection, TItem, TBindableItem> : Bindable<TCollection>, IEnumerable<TBindableItem>, INotifyCollectionChanged, IList
+public abstract class BindableEnumerable<
+	[DynamicallyAccessedMembers(TRequirements)]
+	TCollection,
+	TItem,
+	TBindableItem
+> : Bindable<TCollection>, IEnumerable<TBindableItem>, INotifyCollectionChanged, IList
 	where TCollection : IEnumerable<TItem>
 	where TBindableItem : Bindable<TItem>
 	where TItem : notnull


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno.extensions/pull/2966
Context: https://github.com/unoplatform/uno.chefs/pull/1709

While running the uno.chefs app on macOS under NativeAOT:

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop -bl \
	  Chefs/Chefs.csproj \
	  -p:SelfContained=true -p:PublishAot=true -p:IsAotCompatible=true -p:UseSkiaRendering=true \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen
	Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs

(along with a change from unoplatform/uno.chefs#1709 to `Program.cs` to call `App.InitializeLogging()`…)

Console output would contain the following error:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [CurrentIndex] property getter does not exist on type [Chefs.Business.Models.BindableIntIteratorViewModel]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The property setter for [CurrentIndex] does not exist on [Chefs.Business.Models.BindableIntIteratorViewModel]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Value] property getter does not exist on type [Chefs.Business.Models.BindableIntIteratorViewModel]

PR #2966 had a similar set of messages, and the general fix is to use `[DynamicallyAccessedMembers]` so that NativeAOT preserves property metadata.

The problem *here* is that there is no good place to put `[DynamicallyAccessedMembers]` that will preserve the ViewModel types generated by Uno.Extensions.Reactive.Generator:

	namespace Chefs.Business.Models {
	  [GeneratedCodeAttribute("ViewModelGenerator_2", "2")]
	  [Bindable(typeof(IntIterator))]
	  public partial class BindableIntIteratorViewModel : global::Uno.Extensions.Reactive.Bindings.Bindable<Chefs.Business.Models.IntIterator> {
	    public IntIterator Value {get => …; set => …;}
	    public int CurrentIndex {get => …; set => …;}
	  }
	}
	namespace Chefs.Presentation {
	  [GeneratedCodeAttribute("ViewModelGenTool_3", "3")]
	  [Bindable(typeof(global::Chefs.Presentation.WelcomeModel))]
	  public partial class WelcomeViewModel {
	    protected WelcomeViewModel(global::Chefs.Presentation.WelcomeModel model) {
	      // …
	      Pages ??= new Chefs.Business.Models.BindableIntIteratorViewModel(…);
	      // …
	    }
	    public Chefs.Business.Models.BindableIntIteratorViewModel Pages { get; private set; }
	  }
	}

Nothing tells NativeAOT to preserve the `BindableIntIteratorViewModel` properties, so they're "removed" from Reflection metadata.

Update `BindableFromFeedProperty.cs` to use `[DynamicDependency]` on the `WelcomeViewModel.Pages` property accessor:

	namespace Chefs.Presentation {
	  public partial class WelcomeViewModel {
	    public Chefs.Business.Models.BindableIntIteratorViewModel Pages
	    {
	      [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(Chefs.Business.Models.BindableIntIteratorViewModel))]
	      get;
	      private set;
	    }
	  }
	}

This change informs NativeAOT that if the `WelcomeViewModel.Pages` property getter is preserved, then the public properties on `BindableIntIteratorViewModel` should also be made accessible via Reflection.  This fixes the original message:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [CurrentIndex] property getter does not exist on type [Chefs.Business.Models.BindableIntIteratorViewModel]

…only to replace it with this *different* set of failure messages:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [CanMovePrevious] property getter does not exist on type [Chefs.Business.Models.IntIterator]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [CanMovePrevious] property getter does not exist on type [Chefs.Business.Models.IntIterator]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [CanMoveNext] property getter does not exist on type [Chefs.Business.Models.IntIterator]
	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [CanMoveNext] property getter does not exist on type [Chefs.Business.Models.IntIterator]

Address this new set of messages by updating `Bindable<T>` to

	partial class Bindable<
	  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
	  T
	> : IBindable
	{
	}

As `BindableIntIteratorViewModel` inherits from `Bindable<IntIterator>` this causes the public properties on `IntIterator` to be preserved, fixing the previous set of failure messages.

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
