### PR TITLE
chore: propagate exceptions to DispatcherQueue

### DIFF
--- a/src/Uno.Extensions.Core.UI/CoreDispatcherExtensions.cs
+++ b/src/Uno.Extensions.Core.UI/CoreDispatcherExtensions.cs
@@ -19,6 +19,7 @@ public static class CoreDispatcherExtensions
 			catch (Exception ex)
 			{
 				completion.TrySetException(ex);
+				throw;
 			}
 		});
 		return await completion.Task;

--- a/src/Uno.Extensions.Core.UI/DispatcherQueueExtensions.cs
+++ b/src/Uno.Extensions.Core.UI/DispatcherQueueExtensions.cs
@@ -18,6 +18,7 @@ public static class DispatcherQueueExtensions
 							catch (Exception ex)
 							{
 								completion.SetException(ex);
+								throw;
 							}
 						});
 		return await completion.Task;

--- a/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispatcherQueueProvider.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispatcherQueueProvider.cs
@@ -58,6 +58,7 @@ public static class DispatcherQueueProvider
 				catch (Exception error)
 				{
 					tcs.TrySetException(error);
+					throw;
 				}
 			}
 		}


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno-private/issues/1562#issuecomment-3639770255
Context: https://github.com/unoplatform/uno/pull/22082

While running the uno.chefs app on macOS under NativeAOT, with lots of other changes applied such as unoplatform/uno#22082:

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop -bl \
	  Chefs/Chefs.csproj \
	  -p:SelfContained=true -p:PublishAot=true -p:IsAotCompatible=true -p:UseSkiaRendering=true \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true -p:IlcGenerateMetadataLog=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen
	Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs

The app *runs*, but after logging in no recipes are shown.

![No recipes shown!][0]

The "obvious" thing to do at this point is look at application output and see what "fail" message appear.

The problem?  There are no obviously related "fail" messages! The only fail message printed is:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [SplashScreenContent] property getter does not exist on type [Uno.Toolkit.UI.ExtendedSplashScreen]

which doesn't feel particularly relevant here.

A fair bit of "printf debugging" later, and I observe that `ControlNavigator.CreateViewModel()` is throwing an exception from `services.GetService(mapping!.ViewModel)`, but that exception isn't logged anywhere.

I thus assume that the exception is being caught and discarded "somewhere", but cannot determine where that "somewhere" would be.

Thus, punt: the complete observed callstack included `Uno.UI.Dispatching.NativeDispatcher.RunAction(NativeDispatcher, Action)`, which catches *and logs* all exceptions thrown from the callback.

Review use of `catch` alongside
`TaskCompletionSource<TResult>.{Try}SetException()`, and update the callsite to `throw` the original exception when interacting with `DispatcherQueue` or `IDispatcher` or `CoreDispatcher` (which uses `DispatcherQueue` internally):

	var completion = new TaskCompletionSource<TResult>();
	dispatcher.TryEnqueue(async () =>
	{
	  try
	  {
	    var result = await actionWithResult(cancellation);
	    completion.SetResult(result);
	  }
	  catch (Exception ex)
	  {
	    completion.SetException(ex);
	    throw; // NEW!
	  }
	});

Propagating the exception in this manner allows
`NativeDispatcher.RunAction()` to log the exception, which now provides a much more useful `fail` message (vs. none at all!):

	fail: Uno.UI.Dispatching.NativeDispatcher[0]
	      NativeDispatcher unhandled exception
	      System.InvalidOperationException: A suitable constructor for type 'Microsoft.Kiota.Http.HttpClientLibrary.Middleware.UriReplacementHandler`1[Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options.UriReplacementHandlerOption]' could not be located. Ensure the type is concrete and services are registered for all parameters of a public constructor.
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateConstructorCallSite(ResultCache, ServiceIdentifier, Type, CallSiteChain) + 0x3e9
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateExact(ServiceDescriptor, ServiceIdentifier, CallSiteChain, Int32) + 0x181
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateExact(ServiceIdentifier, CallSiteChain) + 0x14f
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateCallSite(ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain) + 0xc9
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.GetCallSite(ServiceIdentifier, CallSiteChain) + 0x92
	         at Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(ServiceIdentifier serviceIdentifier) + 0x68
	         at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey, Func`2) + 0xd2
	         at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(ServiceIdentifier, ServiceProviderEngineScope) + 0x39
	         at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider, Type) + 0x3d
	         at Uno.Extensions.Http.Kiota.ServiceCollectionExtensions.<>c__DisplayClass3_0.<AttachKiotaHandlers>b__0(IServiceProvider sp) + 0x10
	         at Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.<>c__DisplayClass3_0.<AddHttpMessageHandler>b__1(HttpMessageHandlerBuilder b) + 0x14
	         at Microsoft.Extensions.Http.DefaultHttpClientFactory.<>c__DisplayClass17_0.<CreateHandlerEntry>g__Configure|0(HttpMessageHandlerBuilder b) + 0x5c
	         at Microsoft.Extensions.Http.MetricsFactoryHttpMessageHandlerFilter.<>c__DisplayClass2_0.<Configure>b__0(HttpMessageHandlerBuilder builder) + 0x1d
	         at Microsoft.Extensions.Http.LoggingHttpMessageHandlerBuilderFilter.<>c__DisplayClass6_0.<Configure>b__0(HttpMessageHandlerBuilder builder) + 0x24
	         at Microsoft.Extensions.Http.DefaultHttpClientFactory.CreateHandlerEntry(String) + 0x1dc
	         at System.Lazy`1.ViaFactory(LazyThreadSafetyMode) + 0xac
	         at System.Lazy`1.ExecutionAndPublication(LazyHelper, Boolean) + 0x4c
	         at System.Lazy`1.CreateValue() + 0x53
	         at Microsoft.Extensions.Http.DefaultHttpClientFactory.CreateHandler(String) + 0x35
	         at Microsoft.Extensions.Http.DefaultHttpClientFactory.CreateClient(String) + 0x35
	         at Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.<>c__DisplayClass21_0`1.<AddTypedClientCore>b__0(IServiceProvider s) + 0x30
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitDisposeCache(ServiceCallSite, RuntimeResolverContext) + 0xe
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite, RuntimeResolverContext) + 0x79
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitRootCache(ServiceCallSite, RuntimeResolverContext) + 0x64
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite, RuntimeResolverContext) + 0x79
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitDisposeCache(ServiceCallSite, RuntimeResolverContext) + 0xe
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.<>c__DisplayClass8_1.<<CreateViewModel>b__0>d.MoveNext() + 0x93
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.<CreateViewModel>d__8.MoveNext() + 0x15e
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator`1.<InitializeCurrentView>d__9.MoveNext() + 0xec
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.Navigation.Navigators.FrameNavigator.<NavigateForwardAsync>d__9.MoveNext() + 0x91
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.<ControlNavigateAsync>d__6.MoveNext() + 0x5c
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.<>c__DisplayClass4_0.<<ControlCoreNavigateAsync>b__0>d.MoveNext() + 0x51
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.DispatcherExtensions.<>c__DisplayClass2_0`1.<<ExecuteAsync>b__0>d.MoveNext() + 0x1a0
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.DispatcherQueueExtensions.<>c__DisplayClass0_0`1.<<ExecuteAsync>b__0>d.MoveNext() + 0x269
	      --- End of stack trace from previous location ---
	         at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__124_0(Object state) + 0x17
	         at Uno.UI.Dispatching.NativeDispatcher.RunAction(NativeDispatcher, Action) + 0x7a

[0]: https://private-user-images.githubusercontent.com/155958/525151880-41ade08f-e3a7-4198-b76b-12084b81b080.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjU4MTc3MDAsIm5iZiI6MTc2NTgxNzQwMCwicGF0aCI6Ii8xNTU5NTgvNTI1MTUxODgwLTQxYWRlMDhmLWUzYTctNDE5OC1iNzZiLTEyMDg0YjgxYjA4MC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUxMjE1JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MTIxNVQxNjUwMDBaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT05N2MwMGI4M2NmNWMwNzYwNzg3Y2NiYmE5NTQyMGUzZmIwZmNlYTJmZTgyYmY4M2JlZThkMmVmOTVjMWQ0NzY3JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.99XXNo0GGzEgZfwLA4ZiFfqY13vmy0748gK3_MdGE0U

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
