### PR TITLE
chore: Fix trimmer warnings

### DIFF
--- a/src/Uno.Extensions.Authentication.MSAL/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication.MSAL/HostBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System.Diagnostics.CodeAnalysis;
+
 namespace Uno.Extensions;
 
 /// <summary>
@@ -6,6 +7,9 @@ namespace Uno.Extensions;
 /// </summary>
 public static class HostBuilderExtensions
 {
+	internal const string RequiresDynamicCodeMessage = "Binding strongly typed objects to configuration values may require generating dynamic code at runtime. [From Array.CreateInstance() and others.]";
+	internal const string RequiresUnreferencedCodeMessage = "Cannot statically analyze the type of instance so its members may be trimmed. [From TypeDescriptor.GetConverter() and others.]";
+
 	/// <summary>
 	/// Adds MSAL authentication to the specified <see cref="IAuthenticationBuilder"/>.
 	/// </summary>
@@ -22,6 +26,8 @@ public static class HostBuilderExtensions
 	/// The <see cref="IAuthenticationBuilder"/> that was passed in.
 	/// </returns>
 	[Obsolete("This method is obsolete. Please use the AddMsal overload that accepts a 'Window' parameter to specify the authentication window. The overload without 'Window' will be removed in a future release.", false)]
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IAuthenticationBuilder AddMsal(
 		this IAuthenticationBuilder builder,
 		Action<IMsalAuthenticationBuilder>? configure = default,
@@ -48,6 +54,8 @@ public static class HostBuilderExtensions
 	/// <returns>
 	/// The <see cref="IAuthenticationBuilder"/> that was passed in.
 	/// </returns>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IAuthenticationBuilder AddMsal(
 		this IAuthenticationBuilder builder,
 		Window window,
@@ -57,6 +65,8 @@ public static class HostBuilderExtensions
 		return InternalAddMsal(builder, window, configure, name);
 	}
 
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	private static IAuthenticationBuilder InternalAddMsal(
 		this IAuthenticationBuilder builder,
 		Window? window,

--- a/src/Uno.Extensions.Authentication.MSAL/Uno.Extensions.Authentication.MSAL.WinUI.csproj
+++ b/src/Uno.Extensions.Authentication.MSAL/Uno.Extensions.Authentication.MSAL.WinUI.csproj
@@ -4,6 +4,7 @@
 	<PropertyGroup>
 		<PackageId>Uno.Extensions.Authentication.MSAL.WinUI</PackageId>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
+		<IsAotCompatible>true</IsAotCompatible>
 
 		<Description>MSAL Authentication Extensions for the Uno Platform (WinUI)</Description>
 		<EnableDefaultPageItems>false</EnableDefaultPageItems>

--- a/src/Uno.Extensions.Authentication.Oidc/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication.Oidc/HostBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Duende.IdentityModel.OidcClient.Browser;
+﻿using System.Diagnostics.CodeAnalysis;
+using Duende.IdentityModel.OidcClient.Browser;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Uno.Extensions;
@@ -8,6 +9,9 @@ namespace Uno.Extensions;
 /// </summary>
 public static class HostBuilderExtensions
 {
+	internal const string RequiresDynamicCodeMessage = "Binding strongly typed objects to configuration values may require generating dynamic code at runtime. [From Array.CreateInstance() and others.]";
+	internal const string RequiresUnreferencedCodeMessage = "Cannot statically analyze the type of instance so its members may be trimmed. [From TypeDescriptor.GetConverter() and others.]";
+
 	/// <summary>
 	/// Adds OIDC authentication to the specified <see cref="IAuthenticationBuilder"/>.
 	/// </summary>
@@ -23,6 +27,7 @@ public static class HostBuilderExtensions
 	/// <returns>
 	/// The <see cref="IAuthenticationBuilder"/> that was passed in.
 	/// </returns>
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IAuthenticationBuilder AddOidc(
 		this IAuthenticationBuilder builder,
 		Action<IOidcAuthenticationBuilder>? configure = default,

--- a/src/Uno.Extensions.Authentication.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication.UI/HostBuilderExtensions.cs
@@ -1,10 +1,15 @@
-﻿namespace Uno.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions;
 
 /// <summary>
 /// Provides extension methods for web authentication to use with <see cref="IAuthenticationBuilder"/>.
 /// </summary>
 public static class HostBuilderExtensions
 {
+	internal const string RequiresDynamicCodeMessage = "Binding strongly typed objects to configuration values may require generating dynamic code at runtime. [From Array.CreateInstance() and others.]";
+	internal const string RequiresUnreferencedCodeMessage = "Cannot statically analyze the type of instance so its members may be trimmed. [From TypeDescriptor.GetConverter() and others.]";
+
 	/// <summary>
 	/// Adds web authentication to the specified <see cref="IAuthenticationBuilder"/>.
 	/// </summary>
@@ -20,6 +25,7 @@ public static class HostBuilderExtensions
 	/// <returns>
 	/// The <see cref="IAuthenticationBuilder"/> that was passed in.
 	/// </returns>
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IAuthenticationBuilder AddWeb(
 		this IAuthenticationBuilder builder,
 		Action<IWebAuthenticationBuilder>? configure = default,
@@ -70,6 +76,7 @@ public static class HostBuilderExtensions
 	/// <returns>
 	/// The <see cref="IAuthenticationBuilder"/> that was passed in.
 	/// </returns>
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IAuthenticationBuilder AddWeb<TService>(
 		this IAuthenticationBuilder builder,
 		Action<IWebAuthenticationBuilder<TService>>? configure = default,

--- a/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ConfigBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Configuration;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions.Configuration;
 
 /// <summary>
 /// Extension methods for registering a configuration source with an instance
@@ -112,6 +114,8 @@ public static class ConfigBuilderExtensions
 	/// <returns>
 	/// An instance of the <see cref="IConfigBuilder"/> for chaining.
 	/// </returns>
+	[RequiresDynamicCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresUnreferencedCodeMessage)]
 	public static IConfigBuilder Section<TSettingsOptions>(
 		this IConfigBuilder hostBuilder,
 		string? configurationSection = "",
@@ -181,6 +185,8 @@ public static class ConfigBuilderExtensions
 	/// <returns>
 	/// An instance of the <see cref="IConfigBuilder"/> for chaining.
 	/// </returns>
+	[RequiresDynamicCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresUnreferencedCodeMessage)]
 	public static IConfigBuilder WithConfigurationSectionFromEntity<TEntity>(
 		this IConfigBuilder hostBuilder,
 		TEntity entity,

--- a/src/Uno.Extensions.Configuration/ConfigurationBinder.cs
+++ b/src/Uno.Extensions.Configuration/ConfigurationBinder.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Uno.Extensions.Configuration.Internal;
 
@@ -11,9 +12,34 @@ namespace Uno.Extensions.Configuration.Internal;
 public static class ConfigurationBinder
 {
 	private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+	private const DynamicallyAccessedMemberTypes DeclaredOnlyMethodRequirements =
+		  DynamicallyAccessedMemberTypes.NonPublicMethods
+		| DynamicallyAccessedMemberTypes.PublicMethods;
+	private const DynamicallyAccessedMemberTypes DeclaredOnlyPropertyRequirements =
+		  DynamicallyAccessedMemberTypes.NonPublicProperties
+		| DynamicallyAccessedMemberTypes.PublicProperties;
+	private const DynamicallyAccessedMemberTypes AllMembersAndInterfaces =
+		  DynamicallyAccessedMemberTypes.PublicConstructors
+		| DynamicallyAccessedMemberTypes.NonPublicConstructors
+		| DynamicallyAccessedMemberTypes.PublicEvents
+		| DynamicallyAccessedMemberTypes.NonPublicEvents
+		| DynamicallyAccessedMemberTypes.PublicFields
+		| DynamicallyAccessedMemberTypes.NonPublicFields
+		| DynamicallyAccessedMemberTypes.PublicMethods
+		| DynamicallyAccessedMemberTypes.NonPublicMethods
+		| DynamicallyAccessedMemberTypes.PublicNestedTypes
+		| DynamicallyAccessedMemberTypes.NonPublicNestedTypes
+		| DynamicallyAccessedMemberTypes.PublicProperties
+		| DynamicallyAccessedMemberTypes.NonPublicProperties
+		| DynamicallyAccessedMemberTypes.Interfaces
+		;
+
 	private const string TrimmingWarningMessage = "In case the type is non-primitive, the trimmer cannot statically analyze the object's type so its members may be trimmed.";
 	private const string InstanceGetTypeTrimmingWarningMessage = "Cannot statically analyze the type of instance so its members may be trimmed";
 	private const string PropertyTrimmingWarningMessage = "Cannot statically analyze property.PropertyType so its members may be trimmed.";
+
+	internal const string RequiresDynamicCodeMessage = "Binding strongly typed objects to configuration values may require generating dynamic code at runtime. [From Array.CreateInstance() and others.]";
+	internal const string RequiresUnreferencedCodeMessage = "Cannot statically analyze the type of instance so its members may be trimmed. [From TypeDescriptor.GetConverter() and others.]";
 
 	/// <summary>
 	/// Attempts to bind the configuration instance to a new instance of type T.
@@ -23,6 +49,8 @@ public static class ConfigurationBinder
 	/// <typeparam name="T">The type of the new instance to bind.</typeparam>
 	/// <param name="configuration">The configuration instance to bind.</param>
 	/// <returns>The new instance of T if successful, default(T) otherwise.</returns>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static T Get<T>(this IConfiguration configuration)
 		=> configuration.Get<T>(_ => { });
 
@@ -35,7 +63,8 @@ public static class ConfigurationBinder
 	/// <param name="configuration">The configuration instance to bind.</param>
 	/// <param name="configureOptions">Configures the binder options.</param>
 	/// <returns>The new instance of T if successful, default(T) otherwise.</returns>
-
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static T Get<T>(this IConfiguration configuration, Action<BinderOptions> configureOptions)
 	{
 		if (configuration == null)
@@ -59,7 +88,8 @@ public static class ConfigurationBinder
 	/// <param name="configuration">The configuration instance to bind.</param>
 	/// <param name="type">The type of the new instance to bind.</param>
 	/// <returns>The new instance if successful, null otherwise.</returns>
-
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static object? Get(this IConfiguration configuration, Type type)
 		=> configuration.Get(type, _ => { });
 
@@ -72,7 +102,8 @@ public static class ConfigurationBinder
 	/// <param name="type">The type of the new instance to bind.</param>
 	/// <param name="configureOptions">Configures the binder options.</param>
 	/// <returns>The new instance if successful, null otherwise.</returns>
-
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static object? Get(
 		this IConfiguration configuration,
 
@@ -95,7 +126,8 @@ public static class ConfigurationBinder
 	/// <param name="configuration">The configuration instance to bind.</param>
 	/// <param name="key">The key of the configuration section to bind.</param>
 	/// <param name="instance">The object to bind.</param>
-
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static void Bind(this IConfiguration configuration, string key, object instance)
 		=> configuration.GetSection(key).Bind(instance);
 
@@ -104,7 +136,8 @@ public static class ConfigurationBinder
 	/// </summary>
 	/// <param name="configuration">The configuration instance to bind.</param>
 	/// <param name="instance">The object to bind.</param>
-
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static void Bind(this IConfiguration configuration, object instance)
 		=> configuration.Bind(instance, o => { });
 
@@ -114,7 +147,8 @@ public static class ConfigurationBinder
 	/// <param name="configuration">The configuration instance to bind.</param>
 	/// <param name="instance">The object to bind.</param>
 	/// <param name="configureOptions">Configures the binder options.</param>
-
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static void Bind(this IConfiguration configuration, object instance, Action<BinderOptions> configureOptions)
 	{
 		if (configuration == null)
@@ -137,7 +171,7 @@ public static class ConfigurationBinder
 	/// <param name="configuration">The configuration.</param>
 	/// <param name="key">The key of the configuration section's value to convert.</param>
 	/// <returns>The converted value.</returns>
-
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static T GetValue<T>(this IConfiguration configuration, string key)
 	{
 		return GetValue(configuration, key, default(T))!;
@@ -151,7 +185,7 @@ public static class ConfigurationBinder
 	/// <param name="key">The key of the configuration section's value to convert.</param>
 	/// <param name="defaultValue">The default value to use if no value is found.</param>
 	/// <returns>The converted value.</returns>
-
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static T GetValue<T>(this IConfiguration configuration, string key, T defaultValue)
 	{
 		return (T)GetValue(configuration, typeof(T), key, defaultValue!);
@@ -164,7 +198,7 @@ public static class ConfigurationBinder
 	/// <param name="type">The type to convert the value to.</param>
 	/// <param name="key">The key of the configuration section's value to convert.</param>
 	/// <returns>The converted value.</returns>
-
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static object GetValue(
 		this IConfiguration configuration,
 
@@ -182,7 +216,7 @@ public static class ConfigurationBinder
 	/// <param name="key">The key of the configuration section's value to convert.</param>
 	/// <param name="defaultValue">The default value to use if no value is found.</param>
 	/// <returns>The converted value.</returns>
-
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static object GetValue(
 		this IConfiguration configuration,
 
@@ -199,6 +233,9 @@ public static class ConfigurationBinder
 	}
 
 
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "TODO")]
 	private static void BindNonScalar(this IConfiguration configuration, object? instance, BinderOptions options)
 	{
 		if (instance != null)
@@ -230,6 +267,8 @@ public static class ConfigurationBinder
 	}
 
 
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	private static void BindProperty(PropertyInfo property, object instance, IConfiguration config, BinderOptions options)
 	{
 		// We don't support set only, non public, or indexer properties
@@ -258,6 +297,8 @@ public static class ConfigurationBinder
 		}
 	}
 
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	private static object? BindToCollection(Type type, IConfiguration config, BinderOptions options)
 	{
 		Type genericType = typeof(List<>).MakeGenericType(type.GenericTypeArguments[0]);
@@ -267,8 +308,10 @@ public static class ConfigurationBinder
 	}
 
 	// Try to create an array/dictionary instance to back various collection interfaces
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	private static object? AttemptBindToCollectionInterfaces(
-
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 			Type type,
 		IConfiguration config, BinderOptions options)
 	{
@@ -326,7 +369,10 @@ public static class ConfigurationBinder
 	}
 
 
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	private static object? BindInstance(
+		[DynamicallyAccessedMembers(AllMembersAndInterfaces)]
 		Type type,
 		object? instance,
 		IConfiguration config,
@@ -405,8 +451,9 @@ public static class ConfigurationBinder
 		return instance;
 	}
 
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
 	private static object? CreateInstance(
-
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 		Type type)
 	{
 		if (type.IsInterface || type.IsAbstract)
@@ -426,11 +473,15 @@ public static class ConfigurationBinder
 
 		if (!type.IsValueType)
 		{
-			bool hasDefaultConstructor = type.GetConstructors(DeclaredOnlyLookup).Any(ctor => ctor.IsPublic && ctor.GetParameters().Length == 0);
+			bool hasDefaultConstructor = HasDefaultConstructor(type);
 			if (!hasDefaultConstructor)
 			{
 				throw new InvalidOperationException("error");
 			}
+
+			[UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "We don't need *all* constructors, just the default, which is part of `type`.")]
+			static bool HasDefaultConstructor(Type t)
+				=> t.GetConstructors(DeclaredOnlyLookup).Any(ctor => ctor.IsPublic && ctor.GetParameters().Length == 0);
 		}
 
 		try
@@ -443,9 +494,12 @@ public static class ConfigurationBinder
 		}
 	}
 
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+	[UnconditionalSuppressMessage("Trimming", "IL2062", Justification = "Unable to add `DynamicallyAccessedMemberTypes.*` to `Type.GenericTypeArguments[1]`.")]
 	private static void BindDictionary(
 		object? dictionary,
-			Type dictionaryType,
+		[DynamicallyAccessedMembers(DeclaredOnlyPropertyRequirements)] Type dictionaryType,
 		IConfiguration config, BinderOptions options)
 	{
 		// IDictionary<K,V> is guaranteed to have exactly two parameters
@@ -483,9 +537,12 @@ public static class ConfigurationBinder
 		}
 	}
 
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+	[UnconditionalSuppressMessage("Trimming", "IL2062", Justification = "Unable to add `DynamicallyAccessedMemberTypes.*` to `Type.GenericTypeArguments[0]`.")]
 	private static void BindCollection(
 		object? collection,
-			Type collectionType,
+		[DynamicallyAccessedMembers(DeclaredOnlyMethodRequirements)] Type collectionType,
 		IConfiguration config, BinderOptions options)
 	{
 		// ICollection<T> is guaranteed to have exactly one parameter
@@ -513,8 +570,12 @@ public static class ConfigurationBinder
 		}
 	}
 
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+	[UnconditionalSuppressMessage("Trimming", "IL2062", Justification = "Unable to add `DynamicallyAccessedMemberTypes.*` to `Type.GenericTypeArguments[0]`.")]
 	private static object? BindImmutableList(
 		object? collection,
+		[DynamicallyAccessedMembers(DeclaredOnlyMethodRequirements)]
 		Type collectionType,
 		IConfiguration config, BinderOptions options)
 	{
@@ -544,7 +605,9 @@ public static class ConfigurationBinder
 		return collection;
 	}
 
-
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Cannot add `DynamicallyAccessedMemberTypes.Interfaces` to `Type.GetElementType()`.")]
 	private static Array BindArray(Array source, IConfiguration config, BinderOptions options)
 	{
 		IConfigurationSection[] children = config.GetChildren().ToArray();
@@ -581,9 +644,9 @@ public static class ConfigurationBinder
 	}
 
 
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	private static bool TryConvertValue(
-
-			Type type,
+		[DynamicallyAccessedMembers(AllMembersAndInterfaces)] Type type,
 		string value, string path, out object result, out Exception error)
 	{
 		error = null!;
@@ -633,10 +696,9 @@ public static class ConfigurationBinder
 		return false;
 	}
 
-
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	private static object ConvertValue(
-
-			Type type,
+		[DynamicallyAccessedMembers(AllMembersAndInterfaces)] Type type,
 		string value, string path)
 	{
 		object result;
@@ -649,8 +711,12 @@ public static class ConfigurationBinder
 		return result;
 	}
 
+	[return: DynamicallyAccessedMembers(DeclaredOnlyMethodRequirements | DeclaredOnlyPropertyRequirements)]
+	[UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "There is no way to declare that the return type *actually* fulfills `[return: DAM]`.")]
+	[UnconditionalSuppressMessage("Trimming", "IL2068", Justification = "There is no way to declare that the return type *actually* fulfills `[return: DAM]`.")]
 	private static Type FindOpenGenericInterface(
 		Type expected,
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 			Type actual)
 	{
 		if (actual.IsGenericType &&
@@ -671,8 +737,9 @@ public static class ConfigurationBinder
 		return null!;
 	}
 
+	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Cannot add `DynamicallyAccessedMemberTypes.NonPublicProperties` to `Type.BaseType`.")]
 	private static List<PropertyInfo> GetAllProperties(
-
+			[DynamicallyAccessedMembers(DeclaredOnlyPropertyRequirements)]
 			Type type)
 	{
 		var allProperties = new List<PropertyInfo>();
@@ -687,7 +754,9 @@ public static class ConfigurationBinder
 		return allProperties;
 	}
 
-
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Cannot add `DynamicallyAccessedMemberTypes.Interfaces` to `PropertyInfo.PropertyType`.")]
 	private static object? GetPropertyValue(PropertyInfo property, object instance, IConfiguration config, BinderOptions options)
 	{
 		string propertyName = GetPropertyName(property);

--- a/src/Uno.Extensions.Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ConfigurationBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Configuration;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions.Configuration;
 
 /// <summary>
 /// Extension methods for registering sources with the <see cref="IConfigurationBuilder"/> 
@@ -164,6 +166,8 @@ public static class ConfigurationBuilderExtensions
 	/// <param name="entity">An entity of the specified type parameter to be serialized</param>
 	/// <param name="sectionName">A name for the added configuration section. Optional</param>
 	/// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+	[RequiresDynamicCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresUnreferencedCodeMessage)]
 	public static IConfigurationBuilder AddSectionFromEntity<TEntity>(
 		this IConfigurationBuilder configurationBuilder,
 		TEntity entity,

--- a/src/Uno.Extensions.Configuration/NamedConfigureFromConfigurationOptions.cs
+++ b/src/Uno.Extensions.Configuration/NamedConfigureFromConfigurationOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Configuration.Internal;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions.Configuration.Internal;
 
 internal class NamedConfigureFromConfigurationOptions<TOptions> : ConfigureNamedOptions<TOptions>
 		where TOptions : class
@@ -8,6 +10,8 @@ internal class NamedConfigureFromConfigurationOptions<TOptions> : ConfigureNamed
 	/// </summary>
 	/// <param name="name">The name of the options instance.</param>
 	/// <param name="config">The <see cref="IConfiguration"/> instance.</param>
+	[RequiresDynamicCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresUnreferencedCodeMessage)]
 	public NamedConfigureFromConfigurationOptions(string? name, IConfiguration config)
 		: this(name, config, _ => { })
 	{ }
@@ -18,6 +22,8 @@ internal class NamedConfigureFromConfigurationOptions<TOptions> : ConfigureNamed
 	/// <param name="name">The name of the options instance.</param>
 	/// <param name="config">The <see cref="IConfiguration"/> instance.</param>
 	/// <param name="configureBinder">Used to configure the <see cref="BinderOptions"/>.</param>
+	[RequiresDynamicCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresUnreferencedCodeMessage)]
 	public NamedConfigureFromConfigurationOptions(string? name, IConfiguration config, Action<BinderOptions>? configureBinder)
 		: base(name, options => config.Bind(options, configureBinder!))
 	{

--- a/src/Uno.Extensions.Configuration/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Configuration/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Uno.Extensions.Serialization;
+﻿using System.Diagnostics.CodeAnalysis;
+using Uno.Extensions.Serialization;
 
 namespace Uno.Extensions.Configuration;
 
@@ -19,6 +20,8 @@ public static class ServiceCollectionExtensions
 	/// <param name="file">The full path to the file where updated section data will be written.</param>
 	/// <param name="name">The named options value to register</param>
 	/// <returns>The Microsoft.Extensions.DependencyInjection.IServiceCollection so that additional calls can be chained.</returns>
+	[RequiresDynamicCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(Uno.Extensions.Configuration.Internal.ConfigurationBinder.RequiresUnreferencedCodeMessage)]
 	public static IServiceCollection ConfigureAsWritable<T>(
 		this IServiceCollection services,
 		IConfigurationSection section,

--- a/src/Uno.Extensions.Configuration/Uno.Extensions.Configuration.csproj
+++ b/src/Uno.Extensions.Configuration/Uno.Extensions.Configuration.csproj
@@ -4,6 +4,8 @@
 	<PropertyGroup>
 		<Description>Configuration Extensions for reading configuration and writing settings for the Uno Platform, UWP and WinUI</Description>
 
+		<IsAotCompatible>true</IsAotCompatible>
+
 		<!--Temporary disable missing XML doc until fixed in the whole package-->
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
 	</PropertyGroup>

--- a/src/Uno.Extensions.Hosting.UI/ApplicationBuilder.cs
+++ b/src/Uno.Extensions.Hosting.UI/ApplicationBuilder.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Uno.Extensions.Hosting;
 
 internal record ApplicationBuilder(Application App, LaunchActivatedEventArgs Arguments, Assembly ApplicationAssembly) : IApplicationBuilder
@@ -13,6 +15,8 @@ internal record ApplicationBuilder(Application App, LaunchActivatedEventArgs Arg
 		Window.Current!;
 #endif
 
+	[RequiresDynamicCode(UnoHost.RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(UnoHost.RequiresUnreferencedCodeMessage)]
 	public IHost Build()
 	{
 		var builder = UnoHost.CreateDefaultBuilder(

--- a/src/Uno.Extensions.Hosting.UI/IApplicationBuilder.cs
+++ b/src/Uno.Extensions.Hosting.UI/IApplicationBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Hosting;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions.Hosting;
 
 /// <summary>
 /// Defines an abstraction for building your application and App Host
@@ -44,5 +46,7 @@ public interface IApplicationBuilder
 	/// and then calls the internal Build on the <see cref="IHostBuilder" />
 	/// </summary>
 	/// <returns>The <see cref="IHost" /></returns>
+	[RequiresDynamicCode(UnoHost.RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(UnoHost.RequiresUnreferencedCodeMessage)]
 	IHost Build();
 }

--- a/src/Uno.Extensions.Hosting.UI/Uno.Extensions.Hosting.WinUI.csproj
+++ b/src/Uno.Extensions.Hosting.UI/Uno.Extensions.Hosting.WinUI.csproj
@@ -13,6 +13,7 @@
 		<OutputType>Library</OutputType>
 
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 	
 	<ItemGroup>

--- a/src/Uno.Extensions.Hosting.UI/UnoHost.cs
+++ b/src/Uno.Extensions.Hosting.UI/UnoHost.cs
@@ -7,6 +7,8 @@ namespace Uno.Extensions.Hosting;
 /// </summary>
 public static class UnoHost
 {
+	internal const string RequiresDynamicCodeMessage = "Binding strongly typed objects to configuration values may require generating dynamic code at runtime. [From Array.CreateInstance() and others.]";
+	internal const string RequiresUnreferencedCodeMessage = "Cannot statically analyze the type of instance so its members may be trimmed. [From TypeDescriptor.GetConverter() and others.]";
 
 	/// <summary>
 	/// Obsolete; use <see cref="CreateDefaultBuilder(Assembly, System.String[])"/> or
@@ -19,6 +21,8 @@ public static class UnoHost
 	/// The initialized IHostBuilder.
 	/// </returns>
 	[Obsolete("Use CreateDefaultBuilder(Assembly, string[]) or CreateDefaultBuilder<TApplication>(string[]) instead.")]
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IHostBuilder CreateDefaultBuilder(string[]? args = null)
 	{
 		return CreateDefaultBuilder(PlatformHelper.GetAppAssembly()!, args);
@@ -37,6 +41,8 @@ public static class UnoHost
 	/// <returns>
 	/// The initialized IHostBuilder.
 	/// </returns>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IHostBuilder CreateDefaultBuilder<TApplication>(string[]? args = null)
 		where TApplication : Application
 	{
@@ -57,6 +63,8 @@ public static class UnoHost
 	/// <returns>
 	/// The initialized IHostBuilder.
 	/// </returns>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IHostBuilder CreateDefaultBuilder(Assembly applicationAssembly, string[]? args = null)
 	{
 		PlatformHelper.SetAppAssembly(applicationAssembly);

--- a/src/Uno.Extensions.Http.Kiota/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Http.Kiota/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Kiota.Abstractions;
@@ -12,6 +14,9 @@ namespace Uno.Extensions.Http.Kiota;
 /// </summary>
 public static class ServiceCollectionExtensions
 {
+	internal const string RequiresDynamicCodeMessage = "Binding strongly typed objects to configuration values may require generating dynamic code at runtime. [From Array.CreateInstance() and others.]";
+	internal const string RequiresUnreferencedCodeMessage = "Cannot statically analyze the type of instance so its members may be trimmed. [From TypeDescriptor.GetConverter() and others.]";
+
 	/// <summary>
 	/// Registers a Kiota client with the specified <paramref name="name"/> and endpoint options.
 	/// </summary>
@@ -22,7 +27,12 @@ public static class ServiceCollectionExtensions
 	/// <param name="name">[Optional] The name for locating endpoint information in appsettings.</param>
 	/// <param name="configure">[Optional] A callback for configuring the endpoint.</param>
 	/// <returns>The updated <see cref="IServiceCollection"/> with the registered Kiota client.</returns>
-	public static IServiceCollection AddKiotaClient<TClient>(
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+	public static IServiceCollection AddKiotaClient<
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+		TClient
+	>(
 		this IServiceCollection services,
 		HostBuilderContext context,
 		EndpointOptions? options = null,
@@ -43,7 +53,13 @@ public static class ServiceCollectionExtensions
 	/// <param name="name">[Optional] The name for locating endpoint information in appsettings.</param>
 	/// <param name="configure">[Optional] A callback for configuring the endpoint.</param>
 	/// <returns>The updated <see cref="IServiceCollection"/> with the registered Kiota client.</returns>
-	public static IServiceCollection AddKiotaClientWithEndpoint<TClient, TEndpoint>(
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+	public static IServiceCollection AddKiotaClientWithEndpoint<
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+		TClient,
+		TEndpoint
+	>(
 	this IServiceCollection services,
 	HostBuilderContext context,
 	TEndpoint? options = null,
@@ -83,6 +99,7 @@ public static class ServiceCollectionExtensions
 	/// </summary>
 	/// <param name="services">The <see cref="IServiceCollection"/> to register the handlers with.</param>
 	/// <returns>The updated <see cref="IServiceCollection"/> with the registered Kiota handlers.</returns>
+	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Cannot annotate IEnumerator<T>.Current.get")]
 	private static IServiceCollection AddKiotaHandlers(this IServiceCollection services)
 	{
 		var kiotaHandlers = KiotaClientFactory.GetDefaultHandlerTypes();

--- a/src/Uno.Extensions.Http.Kiota/Uno.Extensions.Http.Kiota.csproj
+++ b/src/Uno.Extensions.Http.Kiota/Uno.Extensions.Http.Kiota.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Uno.Extensions.Http.UI/Uno.Extensions.Http.WinUI.csproj
+++ b/src/Uno.Extensions.Http.UI/Uno.Extensions.Http.WinUI.csproj
@@ -4,6 +4,8 @@
 	<PropertyGroup>
 		<Description>HTTP Extensions for registering endpoints for Uno Platform, UWP and WinUI</Description>
 
+		<IsAotCompatible>true</IsAotCompatible>
+
 		<!--Temporary disable missing XML doc until fixed in the whole package-->
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
 		

--- a/src/Uno.Extensions.Http/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Http/ServiceCollectionExtensions.cs
@@ -7,6 +7,9 @@ namespace Uno.Extensions;
 /// </summary>
 public static class ServiceCollectionExtensions
 {
+	internal const string RequiresDynamicCodeMessage = "Binding strongly typed objects to configuration values may require generating dynamic code at runtime. [From Array.CreateInstance() and others.]";
+	internal const string RequiresUnreferencedCodeMessage = "Cannot statically analyze the type of instance so its members may be trimmed. [From TypeDescriptor.GetConverter() and others.]";
+
 	private static char[] InterfaceNamePrefix = new[] { 'i', 'I' };
 
 	private static T Conditional<T>(
@@ -28,7 +31,14 @@ public static class ServiceCollectionExtensions
 	/// <param name="name">[optional] Name of the endpoint (used to load from appsettings)</param>
 	/// <param name="configure">[optional] Callback to configure the endpoint</param>
 	/// <returns>Updated service collection</returns>
-	public static IServiceCollection AddClient<TClient, TImplementation>(
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+	public static IServiceCollection AddClient<
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+		TClient,
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+		TImplementation
+	>(
 		 this IServiceCollection services,
 		 HostBuilderContext context,
 		 EndpointOptions? options = null,
@@ -51,6 +61,8 @@ public static class ServiceCollectionExtensions
 	/// <param name="name">[optional] Name of the endpoint (used to load from appsettings)</param>
 	/// <param name="configure">[optional] Callback to configure the endpoint</param>
 	/// <returns>Updated service collection</returns>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IServiceCollection AddClientWithEndpoint<
 		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 		TClient,
@@ -88,6 +100,8 @@ public static class ServiceCollectionExtensions
 	/// <param name="httpClientFactory">[optional] Callback to configure the HttpClient</param>
 	/// <param name="configure">[optional] Callback to configure the endpoint</param>
 	/// <returns>Updated service collection</returns>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IServiceCollection AddClient<TInterface>(
 		  this IServiceCollection services,
 		  HostBuilderContext context,
@@ -111,7 +125,8 @@ public static class ServiceCollectionExtensions
 	/// <param name="httpClientFactory">[optional] Callback to configure the HttpClient</param>
 	/// <param name="configure">[optional] Callback to configure the endpoint</param>
 	/// <returns>Updated service collection</returns>
-	[RequiresUnreferencedCode("From `ConfigurationBinder.Get<T>(IConfiguration)`.")]
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IServiceCollection AddClientWithEndpoint<
 		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
 		TInterface,

--- a/src/Uno.Extensions.Http/Uno.Extensions.Http.csproj
+++ b/src/Uno.Extensions.Http/Uno.Extensions.Http.csproj
@@ -4,6 +4,8 @@
 	<PropertyGroup>
 		<Description>HTTP Extensions for registering endpoints for Uno Platform, UWP and WinUI</Description>
 
+		<IsAotCompatible>true</IsAotCompatible>
+
 		<!--Temporary disable missing XML doc until fixed in the whole package-->
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
 	</PropertyGroup>

--- a/src/Uno.Extensions.Localization.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Localization.UI/HostBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Uno.Extensions.Hosting;
+﻿using System.Diagnostics.CodeAnalysis;
+using Uno.Extensions.Hosting;
 
 namespace Uno.Extensions.Localization;
 
@@ -7,6 +8,9 @@ namespace Uno.Extensions.Localization;
 /// </summary>
 public static class HostBuilderExtensions
 {
+	internal const string RequiresDynamicCodeMessage = "Binding strongly typed objects to configuration values may require generating dynamic code at runtime. [From Array.CreateInstance() and others.]";
+	internal const string RequiresUnreferencedCodeMessage = "Cannot statically analyze the type of instance so its members may be trimmed. [From TypeDescriptor.GetConverter() and others.]";
+
 	/// <summary>
 	/// Configures the localization service.
 	/// </summary>
@@ -19,6 +23,8 @@ public static class HostBuilderExtensions
 	/// <returns>
 	/// The host builder for chaining.
 	/// </returns>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IHostBuilder UseLocalization(
 		this IHostBuilder hostBuilder,
 		Action<IServiceCollection> configure)
@@ -38,6 +44,8 @@ public static class HostBuilderExtensions
 	/// <returns>
 	/// The host builder for chaining.
 	/// </returns>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IHostBuilder UseLocalization(
 		this IHostBuilder hostBuilder,
 		Action<HostBuilderContext, IServiceCollection>? configure = default)

--- a/src/Uno.Extensions.Localization.UI/Uno.Extensions.Localization.WinUI.csproj
+++ b/src/Uno.Extensions.Localization.UI/Uno.Extensions.Localization.WinUI.csproj
@@ -3,6 +3,7 @@
 
 	<PropertyGroup>
 		<Description>Localization Extensions for registering IStringLocalizer implementation for Uno Platform (WinUI)</Description>
+		<IsAotCompatible>true</IsAotCompatible>
 
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 		<!--Temporary disable missing XML doc until fixed in the whole package-->

--- a/src/Uno.Extensions.Navigation.UI/ApplicationBuilderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ApplicationBuilderExtensions.cs
@@ -1,7 +1,11 @@
-﻿namespace Uno.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions;
 
 public static class ApplicationBuilderExtensions
 {
+	internal const string RequiresUnreferencedCodeMessage = "Cannot statically analyze the type of instance so its members may be trimmed. [From TypeDescriptor.GetConverter() and others.]";
+
 	/// <summary>
 	/// Creates the Application Shell and will initialize the Shell Content before creating
 	/// the <see cref="IHost" /> and initializing the app with the initial navigation.
@@ -10,6 +14,7 @@ public static class ApplicationBuilderExtensions
 	/// <param name="appBuilder">The <see cref="IApplicationBuilder" />.</param>
 	/// <param name="initialNavigate">An optional Navigation Delegate to conditionally control where the app should navigate on launch.</param>
 	/// <returns>The <see cref="IHost" />.</returns>
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static async Task<IHost> NavigateAsync<TShell>(this IApplicationBuilder appBuilder,
 		Func<IServiceProvider, INavigator, Task>? initialNavigate = null)
 		where TShell : UIElement, new()

--- a/src/Uno.Extensions.Navigation.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/HostBuilderExtensions.cs
@@ -1,10 +1,15 @@
-﻿namespace Uno.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions;
 
 /// <summary>
 /// Extensions for configuring navigation.
 /// </summary>
 public static class HostBuilderExtensions
 {
+	internal const string RequiresDynamicCodeMessage = "Binding strongly typed objects to configuration values may require generating dynamic code at runtime. [From Array.CreateInstance() and others.]";
+	internal const string RequiresUnreferencedCodeMessage = "Cannot statically analyze the type of instance so its members may be trimmed. [From TypeDescriptor.GetConverter() and others.]";
+
 	/// <summary>
 	/// Configures navigation services
 	/// </summary>
@@ -15,6 +20,7 @@ public static class HostBuilderExtensions
 	/// <param name="configure">Callback to adjust navigation configuration (default should be to use appsettings.json)</param>
 	/// <param name="configureServices">Callback to register other services related to navigation</param>
 	/// <returns>The host builder</returns>
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IHostBuilder UseNavigation(
 		this IHostBuilder hostBuilder,
 		Action<IViewRegistry, IRouteRegistry>? viewRouteBuilder,
@@ -41,6 +47,7 @@ public static class HostBuilderExtensions
 	/// <param name="configure">Callback to adjust navigation configuration (default should be to use appsettings.json)</param>
 	/// <param name="configureServices">Callback to register other services related to navigation</param>
 	/// <returns>The host builder</returns>
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IHostBuilder UseNavigation(
 		this IHostBuilder hostBuilder,
 		Action<IViewRegistry, IRouteRegistry>? viewRouteBuilder = null,
@@ -76,6 +83,7 @@ public static class HostBuilderExtensions
 	/// <param name="configure">Callback to adjust navigation configuration (default should be to use appsettings.json)</param>
 	/// <param name="configureServices">Callback to register other services related to navigation</param>
 	/// <returns>The host builder</returns>
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IHostBuilder UseNavigation(
 		this IHostBuilder hostBuilder,
 		IDictionary<Type, Type> viewModelMapping,

--- a/src/Uno.Extensions.Storage.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Storage.UI/HostBuilderExtensions.cs
@@ -1,16 +1,23 @@
-﻿namespace Uno.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Uno.Extensions;
 
 /// <summary>
 /// Extensions for working with <see cref="IHostBuilder"/>.
 /// </summary>
 public static class HostBuilderExtensions
 {
+	internal const string RequiresDynamicCodeMessage = "Binding strongly typed objects to configuration values may require generating dynamic code at runtime. [From Array.CreateInstance() and others.]";
+	internal const string RequiresUnreferencedCodeMessage = "Cannot statically analyze the type of instance so its members may be trimmed. [From TypeDescriptor.GetConverter() and others.]";
+
 	/// <summary>
 	/// Registers storage services.
 	/// </summary>
 	/// <param name="hostBuilder">The host builder instance to register with</param>
 	/// <param name="configure">Callback for configuring services</param>
 	/// <returns>The updated host builder instance</returns>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IHostBuilder UseStorage(
 		this IHostBuilder hostBuilder,
 		Action<IServiceCollection> configure)
@@ -22,6 +29,8 @@ public static class HostBuilderExtensions
 	/// <param name="hostBuilder">The host builder instance to register with</param>
 	/// <param name="configure">Callback for configuring services</param>
 	/// <returns></returns>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public static IHostBuilder UseStorage(
 		this IHostBuilder hostBuilder,
 		Action<HostBuilderContext, IServiceCollection>? configure = default)


### PR DESCRIPTION
Enable `$(IsAotCompatible)`=true for the following projects:

  * `src/Uno.Extensions.Authentication.MSAL/Uno.Extensions.Authentication.MSAL.WinUI.csproj`
  * `src/Uno.Extensions.Configuration/Uno.Extensions.Configuration.csproj`
  * `src/Uno.Extensions.Hosting.UI/Uno.Extensions.Hosting.WinUI.csproj`
  * `src/Uno.Extensions.Http/Uno.Extensions.Http.csproj`
  * `src/Uno.Extensions.Http.UI/Uno.Extensions.Http.WinUI.csproj`
  * `src/Uno.Extensions.Localization.UI/Uno.Extensions.Localization.WinUI.csproj`
  * `src/Uno.Extensions.Storage.UI/Uno.Extensions.Storage.WinUI.csproj`

Fix the following warnings:

	src/Uno.Extensions.Http/ServiceCollectionExtensions.cs(40,6): error IL2091:
	  'TClient' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in 'Uno.Extensions.ServiceCollectionExtensions.AddClientWithEndpoint<TClient, TImplementation, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>)'.
	  The generic parameter 'TClient' of 'Uno.Extensions.ServiceCollectionExtensions.AddClient<TClient, TImplementation>(IServiceCollection, HostBuilderContext, EndpointOptions, String, Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Http/ServiceCollectionExtensions.cs(40,6): error IL2091:
	  'TImplementation' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in 'Uno.Extensions.ServiceCollectionExtensions.AddClientWithEndpoint<TClient, TImplementation, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>)'.
	  The generic parameter 'TImplementation' of 'Uno.Extensions.ServiceCollectionExtensions.AddClient<TClient, TImplementation>(IServiceCollection, HostBuilderContext, EndpointOptions, String, Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Http/ServiceCollectionExtensions.cs(100,6): error IL2091:
	  'TInterface' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in 'Uno.Extensions.ServiceCollectionExtensions.AddClientWithEndpoint<TInterface, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>, Func<IHttpClientBuilder, TEndpoint, IHttpClientBuilder>)'.
	  The generic parameter 'TInterface' of 'Uno.Extensions.ServiceCollectionExtensions.AddClient<TInterface>(IServiceCollection, HostBuilderContext, EndpointOptions, String, Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>, Func<IHttpClientBuilder, EndpointOptions, IHttpClientBuilder>)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(287,30): error IL2067:
	  'actual' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.FindOpenGenericInterface(Type, Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.AttemptBindToCollectionInterfaces(Type, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(294,25): error IL2067:
	  'actual' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.FindOpenGenericInterface(Type, Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.AttemptBindToCollectionInterfaces(Type, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(303,25): error IL2067:
	  'actual' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.FindOpenGenericInterface(Type, Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.AttemptBindToCollectionInterfaces(Type, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(311,25): error IL2067:
	  'actual' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.FindOpenGenericInterface(Type, Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.AttemptBindToCollectionInterfaces(Type, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(318,25): error IL2067:
	  'actual' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.FindOpenGenericInterface(Type, Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.AttemptBindToCollectionInterfaces(Type, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(325,25): error IL2067:
	  'actual' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.FindOpenGenericInterface(Type, Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.AttemptBindToCollectionInterfaces(Type, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(352,30): error IL2067:
	  'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.All' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.TryConvertValue(Type, String, String, out Object, out Exception)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.BindInstance(Type, Object, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(379,31): error IL2067:
	  'actual' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.FindOpenGenericInterface(Type, Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.BindInstance(Type, Object, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(390,30): error IL2067:
	  'actual' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.FindOpenGenericInterface(Type, Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.BindInstance(Type, Object, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(393,17): error IL2072:
	  'collectionType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.BindImmutableList(Object, Type, IConfiguration, BinderOptions)'.
	  The return value of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.FindOpenGenericInterface(Type, Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(398,28): error IL2067:
	  'actual' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.FindOpenGenericInterface(Type, Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.BindInstance(Type, Object, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(429,33): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Type.GetConstructors(BindingFlags)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.CreateInstance(Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(436,33): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Type.GetConstructors(BindingFlags)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.CreateInstance(Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(438,11): error IL2067:
	  'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.CreateInstance(Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(445,11): error IL2067:
	  'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.CreateInstance(Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(462,26): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Type.GetProperty(String, BindingFlags)'.
	  The parameter 'dictionaryType' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.BindDictionary(Object, Type, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(469,26): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Type.GetProperty(String, BindingFlags)'.
	  The parameter 'dictionaryType' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.BindDictionary(Object, Type, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(493,27): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Type.GetMethod(String, BindingFlags)'.
	  The parameter 'collectionType' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.BindCollection(Object, Type, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(500,27): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Type.GetMethod(String, BindingFlags)'.
	  The parameter 'collectionType' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.BindCollection(Object, Type, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(523,27): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.NonPublicMethods' in call to 'System.Type.GetMethod(String, BindingFlags)'.
	  The parameter 'collectionType' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.BindImmutableList(Object, Type, IConfiguration, BinderOptions)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(606,29): error IL2067:
	  'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.All' in call to 'System.ComponentModel.TypeDescriptor.GetConverter(Type)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.TryConvertValue(Type, String, String, out Object, out Exception)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(653,3): error IL2067:
	  'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.All' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.TryConvertValue(Type, String, String, out Object, out Exception)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.ConvertValue(Type, String, String)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(662,23): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'System.Type.GetInterfaces()'.
	  The parameter 'actual' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.FindOpenGenericInterface(Type, Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(682,27): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Type.GetProperties(BindingFlags)'.
	  The parameter 'type' of method 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.GetAllProperties(Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(693,4): error IL2072:
	  'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.GetAllProperties(Type)'.
	  The return value of method 'System.Type.BaseType.get' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Http.Kiota/ServiceCollectionExtensions.cs(59,10): warning IL2091:
	  'TInterface' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in 'Uno.Extensions.ServiceCollectionExtensions.AddClientWithEndpoint<TInterface, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>, Func<IHttpClientBuilder, TEndpoint, IHttpClientBuilder>)'.
	  The generic parameter 'TClient' of 'Uno.Extensions.Http.Kiota.ServiceCollectionExtensions.AddKiotaClientWithEndpoint<TClient, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IHttpClientBuilder, TEndpoint, IHttpClientBuilder>)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Http.Kiota/ServiceCollectionExtensions.cs(59,10): warning IL2091:
	  'TEndpoint' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.All' in 'Uno.Extensions.ServiceCollectionExtensions.AddClientWithEndpoint<TInterface, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>, Func<IHttpClientBuilder, TEndpoint, IHttpClientBuilder>)'.
	  The generic parameter 'TEndpoint' of 'Uno.Extensions.Http.Kiota.ServiceCollectionExtensions.AddKiotaClientWithEndpoint<TClient, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IHttpClientBuilder, TEndpoint, IHttpClientBuilder>)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Http.Kiota/ServiceCollectionExtensions.cs(63,33): warning IL2091:
	  'TClient' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in 'Microsoft.Extensions.DependencyInjection.HttpClientFactoryServiceCollectionExtensions.AddHttpClient<TClient>(IServiceCollection, String)'.
	  The generic parameter 'TClient' of 'Uno.Extensions.Http.Kiota.ServiceCollectionExtensions.AddKiotaClientWithEndpoint<TClient, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IHttpClientBuilder, TEndpoint, IHttpClientBuilder>)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.Extensions.Http.Kiota/ServiceCollectionExtensions.cs(74,22): warning IL2087:
	  'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'System.Activator.CreateInstance(Type, params Object[])'.
	  The generic parameter 'TClient' of 'Uno.Extensions.Http.Kiota.ServiceCollectionExtensions.AddKiotaClientWithEndpoint<TClient, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IHttpClientBuilder, TEndpoint, IHttpClientBuilder>)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Add the requested `[DynamicallyAccessedMembers]`.

Address the following warnings:

	src/Uno.Extensions.Authentication.MSAL/HostBuilderExtensions.cs(77,6): error IL2026:
	  Using member 'Uno.Extensions.Configuration.ConfigBuilderExtensions.Section<TSettingsOptions>(IConfigBuilder, String, Func<HostBuilderContext, IConfigurationSection>)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  JSON serialization and deserialization might require types that cannot be statically analyzed.
	  Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(263,22): error IL3050:
	  Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The native code for this instantiation might not be available at runtime.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(270,22): error IL3050:
	  Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The native code for this instantiation might not be available at runtime.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(290,26): error IL3050:
	  Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The native code for this instantiation might not be available at runtime.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(297,26): error IL3050:
	  Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The native code for this instantiation might not be available at runtime.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(299,48): error IL3050:
	  Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The native code for this instantiation might not be available at runtime.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(306,48): error IL3050:
	  Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The native code for this instantiation might not be available at runtime.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(352,30): error IL2026:
	  Using member 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.TryConvertValue(Type, String, String, out Object, out Exception)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From TypeDescriptor.GetConverter().
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(386,16): error IL3050:
	  Using member 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.BindArray(Array, IConfiguration, BinderOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  From Array.CreateInstance(): The code for an array of the specified type might not be available.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(424,11): error IL3050:
	  Using member 'System.Array.CreateInstance(Type, Int32)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The code for an array of the specified type might not be available.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(431,11): error IL3050:
	  Using member 'System.Array.CreateInstance(Type, Int32)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The code for an array of the specified type might not be available.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(553,18): error IL3050:
	  Using member 'System.Array.CreateInstance(Type, Int32)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  The code for an array of the specified type might not be available.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(606,29): error IL2026:
	  Using member 'System.ComponentModel.TypeDescriptor.GetConverter(Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  Generic TypeConverters may require the generic types to be annotated.
	  For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.
	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(653,3): error IL2026:
	  Using member 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.TryConvertValue(Type, String, String, out Object, out Exception)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From TypeDescriptor.GetConverter().
	src/Uno.Extensions.Configuration/ConfigurationBuilderExtensions.cs(176,7): error IL2026:
	  Using member 'System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  JSON serialization and deserialization might require types that cannot be statically analyzed.
	  Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
	src/Uno.Extensions.Configuration/ConfigurationBuilderExtensions.cs(176,7): error IL2026:
	  Using member 'System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  JSON serialization and deserialization might require types that cannot be statically analyzed.
	  Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
	src/Uno.Extensions.Configuration/ConfigurationBuilderExtensions.cs(176,7): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Configuration/ConfigurationBuilderExtensions.cs(176,7): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Http/ServiceCollectionExtensions.cs(77,10): error IL2026:
	  Using member 'Uno.Extensions.ServiceCollectionExtensions.AddClientWithEndpoint<TInterface, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>, Func<IHttpClientBuilder, TEndpoint, IHttpClientBuilder>)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From `ConfigurationBinder.Get<T>(IConfiguration)`.
	src/Uno.Extensions.Http/ServiceCollectionExtensions.cs(100,6): error IL2026:
	  Using member 'Uno.Extensions.ServiceCollectionExtensions.AddClientWithEndpoint<TInterface, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>, Func<IHttpClientBuilder, TEndpoint, IHttpClientBuilder>)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From `ConfigurationBinder.Get<T>(IConfiguration)`.
	src/Uno.Extensions.Http/ServiceCollectionExtensions.cs(132,15): error IL3050:
	  Using member 'Microsoft.Extensions.Configuration.ConfigurationBinder.Get<T>(IConfiguration)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Binding strongly typed objects to configuration values requires generating dynamic code at runtime, for example instantiating generic types.
	src/Uno.Extensions.Http.Kiota/ServiceCollectionExtensions.cs(59,10): warning IL2026:
	  Using member 'Uno.Extensions.ServiceCollectionExtensions.AddClientWithEndpoint<TInterface, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>, Func<IHttpClientBuilder, TEndpoint, IHttpClientBuilder>)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From `ConfigurationBinder.Get<T>(IConfiguration)`.
	src/Uno.Extensions.Http.Kiota/ServiceCollectionExtensions.cs(59,10): warning IL3050:
	  Using member 'Uno.Extensions.ServiceCollectionExtensions.AddClientWithEndpoint<TInterface, TEndpoint>(IServiceCollection, HostBuilderContext, TEndpoint, String, Func<IServiceCollection, HostBuilderContext, IHttpClientBuilder>, Func<IHttpClientBuilder, TEndpoint, IHttpClientBuilder>)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  From `ConfigurationBinder.Get<T>(IConfiguration)`.
	src/Uno.Extensions.Localization.UI/HostBuilderExtensions.cs(53,6): error IL2026:
	  Using member 'Uno.Extensions.Configuration.ConfigBuilderExtensions.Section<TSettingsOptions>(IConfigBuilder, String, Func<HostBuilderContext, IConfigurationSection>)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  JSON serialization and deserialization might require types that cannot be statically analyzed.
	  Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
	src/Uno.Extensions.Localization.UI/HostBuilderExtensions.cs(53,6): error IL2026:
	  Using member 'Uno.Extensions.Configuration.ConfigBuilderExtensions.Section<TSettingsOptions>(IConfigBuilder, String, Func<HostBuilderContext, IConfigurationSection>)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  JSON serialization and deserialization might require types that cannot be statically analyzed.
	  Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
	src/Uno.Extensions.Storage.UI/HostBuilderExtensions.cs(39,13): error IL2026:
	  Using member 'Uno.Extensions.Configuration.ConfigBuilderExtensions.Section<TSettingsOptions>(IConfigBuilder, String, Func<HostBuilderContext, IConfigurationSection>)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  JSON serialization and deserialization might require types that cannot be statically analyzed.
	  Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.

Add `[RequiresDynamicCode]` and/or `[RequiresUnreferencedCode]`.

*Note*: while this silences the warnings by "forwarding" them,
@jonpryor isn't at all sure what this means "downstream" in apps.
For example, uno.chefs has [`.Section<Credentials>()`][0], meaning
adding these attributes to `.Section<TSettingsOptions>()` means that
uno.chefs will now see these IL3050 warnings.

This doesn't actually *solve* the underlying problem of "the trimmer
may remove members", and @jonpryor isn't sure what the *correct*
solution is, either.

Suppress the following warnings:

	src/Uno.Extensions.Configuration/ConfigurationBinder.cs(213,41): error IL2072:
	  'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'Uno.Extensions.Configuration.Internal.ConfigurationBinder.GetAllProperties(Type)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

As these callsites are rooted in `value.GetType().…`, @jonpryor cannot
think of a way to appease NativeAOT here.

Warnings IL2070 and IL2062 are also selectively suppressed because they
come from `Type.GenericTypeParameters[x]`, which cannot be annotated.

Similarly, warnings IL2073 and IL2068 are selectively suppressed
because there is no way to update `Type.GetInterfaces()` or
`Type.GetGenericTypeDefinition()` to have matching annotations.

Warning IL2072 is also selectively suppressed because there is no way
to update `PropertyInfo.PropertyType` to have matching annotations,
or to have `IEnumerator<T>.Current.get` have matching annotations.

[0]: https://github.com/unoplatform/uno.chefs/blob/16a62fdd6950a2f89fe0f94dc5cc67207cab9c4a/Chefs/App.xaml.host.cs#L53-L54

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
