### PR TITLE
chore: update Microsoft.Kiota NuGet package versions

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,12 +8,12 @@
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />
     <PackageVersion Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.16.4" />
-    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.16.4" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Form" Version="1.16.4" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.16.4" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Multipart" Version="1.16.4" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Text" Version="1.16.4" />
+    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.21.0" />
+    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.21.0" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Form" Version="1.21.0" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.21.0" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Multipart" Version="1.21.0" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Text" Version="1.21.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="2.2.9" />
     <PackageVersion Include="MSTest.TestFramework" Version="2.2.9" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />

--- a/src/Uno.Extensions.Http.Kiota/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Http.Kiota/ServiceCollectionExtensions.cs
@@ -102,7 +102,7 @@ public static class ServiceCollectionExtensions
 	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Cannot annotate IEnumerator<T>.Current.get")]
 	private static IServiceCollection AddKiotaHandlers(this IServiceCollection services)
 	{
-		var kiotaHandlers = KiotaClientFactory.GetDefaultHandlerTypes();
+		var kiotaHandlers = KiotaClientFactory.GetDefaultHandlerActivatableTypes();
 		foreach (var handler in kiotaHandlers)
 		{
 			services.AddTransient(handler);
@@ -118,7 +118,7 @@ public static class ServiceCollectionExtensions
 	/// <returns>The updated <see cref="IHttpClientBuilder"/> with the attached Kiota handlers.</returns>
 	private static IHttpClientBuilder AttachKiotaHandlers(this IHttpClientBuilder builder)
 	{
-		var kiotaHandlers = KiotaClientFactory.GetDefaultHandlerTypes();
+		var kiotaHandlers = KiotaClientFactory.GetDefaultHandlerActivatableTypes();
 		foreach (var handler in kiotaHandlers)
 		{
 			builder.AddHttpMessageHandler((sp) => (DelegatingHandler)sp.GetRequiredService(handler));


### PR DESCRIPTION
Context: 3cc5c235e551c567369a3b2fc5826cb50d63251a
Context: cd3e1a6dc692c6bfaa0c7bacb211e72976e26446
Context: https://github.com/microsoft/kiota-dotnet/commit/a2800ab7c9bfa0292b8490b91962636917fa8c4c
Changes: https://github.com/microsoft/kiota-dotnet/compare/v1.16.4...v1.21.0

	% git diff --shortstat v1.16.4...v1.21.0
	 48 files changed, 1209 insertions(+), 224 deletions(-)

It's our favorite exercise, making uno.chefs run under NativeAOT!

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop -bl \
	  Chefs/Chefs.csproj \
	  -p:SelfContained=true -p:PublishAot=true -p:IsAotCompatible=true -p:UseSkiaRendering=true \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true -p:IlcGenerateMetadataLog=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen
	Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs

When running the app with an updated set of `Uno.Extensions.*` assemblies from commit 3cc5c235, the app log contains:

	fail: Uno.UI.Dispatching.NativeDispatcher[0]
	      NativeDispatcher unhandled exception
	      System.InvalidOperationException: A suitable constructor for type 'Microsoft.Kiota.Http.HttpClientLibrary.Middleware.UriReplacementHandler`1[Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options.UriReplacementHandlerOption]' could not be located. Ensure the type is concrete and services are registered for all parameters of a public constructor.
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateConstructorCallSite(ResultCache, ServiceIdentifier, Type, CallSiteChain) + 0x3e9

The hope had been that commit cd3e1a6d, in fixing various uno.extensions trimmer warnings, would also fix this warning. That hope turns out to have been wrong.

Thus, the question: why weren't the constructors for `UriReplacementHandler<TUriReplacementHandlerOption>` being preserved?

Investigation found that `KiotaClientFactory.GetDefaultHandlerTypes()` returned a list of types:

	partial class KiotaClientFactory {
	    public static IList<Type> GetDefaultHandlerTypes() => [
	        typeof(UriReplacementHandler<UriReplacementHandlerOption>),
	        typeof(RetryHandler),
	        // …
	    ];
	}

As we know from our [NativeAOT+Reflection Primer][0], if code is going to use `Activator.CreateInstance()`/etc. to instantiate a type, then "reflection metadata" for the type's constructors must be retained, which in turn is influenced by `[DynamicallyAccessedMembers]` and/or `[DynamicDependency]`.

Note that the above *does not use* `[DynamicallyAccessedMembers]`.

Fortunately, this problem was addressed in
microsoft/kiota-dotnet@a2800ab7, which *obsoleted* `KiotaClientFactory.GetDefaultHandlerTypes()`, replacing it with a new `KiotaClientFactory.GetDefaultHandlerActivatableTypes()` method which uses an `ActivatableType` type which uses
`[DynamicallyAccessedMembers]`, a'la:

	partial class KiotaClientFactory {
	    [Obsolete("Use GetDefaultHandlerActivatableTypes")]
	    public static IList<Type> GetDefaultHandlerTypes() => …;

	    public static IList<ActivatableType> GetDefaultHandlerActivatableTypes() => [
	        new(typeof(UriReplacementHandler<UriReplacementHandlerOption>)),
	        new(typeof(RetryHandler)),
	        // …
	    ];
	    public readonly struct ActivableType {
	        public ActivatableType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
	        {
	            Type = type;
	        }
	        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
	        public readonly Type type;

	        // "API Compatibility": permit implicit conversion to Type
	        public static implicit operator Type(ActivatableType type) => type.Type;
	    }
	}

There are two "problems" here:

 1. It's in a new assembly version + NuGet package version, and
 2. It's a new API, so it's not just a "update the package version and things work" affair.

Regardless, it *is* a fix, and *does* address the original `InvalidOperationException`.

Update the `Microsoft.Kiota.*` NuGet packages to v1.21.0, which contains this fix (plus many others, one imagines), and update `ServiceCollectionExtensions.AddKiotaHandlers()` and `ServiceCollectionExtensions.AttachKiotaHandlers()` to use the new `KiotaClientFactory.GetDefaultHandlerActivatableTypes()` method.

[0]: https://github.com/unoplatform/uno/commit/7266db13eafdfcdd7f5569fdd195fc26658c8186

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
