### PR TITLE
chore: preserve properties on IListFeed<T>

### DIFF
--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableFactory.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Uno.Extensions.Reactive.Core;
 using Uno.Extensions.Reactive.Utils;
@@ -24,6 +25,9 @@ public sealed class BindableFactory : IBindableFactory
 	}
 
 	/// <inheritdoc />
-	public IListFeed<T> CreateList<T>(string name, IListState<T> source)
+	public IListFeed<T> CreateList<
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+		T
+	>(string name, IListState<T> source)
 		=> new BindableListFeed<T>(name, source);
 }

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -19,7 +20,10 @@ namespace Uno.Extensions.Reactive.Bindings;
 /// An helper class use to data-bind a <see cref="IListFeed{T}"/>.
 /// </summary>
 /// <typeparam name="T">The type of the items.</typeparam>
-public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<T>, IInput<IImmutableList<T>>
+public sealed partial class BindableListFeed<
+	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+	T
+> : ISignal<IMessage>, IListState<T>, IInput<IImmutableList<T>>
 {
 	private readonly BindableCollection _items;
 	private readonly IListState<T> _state;
@@ -30,6 +34,7 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 	/// <param name="propertyName">The name of the property backed by the object.</param>
 	/// <param name="source">The source data stream.</param>
 	/// <param name="ctx">The context of the owner.</param>
+	[DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(BindableListFeed<>))]
 	public BindableListFeed(string propertyName, IListFeed<T> source, SourceContext ctx)
 	{
 		PropertyName = propertyName;
@@ -43,6 +48,7 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 	/// </summary>
 	/// <param name="propertyName">The name of the property backed by the object.</param>
 	/// <param name="source">The source data stream.</param>
+	[DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(BindableListFeed<>))]
 	public BindableListFeed(string propertyName, IListState<T> source)
 	{
 		PropertyName = propertyName;

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Windows.Foundation;
@@ -22,6 +23,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 		private readonly PaginationFacet? _pagination;
 		private readonly EditionFacet? _edition;
 
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(BasicView))]
 		public BasicView(
 			CollectionFacet collectionFacet,
 			CollectionChangedFacet collectionChangedFacet,

--- a/src/Uno.Extensions.Reactive/Core/Feed.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Uno.Extensions.Reactive.Operators;
@@ -233,7 +234,11 @@ public static partial class Feed
 	/// <param name="source">The source feed to project.</param>
 	/// <param name="getPage">The async method to load a page of items.</param>
 	/// <returns>A paginated list feed.</returns>
-	public static IListFeed<TResult> SelectPaginatedAsync<TSource, TResult>(
+	public static IListFeed<TResult> SelectPaginatedAsync<
+		TSource,
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TResult
+	>(
 		this IFeed<TSource> source,
 		AsyncFunc<TSource, PageRequest, IImmutableList<TResult>> getPage)
 		where TSource : notnull
@@ -273,7 +278,12 @@ public static partial class Feed
 	/// <param name="firstPage">The cursor of the first page.</param>
 	/// <param name="getPage">The async method to load a page of items.</param>
 	/// <returns>A paginated list feed.</returns>
-	public static IListFeed<TResult> SelectPaginatedByCursorAsync<TSource, TCursor, TResult>(
+	public static IListFeed<TResult> SelectPaginatedByCursorAsync<
+		TSource,
+		TCursor,
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TResult
+	>(
 		this IFeed<TSource> source,
 		TCursor firstPage,
 		GetPage<TSource, TCursor, TResult> getPage)

--- a/src/Uno.Extensions.Reactive/Core/IListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Core/IListFeed.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Uno.Extensions.Reactive;
@@ -8,6 +9,9 @@ namespace Uno.Extensions.Reactive;
 /// A **stateless** stream of list of items.
 /// </summary>
 /// <typeparam name="T">The type of the items in the list.</typeparam>
-public interface IListFeed<T> : ISignal<Message<IImmutableList<T>>>
+public interface IListFeed<
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	T
+> : ISignal<Message<IImmutableList<T>>>
 {
 }

--- a/src/Uno.Extensions.Reactive/Core/IListState.cs
+++ b/src/Uno.Extensions.Reactive/Core/IListState.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,7 +13,10 @@ namespace Uno.Extensions.Reactive;
 /// 2. can be updated
 /// </summary>
 /// <typeparam name="T">The type of the items in the list.</typeparam>
-public interface IListState<T> : IListFeed<T>, IState
+public interface IListState<
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	T
+> : IListFeed<T>, IState
 {
 	/// <summary>
 	/// Updates the current internal message.

--- a/src/Uno.Extensions.Reactive/Core/Internal/ListStateImpl.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/ListStateImpl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +18,10 @@ namespace Uno.Extensions.Reactive;
 
 // Note: This is a "quick implementation". Inheriting from FeedToListFeedAdapter is most probably not a good idea.
 
-internal class ListStateImpl<T> : FeedToListFeedAdapter<T>, IListState<T>, IStateImpl
+internal class ListStateImpl<
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	T
+> : FeedToListFeedAdapter<T>, IListState<T>, IStateImpl
 {
 	private readonly StateImpl<IImmutableList<T>> _implementation;
 

--- a/src/Uno.Extensions.Reactive/Core/Internal/SourceContext.cs
+++ b/src/Uno.Extensions.Reactive/Core/Internal/SourceContext.cs
@@ -330,7 +330,10 @@ public sealed class SourceContext : IAsyncDisposable
 	/// <param name="feed">The list feed to get source from.</param>
 	/// <returns>The list state wrapping the given list feed</returns>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
-	public IListState<T> GetOrCreateListState<T>(IListFeed<T> feed)
+	public IListState<T> GetOrCreateListState<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(IListFeed<T> feed)
 		=> States.GetOrCreateState<IListFeed<T>, IListState<T>>(feed, static (ctx, f) => new ListStateImpl<T>((StateImpl<IImmutableList<T>>)ctx.GetOrCreateState(f.AsFeed())));
 
 	/// <summary>
@@ -340,12 +343,18 @@ public sealed class SourceContext : IAsyncDisposable
 	/// <param name="feed">The list feed to get source from.</param>
 	/// <returns>The list state wrapping the given list feed</returns>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
-	public IListState<T> GetOrCreateListState<T>(IFeed<IImmutableList<T>> feed)
+	public IListState<T> GetOrCreateListState<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(IFeed<IImmutableList<T>> feed)
 		=> States.GetOrCreateState<IFeed<IImmutableList<T>>, IListState<T>>(feed, static (ctx, f) => new ListStateImpl<T>((StateImpl<IImmutableList<T>>)ctx.GetOrCreateState(f)));
 
 	// WARNING: DO NOT USE, this breaks the cache by providing a custom config!
 	// We need to make those config "upgradable" in order to properly share the instances of State
-	internal ListStateImpl<T> DoNotUse_GetOrCreateListState<T>(IListFeed<T> feed, StateUpdateKind updatesKind)
+	internal ListStateImpl<T> DoNotUse_GetOrCreateListState<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(IListFeed<T> feed, StateUpdateKind updatesKind)
 		=> States.GetOrCreateState(feed, /*static*/ (ctx, f) => new ListStateImpl<T>(new StateImpl<IImmutableList<T>>(ctx, f.AsFeed(), updatesKind: updatesKind)));
 
 	/// <summary>
@@ -367,7 +376,10 @@ public sealed class SourceContext : IAsyncDisposable
 	/// <returns>The list state wrapping the given list feed</returns>
 	/// <exception cref="ObjectDisposedException">This context has been disposed.</exception>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
-	public IListState<T> CreateListState<T>(Option<IImmutableList<T>> initialValue)
+	public IListState<T> CreateListState<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(Option<IImmutableList<T>> initialValue)
 		=> States.CreateState<IImmutableList<T>, IListState<T>>(initialValue, static (ctx, iv) => new ListStateImpl<T>((StateImpl<IImmutableList<T>>)ctx.CreateState(iv)));
 	#endregion
 

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.Extensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
@@ -25,7 +26,10 @@ public static partial class ListFeed
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
 	/// <param name="listFeed">The list feed to get data from.</param>
 	/// <returns>An awaiter to asynchronously get the next data produced by the feed.</returns>
-	public static ValueTaskAwaiter<IImmutableList<T>> GetAwaiter<T>(this IListFeed<T> listFeed)
+	public static ValueTaskAwaiter<IImmutableList<T>> GetAwaiter<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed)
 		=> listFeed.Value(SourceContext.Current.Token).GetAwaiter();
 
 	/// <summary>
@@ -35,7 +39,10 @@ public static partial class ListFeed
 	/// <param name="listFeed">The feed to get data from.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to asynchronously get the next data produced by the feed.</returns>
-	public static async ValueTask<IImmutableList<T>> Value<T>(this IListFeed<T> listFeed, CancellationToken ct = default)
+	public static async ValueTask<IImmutableList<T>> Value<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed, CancellationToken ct = default)
 		=> await FeedDependency.TryGetCurrentMessage(listFeed).ConfigureAwait(false) switch
 		{
 			{ } message => message.Current.EnsureNoError().Data.SomeOrDefault(ImmutableList<T>.Empty),
@@ -50,7 +57,10 @@ public static partial class ListFeed
 	/// <param name="kind">Specify which data can be returned or not.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to asynchronously get the next acceptable data produced by the feed.</returns>
-	public static async ValueTask<IImmutableList<T>> Value<T>(this IListFeed<T> listFeed, AsyncFeedValue kind, CancellationToken ct = default)
+	public static async ValueTask<IImmutableList<T>> Value<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed, AsyncFeedValue kind, CancellationToken ct = default)
 		=> await FeedDependency.TryGetCurrentMessage(listFeed).ConfigureAwait(false) switch
 		{
 			not null when kind is not AsyncFeedValue.Default => throw new NotSupportedException($"Only kind AsyncFeedValue.Default is currently supported by the dynamic feed (requested: {kind})."),
@@ -66,7 +76,10 @@ public static partial class ListFeed
 	/// <param name="kind">Specify which data can be returned or not.</param>
 	/// <param name="ct">A cancellation to cancel the async enumeration.</param>
 	/// <returns>An async enumeration sequence of all acceptable data produced by a feed.</returns>
-	public static IAsyncEnumerable<IImmutableList<T>> Values<T>(this IListFeed<T> listFeed, AsyncFeedValue kind = AsyncFeedValue.AllowError, CancellationToken ct = default)
+	public static IAsyncEnumerable<IImmutableList<T>> Values<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed, AsyncFeedValue kind = AsyncFeedValue.AllowError, CancellationToken ct = default)
 		=> listFeed.DataSet(kind, ct).Select(opt => opt.SomeOrDefault(ImmutableList<T>.Empty));
 
 	/// <summary>
@@ -76,7 +89,10 @@ public static partial class ListFeed
 	/// <param name="listFeed">The feed to get data from.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to asynchronously get the next data produced by the feed.</returns>
-	public static async ValueTask<Option<IImmutableList<T>>> Data<T>(this IListFeed<T> listFeed, CancellationToken ct = default)
+	public static async ValueTask<Option<IImmutableList<T>>> Data<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed, CancellationToken ct = default)
 		=> await FeedDependency.TryGetCurrentMessage(listFeed).ConfigureAwait(false) switch
 		{
 			{ } message => message.Current.EnsureNoError().Data,
@@ -91,7 +107,10 @@ public static partial class ListFeed
 	/// <param name="kind">Specify which data can be returned or not.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to asynchronously get the next acceptable data produced by the feed.</returns>
-	public static async ValueTask<Option<IImmutableList<T>>> Data<T>(this IListFeed<T> listFeed, AsyncFeedValue kind, CancellationToken ct = default)
+	public static async ValueTask<Option<IImmutableList<T>>> Data<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed, AsyncFeedValue kind, CancellationToken ct = default)
 		=> await FeedDependency.TryGetCurrentMessage(listFeed).ConfigureAwait(false) switch
 		{
 			not null when kind is not AsyncFeedValue.Default => throw new NotSupportedException($"Only kind AsyncFeedValue.Default is currently supported by the dynamic feed (requested: {kind})."),
@@ -107,7 +126,10 @@ public static partial class ListFeed
 	/// <param name="kind">Specify which data can be returned or not.</param>
 	/// <param name="ct">A cancellation to cancel the async enumeration.</param>
 	/// <returns>An async enumeration sequence of all acceptable data produced by a feed.</returns>
-	public static async IAsyncEnumerable<Option<IImmutableList<T>>> DataSet<T>(this IListFeed<T> listFeed, AsyncFeedValue kind = AsyncFeedValue.AllowError, [EnumeratorCancellation] CancellationToken ct = default)
+	public static async IAsyncEnumerable<Option<IImmutableList<T>>> DataSet<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed, AsyncFeedValue kind = AsyncFeedValue.AllowError, [EnumeratorCancellation] CancellationToken ct = default)
 	{
 		using var enumCt = CancellationTokenSource.CreateLinkedTokenSource(ct);
 		try
@@ -151,7 +173,10 @@ public static partial class ListFeed
 #if DEBUG
 	[Obsolete("Use Data instead")]
 #endif
-	public static ValueTask<Option<IImmutableList<T>>> Option<T>(this IListFeed<T> listFeed, CancellationToken ct)
+	public static ValueTask<Option<IImmutableList<T>>> Option<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed, CancellationToken ct)
 		=> listFeed.Data(ct);
 
 	/// <summary>
@@ -162,7 +187,10 @@ public static partial class ListFeed
 #if DEBUG
 	[Obsolete("Use Data instead")]
 #endif
-	public static ValueTask<Option<IImmutableList<T>>> Option<T>(this IListFeed<T> listFeed, AsyncFeedValue kind, CancellationToken ct)
+	public static ValueTask<Option<IImmutableList<T>>> Option<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed, AsyncFeedValue kind, CancellationToken ct)
 		=> listFeed.Data(kind, ct);
 
 	/// <summary>
@@ -173,7 +201,10 @@ public static partial class ListFeed
 #if DEBUG
 	[Obsolete("Use DataSet instead")]
 #endif
-	public static IAsyncEnumerable<Option<IImmutableList<T>>> Options<T>(this IListFeed<T> listFeed, AsyncFeedValue kind = AsyncFeedValue.AllowError, CancellationToken ct = default)
+	public static IAsyncEnumerable<Option<IImmutableList<T>>> Options<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed, AsyncFeedValue kind = AsyncFeedValue.AllowError, CancellationToken ct = default)
 		=> listFeed.DataSet(kind, ct);
 
 	/// <summary>
@@ -183,7 +214,10 @@ public static partial class ListFeed
 	/// <param name="listFeed">The list feed to get message from.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to asynchronously get the next message produced by the feed.</returns>
-	public static async ValueTask<Message<IImmutableList<T>>> Message<T>(this IListFeed<T> listFeed, CancellationToken ct = default)
+	public static async ValueTask<Message<IImmutableList<T>>> Message<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed, CancellationToken ct = default)
 		=> await FeedDependency.TryGetCurrentMessage(listFeed).ConfigureAwait(false)
 			?? await listFeed.Messages().FirstAsync(ct).ConfigureAwait(false);
 
@@ -193,7 +227,10 @@ public static partial class ListFeed
 	/// <typeparam name="T">The type of the value of the feed.</typeparam>
 	/// <param name="listFeed">The list feed to get messages from.</param>
 	/// <returns>An async enumeration sequence of all acceptable messages produced by a feed.</returns>
-	public static IAsyncEnumerable<Message<IImmutableList<T>>> Messages<T>(this IListFeed<T> listFeed)
+	public static IAsyncEnumerable<Message<IImmutableList<T>>> Messages<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> listFeed)
 		=> SourceContext.Current.GetOrCreateSource(listFeed);
 
 	#region Convertions
@@ -203,7 +240,10 @@ public static partial class ListFeed
 	/// <typeparam name="TItem">Type of items in the list.</typeparam>
 	/// <param name="source">The source list stream to wrap.</param>
 	/// <returns>A <see cref="IListFeed{T}"/> that wraps the given source data stream of list.</returns>
-	public static IListFeed<TItem> AsListFeed<TItem>(this IFeed<IImmutableList<TItem>> source)
+	public static IListFeed<TItem> AsListFeed<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TItem
+	>(this IFeed<IImmutableList<TItem>> source)
 		=> source is ListFeedToFeedAdapter<TItem> adapter
 			? adapter.Source
 			: AttachedProperty.GetOrCreate(source, typeof(TItem), (s, _) => new FeedToListFeedAdapter<TItem>(s));
@@ -214,7 +254,10 @@ public static partial class ListFeed
 	/// <typeparam name="TItem">Type of items in the list.</typeparam>
 	/// <param name="source">The source list stream to wrap.</param>
 	/// <returns>A <see cref="IListFeed{T}"/> that wraps the given source data stream of list.</returns>
-	public static IListFeed<TItem> AsListFeed<TItem>(this IFeed<ImmutableList<TItem>> source)
+	public static IListFeed<TItem> AsListFeed<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TItem
+	>(this IFeed<ImmutableList<TItem>> source)
 		=> AttachedProperty.GetOrCreate(source, typeof(TItem), (s, _) => new FeedToListFeedAdapter<ImmutableList<TItem>, TItem>(s, list => list));
 
 	/// <summary>
@@ -224,7 +267,11 @@ public static partial class ListFeed
 	/// <typeparam name="TItem">Type of items in the list.</typeparam>
 	/// <param name="source">The source list stream to wrap.</param>
 	/// <returns>A <see cref="IListFeed{T}"/> that wraps the given source data stream.</returns>
-	public static IListFeed<TItem> AsListFeed<TCollection, TItem>(this IFeed<TCollection> source)
+	public static IListFeed<TItem> AsListFeed<
+		TCollection,
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TItem
+	>(this IFeed<TCollection> source)
 		where TCollection : IImmutableList<TItem>
 		=> AttachedProperty.GetOrCreate(source, typeof(TItem), (s, _) => new FeedToListFeedAdapter<TCollection, TItem>(s, list => list));
 
@@ -240,7 +287,11 @@ public static partial class ListFeed
 	/// Use with caution.
 	/// </remarks>
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public static IListFeed<TItem> ToListFeed<TCollection, TItem>(this IFeed<TCollection> source)
+	public static IListFeed<TItem> ToListFeed<
+		TCollection,
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TItem
+	>(this IFeed<TCollection> source)
 		where TCollection : IEnumerable<TItem>
 		=> AttachedProperty.GetOrCreate(source, typeof(TItem), (s, _) => new FeedToListFeedAdapter<TCollection, TItem>(s, list => list?.ToImmutableList() ?? ImmutableList<TItem>.Empty));
 
@@ -250,7 +301,10 @@ public static partial class ListFeed
 	/// <typeparam name="TItem">Type of items in the list.</typeparam>
 	/// <param name="source">The source list stream to wrap.</param>
 	/// <returns>The source data stream of list of the given <see cref="IListFeed{T}"/>.</returns>
-	public static IFeed<IImmutableList<TItem>> AsFeed<TItem>(
+	public static IFeed<IImmutableList<TItem>> AsFeed<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TItem
+	>(
 		this IListFeed<TItem> source)
 		// Note: DO NOT unwrap FeedToListFeedAdapter, as it adds some behavior
 		=> AttachedProperty.GetOrCreate(source, typeof(TItem), (s, _) => new ListFeedToFeedAdapter<TItem>(s));
@@ -264,7 +318,10 @@ public static partial class ListFeed
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>The selected items, or an empty collection if none.</returns>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
-	public static async ValueTask<IImmutableList<T>> GetSelectedItems<T>(this IListFeed<T> source, CancellationToken ct = default)
+	public static async ValueTask<IImmutableList<T>> GetSelectedItems<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> source, CancellationToken ct = default)
 		=> (await source.Message(ct).ConfigureAwait(false)).Current.GetSelectedItems();
 
 	/// <summary>
@@ -275,7 +332,10 @@ public static partial class ListFeed
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>The selected item, or null if none.</returns>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
-	public static async ValueTask<T?> GetSelectedItem<T>(this IListFeed<T> source, CancellationToken ct = default)
+	public static async ValueTask<T?> GetSelectedItem<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListFeed<T> source, CancellationToken ct = default)
 		where T : notnull
 		=> (await source.Message(ct).ConfigureAwait(false)).Current.GetSelectedItem();
 }

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.T.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -16,7 +17,10 @@ namespace Uno.Extensions.Reactive;
 /// Provides a set of static methods to create and manipulate <see cref="IListFeed{T}"/>.
 /// </summary>
 /// <typeparam name="T">The type of the items.</typeparam>
-public static partial class ListFeed<T>
+public static partial class ListFeed<
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	T
+>
 {
 	/// <summary>
 	/// Creates a custom feed from a raw <see cref="IAsyncEnumerable{T}"/> sequence of <see cref="Uno.Extensions.Reactive.Message{T}"/>.

--- a/src/Uno.Extensions.Reactive/Core/ListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListFeed.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -14,6 +15,9 @@ namespace Uno.Extensions.Reactive;
 
 public static partial class ListFeed
 {
+	internal const DynamicallyAccessedMemberTypes TRequirements =
+		DynamicallyAccessedMemberTypes.PublicProperties;
+
 	#region Sources
 	// Note: Those are helpers for which the T is set by type inference on provider.
 	//		 We must have only one overload per method.
@@ -24,7 +28,10 @@ public static partial class ListFeed
 	/// <typeparam name="T">The type of the value of the resulting feed.</typeparam>
 	/// <param name="sourceProvider">The provider of the message enumerable sequence.</param>
 	/// <returns>A feed that encapsulate the source.</returns>
-	public static IListFeed<T> Create<T>(Func<CancellationToken, IAsyncEnumerable<Message<IImmutableList<T>>>> sourceProvider)
+	public static IListFeed<T> Create<
+		[DynamicallyAccessedMembers(TRequirements)]
+		T
+	>(Func<CancellationToken, IAsyncEnumerable<Message<IImmutableList<T>>>> sourceProvider)
 		=> Feed.Create(sourceProvider).AsListFeed();
 
 	/// <summary>
@@ -34,7 +41,10 @@ public static partial class ListFeed
 	/// <param name="valueProvider">The async method to use to load the value of the resulting feed.</param>
 	/// <param name="refresh">A refresh trigger to reload the <paramref name="valueProvider"/>.</param>
 	/// <returns>A feed that encapsulate the source.</returns>
-	public static IListFeed<T> Async<T>(AsyncFunc<IImmutableList<T>> valueProvider, Signal? refresh = null)
+	public static IListFeed<T> Async<
+		[DynamicallyAccessedMembers(TRequirements)]
+		T
+	>(AsyncFunc<IImmutableList<T>> valueProvider, Signal? refresh = null)
 		=> Feed.Async(valueProvider, refresh).AsListFeed();
 
 	/// <summary>
@@ -44,7 +54,10 @@ public static partial class ListFeed
 	/// <param name="valueProvider">The async method to use to load the value of the resulting feed.</param>
 	/// <param name="refresh">A refresh trigger to reload the <paramref name="valueProvider"/>.</param>
 	/// <returns>A feed that encapsulate the source.</returns>
-	public static IListFeed<T> Async<T>(AsyncFunc<ImmutableList<T>> valueProvider, Signal? refresh = null)
+	public static IListFeed<T> Async<
+		[DynamicallyAccessedMembers(TRequirements)]
+		T
+	>(AsyncFunc<ImmutableList<T>> valueProvider, Signal? refresh = null)
 		=> Feed.Async(valueProvider, refresh).AsListFeed();
 
 	/// <summary>
@@ -53,7 +66,10 @@ public static partial class ListFeed
 	/// <typeparam name="T">The type of the data of the resulting feed.</typeparam>
 	/// <param name="enumerableProvider">The async enumerable sequence of value of the resulting feed.</param>
 	/// <returns>A feed that encapsulate the source.</returns>
-	public static IListFeed<T> AsyncEnumerable<T>(Func<CancellationToken, IAsyncEnumerable<IImmutableList<T>>> enumerableProvider)
+	public static IListFeed<T> AsyncEnumerable<
+		[DynamicallyAccessedMembers(TRequirements)]
+		T
+	>(Func<CancellationToken, IAsyncEnumerable<IImmutableList<T>>> enumerableProvider)
 		=> Feed.AsyncEnumerable(enumerableProvider).AsListFeed();
 
 	/// <summary>
@@ -67,7 +83,10 @@ public static partial class ListFeed
 #if DEBUG
 	[Obsolete("Use PaginatedAsync instead")]
 #endif
-	public static IListFeed<T> AsyncPaginated<T>(AsyncFunc<PageRequest, IImmutableList<T>> getPage)
+	public static IListFeed<T> AsyncPaginated<
+		[DynamicallyAccessedMembers(TRequirements)]
+		T
+	>(AsyncFunc<PageRequest, IImmutableList<T>> getPage)
 		=> PaginatedAsync(getPage);
 
 	/// <summary>
@@ -76,7 +95,10 @@ public static partial class ListFeed
 	/// <typeparam name="T">The type of the data of the resulting feed.</typeparam>
 	/// <param name="getPage">The async method to load a page of items.</param>
 	/// <returns>A paginated list feed.</returns>
-	public static IListFeed<T> PaginatedAsync<T>(AsyncFunc<PageRequest, IImmutableList<T>> getPage)
+	public static IListFeed<T> PaginatedAsync<
+		[DynamicallyAccessedMembers(TRequirements)]
+		T
+	>(AsyncFunc<PageRequest, IImmutableList<T>> getPage)
 		=> ListFeed<T>.PaginatedAsync(getPage);
 	#endregion
 
@@ -93,7 +115,10 @@ public static partial class ListFeed
 	/// if all items are filtered out from source list feed,
 	/// the resulting list feed  **will produce a message** with its data set to None.
 	/// </remarks>
-	public static IListFeed<TSource> Where<TSource>(
+	public static IListFeed<TSource> Where<
+		[DynamicallyAccessedMembers(TRequirements)]
+		TSource
+	>(
 		this IListFeed<TSource> source,
 		Predicate<TSource> predicate)
 		=> AttachedProperty.GetOrCreate(source, predicate, static (src, p) => new WhereListFeed<TSource>(src, p));
@@ -119,7 +144,10 @@ public static partial class ListFeed
 	/// <param name="caller">For debug purposes, the name of this subscription. DO NOT provide anything here, let the compiler provide this.</param>
 	/// <param name="line">For debug purposes, the name of this subscription. DO NOT provide anything here, let the compiler provide this.</param>
 	/// <returns>A ListState from and onto which the selection is going to be synced.</returns>
-	public static IListState<TSource> Selection<TSource>(
+	public static IListState<TSource> Selection<
+		[DynamicallyAccessedMembers(TRequirements)]
+		TSource
+	>(
 		this IListFeed<TSource> source,
 		IState<IImmutableList<TSource>> selectionState,
 		[CallerMemberName] string caller = "",
@@ -138,7 +166,10 @@ public static partial class ListFeed
 	/// <param name="caller">For debug purposes, the name of this subscription. DO NOT provide anything here, let the compiler provide this.</param>
 	/// <param name="line">For debug purposes, the name of this subscription. DO NOT provide anything here, let the compiler provide this.</param>
 	/// <returns>A ListState from and onto which the selection is going to be synced.</returns>
-	public static IListState<TSource> Selection<TSource>(
+	public static IListState<TSource> Selection<
+		[DynamicallyAccessedMembers(TRequirements)]
+		TSource
+	>(
 		this IListFeed<TSource> source,
 		IState<TSource> selectionState,
 		[CallerMemberName] string caller = "",
@@ -169,7 +200,12 @@ public static partial class ListFeed
 	/// DO NOT provide anything here, let the compiler provide this.
 	/// </param>
 	/// <returns>A ListState from and onto which the selection is going to be synced.</returns>
-	public static IListState<TSource> Selection<TSource, TSourceKey, TOther>(
+	public static IListState<TSource> Selection<
+		[DynamicallyAccessedMembers(TRequirements)]
+		TSource,
+		TSourceKey,
+		TOther
+	>(
 		this IListFeed<TSource> source,
 		IState<TOther> selectionState,
 		PropertySelector<TOther, TSourceKey?> keySelector,
@@ -212,7 +248,12 @@ public static partial class ListFeed
 	/// DO NOT provide anything here, let the compiler provide this.
 	/// </param>
 	/// <returns>A ListState from and onto which the selection is going to be synced.</returns>
-	public static IListState<TSource> Selection<TSource, TSourceKey, TOther>(
+	public static IListState<TSource> Selection<
+		[DynamicallyAccessedMembers(TRequirements)]
+		TSource,
+		TSourceKey,
+		TOther
+	>(
 		this IListFeed<TSource> source,
 		IState<TOther> selectionState,
 		PropertySelector<TOther, TSourceKey?> keySelector,

--- a/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.Extensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -20,7 +21,10 @@ static partial class ListState
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use UpdateMessageAsync")]
 #endif
-	public static ValueTask UpdateMessage<T>(this IListState<T> state, Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
+	public static ValueTask UpdateMessage<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, Action<MessageBuilder<IImmutableList<T>>> updater, CancellationToken ct)
 		=> state.UpdateMessageAsync(updater, ct);
 
 	/// <summary>
@@ -31,7 +35,10 @@ static partial class ListState
 	/// <param name="updater">The update method to apply to the current value.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask UpdateAsync<T>(this IListState<T> state, Func<IImmutableList<T>, IImmutableList<T>?> updater, CancellationToken ct = default)
+	public static ValueTask UpdateAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, Func<IImmutableList<T>, IImmutableList<T>?> updater, CancellationToken ct = default)
 		=> state.UpdateMessageAsync(
 			m =>
 			{
@@ -50,7 +57,10 @@ static partial class ListState
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use UpdateAsync")]
 #endif
-	public static ValueTask Update<T>(this IListState<T> state, Func<IImmutableList<T>, IImmutableList<T>> updater, CancellationToken ct)
+	public static ValueTask Update<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, Func<IImmutableList<T>, IImmutableList<T>> updater, CancellationToken ct)
 		=> UpdateAsync(state, updater, ct);
 
 	/// <summary>
@@ -61,7 +71,10 @@ static partial class ListState
 	/// <param name="updater">The update method to apply to the current list.</param>
 	/// <param name="ct">A cancellation to cancel the async operation.</param>
 	/// <returns>A ValueTask to track the async update.</returns>
-	public static ValueTask UpdateDataAsync<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct = default)
+	public static ValueTask UpdateDataAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct = default)
 		=> state.UpdateMessageAsync(m => m.Data(updater(m.CurrentData)), ct);
 
 	/// <summary>
@@ -72,7 +85,10 @@ static partial class ListState
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use UpdateDataAsync")]
 #endif
-	public static ValueTask UpdateData<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
+	public static ValueTask UpdateData<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
 		=> UpdateDataAsync(state, updater, ct);
 
 
@@ -84,7 +100,10 @@ static partial class ListState
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use UpdateDataAsync")]
 #endif
-	public static ValueTask UpdateValue<T>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
+	public static ValueTask UpdateValue<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, Func<Option<IImmutableList<T>>, Option<IImmutableList<T>>> updater, CancellationToken ct)
 		=> UpdateDataAsync(state, updater, ct);
 
 
@@ -97,7 +116,10 @@ static partial class ListState
 	/// <param name="item">The item to add.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static ValueTask InsertAsync<T>(this IListState<T> state, T item, CancellationToken ct = default)
+	public static ValueTask InsertAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, T item, CancellationToken ct = default)
 		=> state.UpdateDataAsync(items => Option.Some((items.SomeOrDefault() ?? ImmutableList<T>.Empty).Insert(0, item)), ct);
 
 	/// <summary>
@@ -108,7 +130,10 @@ static partial class ListState
 	/// <param name="item">The item to add.</param>
 	/// <param name="ct">A token to abort the async add operation.</param>
 	/// <returns></returns>
-	public static ValueTask AddAsync<T>(this IListState<T> state, T item, CancellationToken ct = default)
+	public static ValueTask AddAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, T item, CancellationToken ct = default)
 		=> state.UpdateDataAsync(items => Option.Some((items.SomeOrDefault() ?? ImmutableList<T>.Empty).Add(item)), ct);
 
 	/// <summary>
@@ -119,7 +144,10 @@ static partial class ListState
 	/// <param name="match">Predicate to determine which items should be removed.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static ValueTask RemoveAllAsync<T>(this IListState<T> state, Predicate<T> match, CancellationToken ct = default)
+	public static ValueTask RemoveAllAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, Predicate<T> match, CancellationToken ct = default)
 		=> state.UpdateDataAsync(itemsOpt => itemsOpt.Map(items => items.RemoveAll(match)), ct);
 
 
@@ -132,7 +160,10 @@ static partial class ListState
 	/// <param name="newItem">The new value for the item.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static ValueTask UpdateItemAsync<T>(this IListState<T> state, T oldItem, T newItem, CancellationToken ct = default)
+	public static ValueTask UpdateItemAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, T oldItem, T newItem, CancellationToken ct = default)
 		where T : notnull, IKeyEquatable<T>
 		=> state.UpdateDataAsync(
 			itemsOpt => itemsOpt.Map(items =>
@@ -159,7 +190,10 @@ static partial class ListState
 	/// <param name="newItem">The new value for the item.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static ValueTask UpdateItemAsync<T>(this IListState<T?> state, T oldItem, T? newItem, CancellationToken ct = default)
+	public static ValueTask UpdateItemAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T?> state, T oldItem, T? newItem, CancellationToken ct = default)
 		where T : struct, IKeyEquatable<T>
 		=> state.UpdateDataAsync(
 			itemsOpt => itemsOpt.Map(items =>
@@ -186,7 +220,10 @@ static partial class ListState
 	/// <param name="updater">How to update items.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static ValueTask UpdateItemAsync<T>(this IListState<T> state, T oldItem, Func<T, T> updater, CancellationToken ct = default)
+	public static ValueTask UpdateItemAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, T oldItem, Func<T, T> updater, CancellationToken ct = default)
 		where T : notnull, IKeyEquatable<T>
 		=> state.UpdateDataAsync(
 			itemsOpt => itemsOpt.Map(items =>
@@ -212,7 +249,10 @@ static partial class ListState
 	/// <param name="updater">How to update items.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static ValueTask UpdateItemAsync<T>(this IListState<T?> state, T oldItem, Func<T?, T?> updater, CancellationToken ct = default)
+	public static ValueTask UpdateItemAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T?> state, T oldItem, Func<T?, T?> updater, CancellationToken ct = default)
 		where T : struct, IKeyEquatable<T>
 		=> state.UpdateDataAsync(
 			itemsOpt => itemsOpt.Map(items =>
@@ -239,7 +279,10 @@ static partial class ListState
 	/// <param name="updater">How to update items.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static ValueTask UpdateAllAsync<T>(this IListState<T> state, Predicate<T> match, Func<T, T> updater, CancellationToken ct = default)
+	public static ValueTask UpdateAllAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, Predicate<T> match, Func<T, T> updater, CancellationToken ct = default)
 		=> state.UpdateDataAsync(
 			itemsOpt => itemsOpt.Map(items =>
 			{
@@ -263,7 +306,10 @@ static partial class ListState
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use UpdateAllAsync")]
 #endif
-	public static ValueTask UpdateAsync<T>(this IListState<T> state, Predicate<T> match, Func<T, T> updater, CancellationToken ct)
+	public static ValueTask UpdateAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, Predicate<T> match, Func<T, T> updater, CancellationToken ct)
 		=> UpdateAllAsync(state, match, updater, ct);
 
 	/// <summary>
@@ -274,7 +320,10 @@ static partial class ListState
 	/// <param name="item">The updated version of the item.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static ValueTask UpdateAsync<T>(this IListState<T> listState, T item, CancellationToken ct = default)
+	public static ValueTask UpdateAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> listState, T item, CancellationToken ct = default)
 		where T : IKeyEquatable<T>
 		=> listState.UpdateAsync(items =>
 		{
@@ -292,7 +341,10 @@ static partial class ListState
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use ForEach")]
 #endif
-	public static IDisposable Execute<T>(this IListState<T> state, AsyncAction<IImmutableList<T>> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
+	public static IDisposable Execute<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, AsyncAction<IImmutableList<T>> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
 		where T : notnull
 		=> ForEachAsync(state, action, caller, line);
 
@@ -305,7 +357,10 @@ static partial class ListState
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use ForEach")]
 #endif
-	public static IDisposable ForEachAsync<T>(this IListState<T> state, AsyncAction<IImmutableList<T>> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
+	public static IDisposable ForEachAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, AsyncAction<IImmutableList<T>> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
 		where T : notnull
 		=> new StateForEach<IImmutableList<T>>(state, (list, ct) => action(list.SomeOrDefault() ?? ImmutableList<T>.Empty, ct), $"ForEachAsync defined in {caller} at line {line}.");
 
@@ -319,7 +374,10 @@ static partial class ListState
 	/// <param name="caller"> For debug purposes, the name of this subscription. DO NOT provide anything here, let the compiler fulfill this.</param>
 	/// <param name="line">For debug purposes, the name of this subscription. DO NOT provide anything here, let the compiler fulfill this.</param>
 	/// <returns>A <see cref="IListState{T}"/> that can be used to chain other operations.</returns>
-	public static IListState<T> ForEach<T>(this IListState<T> state, AsyncAction<IImmutableList<T>> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
+	public static IListState<T> ForEach<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, AsyncAction<IImmutableList<T>> action, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
 		where T : notnull
 	{
 		_ = AttachedProperty.GetOrCreate(
@@ -341,7 +399,10 @@ static partial class ListState
 	/// <param name="line">For debug purposes, the name of this subscription. DO NOT provide anything here, let the compiler fulfill this.</param>
 	/// <param name="disposable"> A <see cref="IDisposable"/> that can be used to remove the callback registration.</param>
 	/// <returns>A <see cref="IListState{T}"/> that can be used to chain other operations.</returns>
-	public static IListState<T> ForEach<T>(this IListState<T> state, AsyncAction<IImmutableList<T>> action, out IDisposable disposable, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
+	public static IListState<T> ForEach<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, AsyncAction<IImmutableList<T>> action, out IDisposable disposable, [CallerMemberName] string? caller = null, [CallerLineNumber] int line = -1)
 		where T : notnull
 	{
 		disposable = AttachedProperty.GetOrCreate(
@@ -363,7 +424,10 @@ static partial class ListState
 	/// <param name="selectedItems">The items to flag as selected.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static async ValueTask<bool> TrySelectAsync<T>(this IListState<T> state, IImmutableList<T> selectedItems, CancellationToken ct = default)
+	public static async ValueTask<bool> TrySelectAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, IImmutableList<T> selectedItems, CancellationToken ct = default)
 	{
 		var comparer = ListFeed<T>.DefaultComparer.Entity;
 		var success = false;
@@ -393,7 +457,10 @@ static partial class ListState
 	/// <param name="selectedItem">The item to flag as selected.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static async ValueTask<bool> TrySelectAsync<T>(this IListState<T> state, T selectedItem, CancellationToken ct = default)
+	public static async ValueTask<bool> TrySelectAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, T selectedItem, CancellationToken ct = default)
 		where T : notnull
 	{
 		var comparer = ListFeed<T>.DefaultComparer.Entity;
@@ -424,7 +491,10 @@ static partial class ListState
 	/// <param name="itemToDeselect">The item to deselect.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns>True if the item was found and deselected, false otherwise.</returns>
-	public static async ValueTask<bool> TryDeselectAsync<T>(this IListState<T> state, T itemToDeselect, CancellationToken ct = default)
+	public static async ValueTask<bool> TryDeselectAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, T itemToDeselect, CancellationToken ct = default)
 		where T : notnull
 	{
 		var comparer = ListFeed<T>.DefaultComparer.Entity;
@@ -464,7 +534,10 @@ static partial class ListState
 	/// <param name="itemsToDeselect">The items to deselect.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns>The number of items that were deselected.</returns>
-	public static async ValueTask<int> TryDeselectAsync<T>(this IListState<T> state, IImmutableList<T> itemsToDeselect, CancellationToken ct = default)
+	public static async ValueTask<int> TryDeselectAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, IImmutableList<T> itemsToDeselect, CancellationToken ct = default)
 		where T : notnull
 	{
 		var comparer = ListFeed<T>.DefaultComparer.Entity;
@@ -504,7 +577,10 @@ static partial class ListState
 	/// <param name="state">The state to update.</param>
 	/// <param name="ct">A token to abort the async operation.</param>
 	/// <returns></returns>
-	public static ValueTask ClearSelectionAsync<T>(this IListState<T> state, CancellationToken ct = default)
+	public static ValueTask ClearSelectionAsync<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, CancellationToken ct = default)
 		where T : notnull
 		=> state.UpdateMessageAsync(msg => msg.Selected(SelectionInfo.Empty), ct);
 
@@ -516,7 +592,10 @@ static partial class ListState
 #if DEBUG // To avoid usage in internal reactive code, but without forcing apps to update right away
 	[Obsolete("Use ClearSelectionAsync")]
 #endif
-	public static ValueTask ClearSelection<T>(this IListState<T> state, CancellationToken ct = default)
+	public static ValueTask ClearSelection<
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		T
+	>(this IListState<T> state, CancellationToken ct = default)
 		where T : notnull
 		=> ClearSelectionAsync(state, ct);
 }

--- a/src/Uno.Extensions.Reactive/Core/ListState.T.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.T.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -16,7 +17,10 @@ namespace Uno.Extensions.Reactive;
 /// Provides a set of static methods to create and manipulate <see cref="IListState{T}"/>.
 /// </summary>
 /// <typeparam name="T">The type of the data.</typeparam>
-public static class ListState<T>
+public static class ListState<
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	T
+>
 {
 	/// <summary>
 	/// Creates a custom feed from a raw <see cref="IAsyncEnumerable{T}"/> sequence of <see cref="Message{T}"/>.

--- a/src/Uno.Extensions.Reactive/Core/ListState.cs
+++ b/src/Uno.Extensions.Reactive/Core/ListState.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 
@@ -23,7 +24,11 @@ public static partial class ListState
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="sourceProvider">The provider of the message enumerable sequence.</param>
 	/// <returns>A state that encapsulate the source.</returns>
-	public static IListState<TValue> Create<TOwner, TValue>(TOwner owner, Func<CancellationToken, IAsyncEnumerable<Message<IImmutableList<TValue>>>> sourceProvider)
+	public static IListState<TValue> Create<
+		TOwner,
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TValue
+	>(TOwner owner, Func<CancellationToken, IAsyncEnumerable<Message<IImmutableList<TValue>>>> sourceProvider)
 		where TOwner : class
 		=> ListState<TValue>.Create(owner, sourceProvider);
 
@@ -35,7 +40,11 @@ public static partial class ListState
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="valueProvider">The provider of the initial value of the state.</param>
 	/// <returns>A state that encapsulate the source.</returns>
-	public static IListState<TValue> Value<TOwner, TValue>(TOwner owner, Func<IImmutableList<TValue>> valueProvider)
+	public static IListState<TValue> Value<
+		TOwner,
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TValue
+	>(TOwner owner, Func<IImmutableList<TValue>> valueProvider)
 		where TOwner : class
 	// Note: We force the usage of delegate so 2 properties which are doing State.Value(this, () => 42) will effectively have 2 distinct states.
 		=> ListState<TValue>.Value(owner, valueProvider);
@@ -48,7 +57,11 @@ public static partial class ListState
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="valueProvider">The provider of the initial value of the state.</param>
 	/// <returns>A state that encapsulate the source.</returns>
-	public static IListState<TValue> Value<TOwner, TValue>(TOwner owner, Func<ImmutableList<TValue>> valueProvider)
+	public static IListState<TValue> Value<
+		TOwner,
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TValue
+	>(TOwner owner, Func<ImmutableList<TValue>> valueProvider)
 		where TOwner : class
 	// Note: We force the usage of delegate so 2 properties which are doing State.Value(this, () => 42) will effectively have 2 distinct states.
 		=> ListState<TValue>.Value(owner, valueProvider);
@@ -62,7 +75,11 @@ public static partial class ListState
 	/// <param name="valueProvider">The async method to use to load the value of the resulting feed.</param>
 	/// <param name="refresh">A refresh trigger to reload the <paramref name="valueProvider"/>.</param>
 	/// <returns>A state that encapsulate the source.</returns>
-	public static IListState<TValue> Async<TOwner, TValue>(TOwner owner, AsyncFunc<IImmutableList<TValue>> valueProvider, Signal? refresh = null)
+	public static IListState<TValue> Async<
+		TOwner,
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TValue
+	>(TOwner owner, AsyncFunc<IImmutableList<TValue>> valueProvider, Signal? refresh = null)
 		where TOwner : class
 		=> ListState<TValue>.Async(owner, valueProvider, refresh);
 
@@ -75,7 +92,11 @@ public static partial class ListState
 	/// <param name="valueProvider">The async method to use to load the value of the resulting feed.</param>
 	/// <param name="refresh">A refresh trigger to reload the <paramref name="valueProvider"/>.</param>
 	/// <returns>A state that encapsulate the source.</returns>
-	public static IListState<TValue> Async<TOwner, TValue>(TOwner owner, AsyncFunc<ImmutableList<TValue>> valueProvider, Signal? refresh = null)
+	public static IListState<TValue> Async<
+		TOwner,
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TValue
+	>(TOwner owner, AsyncFunc<ImmutableList<TValue>> valueProvider, Signal? refresh = null)
 		where TOwner : class
 		=> ListState<TValue>.Async(owner, valueProvider, refresh);
 
@@ -87,7 +108,11 @@ public static partial class ListState
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="enumerableProvider">The async enumerable sequence of value of the resulting feed.</param>
 	/// <returns>A state that encapsulate the source.</returns>
-	public static IListState<TValue> AsyncEnumerable<TOwner, TValue>(TOwner owner, Func<CancellationToken, IAsyncEnumerable<IImmutableList<TValue>>> enumerableProvider)
+	public static IListState<TValue> AsyncEnumerable<
+		TOwner,
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TValue
+	>(TOwner owner, Func<CancellationToken, IAsyncEnumerable<IImmutableList<TValue>>> enumerableProvider)
 		where TOwner : class
 		=> ListState<TValue>.AsyncEnumerable(owner, enumerableProvider);
 
@@ -99,7 +124,11 @@ public static partial class ListState
 	/// <param name="owner">The owner of the state.</param>
 	/// <param name="feed">The source list feed of the resulting list state.</param>
 	/// <returns>A state that encapsulate the source.</returns>
-	public static IListState<TValue> FromFeed<TOwner, TValue>(TOwner owner, IListFeed<TValue> feed)
+	public static IListState<TValue> FromFeed<
+		TOwner,
+		[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+		TValue
+	>(TOwner owner, IListFeed<TValue> feed)
 		where TOwner : class
 		=> ListState<TValue>.FromFeed(owner, feed);
 	#endregion

--- a/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
+++ b/src/Uno.Extensions.Reactive/Operators/FeedToListFeedAdapter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -11,7 +12,10 @@ using Uno.Extensions.Reactive.Core;
 
 namespace Uno.Extensions.Reactive.Operators;
 
-internal class FeedToListFeedAdapter<T> : FeedToListFeedAdapter<IImmutableList<T>, T>
+internal class FeedToListFeedAdapter<
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	T
+> : FeedToListFeedAdapter<IImmutableList<T>, T>
 {
 	public FeedToListFeedAdapter(IFeed<IImmutableList<T>> source, ItemComparer<T> itemComparer = default)
 		: base(source, list => list, itemComparer)
@@ -23,7 +27,11 @@ internal class FeedToListFeedAdapter<T> : FeedToListFeedAdapter<IImmutableList<T
 // which crashes when using instances of this record in dictionaries (caching) and break the AOT build.
 // cf. https://github.com/unoplatform/Uno.Samples/issues/139
 
-internal class FeedToListFeedAdapter<TCollection, TItem> : IListFeed<TItem>
+internal class FeedToListFeedAdapter<
+	TCollection,
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	TItem
+> : IListFeed<TItem>
 {
 	private readonly IFeed<TCollection> _source;
 	private readonly Func<TCollection, IImmutableList<TItem>> _toImmutable;

--- a/src/Uno.Extensions.Reactive/Operators/ListFeedSelection.Factories.cs
+++ b/src/Uno.Extensions.Reactive/Operators/ListFeedSelection.Factories.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Uno.Extensions.Edition;
 using Uno.Extensions.Reactive.Logging;
 
 namespace Uno.Extensions.Reactive.Operators;
 
-internal static class ListFeedSelection<T>
+internal static class ListFeedSelection<
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	T
+>
 {
 	public static IListState<T> Create(IListFeed<T> source, IState<IImmutableList<T>> selectionState, string logTag)
 	{

--- a/src/Uno.Extensions.Reactive/Operators/ListFeedSelection.cs
+++ b/src/Uno.Extensions.Reactive/Operators/ListFeedSelection.cs
@@ -11,7 +11,11 @@ using Uno.Extensions.Reactive.Utils;
 
 namespace Uno.Extensions.Reactive.Operators;
 
-internal sealed class ListFeedSelection<TSource, TOther> : IListState<TSource>, IStateImpl
+internal sealed class ListFeedSelection<
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	TSource,
+	TOther
+> : IListState<TSource>, IStateImpl
 {
 	internal static MessageAxis<object?> SelectionUpdateSource { get; } = new(MessageAxes.SelectionSource, _ => null) { IsTransient = true };
 	

--- a/src/Uno.Extensions.Reactive/Operators/ListFeedToFeedAdapter.cs
+++ b/src/Uno.Extensions.Reactive/Operators/ListFeedToFeedAdapter.cs
@@ -1,13 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Threading;
 using Uno.Extensions.Reactive.Core;
 
 namespace Uno.Extensions.Reactive.Operators;
 
-internal sealed record ListFeedToFeedAdapter<T>(IListFeed<T> Source) : IFeed<IImmutableList<T>>
+internal sealed record ListFeedToFeedAdapter<
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	T
+>(IListFeed<T> Source) : IFeed<IImmutableList<T>>
 {
 	/// <inheritdoc />
 	public IAsyncEnumerable<Message<IImmutableList<T>>> GetSource(SourceContext context, CancellationToken ct = default)

--- a/src/Uno.Extensions.Reactive/Operators/WhereListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Operators/WhereListFeed.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -10,7 +11,10 @@ using Uno.Extensions.Reactive.Core;
 
 namespace Uno.Extensions.Reactive.Operators;
 
-internal sealed class WhereListFeed<T> : IListFeed<T>
+internal sealed class WhereListFeed<
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	T
+> : IListFeed<T>
 {
 	private static readonly CollectionAnalyzer<T> _analyzer = ListFeed<T>.DefaultAnalyzer;
 

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableHelper.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Uno.Extensions.Reactive.Core;
 
@@ -30,13 +31,19 @@ public class BindableHelper
 	/// <param name="name">Name of the property backed by the resulting bindable list.</param>
 	/// <param name="source">The source list state.</param>
 	/// <returns>A bindable friendly list feed.</returns>
-	public static IListFeed<T> CreateBindableList<T>(string name, IListState<T> source)
+	public static IListFeed<T> CreateBindableList<
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+		T
+	>(string name, IListState<T> source)
 		=> _factory.CreateList(name, source);
 
 	private class NullBindableFactory : IBindableFactory
 	{
 		/// <inheritdoc />
-		public IListFeed<T> CreateList<T>(string name, IListState<T> source)
+		public IListFeed<T> CreateList<
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+			T
+		>(string name, IListState<T> source)
 			=> source;
 	}
 }

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableImmutableList.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/BindableImmutableList.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Uno.Extensions.Collections.Tracking;
 using Uno.Extensions.Reactive.Collections;
@@ -15,7 +16,11 @@ namespace Uno.Extensions.Reactive.Bindings;
 /// <typeparam name="TItem">The type of the items.</typeparam>
 /// <typeparam name="TBindableItem">The type of the bindable of the item.</typeparam>
 [EditorBrowsable(EditorBrowsableState.Never)]
-public class BindableImmutableList<TItem, TBindableItem> : BindableEnumerable<IImmutableList<TItem>, TItem, TBindableItem>, IList<TItem>
+public class BindableImmutableList<
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	TItem,
+	TBindableItem
+> : BindableEnumerable<IImmutableList<TItem>, TItem, TBindableItem>, IList<TItem>
 	where TBindableItem : Bindable<TItem>
 	where TItem : notnull
 {

--- a/src/Uno.Extensions.Reactive/Presentation/Bindings/IBindableFactory.cs
+++ b/src/Uno.Extensions.Reactive/Presentation/Bindings/IBindableFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Uno.Extensions.Reactive.Bindings;
@@ -22,5 +23,8 @@ public interface IBindableFactory
 	/// <param name="name">Name of the property backed by the resulting bindable list.</param>
 	/// <param name="source">The source list state.</param>
 	/// <returns>A bindable friendly list feed.</returns>
-	IListFeed<T> CreateList<T>(string name, IListState<T> source);
+	IListFeed<T> CreateList<
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+		T
+	>(string name, IListState<T> source);
 }

--- a/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/PaginatedListFeed.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,7 +14,11 @@ using Uno.Extensions.Reactive.Utils;
 
 namespace Uno.Extensions.Reactive.Sources;
 
-internal class PaginatedListFeed<TCursor, TItem> : IListFeed<TItem>
+internal class PaginatedListFeed<
+	TCursor,
+	[DynamicallyAccessedMembers(ListFeed.TRequirements)]
+	TItem
+> : IListFeed<TItem>
 {
 	private readonly TCursor _firstPage;
 	private readonly GetPage<TCursor, TItem> _getPage;


### PR DESCRIPTION
It's our favorite exercise, making uno.chefs run under NativeAOT!

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop -bl \
	  Chefs/Chefs.csproj \
	  -p:SelfContained=true -p:PublishAot=true -p:IsAotCompatible=true -p:UseSkiaRendering=true \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true -p:IlcGenerateMetadataLog=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen
	Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs

Login to the app, click on a recipe, and no Ingredients are shown.

The app log contains messages such as:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Name] property getter does not exist on type [Chefs.Business.Models.Ingredient]

The problem is that the properties on `Ingredient` are not being
preserved.

The question: how "best" to preserve them?

As @jonpryor is the "automagic" sort, the "obvious" (and possibly
incorrect) answer is "something *outside* of uno.chefs should ensure
that the properties are preserved".

But where is `Ingredient` mentioned within uno.chefs?  What types
can be (ab)used to preserve properties?

Turns out, not too many places:

	% git grep '\<Ingredient\>'
	Chefs/Business/Models/Ingredient.cs:public record Ingredient
	Chefs/Business/Models/Ingredient.cs:    public Ingredient(IngredientData ingredientData)
	Chefs/Business/Services/Recipes/IRecipeService.cs:      ValueTask<IImmutableList<Ingredient>> GetIngredients(Guid recipeId, CancellationToken ct);
	Chefs/Business/Services/Recipes/RecipeService.cs:       public async ValueTask<IImmutableList<Ingredient>> GetIngredients(Guid recipeId, CancellationToken ct)
	Chefs/Business/Services/Recipes/RecipeService.cs:               return ingredientsData?.Select(x => new Ingredient(x)).ToImmutableList() ?? ImmutableList<Ingredient>.Empty;
	Chefs/Presentation/RecipeDetailsModel.cs:       public IListFeed<Ingredient> Ingredients => ListFeed.Async(async ct => await _recipeService.GetIngredients(Recipe.Id, ct));

The `Ingredient` type definition won't help, `IImmutableList<T>`
would be a *massive* stretch (plus we don't own it), which brings us
to `IListFeed<T>`: that *is* a type that we control!

Update `IListFeed<T>` to preserve properties on `T`:

	partial interface IListFeed<
	  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
	> {}

Perhaps unsurprisingly, that change impacts *everything*.
(The patch size escalated quickly.)

Integrating this change back into uno.chefs, and now I'm able to see
Ingredients, without other changes to uno.chefs!  (At least it worked.)

But!  We next see this message in the app log:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Count] property getter does not exist on type [Uno.Extensions.Reactive.Bindings.BindableListFeed`1[Chefs.Business.Models.Ingredient]]

Similar question as before: how do we preserve the properties on
`BindableListFeed<T>`?

Raising the question: where is `BindableListFeed<T>` coming from?

This was *quite* interesting, as `BindableListFeed<T>` doesn't appear
*anywhere* in uno.chefs!

	% git grep BindableListFeed
	# no source code matches
	% grep -ril BindableListFeed _gen
	# no matches

Add some printf logging to the `BindableListFeed<T>` constructors to
see how it's constructed, and:

	   at Uno.Extensions.Reactive.Bindings.BindableListFeed`1..ctor(String, IListState`1) + 0x91
	   at Uno.Extensions.Reactive.Bindings.BindableFactory.CreateList[T](String, IListState`1) + 0x2d
	   at Chefs.Presentation.RecipeDetailsViewModel..ctor(RecipeDetailsModel) + 0x333
	   at Chefs.Presentation.RecipeDetailsViewModel..ctor(Recipe recipe, INavigator navigator, IRecipeService recipeService, IUserService userService, IMessenger messenger, IShareService shareService) + 0xa0

`BindableListFeed<Ingredient>` is constructed via a
`BindableFactory.CreateList(…)` invocation within the generated
`RecipeDetailsViewModel` constructor.

Slight problem: there is no `BindableFactory.CreateList(…)` invocation
within the `RecipeDetailsViewModel` constructor!

	public partial class RecipeDetailsViewModel {
	  protected RecipeDetailsViewModel(global::Chefs.Presentation.RecipeDetailsModel model)
	  {
	    // …
	    if (Ingredients is null)
	    {
	      var ingredientsSource = (global::Uno.Extensions.Reactive.IListFeed<global::Chefs.Business.Models.Ingredient>) model.Ingredients ?? throw new NullReferenceException("The list feed property 'Ingredients' is null. Public feeds properties must be initialized in the constructor.");
	      var ingredientsSourceListState = ctx.GetOrCreateListState(ingredientsSource);
	      Ingredients = global::Uno.Extensions.Reactive.Bindings.BindableHelper.CreateBindableList(nameof(Ingredients), ingredientsSourceListState);
	    }
	    // …
	  }
	}

However, `BindableHelper.CreateBindableList(…)` *does* call
`BindableFactory.CreateList(…)`, so this is presumably a case of
method inlining by NativeAOT.

With that in mind, @jonpryor can think of three ways to cause the
`BindableListFeed<Ingredient>` properties to be preserved:

 1. Some form of change within FeedsGenerator, or
 2. Update `BindableFactory.CreateList<T>()` to use
    `[DynamicDependency]` to preserve the properties, or
 3. Update the `BindableListFeed<T>` constructors to have
    `[DynamicDependency]`.

The advantages to (3) is that it works, it's straightforward, and
annotation site is "close" to the site of intended effect.
(`BindableFactory.CreateList<T>()` doesn't obviously scream out
"I may require dynamic dependencies!"  The constructor doesn't either,
but at least it's on the type being impacted!)

(3) also gives us an interesting "hammer" with which to solve related
issues.  Issues such as:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Count] property getter does not exist on type [Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views.BasicView]

@jonpryor has no idea where `BasicView` is constructed from, but if
it's constructed, we *probably* need its properties, so: add
`[DynamicDependency]` to the `BasicView` constructor!  The message
is fixed.  (This is a fascinating hammer, ripe for abuse.)

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
