### PR TITLE
chore: Preserve properties on IListFeed<T> targets

### DIFF
--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListField.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListField.cs
@@ -15,8 +15,12 @@ internal record BindableListFromFeedOfListField(IFieldSymbol Field, ITypeSymbol 
 		=> null;
 
 	/// <inheritdoc />
-	public string GetDeclaration()
-		=> $"{Field.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{ItemType.ToFullString()}> {Field.Name};"; // Note: This should be a State
+	// Note: This should be a State
+	public string GetDeclaration() =>
+		$$"""
+		[global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof({{ItemType.ToFullString()}}))]
+		{{Field.GetAccessibilityAsCSharpCodeString()}} {{NS.Reactive}}.IListFeed<{{ItemType.ToFullString()}}> {{Field.Name}};
+		""";
 
 	/// <inheritdoc />
 	public string? GetInitialization()

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListProperty.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromFeedOfListProperty.cs
@@ -15,8 +15,16 @@ internal record BindableListFromFeedOfListProperty(IPropertySymbol Property, ITy
 		=> null;
 
 	/// <inheritdoc />
-	public string GetDeclaration()
-		=> $"{Property.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{ItemType.ToFullString()}> {Property.Name} {{ get; private set; }}"; // Note: This should be a State
+	// Note: This should be a State
+	public string GetDeclaration() =>
+		$$"""
+		{{Property.GetAccessibilityAsCSharpCodeString()}} {{NS.Reactive}}.IListFeed<{{ItemType.ToFullString()}}> {{Property.Name}}
+		{
+			[global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof({{ItemType.ToFullString()}}))]
+			get;
+			private set;
+		}
+		""";
 
 	/// <inheritdoc />
 	public string GetInitialization()

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedField.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedField.cs
@@ -18,8 +18,12 @@ internal record BindableListFromListFeedField(IFieldSymbol _field, ITypeSymbol _
 		=> null;
 
 	/// <inheritdoc />
-	public string GetDeclaration()
-		=> $"{_field.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{_valueType.ToFullString()}> {_field.Name};"; // Note: This should be a State
+	// Note: This should be a State
+	public string GetDeclaration() =>
+		$$"""
+		[global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof({{_valueType.ToFullString()}}))]
+		{{_field.GetAccessibilityAsCSharpCodeString()}} {{NS.Reactive}}.IListFeed<{{_valueType.ToFullString()}}> {{_field.Name}};
+		""";
 
 	/// <inheritdoc />
 	public string? GetInitialization()

--- a/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedProperty.cs
+++ b/src/Uno.Extensions.Reactive.Generator/Bindables/MappedMembers/BindableListFromListFeedProperty.cs
@@ -18,8 +18,16 @@ internal record BindableListFromListFeedProperty(IPropertySymbol _property, ITyp
 		=> null;
 
 	/// <inheritdoc />
-	public string GetDeclaration()
-		=> $"{_property.GetAccessibilityAsCSharpCodeString()} {NS.Reactive}.IListFeed<{_valueType.ToFullString()}> {_property.Name} {{ get; private set; }}"; // Note: This should be a State
+	// Note: This should be a State
+	public string GetDeclaration() =>
+		$$"""
+		{{_property.GetAccessibilityAsCSharpCodeString()}} {{NS.Reactive}}.IListFeed<{{_valueType.ToFullString()}}> {{_property.Name}}
+		{
+			[global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties, typeof({{_valueType.ToFullString()}}))]
+			get;
+			private set;
+		}
+		""";
 
 	/// <inheritdoc />
 	public string GetInitialization()

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/BindableListFeed.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -30,6 +31,7 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 	/// <param name="propertyName">The name of the property backed by the object.</param>
 	/// <param name="source">The source data stream.</param>
 	/// <param name="ctx">The context of the owner.</param>
+	[DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(BindableListFeed<>))]
 	public BindableListFeed(string propertyName, IListFeed<T> source, SourceContext ctx)
 	{
 		PropertyName = propertyName;
@@ -43,6 +45,7 @@ public sealed partial class BindableListFeed<T> : ISignal<IMessage>, IListState<
 	/// </summary>
 	/// <param name="propertyName">The name of the property backed by the object.</param>
 	/// <param name="source">The source data stream.</param>
+	[DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(BindableListFeed<>))]
 	public BindableListFeed(string propertyName, IListState<T> source)
 	{
 		PropertyName = propertyName;

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/Views/BasicView.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Windows.Foundation;
@@ -22,6 +23,7 @@ namespace Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views
 		private readonly PaginationFacet? _pagination;
 		private readonly EditionFacet? _edition;
 
+		[DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(BasicView))]
 		public BasicView(
 			CollectionFacet collectionFacet,
 			CollectionChangedFacet collectionChangedFacet,


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno.extensions/pull/2990
Context: https://github.com/unoplatform/uno.extensions/pull/2990#pullrequestreview-3599728009
Context: https://github.com/unoplatform/uno.extensions/pull/2969
Context: 8870ddf4bc3f96fb8d9c50e001fb5f43824b5a44

It's our favorite exercise, making uno.chefs run under NativeAOT!

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop -bl \
	  Chefs/Chefs.csproj \
	  -p:SelfContained=true -p:PublishAot=true -p:IsAotCompatible=true -p:UseSkiaRendering=true \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true -p:IlcGenerateMetadataLog=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen
	Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs

Login to the app, click on a recipe, and no Ingredients are shown.

The app log contains messages such as:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Name] property getter does not exist on type [Chefs.Business.Models.Ingredient]

The problem is that the properties on `Ingredient` are not being preserved.

The question: how "best" to preserve them?

As @jonpryor is the "automagic" sort, the "obvious" (and possibly incorrect) answer is "something *outside* of uno.chefs should ensure that the properties are preserved".

But where is `Ingredient` mentioned within uno.chefs?  What types can be (ab)used to preserve properties?

Turns out, not too many places:

	% git grep '\<Ingredient\>'
	Chefs/Business/Models/Ingredient.cs:public record Ingredient
	Chefs/Business/Models/Ingredient.cs:    public Ingredient(IngredientData ingredientData)
	Chefs/Business/Services/Recipes/IRecipeService.cs:      ValueTask<IImmutableList<Ingredient>> GetIngredients(Guid recipeId, CancellationToken ct);
	Chefs/Business/Services/Recipes/RecipeService.cs:       public async ValueTask<IImmutableList<Ingredient>> GetIngredients(Guid recipeId, CancellationToken ct)
	Chefs/Business/Services/Recipes/RecipeService.cs:               return ingredientsData?.Select(x => new Ingredient(x)).ToImmutableList() ?? ImmutableList<Ingredient>.Empty;
	Chefs/Presentation/RecipeDetailsModel.cs:       public IListFeed<Ingredient> Ingredients => ListFeed.Async(async ct => await _recipeService.GetIngredients(Recipe.Id, ct));

The `Ingredient` type definition won't help, `IImmutableList<T>` would be a *massive* stretch (plus we don't own it), which brings us to `IListFeed<T>`: that *is* a type that we control!

PR #2990 explored an approach of updating `IListFeed<T>` to preserve properties on `T`:

	partial interface IListFeed<
	  [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
	> {}

This approach was deemed far-reaching and undesirable.

What else can be used to preserve `Ingredient` properties? Let's look at the *generated* code:

	% grep -ri '\<Ingredient\>' _gen
	_gen/Uno.Extensions.Reactive.Generator/Uno.Extensions.Reactive.Generator.FeedsGenerator/Chefs.Presentation.RecipeDetailsModel.Bindable.g.cs:				var ingredientsSource = (global::Uno.Extensions.Reactive.IListFeed<global::Chefs.Business.Models.Ingredient>) model.Ingredients ?? throw new NullReferenceException("The list feed property 'Ingredients' is null. Public feeds properties must be initialized in the constructor.");
	_gen/Uno.Extensions.Reactive.Generator/Uno.Extensions.Reactive.Generator.FeedsGenerator/Chefs.Presentation.RecipeDetailsModel.Bindable.g.cs:				var ingredientsSource = (global::Uno.Extensions.Reactive.IListFeed<global::Chefs.Business.Models.Ingredient>) model.Ingredients ?? throw new NullReferenceException("The list feed property 'Ingredients' is null. Public feeds properties must be initialized in the constructor.");
	_gen/Uno.Extensions.Reactive.Generator/Uno.Extensions.Reactive.Generator.FeedsGenerator/Chefs.Presentation.RecipeDetailsModel.Bindable.g.cs:		public global::Uno.Extensions.Reactive.IListFeed<global::Chefs.Business.Models.Ingredient> Ingredients { get; private set; }

The last line -- the `Ingredients` property -- is similar to PR #2969/8870ddf4.  We could do something similar for `IListFeed<T>` usage, and generate:

	namespace Chefs.Presentation;
	public partial class RecipeDetailsViewModel
	{
	  public Uno.Extensions.Reactive.IListFeed<Chefs.Business.Models.Ingredient> Ingredients
	  {
	    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(Chefs.Business.Models.Ingredient))]
	    get;
	    private set;
	  }
	}

The use of `[DynamicDependency]` ensures that the public properties on `Ingredient` can still be accessed via Reflection, *without* needing to modify `IListFeed<T>`itself.

Integrating this change back into uno.chefs, and now I'm able to see Ingredients, without other changes to uno.chefs!

But!  We next see this message in the app log:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Count] property getter does not exist on type [Uno.Extensions.Reactive.Bindings.BindableListFeed`1[Chefs.Business.Models.Ingredient]]

Similar question as before: how do we preserve the properties on `BindableListFeed<T>`?

Raising the question: where is `BindableListFeed<T>` coming from?

This was *quite* interesting, as `BindableListFeed<T>` doesn't appear *anywhere* in uno.chefs!

	% git grep BindableListFeed
	# no source code matches
	% grep -ril BindableListFeed _gen
	# no matches

Add some printf logging to the `BindableListFeed<T>` constructors to see how it's constructed, and:

	   at Uno.Extensions.Reactive.Bindings.BindableListFeed`1..ctor(String, IListState`1) + 0x91
	   at Uno.Extensions.Reactive.Bindings.BindableFactory.CreateList[T](String, IListState`1) + 0x2d
	   at Chefs.Presentation.RecipeDetailsViewModel..ctor(RecipeDetailsModel) + 0x333
	   at Chefs.Presentation.RecipeDetailsViewModel..ctor(Recipe recipe, INavigator navigator, IRecipeService recipeService, IUserService userService, IMessenger messenger, IShareService shareService) + 0xa0

`BindableListFeed<Ingredient>` is constructed via a `BindableFactory.CreateList(…)` invocation within the generated `RecipeDetailsViewModel` constructor.

Slight problem: *there is no* `BindableFactory.CreateList(…)` invocation within the `RecipeDetailsViewModel` constructor!

	public partial class RecipeDetailsViewModel {
	  protected RecipeDetailsViewModel(global::Chefs.Presentation.RecipeDetailsModel model)
	  {
	    // …
	    if (Ingredients is null)
	    {
	      var ingredientsSource = (global::Uno.Extensions.Reactive.IListFeed<global::Chefs.Business.Models.Ingredient>) model.Ingredients ?? throw new NullReferenceException("The list feed property 'Ingredients' is null. Public feeds properties must be initialized in the constructor.");
	      var ingredientsSourceListState = ctx.GetOrCreateListState(ingredientsSource);
	      Ingredients = global::Uno.Extensions.Reactive.Bindings.BindableHelper.CreateBindableList(nameof(Ingredients), ingredientsSourceListState);
	    }
	    // …
	  }
	}

However, `BindableHelper.CreateBindableList(…)` *does* call `BindableFactory.CreateList(…)`, so this is presumably a case of method inlining by NativeAOT.

With that in mind, @jonpryor can think of three ways to cause the `BindableListFeed<Ingredient>` properties to be preserved:

 1. Some form of change within FeedsGenerator, or
 2. Update `BindableFactory.CreateList<T>()` to use `[DynamicDependency]` to preserve the properties, or
 3. Update the `BindableListFeed<T>` constructors to have `[DynamicDependency]`.

The problem with (1) is that it associates types which perhaps shouldn't be associated "like that", e.g.

	namespace Chefs.Presentation;
	public partial class RecipeDetailsViewModel
	{
	  public Uno.Extensions.Reactive.IListFeed<Chefs.Business.Models.Ingredient> Ingredients
	  {
	    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(Chefs.Business.Models.Ingredient))]
	    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(Uno.Extensions.Reactive.Bindings.BindableListFeed<>))]
	    get;
	    private set;
	  }
	}

Why should `IListFeed<Ingredient>` use dictate referencing of `BindableListFeed<T>`?

(2) is reasonable.

The advantages to (3) is that it works, it's straightforward, and annotation site is "close" to the site of intended effect. (`BindableFactory.CreateList<T>()` doesn't obviously scream out "I may require dynamic dependencies!"  The constructor doesn't either, but at least it's on the type being impacted!)

(3) also gives us an interesting "hammer" with which to solve related issues.  Issues such as:

	fail: Uno.UI.DataBinding.BindingPropertyHelper[0]
	      The [Count] property getter does not exist on type [Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views.BasicView]

`BasicView` in turn is constructed via:

	   at Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Views.BasicView..ctor(CollectionFacet, CollectionChangedFacet, BindableCollectionExtendedProperties, SelectionFacet, PaginationFacet, EditionFacet) + 0x4f
	   at Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data.LeafStrategy.CreateView(IBindableCollectionViewSource) + 0x1d4
	   at Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data.DataLayer..ctor(DataLayer, IServiceProvider, IBindableCollectionDataLayerStrategy, IDispatcher) + 0x71
	   at Uno.Extensions.Reactive.Bindings.Collections._BindableCollection.Data.DataLayer.Create(IBindableCollectionDataLayerStrategy, IObservableCollection, IServiceProvider, IDispatcher) + 0x3e
	   at Uno.Extensions.Reactive.Dispatching.DispatcherLocal`1.GetValueCore(IDispatcher, IDispatcher) + 0x285
	   at Uno.Extensions.Reactive.Dispatching.DispatcherLocal`1.GetValue(IDispatcher) + 0x3f
	   at Uno.Extensions.Reactive.Bindings.BindableListFeed`1.<Uno-Extensions-Reactive-ISignal<Uno-Extensions-Reactive-IMessage>-GetSource>d__66.MoveNext() + 0xb1
	   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine&) + 0x4d
	   at Uno.Extensions.Reactive.Bindings.BindableListFeed`1.<Uno-Extensions-Reactive-ISignal<Uno-Extensions-Reactive-IMessage>-GetSource>d__66.System.Collections.Generic.IAsyncEnumerator<Uno.Extensions.Reactive.IMessage>.MoveNextAsync() + 0x46
	   at Uno.Extensions.Reactive.Utils.FeedUIHelper.<MoveNext>d__4`1.MoveNext() + 0x115
	   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine&) + 0x4d
	   at Uno.Extensions.Reactive.Utils.FeedUIHelper.MoveNext[T](IAsyncEnumerator`1, CancellationToken) + 0x82
	   at Uno.Extensions.Reactive.Utils.FeedUIHelper.<GetSource>d__0.MoveNext() + 0x227
	   at System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object) + 0x89
	   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread) + 0x57
	   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox, Boolean) + 0x52
	   at System.Threading.Tasks.Task.RunContinuations(Object) + 0x4f
	   at System.Threading.Tasks.Task`1.TrySetResult(TResult) + 0x8e
	   at System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.SetResult(TResult) + 0x29
	   at Uno.Extensions.Reactive.Utils.FeedUIHelper.<GetSourceEnumerator>d__3`1.MoveNext() + 0x284
	   at System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object) + 0x89

i.e. "nowhere" near `*.Presentation` logic, and yet its properties are used by XAML.

Regardless, if it's constructed, we *probably* need its properties, so: add `[DynamicDependency]` to the `BasicView` constructor!  The message is fixed.  (This is a fascinating hammer, ripe for abuse.)

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
