### PR TITLE
chore: Fix trimmer warnings in Uno.Extensions.Serialization

### DIFF
--- a/src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs
+++ b/src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs
@@ -5,8 +5,15 @@ namespace Uno.Extensions.Serialization;
 /// <summary>
 /// A reflection-based serializer implementation for System.Text.Json.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2046",
+	Justification = "This type uses JsonSerializer, requiring [RequiresDynamicCode] and [RequiresUnreferencedCode], but not all implementations of ISerializer should have that constraint.")]
+[UnconditionalSuppressMessage("Trimming", "IL3051",
+	Justification = "This type uses JsonSerializer, requiring [RequiresDynamicCode] and [RequiresUnreferencedCode], but not all implementations of ISerializer<T> should have that constraint.")]
 public class SystemTextJsonSerializer : ISerializer
 {
+	internal const string RequiresDynamicCodeMessage = "JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications. [From JsonSerializer.Serialize().]";
+	internal const string RequiresUnreferencedCodeMessage = "JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved. [From JsonSerializer.Serialize().]";
+
 	private readonly JsonSerializerOptions? _serializerOptions;
 	private readonly IServiceProvider _services;
 
@@ -39,7 +46,8 @@ public class SystemTextJsonSerializer : ISerializer
 	/// <returns>
 	/// The instance of targetType deserialized from the source.
 	/// </returns>
-	[RequiresUnreferencedCode("From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public object? FromStream(Stream source, Type targetType)
 	{
 		var typedSerializer = TypedSerializer(targetType);
@@ -58,7 +66,8 @@ public class SystemTextJsonSerializer : ISerializer
 	/// <param name="valueType">
 	/// The type to use to serialize the object. value must be convertible to this type.
 	/// </param>
-	[RequiresUnreferencedCode("From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public void ToStream(Stream stream, object value, Type valueType)
 	{
 		var typedSerializer = TypedSerializer(valueType);
@@ -84,7 +93,8 @@ public class SystemTextJsonSerializer : ISerializer
 	/// <returns>
 	/// The serialized representation of value.
 	/// </returns>
-	[RequiresUnreferencedCode("From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public string ToString(object value, Type valueType)
 	{
 		var typedSerializer = TypedSerializer(valueType);
@@ -103,7 +113,8 @@ public class SystemTextJsonSerializer : ISerializer
 	/// <returns>
 	/// The instance of targetType deserialized from the source.
 	/// </returns>
-	[RequiresUnreferencedCode("From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public object? FromString(string source, Type targetType)
 	{
 		var typedSerializer = TypedSerializer(targetType);
@@ -117,6 +128,10 @@ public class SystemTextJsonSerializer : ISerializer
 /// <typeparam name="T">
 /// The type of the objects to serialize and deserialize.
 /// </typeparam>
+[UnconditionalSuppressMessage("Trimming", "IL2046",
+	Justification = "This type uses JsonSerializer, requiring [RequiresDynamicCode] and [RequiresUnreferencedCode], but not all implementations of ISerializer<T> should have that constraint.")]
+[UnconditionalSuppressMessage("Trimming", "IL3051",
+	Justification = "This type uses JsonSerializer, requiring [RequiresDynamicCode] and [RequiresUnreferencedCode], but not all implementations of ISerializer<T> should have that constraint.")]
 public class SystemTextJsonSerializer<T> : SystemTextJsonSerializer, ISerializer<T>
 {
 	/// <summary>
@@ -135,18 +150,24 @@ public class SystemTextJsonSerializer<T> : SystemTextJsonSerializer, ISerializer
 	}
 
 	/// <inheritdoc/>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public T? FromString(string source)
 	{
 		return FromString(source, typeof(T)) is T value ? value : default;
 	}
 
 	/// <inheritdoc/>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public T? FromStream(Stream source)
 	{
 		return FromStream(source, typeof(T)) is T value ? value : default;
 	}
 
 	/// <inheritdoc/>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public string ToString(T value)
 	{
 		if (value is null)
@@ -158,6 +179,8 @@ public class SystemTextJsonSerializer<T> : SystemTextJsonSerializer, ISerializer
 	}
 
 	/// <inheritdoc/>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage)]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
 	public void ToStream(Stream stream, T value)
 	{
 		if (value is null)

--- a/src/Uno.Extensions.Serialization/Uno.Extensions.Serialization.csproj
+++ b/src/Uno.Extensions.Serialization/Uno.Extensions.Serialization.csproj
@@ -3,6 +3,7 @@
 
 	<PropertyGroup>
 		<Description>Serialization Extensions for working with ISerializer for the Uno Platform, UWP and WinUI</Description>
+		<IsAotCompatible>true</IsAotCompatible>
 
 		<!--Temporary disable missing XML doc until fixed in the whole package-->
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>


### PR DESCRIPTION
Enable `$(IsAotCompatible)`=true for the following projects:

  * `src/Uno.Extensions.Serialization/Uno.Extensions.Serialization.csproj`

Address the following warnings:

	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(120,14): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToString(Object, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.ToString(Object, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(88,16): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToString(Object, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.ToString(Object, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(107,17): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromString(String, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.FromString(String, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(120,14): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromString(String, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.FromString(String, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(43,17): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromStream(Stream, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.FromStream(Stream, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(120,14): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromStream(Stream, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.FromStream(Stream, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(62,14): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToStream(Stream, Object, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.ToStream(Stream, Object, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(120,14): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToStream(Stream, Object, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.ToStream(Stream, Object, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(146,10): error IL2026:
	  Using member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromStream(Stream, Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(157,10): error IL2026:
	  Using member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToString(Object, Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(140,10): error IL2026:
	  Using member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromString(String, Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(168,3): error IL2026:
	  Using member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToStream(Stream, Object, Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(46,89): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Deserialize(Stream, Type, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(71,4): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Serialize(Stream, Object, Type, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(91,85): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Serialize(Object, Type, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(110,89): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Deserialize(String, Type, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.

Add `[RequiresDynamicCode]` and/or `[RequiresUnreferencedCode]`.

Note: updating `SystemTextJsonSerializer` and
`SystemTextJsonSerializer<T>` to have `[RequiresDynamicCode]` and `[RequiresUnreferencedCode]` on the methods implementing `ISerializer` and `ISerializer<T>` results in warnings such as:

	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(127,14): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToStream(Stream, Object, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.ToStream(Stream, Object, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(131,14): error IL3051:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToStream(Stream, Object, Type)' with 'RequiresDynamicCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.ToStream(Stream, Object, Type)' without 'RequiresDynamicCodeAttribute'.
	  'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.

The problem here is philosophical: while `SystemTextJsonSerializer` and `SystemTextJsonSerializer<T>` use `JsonSerializer` codepaths which are annotated with `[RequiresDynamicCode]` and
`[RequiresUnreferencedCode]`, that doesn't mean that *all* `ISerializer` implementations should have this restriction/requirement.

Use `[UnconditionalSuppressMessage]` to suppress the IL2046 and IL3051 warnings, so that we don't need to update the `ISerializer` interface.

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
