### PR TITLE
chore: Support $(JsonSerializerIsReflectionEnabledByDefault)=false

### DIFF
--- a/Uno.Extensions-packageonly.slnf
+++ b/Uno.Extensions-packageonly.slnf
@@ -38,6 +38,7 @@
       "src\\Uno.Extensions.Reactive\\Uno.Extensions.Reactive.csproj",
       "src\\Uno.Extensions.Serialization.Http\\Uno.Extensions.Serialization.Http.csproj",
       "src\\Uno.Extensions.Serialization.Refit\\Uno.Extensions.Serialization.Refit.csproj",
+      "src\\Uno.Extensions.Serialization.AotTests\\Uno.Extensions.Serialization.AotTests.csproj",
       "src\\Uno.Extensions.Serialization.Tests\\Uno.Extensions.Serialization.Tests.csproj",
       "src\\Uno.Extensions.Serialization\\Uno.Extensions.Serialization.csproj",
       "src\\Uno.Extensions.Storage.UI\\Uno.Extensions.Storage.WinUI.csproj",

--- a/Uno.Extensions-runtimetests.slnf
+++ b/Uno.Extensions-runtimetests.slnf
@@ -37,6 +37,7 @@
       "src\\Uno.Extensions.RuntimeTests\\Uno.Extensions.RuntimeTests\\Uno.Extensions.RuntimeTests.csproj",
       "src\\Uno.Extensions.Serialization.Http\\Uno.Extensions.Serialization.Http.csproj",
       "src\\Uno.Extensions.Serialization.Refit\\Uno.Extensions.Serialization.Refit.csproj",
+      "src\\Uno.Extensions.Serialization.AotTests\\Uno.Extensions.Serialization.AotTests.csproj",
       "src\\Uno.Extensions.Serialization.Tests\\Uno.Extensions.Serialization.Tests.csproj",
       "src\\Uno.Extensions.Serialization\\Uno.Extensions.Serialization.csproj",
       "src\\Uno.Extensions.Storage.UI\\Uno.Extensions.Storage.WinUI.csproj",

--- a/Uno.Extensions.sln
+++ b/Uno.Extensions.sln
@@ -141,6 +141,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Extensions.Http.Kiota",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Maui.WinUI.Runtime.Skia", "src\Uno.Extensions.Maui.WinUI.Runtime.Skia\Uno.Extensions.Maui.WinUI.Runtime.Skia.csproj", "{76AF6C8E-A738-FF6A-EAB1-FE94DAC56658}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Serialization.AotTests", "src\Uno.Extensions.Serialization.AotTests\Uno.Extensions.Serialization.AotTests.csproj", "{DF77B943-13C2-4D98-8364-BA0DDC2C156D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -769,6 +773,22 @@ Global
 		{76AF6C8E-A738-FF6A-EAB1-FE94DAC56658}.Release|x64.Build.0 = Release|Any CPU
 		{76AF6C8E-A738-FF6A-EAB1-FE94DAC56658}.Release|x86.ActiveCfg = Release|Any CPU
 		{76AF6C8E-A738-FF6A-EAB1-FE94DAC56658}.Release|x86.Build.0 = Release|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Debug|arm64.Build.0 = Debug|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Debug|x64.Build.0 = Debug|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Debug|x86.Build.0 = Debug|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|arm64.ActiveCfg = Release|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|arm64.Build.0 = Release|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|x64.ActiveCfg = Release|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|x64.Build.0 = Release|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|x86.ActiveCfg = Release|Any CPU
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -817,6 +837,7 @@ Global
 		{869C9E5B-0F85-4316-BC4B-CB6CBFCC02A3} = {FB399485-A0B1-4416-A494-E19AC7F5A665}
 		{C9827C80-312B-4E81-B539-2D305D893A6C} = {45179294-70DC-47E8-AD22-1296F897B594}
 		{76AF6C8E-A738-FF6A-EAB1-FE94DAC56658} = {2197ADCE-59C4-465A-B380-0B06BF68BBBC}
+		{DF77B943-13C2-4D98-8364-BA0DDC2C156D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E7B035D-9A64-4D95-89AA-9D4653F17C42}

--- a/build/ci/stage-build-packages.yml
+++ b/build/ci/stage-build-packages.yml
@@ -65,6 +65,7 @@ jobs:
     inputs:
       testAssemblyVer2: |
         **/*.Tests.dll
+        **/*.AotTests.dll
         !**/*UI.Tests.dll
         !**/obj/**
       vsTestVersion: toolsInstaller

--- a/doc/Learn/Walkthrough/Serialization.howto.md
+++ b/doc/Learn/Walkthrough/Serialization.howto.md
@@ -34,13 +34,12 @@ protected override void OnLaunched(LaunchActivatedEventArgs args)
     var builder = this.CreateBuilder(args)
         .Configure(host =>
         {
-            host.UseSerialization(services =>
-                services.AddJsonTypeInfo(PersonContext.Default.Person));
+            host.UseSerialization([PersonContext.Default]);
         });
 }
 ```
 
-`AddJsonTypeInfo` registers the compiled metadata so the serializer can avoid runtime reflection.
+`UseSerialization` registers the compiled metadata so the serializer can avoid runtime reflection.
 
 ## Generate the context for your models
 
@@ -61,22 +60,22 @@ public sealed class Person
 }
 ```
 
-At build time the source generator emits `PersonContext.Default.Person`, which exposes the required `JsonTypeInfo<Person>`.
+At build time the source generator emits `PersonContext.Default`, which exposes the required `IJsonTypeInfoResolver`.
 
 ## Customize serialization options
 
-Register `JsonSerializerOptions` to tweak casing, naming, or converters.
+Alter `JsonSerializerOptions` to tweak casing, naming, or converters.
 
 ```csharp
-host.UseSerialization(services =>
+host.UseSerialization([PersonContext.Default], (context, services) =>
 {
-    services.AddJsonTypeInfo(PersonContext.Default.Person);
-    services.AddSingleton(new JsonSerializerOptions
+    services.ConfigureJsonSerializationOptions(options =>
     {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true
+        options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        options.SerializerOptions.WriteIndented = true;
     });
-});
+},
+PersonContext.Default);
 ```
 
 Any options registered in DI apply to all `ISerializer<T>` instances for `System.Text.Json`.

--- a/src/Uno.Extensions.Authentication/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Authentication/HostBuilderExtensions.cs
@@ -144,6 +144,7 @@ public static class HostBuilderExtensions
 							new TokenCache(
 								sp.GetRequiredService<ILogger<TokenCache>>(),
 								sp.GetRequiredDefaultInstance<IKeyValueStorage>()))
+					.AddJsonTypeInfo(TokenCacheContext.Default)
 					.AddSingleton<IAuthenticationService, AuthenticationService>();
 			})
 			.Authorization(configureAuthorization);

--- a/src/Uno.Extensions.Authentication/TokenCache.cs
+++ b/src/Uno.Extensions.Authentication/TokenCache.cs
@@ -1,4 +1,6 @@
-﻿namespace Uno.Extensions.Authentication;
+﻿using System.Text.Json.Serialization;
+
+namespace Uno.Extensions.Authentication;
 
 internal record TokenCache : ITokenCache
 {
@@ -141,4 +143,9 @@ internal record TokenCache : ITokenCache
 			tokenLock.Release();
 		}
 	}
+}
+
+[JsonSerializable(typeof(string))]
+internal partial class TokenCacheContext : JsonSerializerContext
+{
 }

--- a/src/Uno.Extensions.Configuration/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Configuration/HostBuilderExtensions.cs
@@ -39,7 +39,7 @@ public static class HostBuilderExtensions
 			hostBuilder = hostBuilder.ConfigureAppConfiguration(configureAppConfiguration);
 		}
 
-		hostBuilder = hostBuilder.UseSerialization()
+		hostBuilder = hostBuilder.UseSerialization([])
 			.ConfigureServices((ctx, s) =>
 				{
 					// We're doing the IsRegistered check here so that the

--- a/src/Uno.Extensions.Serialization.AotTests/Uno.Extensions.Serialization.AotTests.csproj
+++ b/src/Uno.Extensions.Serialization.AotTests/Uno.Extensions.Serialization.AotTests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+		<Nullable>disable</Nullable>
+    <DefineConstants>$(DefineConstants);WITH_AOT_TRIMMING</DefineConstants>
+		<!-- Disable JSON reflection to test AOT-compatible serialization -->
+		<JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+	</PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Uno.Extensions.Serialization.Tests\**\*.cs" />
+    <Compile Remove="..\Uno.Extensions.Serialization.Tests\obj\**\*.cs" />
+  </ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.Extensions.Serialization\Uno.Extensions.Serialization.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Moq" />
+		<PackageReference Include="MSTest.TestAdapter"  />
+		<PackageReference Include="MSTest.TestFramework"  />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="FluentAssertions" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.Extensions.Serialization.Tests/HostBuilderExtensionsTests.cs
+++ b/src/Uno.Extensions.Serialization.Tests/HostBuilderExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -11,16 +12,43 @@ namespace Uno.Extensions.Serialization.Tests;
 public class HostBuilderExtensionsTests
 {
 	private IServiceProvider _services;
+
 	[TestInitialize]
 	public void InitializeTests()
 	{
+		var hostBuilder = Host.CreateDefaultBuilder();
+		var services = new ServiceCollection();
+
+#if WITH_AOT_TRIMMING
+		hostBuilder.UseSerialization([SimpleClassContext.Default]);
+#else   // !WITH_AOT_TRIMMING
+		hostBuilder.UseSerialization();
+#endif  // WITH_AOT_TRIMMING
+		var host = hostBuilder.Build();
+
+		_services = host.Services;
 	}
 
 	[TestMethod]
 	public void UseSerializationTest()
 	{
+		var serializer = _services.GetService<ISerializer>();
+		serializer.Should().NotBeNull();
+		serializer = _services.GetService<ISerializer<SimpleClass>>();
+		serializer.Should().NotBeNull();
+	}
+
+	[TestMethod]
+	public void UseSerialization_WithCustomSerializerOptions()
+	{
 		var host = Host.CreateDefaultBuilder()
-			.UseSerialization()
+			.UseSerialization([SimpleClassContext.Default], services =>
+			{
+				services.ConfigureJsonSerializationOptions(options =>
+				{
+					options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+				});
+			})
 			.Build();
 		_services = host.Services;
 

--- a/src/Uno.Extensions.Serialization.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/Uno.Extensions.Serialization.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json.Serialization;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -12,22 +13,107 @@ namespace Uno.Extensions.Serialization.Tests;
 public class ServiceCollectionExtensionsTests
 {
 	private IServiceProvider _services;
+
 	[TestInitialize]
 	public void InitializeTests()
 	{
+		var context = new HostBuilderContext(new Dictionary<object,object>());
+		var services = new ServiceCollection();
+
+#if WITH_AOT_TRIMMING
+		services.AddJsonSerialization(context, TestJsonSerializerContext.Default);
+#else   // !WITH_AOT_TRIMMING
+		services.AddSystemTextJsonSerialization(context);
+#endif  // WITH_AOT_TRIMMING
+
+		_services = services.BuildServiceProvider();
 	}
 
 	[TestMethod]
 	public void AddSystemTextJsonSerializationTest()
 	{
-		var context = new HostBuilderContext(new Dictionary<object,object>());
-		var services = new ServiceCollection();
-		services.AddSystemTextJsonSerialization(context);
-		_services = services.BuildServiceProvider();
-
 		var serializer = _services.GetService<ISerializer>();
 		serializer.Should().NotBeNull();
 		serializer = _services.GetService<ISerializer<SimpleClass>>();
 		serializer.Should().NotBeNull();
 	}
+
+	[TestMethod]
+	public void StringSerializationWithRegisteredTypeInfoTest()
+	{
+		var serializer = _services.GetRequiredService<ISerializer>();
+		serializer.Should().NotBeNull();
+
+		// Test string serialization
+		const string testValue = "test token value";
+		var serialized = serializer.ToString(testValue, typeof(string));
+		serialized.Should().NotBeNullOrEmpty();
+		serialized.Should().Be("\"test token value\"");
+
+		var deserialized = serializer.FromString(serialized, typeof(string));
+		deserialized.Should().Be(testValue);
+
+		// Test string[] serialization
+		var testArray = new[] { "value1", "value2", "value3" };
+		var serializedArray = serializer.ToString(testArray, typeof(string[]));
+		serializedArray.Should().NotBeNullOrEmpty();
+		serializedArray.Should().Be("[\"value1\",\"value2\",\"value3\"]");
+
+		var deserializedArray = serializer.FromString(serializedArray, typeof(string[]));
+		deserializedArray.Should().BeEquivalentTo(testArray);
+
+		// Test bool serialization
+		var serializedBool = serializer.ToString(true, typeof(bool));
+		serializedBool.Should().NotBeNullOrEmpty();
+		serializedBool.Should().Be("true");
+
+		var deserializedBool = serializer.FromString(serializedBool, typeof(bool));
+		deserializedBool.Should().Be(true);
+	}
+
+	[TestMethod]
+	public void StringSerializerExtensionsWithRegisteredTypeInfoTest()
+	{
+		var serializer = _services.GetRequiredService<ISerializer>();
+		serializer.Should().NotBeNull();
+
+		// Test using extension method (same as ApplicationDataKeyValueStorage.Serialize<string>)
+		const string testValue = "authentication_token_12345";
+		var serialized = serializer.ToString(testValue);
+		serialized.Should().NotBeNullOrEmpty();
+		serialized.Should().Be("\"authentication_token_12345\"");
+
+		var deserialized = serializer.FromString<string>(serialized);
+		deserialized.Should().Be(testValue);
+	}
+
+	[TestMethod]
+	public void AddSystemTextJsonSerialization_Works_With_AddJsonSerializationTypeInfoResolvers()
+	{
+		var context = new HostBuilderContext(new Dictionary<object,object>());
+		var services = new ServiceCollection();
+
+		services.AddJsonSerialization(context);
+		services.AddJsonTypeInfo(TestJsonSerializerContext.Default);
+
+		var originalServices = _services;
+		try {
+			_services = services.BuildServiceProvider();
+
+			StringSerializationWithRegisteredTypeInfoTest();
+			StringSerializerExtensionsWithRegisteredTypeInfoTest();
+		}
+		finally {
+			_services = originalServices;
+		}
+	}
+}
+
+
+[JsonSourceGenerationOptions]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(bool))]
+internal sealed partial class TestJsonSerializerContext : JsonSerializerContext
+{
 }

--- a/src/Uno.Extensions.Serialization.Tests/StreamSerializerExtensionsTests.cs
+++ b/src/Uno.Extensions.Serialization.Tests/StreamSerializerExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Uno.Extensions.Serialization.Tests;
@@ -12,8 +13,17 @@ public class SerializerExtensionsTests
 	[TestInitialize]
 	public void InitializeTests()
 	{
-		var services = new ServiceCollection().BuildServiceProvider();
-		Serializer = new SystemTextJsonSerializer(services);
+		var context = new HostBuilderContext(new Dictionary<object, object>());
+		var services = new ServiceCollection();
+
+#if WITH_AOT_TRIMMING
+		services.AddJsonSerialization(context, SimpleClassContext.Default);
+#else   // !WITH_AOT_TRIMMING
+		services.AddSystemTextJsonSerialization(context);
+#endif  // WITH_AOT_TRIMMING
+
+		var serviceProvider = services.BuildServiceProvider();
+		Serializer = new SystemTextJsonSerializer(serviceProvider);
 	}
 
 	[TestMethod]

--- a/src/Uno.Extensions.Serialization.Tests/SystemTextJsonGeneratedSerializerTests.cs
+++ b/src/Uno.Extensions.Serialization.Tests/SystemTextJsonGeneratedSerializerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text.Json.Serialization;
 
@@ -15,9 +16,16 @@ public class SystemTextJsonGeneratedSerializerTests
 	[TestInitialize]
 	public void InitializeTests()
 	{
-		var services = new ServiceCollection().BuildServiceProvider();
-		var reflectionSerializer = new SystemTextJsonSerializer(services);
-		Serializer = new SystemTextJsonGeneratedSerializer<SimpleClass>(reflectionSerializer,SimpleClassContext.Default.SimpleClass);
+		var context = new HostBuilderContext(new Dictionary<object, object>());
+		var services = new ServiceCollection();
+
+#if WITH_AOT_TRIMMING
+		services.AddJsonSerialization(context, SimpleClassContext.Default);
+#endif  // WITH_AOT_TRIMMING
+
+		var serviceProvider = services.BuildServiceProvider();
+		var reflectionSerializer = new SystemTextJsonSerializer(serviceProvider);
+		Serializer = new SystemTextJsonGeneratedSerializer<SimpleClass>(reflectionSerializer, SimpleClassContext.Default.SimpleClass);
 	}
 
 	[TestMethod]
@@ -102,7 +110,9 @@ public class SystemTextJsonGeneratedSerializerTests
 	}
 }
 
+[JsonSerializable(typeof(ISimpleText))]
 [JsonSerializable(typeof(SimpleClass))]
+[JsonSerializable(typeof(SimpleRecord))]
 internal partial class SimpleClassContext : JsonSerializerContext
 {
 }

--- a/src/Uno.Extensions.Serialization.Tests/SystemTextJsonStreamSerializerTests.cs
+++ b/src/Uno.Extensions.Serialization.Tests/SystemTextJsonStreamSerializerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 
@@ -15,8 +16,15 @@ public class SystemTextJsonSerializerTests
 	[TestInitialize]
 	public void InitializeTests()
 	{
-		var services = new ServiceCollection().BuildServiceProvider();
-		Serializer = new SystemTextJsonSerializer(services);
+		var context = new HostBuilderContext(new Dictionary<object, object>());
+		var services = new ServiceCollection();
+
+#if WITH_AOT_TRIMMING
+		services.AddJsonSerialization(context, SimpleClassContext.Default);
+#endif  // WITH_AOT_TRIMMING
+
+		var serviceProvider = services.BuildServiceProvider();
+		Serializer = new SystemTextJsonSerializer(serviceProvider);
 	}
 
 	[TestMethod]

--- a/src/Uno.Extensions.Serialization/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Serialization/HostBuilderExtensions.cs
@@ -1,10 +1,16 @@
-﻿namespace Uno.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Uno.Extensions;
 
 /// <summary>
 /// Extensions for <see cref="IHostBuilder"/> to add serialization.
 /// </summary>
 public static class HostBuilderExtensions
 {
+	private const string RequiresDynamicCodeMessage         = $"Default behavior requires Reflection. For trimming support, use: ";
+	private const string RequiresUnreferencedCodeMessage    = $"Default behavior requires Reflection. For trimming support, use: ";
+
 	/// <summary>
 	/// Adds serialization to an <see cref="IHostBuilder"/>, which can be configured using the service collection.
 	/// An example of such configuration is to register <see cref="JsonSerializerOptions"/> as a singleton.
@@ -18,6 +24,8 @@ public static class HostBuilderExtensions
 	/// <returns>
 	/// The <see cref="IHostBuilder"/> with serialization added.
 	/// </returns>
+	[RequiresDynamicCode(RequiresDynamicCodeMessage + TrimSafeUseSerializationOverload + ".")]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage + TrimSafeUseSerializationOverload + ".")]
 	public static IHostBuilder UseSerialization(this IHostBuilder hostBuilder, Action<IServiceCollection> configure)
 	{
 		return hostBuilder.UseSerialization((context, builder) => configure.Invoke(builder));
@@ -35,6 +43,8 @@ public static class HostBuilderExtensions
 	/// <returns>
 	/// The <see cref="IHostBuilder"/> with serialization added.
 	/// </returns>
+	[RequiresDynamicCode(RequiresUnreferencedCodeMessage + "UseSerialization(IHostBuilder, IEnumerable<IJsonTypeInfoResolver>, Action<HostBuilderContext, IServiceCollection>).")]
+	[RequiresUnreferencedCode(RequiresUnreferencedCodeMessage + "UseSerialization(IHostBuilder, IEnumerable<IJsonTypeInfoResolver>, Action<HostBuilderContext, IServiceCollection>).")]
 	public static IHostBuilder UseSerialization(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection>? configure = default)
 	{
 		return hostBuilder
@@ -43,5 +53,50 @@ public static class HostBuilderExtensions
 					_ = s.AddSystemTextJsonSerialization(ctx);
 					configure?.Invoke(ctx, s);
 				});
+	}
+
+	internal const string TrimSafeUseSerializationOverload  = "UseSerialization(IHostBuilder, IEnumerable<IJsonTypeInfoResolver>, Action<IServiceCollection>)";
+
+	/// <summary>
+	///   Adds JSON serialization to an <see cref="IHostBuilder"/>, which can be configured using the host builder context and service collection.
+	/// </summary>
+	/// <param name="hostBuilder">
+	///   The <see cref="IHostBuilder"/> to add JSON serialization to.
+	/// </param>
+	/// <param name="typeInfoResolvers">
+	///   An enumerable of <see cref="IJsonTypeInfoResolver" /> instances to use for JSON serialization and deserialization.
+	/// </param>
+	/// <param name="configure">
+	///   An <see cref="Action{IServiceCollection}" /> to configure the <see cref="IServiceCollection" />.
+	/// </param>
+	/// <returns>
+	///   The modified <see cref="IHostBuilder"/>.
+	/// </returns>
+	public static IHostBuilder UseSerialization(this IHostBuilder hostBuilder, IEnumerable<IJsonTypeInfoResolver> typeInfoResolvers, Action<IServiceCollection> configure)
+		=> hostBuilder.UseSerialization(typeInfoResolvers, (context, builder) => configure.Invoke(builder));
+
+	/// <summary>
+	///   Adds JSON serialization to an <see cref="IHostBuilder"/>, which can be configured using the host builder context and service collection.
+	/// </summary>
+	/// <param name="hostBuilder">
+	///   The <see cref="IHostBuilder"/> to add JSON serialization to.
+	/// </param>
+	/// <param name="typeInfoResolvers">
+	///   An enumerable of <see cref="IJsonTypeInfoResolver" /> instances to use for JSON serialization and deserialization.
+	/// </param>
+	/// <param name="configure">
+	///   An <see cref="Action{HostBuilderContext,IServiceCollection}" /> to configure the <see cref="IServiceCollection" />.
+	/// </param>
+	/// <returns>
+	///   The modified <see cref="IHostBuilder"/>.
+	/// </returns>
+	public static IHostBuilder UseSerialization(this IHostBuilder hostBuilder, IEnumerable<IJsonTypeInfoResolver> typeInfoResolvers, Action<HostBuilderContext, IServiceCollection>? configure = null)
+	{
+		return hostBuilder
+			.ConfigureServices((ctx, s) =>
+			{
+				_ = s.AddJsonSerialization(ctx, typeInfoResolvers);
+				configure?.Invoke(ctx, s);
+			});
 	}
 }

--- a/src/Uno.Extensions.Serialization/JsonSerializationOptions.cs
+++ b/src/Uno.Extensions.Serialization/JsonSerializationOptions.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace Uno.Extensions.Serialization;
+
+/// <summary>
+/// Options to configure JSON serialization settings for <see cref="ServiceCollectionExtensions"/>
+/// and <see cref="HostBuilderExtensions" />.
+/// </summary>
+public class JsonSerializationOptions
+{
+	internal static readonly JsonSerializerOptions DefaultSerializerOptions = new JsonSerializerOptions()
+	{
+		AllowTrailingCommas     = true,
+		DefaultIgnoreCondition  = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
+		NumberHandling          = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString,
+
+		// The JsonSerializerOptions.GetTypeInfo method is called directly and needs a defined resolver
+		// setting the default resolver (reflection-based) but the user can overwrite it directly or by modifying
+		// the TypeInfoResolverChain. Use JsonTypeInfoResolver.Combine() to produce an empty TypeInfoResolver.
+		TypeInfoResolver        = JsonSerializer.IsReflectionEnabledByDefault
+			? CreateDefaultTypeResolver()
+			: JsonTypeInfoResolver.Combine(),
+	};
+
+	/// <summary>
+	/// Gets the <see cref="JsonSerializerOptions"/>.
+	/// </summary>
+	public JsonSerializerOptions SerializerOptions { get; } = new JsonSerializerOptions(DefaultSerializerOptions);
+
+	[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Only used when JsonSerializer.IsReflectionEnabledByDefault=true.")]
+	[UnconditionalSuppressMessage("Trimming", "IL3050", Justification = "Only used when JsonSerializer.IsReflectionEnabledByDefault=true.")]
+	private static IJsonTypeInfoResolver CreateDefaultTypeResolver()
+		=> new DefaultJsonTypeInfoResolver();
+}

--- a/src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs
@@ -1,4 +1,9 @@
-﻿namespace Uno.Extensions;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
+
+using Microsoft.Extensions.Options;
+
+namespace Uno.Extensions;
 
 /// <summary>
 /// This class is used for serialization configuration.
@@ -7,11 +12,53 @@
 public static class ServiceCollectionExtensions
 {
 	/// <summary>
+	///   Adds the serialization services to the <see cref="IServiceCollection"/>.
+	/// </summary>
+	/// <param name="services">
+	///   The <see cref="IServiceCollection"/> to add JSON Serialization to.
+	/// </param>
+	/// <param name="context">The <see cref="HostBuilderContext"/> to use when adding services.</param>
+	/// <param name="typeInfoResolvers">
+	///   An enumerable of <see cref="IJsonTypeInfoResolver" /> instances to use for JSON serialization and deserialization.
+	/// </param>
+	/// <returns>
+	///   The modified <see cref="IServiceCollection" />.
+	/// </returns>
+	public static IServiceCollection AddJsonSerialization(
+		this IServiceCollection services,
+		HostBuilderContext context,
+		params IEnumerable<IJsonTypeInfoResolver> typeInfoResolvers)
+	{
+		if (context.IsRegistered(nameof(AddJsonSerialization)))
+		{
+			return services;
+		}
+		return services
+			.AddSingleton(sp => sp.GetJsonSerializationOptions())
+			.AddSingleton<SystemTextJsonSerializer>()
+			.AddSingleton<ISerializer>(services => services.GetRequiredService<SystemTextJsonSerializer>())
+			.AddSingleton(typeof(ISerializer<>), typeof(SystemTextJsonGeneratedSerializer<>))
+			.AddJsonTypeInfo(typeInfoResolvers);
+	}
+
+	internal static JsonSerializerOptions GetJsonSerializationOptions(this IServiceProvider services)
+		=> services.GetService<IOptions<JsonSerializationOptions>>()?.Value?.SerializerOptions ??
+			JsonSerializationOptions.DefaultSerializerOptions;
+
+
+	/// <summary>
 	/// Adds the serialization services to the <see cref="IServiceCollection"/>.
 	/// </summary>
 	/// <param name="services">Service collection.</param>
 	/// <param name="context">The <see cref="HostBuilderContext"/> to use when adding services</param>
 	/// <returns><see cref="IServiceCollection"/>.</returns>
+	/// <remarks>
+	///   Consider using <see cref="AddJsonSerialization" /> and <see cref="AddJsonTypeInfo" />
+	///   for use in trimming-enabled environments such as NativeAOT.
+	///   Otherwise, methods such as <see cref="ISerializer.ToString" /> may throw <see cref="InvalidOperationException" />.
+	/// </remarks>
+	[RequiresDynamicCode("Default behavior requires Reflection. For trimming support, use: AddJsonSerialization(IServiceCollection, HostBuilderContext, IEnumerable<IJsonTypeInfoResolver>).")]
+	[RequiresUnreferencedCode("Default behavior requires Reflection. For trimming support, use: AddJsonSerialization(IServiceCollection, HostBuilderContext, IEnumerable<IJsonTypeInfoResolver>).")]
 	public static IServiceCollection AddSystemTextJsonSerialization(
 		this IServiceCollection services,
 		HostBuilderContext context)
@@ -22,12 +69,7 @@ public static class ServiceCollectionExtensions
 		}
 
 		return services
-			.AddSingleton(sp => new JsonSerializerOptions
-			{
-				NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString,
-				DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
-				AllowTrailingCommas = true
-			})
+			.AddSingleton(sp => new JsonSerializerOptions(JsonSerializationOptions.DefaultSerializerOptions))
 			.AddSingleton<SystemTextJsonSerializer>()
 			.AddSingleton<ISerializer>(services => services.GetRequiredService<SystemTextJsonSerializer>())
 			.AddSingleton(typeof(ISerializer<>), typeof(SystemTextJsonGeneratedSerializer<>));
@@ -53,9 +95,55 @@ public static class ServiceCollectionExtensions
 		JsonTypeInfo<TEntity> instance
 		)
 	{
+		if (instance.OriginatingResolver is {} resolver)
+		{
+			AddJsonTypeInfo(services, resolver);
+		}
 		return services
 			.AddSingleton(instance)
 			.AddSingleton<ISerializerTypedInstance>(sp => new SerializerTypedInstance<TEntity>(sp, instance));
+	}
+
+	/// <summary>
+	///   Configures options used for reading and writing JSON when using
+	///   <see cref="SystemTextJsonSerializer" />-backed <see cref="ISerializer" /> instances.
+	/// </summary>
+	/// <param name="services">
+	///   The <see cref="IServiceCollection"/> to configure options on.
+	/// </param>
+	/// <param name="configureOptions">
+	///   The <see cref="Action{JsonSerializationOptions}" /> to configure the <see cref="JsonSerializationOptions" />
+	/// </param>
+	/// <returns>
+	///   The modified <see cref="IServiceCollection" />.
+	/// </returns>
+	public static IServiceCollection ConfigureJsonSerializationOptions(this IServiceCollection services, Action<JsonSerializationOptions> configureOptions)
+	{
+		services.Configure<JsonSerializationOptions>(configureOptions);
+		return services;
+	}
+
+	/// <summary>
+	///   Adds additional <see cref="IJsonTypeInfoResolver"/> instances to use for JSON serialization and deserialization.
+	/// </summary>
+	/// <param name="services">
+	///   The <see cref="IServiceCollection"/> to add <see cref="IJsonTypeInfoResolver"/> instances to.
+	/// </param>
+	/// <param name="typeInfoResolvers">
+	///   An enumerable of <see cref="IJsonTypeInfoResolver" /> instances to use for JSON serialization and deserialization.
+	/// </param>
+	/// <returns>
+	///   The modified <see cref="IServiceCollection" />.
+	/// </returns>
+	public static IServiceCollection AddJsonTypeInfo(this IServiceCollection services, params IEnumerable<IJsonTypeInfoResolver> typeInfoResolvers)
+	{
+		return services.ConfigureJsonSerializationOptions(options =>
+		{
+			foreach (var resolver in typeInfoResolvers)
+			{
+				options.SerializerOptions.TypeInfoResolverChain.Add(resolver);
+			}
+		});
 	}
 }
 

--- a/src/Uno.Extensions.Serialization/Uno.Extensions.Serialization.csproj
+++ b/src/Uno.Extensions.Serialization/Uno.Extensions.Serialization.csproj
@@ -3,9 +3,12 @@
 
 	<PropertyGroup>
 		<Description>Serialization Extensions for working with ISerializer for the Uno Platform, UWP and WinUI</Description>
+		<IsAotCompatible>true</IsAotCompatible>
 
 		<!--Temporary disable missing XML doc until fixed in the whole package-->
 		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
+		<!-- error CS0436: The type 'ServiceCollectionExtensions' in '…src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs' conflicts with the imported type 'ServiceCollectionExtensions' in 'Uno.Extensions.Core, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null'. Using the type defined in 'src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs'. -->
+		<NoWarn>$(NoWarn);CS0436</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Storage.UI/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Storage.UI/HostBuilderExtensions.cs
@@ -36,7 +36,7 @@ public static class HostBuilderExtensions
 		Action<HostBuilderContext, IServiceCollection>? configure = default)
 	{
 		return hostBuilder
-			.UseSerialization()
+			.UseSerialization([])
 			.UseConfiguration(
 				configure: configBuilder =>
 				{


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno.extensions/pull/2970
Context: https://github.com/unoplatform/uno.extensions/issues/3001

Fixes: https://github.com/unoplatform/uno.extensions/issues/2908

When [`$(JsonSerializerIsReflectionEnabledByDefault)`][0]=false,
then various `JsonSerializer` methods will throw.

For example:

	partial class SerializerExtensionsTests {
	  [TestMethod]
	  public void ToFromStringTest()
	  {
	    var services    = new ServiceCollection().BuildServiceProvider();
	    var Serializer  = new SystemTextJsonSerializer(services);
	    var classEntity = new SimpleClass { SimpleTextProperty = SimpleText + "Hello World!Class" };
	    var stringValue = Serializer.ToString(classEntity);
	    // …
	  }
	}

Fails with:

	  Failed ToFromStringTest [< 1 ms]
	  Error Message:
	   Test method Uno.Extensions.Serialization.Tests.SerializerExtensionsTests.ToFromStringTest threw exception:
	System.InvalidOperationException: Reflection-based serialization has been disabled for this application. Either use the source generator APIs or explicitly configure the 'JsonSerializerOptions.TypeInfoResolver' property.
	  Stack Trace:
	   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_JsonSerializerIsReflectionDisabled()
	   at System.Text.Json.JsonSerializerOptions.ConfigureForJsonSerializer()
	   at System.Text.Json.JsonSerializer.GetTypeInfo(JsonSerializerOptions options, Type inputType)
	   at System.Text.Json.JsonSerializer.Serialize(Object value, Type inputType, JsonSerializerOptions options)
	   at Uno.Extensions.Serialization.SystemTextJsonSerializer.ToString(Object value, Type valueType) in /Volumes/Xamarin-Work/src/unoplatform/uno.extensions/src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs:line 101
	   at Uno.Extensions.Serialization.SerializerExtensions.ToString[T](ISerializer serializer, T value) in /Volumes/Xamarin-Work/src/unoplatform/uno.extensions/src/Uno.Extensions.Serialization/SerializerExtensions.cs:line 24
	   at Uno.Extensions.Serialization.Tests.SerializerExtensionsTests.ToFromStringTest() in /Volumes/Xamarin-Work/src/unoplatform/uno.extensions/src/Uno.Extensions.Serialization.Tests/StreamSerializerExtensionsTests.cs:line 66
	   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
	   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)

The question: how should this work?  How *can* it work?

The [ASP.NET Core support for Native AOT > Changes to support source generation][1]
documentation section provides some ideas for how this can work.

The fundamental point: if Reflection based JSON (de)serialization
cannot be used, and the suggested alternative is to use
[System.Text.Json source generation][2], then there needs to be a way
for the framework to use the generated code.

In the ASP.NET Core docs, they suggest using the
[`HttpJsonServiceExtensions.ConfigureHttpJsonOptions()`][3] extension
method during service configuration:

	var builder = WebApplication.CreateSlimBuilder(args);
	builder.Services.ConfigureHttpJsonOptions(options =>
	{
	  options.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonSerializerContext.Default);
	});

	// …

	[JsonSerializable(typeof(Todo[]))]
	internal partial class AppJsonSerializerContext : JsonSerializerContext
	{
	}

In order to work when
`$(JsonSerializerIsReflectionEnabledByDefault)`=false,
Uno.Extensions.Serialization needs a similar mechanism, a way to
provide the generated `JsonSerializerContext` types to
Uno.Extensions.Serialization.

Draw inspiration from ASP.NET Core:

  * https://github.com/dotnet/dotnet/blob/9add30f0238eabacba9a92acec51a8d714fd1881/src/aspnetcore/src/Http/Http.Extensions/src/JsonOptions.cs
  * https://github.com/dotnet/dotnet/blob/9add30f0238eabacba9a92acec51a8d714fd1881/src/aspnetcore/src/Http/Http.Extensions/src/HttpJsonServiceExtensions.cs#L23-L27
  * https://github.com/dotnet/dotnet/blob/9add30f0238eabacba9a92acec51a8d714fd1881/src/aspnetcore/src/Http/Http.Extensions/src/HttpRequestJsonExtensions.cs#L397-L401

The core of the new mechanism *mirrors* what ASP.NET Core does:

	public partial class JsonSerializationOptions {
	  public JsonSerializerOptions SerializerOptions { get; }
	}
	public partial class ServiceCollectionExtensions {
	  public static IServiceCollection ConfigureJsonSerializationOptions(this IServiceCollection services, Action<SerializationOptions> configureOptions);
	  public static IServiceCollection AddJsonSerialization(this IServiceCollection services, HostBuilderContext context, params IEnumerable<IJsonTypeInfoResolver> typeInfoResolvers);
	  public static IServiceCollection AddJsonTypeInfo(this IServiceCollection services, params IEnumerable<IJsonTypeInfoResolver> typeInfoResolvers);
	}
	public partial class HostBuilderExtensions {
	  public static IHostBuilder UseSerialization(this IHostBuilder hostBuilder, IEnumerable<IJsonTypeInfoResolver> typeInfoResolvers, Action<IServiceCollection> configure);
	  public static IHostBuilder UseSerialization(this IHostBuilder hostBuilder, IEnumerable<IJsonTypeInfoResolver> typeInfoResolvers, Action<HostBuilderContext, IServiceCollection>? configure = default);
	}

This allows adding the generated `*SerializationContext.Default`
properties for subsequent use:

	hostBuilder.UseSerialization([AppJsonSerializerContext.Default]);

To lead developers to the new APIs, the existing
`IHostBuilder.UseSerialization()` and
`IServiceCollection.AddSystemTextJsonSerialization()`, extension
methods have been marked with `[RequiresDynamicCode]` and
`[RequiresUnreferencedCode]`, as a way to notify developers of the
new mechanism.  This will result in build warnings:

	warning IL3050: Using member 'Uno.Extensions.HostBuilderExtensions.UseSerialization(IHostBuilder, Action<HostBuilderContext, IServiceCollection>)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Default behavior requires Reflection.
	  For trimming support, use: UseSerialization(IHostBuilder, IEnumerable<IJsonTypeInfoResolver>, Action<HostBuilderContext, IServiceCollection>).

To *test* this, add a new `src/Uno.Extensions.Serialization.AotTests`
test project which:

 1. Sets `$(JsonSerializerIsReflectionEnabledByDefault)`=false, and
 2. Defines `WITH_AOT_TRIMMING`, and
 3. Imports all the C# source from
    `src/Uno.Extensions.Serialization.Tests`.

The `WITH_AOT_TRIMMING` define allows us to use the same set of
serialization tests for both untrimmed and trimmed environments.

Update `stage-build-packages.yml` so that `*.AotTests.dll` are also
executed by `VSTest@2`.

Additionally, enable `$(IsAotCompatible)`=true for:

  * `src/Uno.Extensions.Serialization/Uno.Extensions.Serialization.csproj`

Address the following warnings:

	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(120,14): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToString(Object, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.ToString(Object, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(88,16): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToString(Object, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.ToString(Object, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(107,17): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromString(String, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.FromString(String, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(120,14): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromString(String, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.FromString(String, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(43,17): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromStream(Stream, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.FromStream(Stream, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(120,14): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromStream(Stream, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.FromStream(Stream, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(62,14): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToStream(Stream, Object, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.ToStream(Stream, Object, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(120,14): error IL2046:
	  Member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToStream(Stream, Object, Type)' with 'RequiresUnreferencedCodeAttribute' implements interface member 'Uno.Extensions.Serialization.ISerializer.ToStream(Stream, Object, Type)' without 'RequiresUnreferencedCodeAttribute'.
	  'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(146,10): error IL2026:
	  Using member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromStream(Stream, Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(157,10): error IL2026:
	  Using member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToString(Object, Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(140,10): error IL2026:
	  Using member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.FromString(String, Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(168,3): error IL2026:
	  Using member 'Uno.Extensions.Serialization.SystemTextJsonSerializer.ToStream(Stream, Object, Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  From JsonDeserializer: JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(46,89): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Deserialize(Stream, Type, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(71,4): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Serialize(Stream, Object, Type, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(91,85): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Serialize(Object, Type, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs(110,89): error IL3050:
	  Using member 'System.Text.Json.JsonSerializer.Deserialize(String, Type, JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.

Suppress the above warnings.  The foundation logic in
`SystemTextJsonSerializer.cs` has been reworked to check
[`JsonSerializer.IsReflectionEnabledByDefault`][4], which in turn
should mirror the `$(JsonSerializerIsReflectionEnabledByDefault)`
MSBuild property.  This allows us to mirror System.Text.Json default
behavior, attempting Reflection use when
`JsonSerializer.IsReflectionEnabledByDefault` is true, otherwise
throwing an `InvalidOperationException` stating how to address the
problem:

	Reflection-based serialization has been disabled for this application.
	Use the IServiceCollection.AddJsonTypeInfoResolvers() or IHostBuilder.UseSerializationResolvers() extension methods to enable JSON deserialization for type `Example`.

Which brings us to issue https://github.com/unoplatform/uno.extensions/issues/2908: when a Uno app uses
`.UseAuthentication()` when
`$(JsonSerializerIsReflectionEnabledByDefault)`=false, the app
may crash with:

	at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_JsonSerializerIsReflectionDisabled()
	at System.Text.Json.JsonSerializerOptions.ConfigureForJsonSerializer()
	at System.Text.Json.JsonSerializerOptions.MakeReadOnly(Boolean populateMissingResolver)
	at System.Text.Json.JsonSerializer.GetTypeInfo(JsonSerializerOptions options, Type inputType)
	at System.Text.Json.JsonSerializer.Serialize(Object value, Type inputType, JsonSerializerOptions options)
	at Uno.Extensions.Serialization.SystemTextJsonSerializer.ToString(Object value, Type valueType)
	at Uno.Extensions.Serialization.SerializerExtensions.ToString[String](ISerializer serializer, String value)
	at Uno.Extensions.Storage.KeyValueStorage.ApplicationDataKeyValueStorage.Serialize[String](String value)
	at Uno.Extensions.Storage.KeyValueStorage.ApplicationDataKeyValueStorage.<GetObjectValue>d__35`1[[System.String, System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].MoveNext()
	at Uno.Extensions.Storage.KeyValueStorage.ApplicationDataKeyValueStorage.<InternalSetAsync>d__36`1[[System.String, System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].MoveNext()
	at Uno.Extensions.Storage.KeyValueStorage.BaseKeyValueStorageWithCaching.<SetAsync>d__21`1[[System.String, System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].MoveNext()
	at Uno.Extensions.Authentication.TokenCache.SaveAsync(String provider, IDictionary`2 tokens, CancellationToken cancellation)
	at Uno.Extensions.Authentication.AuthenticationService.LoginAsync(IDispatcher dispatcher, IDictionary`2 credentials, String provider, Nullable`1 cancellationToken)
	at UnoApp140.Presentation.LoginModel.Login(CancellationToken token) in X:\src\TestApps\UnoApp140\UnoApp140\Presentation\LoginModel.cs:line 12

How do we fix this?  Based on the above, we need a
`.UseSerialization(…)` invocation which contains the
`IJsonTypeInfoResolver` values which are needed to make the above work.

The problem: what types need to be supported?  This is "fun" because
of generics: `.AddKeyedStorage()` registers an `IKeyValueStorage`
implementation, and `TokenCache` uses `IKeyValueStorage.SetAsync<T>()`.
`Uno.Extensions.Storage` *cannot* know which types that `TokenCache`
will use; it needs to be told.

Update `Uno.Extensions.Authentication` to have a new internal
`TokenCacheContext` type which holds the `JsonTypeInfo<T>` values
that it will use with `IKeyValueStorage.SetAsync<T>()`, and update
`.UseAuthentication()` to call
`.AddJsonSerialization(TokenCacheContext.Default)`, so that the
required types are available at runtime.  This fixes https://github.com/unoplatform/uno.extensions/issues/2908.

TODO: Uno.Extensions.Configuration uses Uno.Extensions.Serialization,
but the types to support are not statically knowable.  For example,
`WritableOptions<T>` needs an `ISerializer<Dictionary<string, T>>`,
but as `T` is provided by a `.Section<TSettingsOptions>()`, which is
part of the *app*, there is no way for `Uno.Extensions.Configuration`
to provide the required `JsonTypeInfo<TSettingsOptions>`.

*A* thought is to provide a `.Section<TSettingsOptions>()` overload
which has a `JsonTypeInfo<TSettingsOptions>` parameter, but this use
case also overlaps with issue https://github.com/unoplatform/uno.extensions/issues/3001.

[0]: https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/8.0/publishtrimmed
[1]: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/native-aot?view=aspnetcore-10.0#changes-to-support-source-generation
[2]: https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation
[3]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.httpjsonserviceextensions.configurehttpjsonoptions?view=aspnetcore-9.0
[4]: https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializer.isreflectionenabledbydefault?view=net-10.0