### PR TITLE
chore: RouteInfo.RenderView annotations should match PageStackEntry ctor

### DIFF
--- a/src/Uno.Extensions.Navigation/RouteInfo.cs
+++ b/src/Uno.Extensions.Navigation/RouteInfo.cs
@@ -23,7 +23,7 @@ public record RouteInfo(
 	public RouteInfo? Parent { get; set; }
 	public RouteInfo? DependsOnRoute { get; set; }
 
-	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicConstructors)]
 	[UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "Cannot 'forward' `[DynamicallyAccessedMembers]` to Func<T>; would need to use a new type, which would be an ABI break.")]
 	public Type? RenderView => View?.Invoke();
 	public bool IsDependent = !string.IsNullOrWhiteSpace(DependsOn);


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/commit/6e631b0bfec24b896558699da70ca3a69d399273

Commit unoplatform/uno@6e631b0b updated the `sourcePageType` constructor argument to preserve all public constructors:

	partial class PageStackEntry {
	  public PageStackEntry(
	    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, DynamicallyAccessedMemberTypes.PublicConstructors)]
	    Type sourcePageType,
	    object parameter,
	    NavigationTransitionInfo navigationTransitionInfo
	  );
	}

`RouteInfo.RenderView` didn't have matching annotations, which meant that "downstream" when building uno.chefs, I would see the warning:

	% dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop \
	  -bl Chefs/Chefs.csproj -p:UseSkiaRendering=true -p:SelfContained=true \
	  -p:PublishAot=true -p:IsAotCompatible=true -p:TrimmerSingleWarn=false -p:_ExtraTrimmerArgs=--verbose \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true -p:IlcGenerateMetadataLog=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen
	…
	ILC : Trim analysis warning IL2072: Uno.Extensions.Navigation.Navigators.FrameNavigator.<NavigateForwardAsync>d__9.MoveNext(): 'sourcePageType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Microsoft.UI.Xaml.Navigation.PageStackEntry.PageStackEntry(Type,Object,NavigationTransitionInfo)'. The return value of method 'Uno.Extensions.Navigation.RouteInfo.RenderView.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Fix this IL2072 warning by updating `RouteInfo.RenderView` to have annotations which match the `PageStackEntry` constructor.

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
