### PR TITLE
feat: ILoggingBuilder.AddSerilog() extension method

### DIFF
--- a/src/Uno.Extensions.Core.UI/Uno.Extensions.Core.WinUI.csproj
+++ b/src/Uno.Extensions.Core.UI/Uno.Extensions.Core.WinUI.csproj
@@ -25,6 +25,7 @@
 	<ItemGroup>
 		<InternalsVisibleTo Include="Uno.Extensions.Hosting.UWP" />
 		<InternalsVisibleTo Include="Uno.Extensions.Hosting.WinUI" />
+		<InternalsVisibleTo Include="Uno.Extensions.Logging.Serilog" />
 
 		<PackageReference Include="Uno.WinUI" />
 	</ItemGroup>

--- a/src/Uno.Extensions.Logging.Serilog/HostBuilderExtensions.cs
+++ b/src/Uno.Extensions.Logging.Serilog/HostBuilderExtensions.cs
@@ -90,7 +90,7 @@ public static class HostBuilderExtensions
                 });
     }
 
-    private static LoggerConfiguration AddConsoleLogging(LoggerConfiguration configuration)
+    internal static LoggerConfiguration AddConsoleLogging(LoggerConfiguration configuration)
     {
 #pragma warning disable CA1416 // Validate platform compatibility: The net8.0 version is not used on older versions of OS
         return configuration
@@ -107,7 +107,7 @@ public static class HostBuilderExtensions
 #pragma warning restore CA1416 // Validate platform compatibility
     }
 
-    private static LoggerConfiguration AddFileLogging(LoggerConfiguration configuration, string logFilePath)
+    internal static LoggerConfiguration AddFileLogging(LoggerConfiguration configuration, string logFilePath)
     {
         //-:cnd:noEmit
 #if __ANDROID__ || __IOS__ || NETSTANDARD

--- a/src/Uno.Extensions.Logging.Serilog/LoggingBuilderExtensions.cs
+++ b/src/Uno.Extensions.Logging.Serilog/LoggingBuilderExtensions.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+
+using Microsoft.Extensions.Logging;
+
+using Serilog;
+
+namespace Uno.Extensions;
+
+/// <summary>
+/// Extension methods to adjust the scope of collected logs. (log level)
+/// </summary>
+public static class LoggingBuilderExtensions
+{
+	public static ILoggingBuilder AddSerilog(
+        this ILoggingBuilder builder,
+        bool consoleLoggingEnabled = false,
+        bool fileLoggingEnabled = false,
+        Action<LoggerConfiguration>? configureLogger = null)
+	{
+#pragma warning disable CS0436
+        var loggerConfiguration = new LoggerConfiguration();
+        // loggerConfiguration.ReadFrom.Configuration(context.Configuration);
+        if (consoleLoggingEnabled)
+        {
+            HostBuilderExtensions.AddConsoleLogging(loggerConfiguration);
+        }
+        if (fileLoggingEnabled)
+        {
+            var logPath = GetLogFilePath();
+            if (logPath is not null)
+            {
+                HostBuilderExtensions.AddFileLogging(loggerConfiguration, logPath);
+            }
+        }
+#pragma warning restore CS0436
+        configureLogger?.Invoke(loggerConfiguration);
+        var logger = loggerConfiguration.CreateLogger();
+
+        builder.AddSerilog(logger);
+		return builder;
+	}
+
+    private static string? GetLogFilePath()
+    {
+        var logDirectory = ApplicationDataExtensions.DataFolder();
+
+        if (string.IsNullOrWhiteSpace(logDirectory))
+        {
+            return null;
+        }
+
+        var assemblyName = PlatformHelper.GetAppAssembly()?.FullName ?? "unologging";
+        return Path.Combine(logDirectory, $"{assemblyName}.log");
+    }
+}

--- a/src/Uno.Extensions.Logging.Serilog/Uno.Extensions.Logging.Serilog.csproj
+++ b/src/Uno.Extensions.Logging.Serilog/Uno.Extensions.Logging.Serilog.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Uno.Extensions.Core.UI\Uno.Extensions.Core.WinUI.csproj" />
     <ProjectReference Include="..\Uno.Extensions.Hosting\Uno.Extensions.Hosting.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno.extensions/issues/3008
Context: https://github.com/unoplatform/uno.extensions/pull/3011
Context: https://github.com/unoplatform/uno.templates/pull/1921

Issue #3008 details that there are two `ILogger` "environments" in a Uno app:

  * The `App.InitializeLogging()` environment ("NoDI"), and
  * The environment configured by Dependency Injection methods such as `.UseLogging()` and `.UseSerilog()` ("DI").

The problem is that "DI" logging *cannot* capture log messages produced before the DI environment is built, frequently via `builder.Build()` or `builder.NavigateAsync<TShell>()`. *A lot* of code can execute before those methods complete.

A further problem is that no default template actually configures both environments: if you use `dotnet new unoapp -di False` you get the NoDI `App.InitializeLogging()` environment, which *will not* log messages from the Dependency Injection enviornment. If you use `dotnet new unoapp -preset "recommended"` you get *only* the DI-based logging, thus missing all messages from the NoDI environment.

Thus, the idea for "`ILogger` configuration unification": What If instead of having two separate places for logging, we just had one: the NoDI `App.InitializeLogging()` location.

This can be made to work via #3011, which updates
`HostBuilder.Build()` so that *if*
`LogExtensionPoint.AmbientLoggerFactory` is set, it *replaces* the `ILoggerFactory` that `HostBuilder.Build()` normally configures. This allows `App.InitializeLogging()` to also be used in the DI environment.

So far, so useful.

But what about [Serilog][0]?  Serilog is a widely recommended logger library, and the current `.UseSerilog()` extension method *requires* a full Dependency Injection environment: it cannot be invoked within `App.InitializeLogging()`.

Try to square this circle by adding a new
`ILoggingBuilder.AddSerilog()` extension method.  This would allow Serilog to be configured within `App.InitializeLogging()`, helping to support a unified logging setup experience.

[0]: https://platform.uno/docs/articles/external/uno.extensions/doc/Overview/Logging/LoggingOverview.html#serilog

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
