### PR TITLE
chore: web auth provider extensions for desktop

### DIFF
--- a/Uno.Extensions.sln
+++ b/Uno.Extensions.sln
@@ -145,6 +145,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Serialization.AotTests", "src\Uno.Extensions.Serialization.AotTests\Uno.Extensions.Serialization.AotTests.csproj", "{DF77B943-13C2-4D98-8364-BA0DDC2C156D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Authentication.WinUI.Runtime.Skia", "src\Uno.Extensions.Authentication.WinUI.Runtime.Skia\Uno.Extensions.Authentication.WinUI.Runtime.Skia.csproj", "{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -789,6 +791,22 @@ Global
 		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|x64.Build.0 = Release|Any CPU
 		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|x86.ActiveCfg = Release|Any CPU
 		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|x86.Build.0 = Release|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Debug|arm64.Build.0 = Debug|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Debug|x64.Build.0 = Debug|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Debug|x86.Build.0 = Debug|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Release|arm64.ActiveCfg = Release|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Release|arm64.Build.0 = Release|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Release|x64.ActiveCfg = Release|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Release|x64.Build.0 = Release|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Release|x86.ActiveCfg = Release|Any CPU
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -838,6 +856,7 @@ Global
 		{C9827C80-312B-4E81-B539-2D305D893A6C} = {45179294-70DC-47E8-AD22-1296F897B594}
 		{76AF6C8E-A738-FF6A-EAB1-FE94DAC56658} = {2197ADCE-59C4-465A-B380-0B06BF68BBBC}
 		{DF77B943-13C2-4D98-8364-BA0DDC2C156D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A} = {FEABD28F-23AE-4CDC-9933-44D6717C681C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E7B035D-9A64-4D95-89AA-9D4653F17C42}

--- a/Uno.Extensions.sln
+++ b/Uno.Extensions.sln
@@ -147,6 +147,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Serializatio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Authentication.WinUI.Runtime.Skia", "src\Uno.Extensions.Authentication.WinUI.Runtime.Skia\Uno.Extensions.Authentication.WinUI.Runtime.Skia.csproj", "{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Authentication.WinUI.Runtime.Skia.Tests", "src\Uno.Extensions.Authentication.WinUI.Runtime.Skia.Tests\Uno.Extensions.Authentication.WinUI.Runtime.Skia.Tests.csproj", "{13974CF0-A259-417C-AA18-C2DF3D185380}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -807,6 +809,22 @@ Global
 		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Release|x64.Build.0 = Release|Any CPU
 		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Release|x86.ActiveCfg = Release|Any CPU
 		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A}.Release|x86.Build.0 = Release|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Debug|arm64.Build.0 = Debug|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Debug|x64.Build.0 = Debug|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Debug|x86.Build.0 = Debug|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Release|arm64.ActiveCfg = Release|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Release|arm64.Build.0 = Release|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Release|x64.ActiveCfg = Release|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Release|x64.Build.0 = Release|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Release|x86.ActiveCfg = Release|Any CPU
+		{13974CF0-A259-417C-AA18-C2DF3D185380}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -857,6 +875,7 @@ Global
 		{76AF6C8E-A738-FF6A-EAB1-FE94DAC56658} = {2197ADCE-59C4-465A-B380-0B06BF68BBBC}
 		{DF77B943-13C2-4D98-8364-BA0DDC2C156D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{50F1F3CD-F9D7-4B67-A475-F16DB0FC6F5A} = {FEABD28F-23AE-4CDC-9933-44D6717C681C}
+		{13974CF0-A259-417C-AA18-C2DF3D185380} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E7B035D-9A64-4D95-89AA-9D4653F17C42}

--- a/build/ci/cspell.json
+++ b/build/ci/cspell.json
@@ -100,6 +100,9 @@
 		"usercontrol",
 		"Validatable",
 		"backstack",
+		"navigations",
+		"reparented",
+		"rollbackable",
 		"viewmap",
 		"datamap"
 	],
@@ -168,7 +171,8 @@
 		"Grial",
 		"Telerik",
 		"listfeed",
-		"Kiota"
+		"Kiota",
+		"Visiblity"
 	],
 	"patterns": [
 		{

--- a/doc/Learn/Authentication/AuthenticationOverview.md
+++ b/doc/Learn/Authentication/AuthenticationOverview.md
@@ -93,6 +93,8 @@ When the `OidcAuthenticationProvider` is automatically built, there are platform
 
 **WebAssembly**: The `OidcAuthenticationProvider` will automatically use the `WebAuthenticationBroker` to obtain redirect URIs during the authentication process. This is done to avoid the need for a redirect to a custom URI scheme, which is not supported in the browser.
 
+**Desktop (Skia — Linux, macOS, Windows)**: On Skia desktop targets, a `SkiaWebAuthenticationBrokerProvider` launches the system's default browser for the OIDC sign-in flow and listens on a local HTTP loopback server (`http://localhost:{port}`) to capture the redirect callback. This enables OIDC authentication on Skia-rendered desktop targets where an in-app browser control is not available. To use this, add a reference to the `Uno.Extensions.Authentication.WinUI.Runtime.Skia` package and call `.AutoRedirectUriFromWebAuthenticationBroker()` on the OIDC builder.
+
 ### Web
 
 The `WebAuthenticationProvider` provides an implementation that displays a web view in order for the user to login. After login, the web view redirects back to the application, along with any tokens. Learn [Web Authentication](xref:Uno.Extensions.Authentication.HowToWebAuthentication)

--- a/doc/Learn/Authentication/HowTo-OidcAuthentication.md
+++ b/doc/Learn/Authentication/HowTo-OidcAuthentication.md
@@ -111,6 +111,8 @@ Under the hood, `OidcAuthenticationProvider` relies on [Duende.IdentityModel.Oid
   >
   > When used, this setting will override the value set in the configuration file for both the redirect URI and the post-logout redirect URI.
   > **This setting is ON by default on WebAssembly but opt-in on other platforms.**
+  >
+  > On **Skia desktop targets** (Linux, macOS, Windows), the `SkiaWebAuthenticationBrokerProvider` supplies a local loopback URI (e.g. `http://localhost:{port}/authentication-callback`). Ensure your identity provider's redirect URI is configured to `http://localhost/authentication-callback` to allow dynamic port matching.
 
 - **Advanced settings**: some advanced settings may need to access directly the `OidcClientOptions` from `IdentityModel.OidcClient` used by this extension. This can be done by using the `.ConfigureOidcClientOptions()` extension method.
 

--- a/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia.Tests/SkiaWebAuthenticationBrokerProviderTests.cs
+++ b/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia.Tests/SkiaWebAuthenticationBrokerProviderTests.cs
@@ -1,0 +1,215 @@
+#nullable enable
+using System.Net;
+using System.Net.Http;
+using System.Web;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Authentication;
+using Windows.Security.Authentication.Web;
+
+namespace Uno.Extensions.Authentication.Tests;
+
+[TestClass]
+public class SkiaWebAuthenticationBrokerProviderTests
+{
+	[TestMethod]
+	public void GetCurrentApplicationCallbackUri_ReturnsLoopbackWithPort()
+	{
+		var provider = new SkiaWebAuthenticationBrokerProvider();
+
+		var uri = provider.GetCurrentApplicationCallbackUri();
+
+		uri.Scheme.Should().Be("http");
+		uri.Host.Should().Be("localhost");
+		uri.Port.Should().BeGreaterThan(0);
+		uri.AbsolutePath.Should().Be("/authentication-callback");
+	}
+
+	[TestMethod]
+	public void GetCurrentApplicationCallbackUri_ReturnsSamePortOnRepeatedCalls()
+	{
+		var provider = new SkiaWebAuthenticationBrokerProvider();
+
+		var uri1 = provider.GetCurrentApplicationCallbackUri();
+		var uri2 = provider.GetCurrentApplicationCallbackUri();
+
+		uri1.Port.Should().Be(uri2.Port);
+	}
+
+	[TestMethod]
+	public void GetCurrentApplicationCallbackUri_DifferentInstances_MayReturnDifferentPorts()
+	{
+		var provider1 = new SkiaWebAuthenticationBrokerProvider();
+		var provider2 = new SkiaWebAuthenticationBrokerProvider();
+
+		var uri1 = provider1.GetCurrentApplicationCallbackUri();
+		var uri2 = provider2.GetCurrentApplicationCallbackUri();
+
+		// Both should have valid ports (may or may not be different)
+		uri1.Port.Should().BeGreaterThan(0);
+		uri2.Port.Should().BeGreaterThan(0);
+	}
+
+	[TestMethod]
+	public void OwnerConstructor_Works()
+	{
+		var provider = new SkiaWebAuthenticationBrokerProvider(owner: new object());
+
+		var uri = provider.GetCurrentApplicationCallbackUri();
+
+		uri.Should().NotBeNull();
+		uri.Host.Should().Be("localhost");
+
+	[TestMethod]
+	public async Task AuthenticateAsync_ReturnsSuccess_WhenCallbackReceived()
+	{
+		var provider = new SkiaWebAuthenticationBrokerProvider();
+		var callbackUri = provider.GetCurrentApplicationCallbackUri();
+
+		// Build a fake request URI with redirect_uri pointing to our callback
+		var requestUri = new Uri($"https://idp.example.com/authorize?client_id=test&redirect_uri={Uri.EscapeDataString(callbackUri.ToString())}");
+
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+		// Start auth (it will try to open a browser which will fail, but the listener starts)
+		var authTask = provider.AuthenticateAsync(
+			WebAuthenticationOptions.None,
+			requestUri,
+			callbackUri,
+			cts.Token);
+
+		// Simulate the IdP callback by sending an HTTP request to the listener
+		using var client = new HttpClient();
+		var callbackUrl = $"{callbackUri}?code=test_auth_code&state=test_state";
+
+		// Small delay to let the listener start
+		await Task.Delay(500);
+
+		var response = await client.GetAsync(callbackUrl, cts.Token);
+		response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+		var result = await authTask;
+
+		result.ResponseStatus.Should().Be(WebAuthenticationStatus.Success);
+		result.ResponseData.Should().Contain("code=test_auth_code");
+		result.ResponseData.Should().Contain("state=test_state");
+	}
+
+	[TestMethod]
+	public async Task AuthenticateAsync_FiltersFaviconRequests()
+	{
+		var provider = new SkiaWebAuthenticationBrokerProvider();
+		var callbackUri = provider.GetCurrentApplicationCallbackUri();
+
+		var requestUri = new Uri($"https://idp.example.com/authorize?redirect_uri={Uri.EscapeDataString(callbackUri.ToString())}");
+
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+		var authTask = provider.AuthenticateAsync(
+			WebAuthenticationOptions.None,
+			requestUri,
+			callbackUri,
+			cts.Token);
+
+		await Task.Delay(500);
+
+		using var client = new HttpClient();
+
+		// First send a favicon request - should be ignored (404)
+		var port = callbackUri.Port;
+		var faviconResponse = await client.GetAsync($"http://localhost:{port}/favicon.ico", cts.Token);
+		faviconResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+		// Then send the real callback - should succeed
+		var callbackResponse = await client.GetAsync($"{callbackUri}?code=real_code", cts.Token);
+		callbackResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+		var result = await authTask;
+		result.ResponseStatus.Should().Be(WebAuthenticationStatus.Success);
+		result.ResponseData.Should().Contain("code=real_code");
+	}
+
+	[TestMethod]
+	public async Task AuthenticateAsync_ReturnsUserCancel_WhenCancelled()
+	{
+		var provider = new SkiaWebAuthenticationBrokerProvider();
+		var callbackUri = provider.GetCurrentApplicationCallbackUri();
+
+		var requestUri = new Uri($"https://idp.example.com/authorize?redirect_uri={Uri.EscapeDataString(callbackUri.ToString())}");
+
+		using var cts = new CancellationTokenSource();
+
+		var authTask = provider.AuthenticateAsync(
+			WebAuthenticationOptions.None,
+			requestUri,
+			callbackUri,
+			cts.Token);
+
+		await Task.Delay(500);
+
+		// Cancel the operation
+		cts.Cancel();
+
+		var result = await authTask;
+		result.ResponseStatus.Should().Be(WebAuthenticationStatus.UserCancel);
+	}
+
+	[TestMethod]
+	public void ResponseHtmlProvider_CanBeOverridden()
+	{
+		var original = SkiaWebAuthenticationBrokerProvider.ResponseHtmlProvider;
+
+		try
+		{
+			SkiaWebAuthenticationBrokerProvider.ResponseHtmlProvider = success =>
+				success ? "<html>Custom OK</html>" : "<html>Custom Fail</html>";
+
+			var html = SkiaWebAuthenticationBrokerProvider.ResponseHtmlProvider(true);
+			html.Should().Be("<html>Custom OK</html>");
+
+			html = SkiaWebAuthenticationBrokerProvider.ResponseHtmlProvider(false);
+			html.Should().Be("<html>Custom Fail</html>");
+		}
+		finally
+		{
+			SkiaWebAuthenticationBrokerProvider.ResponseHtmlProvider = original;
+		}
+	}
+
+	[TestMethod]
+	public async Task AuthenticateAsync_FiltersNonGetRequests()
+	{
+		var provider = new SkiaWebAuthenticationBrokerProvider();
+		var callbackUri = provider.GetCurrentApplicationCallbackUri();
+
+		var requestUri = new Uri($"https://idp.example.com/authorize?redirect_uri={Uri.EscapeDataString(callbackUri.ToString())}");
+
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+		var authTask = provider.AuthenticateAsync(
+			WebAuthenticationOptions.None,
+			requestUri,
+			callbackUri,
+			cts.Token);
+
+		await Task.Delay(500);
+
+		using var client = new HttpClient();
+		var port = callbackUri.Port;
+
+		// POST to callback path - should be filtered (404)
+		var postResponse = await client.PostAsync(
+			$"{callbackUri}?code=post_code",
+			new StringContent(""),
+			cts.Token);
+		postResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+		// GET to callback path - should succeed
+		var getResponse = await client.GetAsync($"{callbackUri}?code=get_code", cts.Token);
+		getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+		var result = await authTask;
+		result.ResponseStatus.Should().Be(WebAuthenticationStatus.Success);
+		result.ResponseData.Should().Contain("code=get_code");
+	}
+}

--- a/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia.Tests/SkiaWebAuthenticationBrokerProviderTests.cs
+++ b/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia.Tests/SkiaWebAuthenticationBrokerProviderTests.cs
@@ -12,6 +12,22 @@ namespace Uno.Extensions.Authentication.Tests;
 [TestClass]
 public class SkiaWebAuthenticationBrokerProviderTests
 {
+	private Func<Uri, bool>? _originalBrowserLauncher;
+
+	[TestInitialize]
+	public void SetUp()
+	{
+		// Stub the browser launcher so tests don't open a real browser
+		_originalBrowserLauncher = SkiaWebAuthenticationBrokerProvider.BrowserLauncher;
+		SkiaWebAuthenticationBrokerProvider.BrowserLauncher = _ => true;
+	}
+
+	[TestCleanup]
+	public void TearDown()
+	{
+		SkiaWebAuthenticationBrokerProvider.BrowserLauncher = _originalBrowserLauncher;
+	}
+
 	[TestMethod]
 	public void GetCurrentApplicationCallbackUri_ReturnsLoopbackWithPort()
 	{
@@ -59,6 +75,7 @@ public class SkiaWebAuthenticationBrokerProviderTests
 
 		uri.Should().NotBeNull();
 		uri.Host.Should().Be("localhost");
+	}
 
 	[TestMethod]
 	public async Task AuthenticateAsync_ReturnsSuccess_WhenCallbackReceived()
@@ -71,7 +88,7 @@ public class SkiaWebAuthenticationBrokerProviderTests
 
 		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-		// Start auth (it will try to open a browser which will fail, but the listener starts)
+		// Start auth (browser launch is stubbed via BrowserLauncher)
 		var authTask = provider.AuthenticateAsync(
 			WebAuthenticationOptions.None,
 			requestUri,

--- a/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia.Tests/Uno.Extensions.Authentication.WinUI.Runtime.Skia.Tests.csproj
+++ b/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia.Tests/Uno.Extensions.Authentication.WinUI.Runtime.Skia.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Uno.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+		<OutputType>Library</OutputType>
+		<UnoSingleProject>true</UnoSingleProject>
+		<NoWarn>$(NoWarn);NU1604</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="MSTest.TestAdapter" />
+		<PackageReference Include="MSTest.TestFramework" />
+		<PackageReference Include="coverlet.collector" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.Extensions.Authentication.WinUI.Runtime.Skia\Uno.Extensions.Authentication.WinUI.Runtime.Skia.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/GlobalUsings.cs
+++ b/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/GlobalUsings.cs
@@ -1,0 +1,7 @@
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Threading;
+global using System.Threading.Tasks;
+global using Microsoft.Extensions.Logging;
+global using Uno.Extensions;

--- a/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/GlobalUsings.cs
+++ b/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/GlobalUsings.cs
@@ -1,7 +1,3 @@
 global using System;
-global using System.Collections.Generic;
-global using System.Linq;
 global using System.Threading;
 global using System.Threading.Tasks;
-global using Microsoft.Extensions.Logging;
-global using Uno.Extensions;

--- a/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/SkiaWebAuthenticationBrokerProvider.cs
+++ b/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/SkiaWebAuthenticationBrokerProvider.cs
@@ -1,0 +1,348 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Uno.AuthenticationBroker;
+using Uno.Foundation.Extensibility;
+using Windows.Security.Authentication.Web;
+
+[assembly: ApiExtension(typeof(IWebAuthenticationBrokerProvider), typeof(Uno.Extensions.Authentication.SkiaWebAuthenticationBrokerProvider))]
+
+namespace Uno.Extensions.Authentication;
+
+/// <summary>
+/// Web Authentication Broker provider implementation for Skia desktop targets.
+/// Uses a local HTTP listener (loopback) to capture OAuth callbacks.
+/// </summary>
+public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvider
+{
+	private const int DefaultListenerPort = 0; // Use any available port
+	private const string LoopbackCallbackPath = "/authentication-callback";
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SkiaWebAuthenticationBrokerProvider"/> class.
+	/// </summary>
+	public SkiaWebAuthenticationBrokerProvider()
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SkiaWebAuthenticationBrokerProvider"/> class.
+	/// Constructor with owner parameter for API extension compatibility.
+	/// </summary>
+	/// <param name="owner">The owner object (required by ApiExtensibility pattern).</param>
+	public SkiaWebAuthenticationBrokerProvider(object? owner) : this()
+	{
+	}
+
+	/// <inheritdoc/>
+	public Uri GetCurrentApplicationCallbackUri()
+	{
+		// For desktop Skia, we use a loopback address with a dynamic port
+		// The actual port will be determined when AuthenticateAsync is called
+		return new Uri($"http://127.0.0.1{LoopbackCallbackPath}");
+	}
+
+	/// <inheritdoc/>
+	public async Task<WebAuthenticationResult> AuthenticateAsync(
+		WebAuthenticationOptions options,
+		Uri requestUri,
+		Uri callbackUri,
+		CancellationToken ct)
+	{
+		// Determine the port to use - if callback specifies a port use that, otherwise use any available
+		var port = callbackUri.IsDefaultPort ? GetAvailablePort() : callbackUri.Port;
+		var listenerUri = BuildListenerUri(callbackUri, port);
+
+		// Update the request URI to use our actual callback URL with port
+		var actualCallbackUri = BuildActualCallbackUri(callbackUri, port);
+		var modifiedRequestUri = UpdateRequestUriWithCallback(requestUri, callbackUri, actualCallbackUri);
+
+		using var listener = new HttpListener();
+		listener.Prefixes.Add(listenerUri);
+
+		try
+		{
+			listener.Start();
+		}
+		catch (HttpListenerException ex)
+		{
+			return new WebAuthenticationResult(
+				$"Failed to start local HTTP listener: {ex.Message}",
+				(uint)ex.ErrorCode,
+				WebAuthenticationStatus.ErrorHttp);
+		}
+
+		// Open the browser with the authentication URL
+		if (!TryOpenBrowser(modifiedRequestUri))
+		{
+			listener.Stop();
+			return new WebAuthenticationResult(
+				"Failed to open the system browser for authentication.",
+				0,
+				WebAuthenticationStatus.ErrorHttp);
+		}
+
+		try
+		{
+			// Wait for the callback
+			var contextTask = listener.GetContextAsync();
+
+			// Create a task that completes when cancellation is requested
+			var tcs = new TaskCompletionSource<bool>();
+			using var registration = ct.Register(() => tcs.TrySetResult(true));
+
+			var completedTask = await Task.WhenAny(contextTask, tcs.Task);
+
+			if (completedTask == tcs.Task)
+			{
+				// Cancellation was requested
+				listener.Stop();
+				return new WebAuthenticationResult(
+					null,
+					0,
+					WebAuthenticationStatus.UserCancel);
+			}
+
+			var context = await contextTask;
+			var responseUrl = context.Request.Url?.ToString() ?? string.Empty;
+
+			// Send a response to the browser
+			await SendBrowserResponse(context.Response, success: true);
+
+			listener.Stop();
+
+			return new WebAuthenticationResult(
+				responseUrl,
+				0,
+				WebAuthenticationStatus.Success);
+		}
+		catch (ObjectDisposedException)
+		{
+			// Listener was stopped due to cancellation
+			return new WebAuthenticationResult(
+				null,
+				0,
+				WebAuthenticationStatus.UserCancel);
+		}
+		catch (HttpListenerException ex) when (ct.IsCancellationRequested)
+		{
+			return new WebAuthenticationResult(
+				null,
+				(uint)ex.ErrorCode,
+				WebAuthenticationStatus.UserCancel);
+		}
+		catch (Exception ex)
+		{
+			return new WebAuthenticationResult(
+				ex.Message,
+				0,
+				WebAuthenticationStatus.ErrorHttp);
+		}
+	}
+
+	private static int GetAvailablePort()
+	{
+		// Find an available port by binding to port 0
+		using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+		socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+		var port = ((IPEndPoint)socket.LocalEndPoint!).Port;
+		return port;
+	}
+
+	private static string BuildListenerUri(Uri callbackUri, int port)
+	{
+		var path = callbackUri.AbsolutePath;
+		if (!path.EndsWith("/"))
+		{
+			path += "/";
+		}
+		return $"http://127.0.0.1:{port}{path}";
+	}
+
+	private static Uri BuildActualCallbackUri(Uri callbackUri, int port)
+	{
+		var builder = new UriBuilder(callbackUri)
+		{
+			Host = "127.0.0.1",
+			Port = port,
+			Scheme = "http"
+		};
+		return builder.Uri;
+	}
+
+	private static Uri UpdateRequestUriWithCallback(Uri requestUri, Uri originalCallback, Uri actualCallback)
+	{
+		var requestUriString = requestUri.ToString();
+		var originalCallbackEncoded = Uri.EscapeDataString(originalCallback.ToString().TrimEnd('/'));
+		var originalCallbackUnencoded = originalCallback.ToString().TrimEnd('/');
+		var actualCallbackString = actualCallback.ToString().TrimEnd('/');
+
+		// Try to replace the callback URI in the request (both encoded and unencoded forms)
+		if (requestUriString.Contains(originalCallbackEncoded))
+		{
+			requestUriString = requestUriString.Replace(
+				originalCallbackEncoded,
+				Uri.EscapeDataString(actualCallbackString));
+		}
+		else if (requestUriString.Contains(originalCallbackUnencoded))
+		{
+			requestUriString = requestUriString.Replace(
+				originalCallbackUnencoded,
+				actualCallbackString);
+		}
+		else
+		{
+			// Try to find and replace redirect_uri parameter
+			var query = HttpUtility.ParseQueryString(requestUri.Query);
+			if (query["redirect_uri"] != null)
+			{
+				query["redirect_uri"] = actualCallbackString;
+				var builder = new UriBuilder(requestUri)
+				{
+					Query = query.ToString()
+				};
+				return builder.Uri;
+			}
+		}
+
+		return new Uri(requestUriString);
+	}
+
+	private static bool TryOpenBrowser(Uri uri)
+	{
+		try
+		{
+			var url = uri.ToString();
+
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				// Use cmd to handle URL opening on Windows
+				Process.Start(new ProcessStartInfo
+				{
+					FileName = "cmd",
+					Arguments = $"/c start \"\" \"{url.Replace("&", "^&")}\"",
+					UseShellExecute = false,
+					CreateNoWindow = true
+				});
+			}
+			else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			{
+				// Try xdg-open on Linux
+				Process.Start(new ProcessStartInfo
+				{
+					FileName = "xdg-open",
+					Arguments = url,
+					UseShellExecute = false,
+					CreateNoWindow = true
+				});
+			}
+			else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			{
+				// Use open on macOS
+				Process.Start(new ProcessStartInfo
+				{
+					FileName = "open",
+					Arguments = url,
+					UseShellExecute = false,
+					CreateNoWindow = true
+				});
+			}
+			else
+			{
+				// Fallback: try UseShellExecute
+				Process.Start(new ProcessStartInfo
+				{
+					FileName = url,
+					UseShellExecute = true
+				});
+			}
+
+			return true;
+		}
+		catch (Exception)
+		{
+			return false;
+		}
+	}
+
+	private static async Task SendBrowserResponse(HttpListenerResponse response, bool success)
+	{
+		var html = success
+			? """
+			<!DOCTYPE html>
+			<html>
+			<head>
+				<title>Authentication Complete</title>
+				<style>
+					body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; 
+						   display: flex; justify-content: center; align-items: center; 
+						   height: 100vh; margin: 0; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); }
+					.container { text-align: center; background: white; padding: 40px 60px; 
+								 border-radius: 10px; box-shadow: 0 10px 40px rgba(0,0,0,0.2); }
+					h1 { color: #28a745; margin-bottom: 10px; }
+					p { color: #666; }
+					.checkmark { font-size: 48px; margin-bottom: 20px; }
+				</style>
+			</head>
+			<body>
+				<div class="container">
+					<div class="checkmark">✓</div>
+					<h1>Authentication Successful</h1>
+					<p>You can close this window and return to the application.</p>
+				</div>
+				<script>setTimeout(function() { window.close(); }, 3000);</script>
+			</body>
+			</html>
+			"""
+			: """
+			<!DOCTYPE html>
+			<html>
+			<head>
+				<title>Authentication Failed</title>
+				<style>
+					body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; 
+						   display: flex; justify-content: center; align-items: center; 
+						   height: 100vh; margin: 0; background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%); }
+					.container { text-align: center; background: white; padding: 40px 60px; 
+								 border-radius: 10px; box-shadow: 0 10px 40px rgba(0,0,0,0.2); }
+					h1 { color: #dc3545; margin-bottom: 10px; }
+					p { color: #666; }
+					.icon { font-size: 48px; margin-bottom: 20px; }
+				</style>
+			</head>
+			<body>
+				<div class="container">
+					<div class="icon">✗</div>
+					<h1>Authentication Failed</h1>
+					<p>Please close this window and try again.</p>
+				</div>
+			</body>
+			</html>
+			""";
+
+		var buffer = Encoding.UTF8.GetBytes(html);
+		response.ContentType = "text/html; charset=utf-8";
+		response.ContentLength64 = buffer.Length;
+		response.StatusCode = 200;
+
+		try
+		{
+			await response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+			response.OutputStream.Close();
+		}
+		catch
+		{
+			// Ignore errors when sending response
+		}
+	}
+}

--- a/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/SkiaWebAuthenticationBrokerProvider.cs
+++ b/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/SkiaWebAuthenticationBrokerProvider.cs
@@ -33,6 +33,13 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 	public static Func<bool, string> ResponseHtmlProvider { get; set; } = GetDefaultResponseHtml;
 
 	/// <summary>
+	/// Gets or sets a delegate used to open the system browser for authentication.
+	/// Can be overridden for testing or custom browser launch behavior.
+	/// Returns true if the browser was opened successfully.
+	/// </summary>
+	public static Func<Uri, bool>? BrowserLauncher { get; set; }
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="SkiaWebAuthenticationBrokerProvider"/> class.
 	/// </summary>
 	public SkiaWebAuthenticationBrokerProvider()
@@ -88,7 +95,8 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 		var modifiedRequestUri = UpdateRedirectUri(requestUri, actualCallbackUri);
 
 		// Open the browser with the authentication URL
-		if (!TryOpenBrowser(modifiedRequestUri))
+		var openBrowser = BrowserLauncher ?? TryOpenBrowser;
+		if (!openBrowser(modifiedRequestUri))
 		{
 			listener.Stop();
 			return new WebAuthenticationResult(
@@ -101,14 +109,12 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 		{
 			while (true)
 			{
-				var contextTask = listener.GetContextAsync();
-
-				var tcs = new TaskCompletionSource<bool>();
-				using var registration = ct.Register(() => tcs.TrySetResult(true));
-
-				var completedTask = await Task.WhenAny(contextTask, tcs.Task);
-
-				if (completedTask == tcs.Task)
+				HttpListenerContext context;
+				try
+				{
+					context = await listener.GetContextAsync().WaitAsync(ct);
+				}
+				catch (OperationCanceledException)
 				{
 					listener.Stop();
 					return new WebAuthenticationResult(
@@ -116,15 +122,15 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 						0,
 						WebAuthenticationStatus.UserCancel);
 				}
-
-				var context = await contextTask;
 				var request = context.Request;
 				var url = request.Url;
 
 				// Filter non-callback requests (e.g. favicon.ico, non-GET)
+				var requestPath = url?.AbsolutePath?.TrimEnd('/');
+				var expectedPath = callbackPath.TrimEnd('/');
 				if (url is null ||
 					!string.Equals(request.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase) ||
-					!url.AbsolutePath.StartsWith(callbackPath, StringComparison.OrdinalIgnoreCase))
+					!string.Equals(requestPath, expectedPath, StringComparison.OrdinalIgnoreCase))
 				{
 					context.Response.StatusCode = (int)HttpStatusCode.NotFound;
 					context.Response.Close();

--- a/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/SkiaWebAuthenticationBrokerProvider.cs
+++ b/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/SkiaWebAuthenticationBrokerProvider.cs
@@ -1,9 +1,6 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -25,14 +22,22 @@ namespace Uno.Extensions.Authentication;
 /// </summary>
 public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvider
 {
-	private const int DefaultListenerPort = 0; // Use any available port
 	private const string LoopbackCallbackPath = "/authentication-callback";
+
+	private readonly Lazy<int> _port;
+
+	/// <summary>
+	/// Gets or sets a delegate that provides the HTML content for the browser response page.
+	/// The boolean parameter indicates whether authentication was successful.
+	/// </summary>
+	public static Func<bool, string> ResponseHtmlProvider { get; set; } = GetDefaultResponseHtml;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="SkiaWebAuthenticationBrokerProvider"/> class.
 	/// </summary>
 	public SkiaWebAuthenticationBrokerProvider()
 	{
+		_port = new Lazy<int>(GetAvailablePort);
 	}
 
 	/// <summary>
@@ -47,9 +52,7 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 	/// <inheritdoc/>
 	public Uri GetCurrentApplicationCallbackUri()
 	{
-		// For desktop Skia, we use a loopback address with a dynamic port
-		// The actual port will be determined when AuthenticateAsync is called
-		return new Uri($"http://127.0.0.1{LoopbackCallbackPath}");
+		return new Uri($"http://localhost:{_port.Value}{LoopbackCallbackPath}");
 	}
 
 	/// <inheritdoc/>
@@ -59,16 +62,14 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 		Uri callbackUri,
 		CancellationToken ct)
 	{
-		// Determine the port to use - if callback specifies a port use that, otherwise use any available
-		var port = callbackUri.IsDefaultPort ? GetAvailablePort() : callbackUri.Port;
-		var listenerUri = BuildListenerUri(callbackUri, port);
+		var port = callbackUri.IsDefaultPort ? _port.Value : callbackUri.Port;
+		var callbackPath = callbackUri.AbsolutePath;
 
-		// Update the request URI to use our actual callback URL with port
-		var actualCallbackUri = BuildActualCallbackUri(callbackUri, port);
-		var modifiedRequestUri = UpdateRequestUriWithCallback(requestUri, callbackUri, actualCallbackUri);
+		// Listen on root to avoid trailing-slash mismatches with IdP redirects
+		var listenerPrefix = $"http://localhost:{port}/";
 
 		using var listener = new HttpListener();
-		listener.Prefixes.Add(listenerUri);
+		listener.Prefixes.Add(listenerPrefix);
 
 		try
 		{
@@ -82,6 +83,10 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 				WebAuthenticationStatus.ErrorHttp);
 		}
 
+		// If the callback port changed, update redirect_uri in the request
+		var actualCallbackUri = new UriBuilder(callbackUri) { Port = port, Host = "localhost", Scheme = "http" }.Uri;
+		var modifiedRequestUri = UpdateRedirectUri(requestUri, actualCallbackUri);
+
 		// Open the browser with the authentication URL
 		if (!TryOpenBrowser(modifiedRequestUri))
 		{
@@ -94,51 +99,60 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 
 		try
 		{
-			// Wait for the callback
-			var contextTask = listener.GetContextAsync();
-
-			// Create a task that completes when cancellation is requested
-			var tcs = new TaskCompletionSource<bool>();
-			using var registration = ct.Register(() => tcs.TrySetResult(true));
-
-			var completedTask = await Task.WhenAny(contextTask, tcs.Task);
-
-			if (completedTask == tcs.Task)
+			while (true)
 			{
-				// Cancellation was requested
+				var contextTask = listener.GetContextAsync();
+
+				var tcs = new TaskCompletionSource<bool>();
+				using var registration = ct.Register(() => tcs.TrySetResult(true));
+
+				var completedTask = await Task.WhenAny(contextTask, tcs.Task);
+
+				if (completedTask == tcs.Task)
+				{
+					listener.Stop();
+					return new WebAuthenticationResult(
+						null,
+						0,
+						WebAuthenticationStatus.UserCancel);
+				}
+
+				var context = await contextTask;
+				var request = context.Request;
+				var url = request.Url;
+
+				// Filter non-callback requests (e.g. favicon.ico, non-GET)
+				if (url is null ||
+					!string.Equals(request.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase) ||
+					!url.AbsolutePath.StartsWith(callbackPath, StringComparison.OrdinalIgnoreCase))
+				{
+					context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+					context.Response.Close();
+					continue;
+				}
+
+				var responseUrl = url.ToString();
+				await SendBrowserResponse(context.Response, success: true);
 				listener.Stop();
+
 				return new WebAuthenticationResult(
-					null,
+					responseUrl,
 					0,
-					WebAuthenticationStatus.UserCancel);
+					WebAuthenticationStatus.Success);
 			}
-
-			var context = await contextTask;
-			var responseUrl = context.Request.Url?.ToString() ?? string.Empty;
-
-			// Send a response to the browser
-			await SendBrowserResponse(context.Response, success: true);
-
-			listener.Stop();
-
-			return new WebAuthenticationResult(
-				responseUrl,
-				0,
-				WebAuthenticationStatus.Success);
 		}
 		catch (ObjectDisposedException)
 		{
-			// Listener was stopped due to cancellation
 			return new WebAuthenticationResult(
 				null,
 				0,
 				WebAuthenticationStatus.UserCancel);
 		}
-		catch (HttpListenerException ex) when (ct.IsCancellationRequested)
+		catch (HttpListenerException) when (ct.IsCancellationRequested)
 		{
 			return new WebAuthenticationResult(
 				null,
-				(uint)ex.ErrorCode,
+				0,
 				WebAuthenticationStatus.UserCancel);
 		}
 		catch (Exception ex)
@@ -159,63 +173,23 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 		return port;
 	}
 
-	private static string BuildListenerUri(Uri callbackUri, int port)
+	private static Uri UpdateRedirectUri(Uri requestUri, Uri actualCallbackUri)
 	{
-		var path = callbackUri.AbsolutePath;
-		if (!path.EndsWith("/"))
+		var query = HttpUtility.ParseQueryString(requestUri.Query);
+		var currentRedirect = query["redirect_uri"];
+		if (currentRedirect is null)
 		{
-			path += "/";
-		}
-		return $"http://127.0.0.1:{port}{path}";
-	}
-
-	private static Uri BuildActualCallbackUri(Uri callbackUri, int port)
-	{
-		var builder = new UriBuilder(callbackUri)
-		{
-			Host = "127.0.0.1",
-			Port = port,
-			Scheme = "http"
-		};
-		return builder.Uri;
-	}
-
-	private static Uri UpdateRequestUriWithCallback(Uri requestUri, Uri originalCallback, Uri actualCallback)
-	{
-		var requestUriString = requestUri.ToString();
-		var originalCallbackEncoded = Uri.EscapeDataString(originalCallback.ToString().TrimEnd('/'));
-		var originalCallbackUnencoded = originalCallback.ToString().TrimEnd('/');
-		var actualCallbackString = actualCallback.ToString().TrimEnd('/');
-
-		// Try to replace the callback URI in the request (both encoded and unencoded forms)
-		if (requestUriString.Contains(originalCallbackEncoded))
-		{
-			requestUriString = requestUriString.Replace(
-				originalCallbackEncoded,
-				Uri.EscapeDataString(actualCallbackString));
-		}
-		else if (requestUriString.Contains(originalCallbackUnencoded))
-		{
-			requestUriString = requestUriString.Replace(
-				originalCallbackUnencoded,
-				actualCallbackString);
-		}
-		else
-		{
-			// Try to find and replace redirect_uri parameter
-			var query = HttpUtility.ParseQueryString(requestUri.Query);
-			if (query["redirect_uri"] != null)
-			{
-				query["redirect_uri"] = actualCallbackString;
-				var builder = new UriBuilder(requestUri)
-				{
-					Query = query.ToString()
-				};
-				return builder.Uri;
-			}
+			return requestUri;
 		}
 
-		return new Uri(requestUriString);
+		var actualCallbackString = actualCallbackUri.ToString().TrimEnd('/');
+		if (string.Equals(currentRedirect.TrimEnd('/'), actualCallbackString, StringComparison.OrdinalIgnoreCase))
+		{
+			return requestUri;
+		}
+
+		query["redirect_uri"] = actualCallbackString;
+		return new UriBuilder(requestUri) { Query = query.ToString() }.Uri;
 	}
 
 	private static bool TryOpenBrowser(Uri uri)
@@ -226,11 +200,11 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
-				// Use cmd to handle URL opening on Windows
+				// Use rundll32 to open URL on Windows
 				Process.Start(new ProcessStartInfo
 				{
-					FileName = "cmd",
-					Arguments = $"/c start \"\" \"{url.Replace("&", "^&")}\"",
+					FileName = "rundll32",
+					Arguments = $"url.dll,FileProtocolHandler {url}",
 					UseShellExecute = false,
 					CreateNoWindow = true
 				});
@@ -277,7 +251,26 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 
 	private static async Task SendBrowserResponse(HttpListenerResponse response, bool success)
 	{
-		var html = success
+		var html = ResponseHtmlProvider(success);
+		var buffer = Encoding.UTF8.GetBytes(html);
+		response.ContentType = "text/html; charset=utf-8";
+		response.ContentLength64 = buffer.Length;
+		response.StatusCode = 200;
+
+		try
+		{
+			await response.OutputStream.WriteAsync(buffer);
+			response.OutputStream.Close();
+		}
+		catch
+		{
+			// Ignore errors when sending response
+		}
+	}
+
+	private static string GetDefaultResponseHtml(bool success)
+	{
+		return success
 			? """
 			<!DOCTYPE html>
 			<html>
@@ -329,20 +322,5 @@ public class SkiaWebAuthenticationBrokerProvider : IWebAuthenticationBrokerProvi
 			</body>
 			</html>
 			""";
-
-		var buffer = Encoding.UTF8.GetBytes(html);
-		response.ContentType = "text/html; charset=utf-8";
-		response.ContentLength64 = buffer.Length;
-		response.StatusCode = 200;
-
-		try
-		{
-			await response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
-			response.OutputStream.Close();
-		}
-		catch
-		{
-			// Ignore errors when sending response
-		}
 	}
 }

--- a/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/Uno.Extensions.Authentication.WinUI.Runtime.Skia.csproj
+++ b/src/Uno.Extensions.Authentication.WinUI.Runtime.Skia/Uno.Extensions.Authentication.WinUI.Runtime.Skia.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Uno.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks Condition="'$(Build_Desktop)'=='true'">$(TargetFrameworks);net9.0-desktop</TargetFrameworks>
+		<TargetFrameworks>$(TargetFrameworks);net9.0</TargetFrameworks>
+	</PropertyGroup>
+	<PropertyGroup>
+		<WindowsSdkPackageVersion>10.0.19041.57</WindowsSdkPackageVersion>
+	</PropertyGroup>
+	<PropertyGroup>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<NoWarn>$(NoWarn);NU5104;NU5048;NU1009</NoWarn>
+		<Description>Skia Desktop support package for Web Authentication in Uno.Extensions (OIDC, MSAL, Web Auth).</Description>
+		<!--Temporary disable missing XML doc until fixed in the whole package-->
+		<WarningsNotAsErrors>$(WarningsNotAsErrors);CS1591</WarningsNotAsErrors>
+		<UnoSingleProject>true</UnoSingleProject>
+		<OutputType>Library</OutputType>
+		<DefineConstants>$(DefineConstants);SKIA_DESKTOP_AUTH</DefineConstants>
+		<UnoFeatures>
+			SkiaRenderer;
+		</UnoFeatures>
+	</PropertyGroup>
+	<PropertyGroup>
+		<PackageId>Uno.Extensions.Authentication.WinUI.Runtime.Skia</PackageId>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.Extensions.Authentication.UI\Uno.Extensions.Authentication.WinUI.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Uno.WinUI" />
+	</ItemGroup>
+</Project>


### PR DESCRIPTION
This pull request adds Skia desktop support for web authentication to the Uno.Extensions solution. The main change is the introduction of a new project, `Uno.Extensions.Authentication.WinUI.Runtime.Skia`, which provides a Skia-compatible implementation of the web authentication broker for desktop platforms. This enables OAuth and similar authentication flows using a local loopback HTTP listener for callback handling.

**New Skia Desktop Authentication Support:**

* Added the new project `Uno.Extensions.Authentication.WinUI.Runtime.Skia` to the solution, including its project file and global usings. This project targets .NET 9 and .NET 9 desktop, and references the necessary Uno and authentication packages. [[1]](diffhunk://#diff-d0dd83e04e9179e5abbf2d128eca3c4e3b748423474576a718ce037bb86413caR148-R149) [[2]](diffhunk://#diff-a27e339d5053a5c4013b8292c2c765ee347112d37ea983d0ceb2f8f38eeafa3eR1-R32) [[3]](diffhunk://#diff-3ba098c2ee36849733c95cb4de5628ea3cbd393956448d3d509f7e4838097df0R1-R7)
* Implemented `SkiaWebAuthenticationBrokerProvider`, which uses an embedded HTTP listener to capture OAuth callbacks on desktop platforms. The class handles browser launching, callback URI management, cancellation, and user feedback via HTML responses.

**Solution Integration:**

* Updated the solution file `Uno.Extensions.sln` to include the new project, its build configurations, and its project folder mapping. [[1]](diffhunk://#diff-d0dd83e04e9179e5abbf2d128eca3c4e3b748423474576a718ce037bb86413caR148-R149) [[2]](diffhunk://#diff-d0dd83e04e9179e5abbf2d128eca3c4e3b748423474576a718ce037bb86413caR794-R809) [[3]](diffhunk://#diff-d0dd83e04e9179e5abbf2d128eca3c4e3b748423474576a718ce037bb86413caR859)