### PR TITLE
ci: reduce cancellation delays

### DIFF
--- a/build/ci/.azure-pipelines.yml
+++ b/build/ci/.azure-pipelines.yml
@@ -24,7 +24,7 @@ stages:
   displayName: Docs Validations
   dependsOn: Determine_Changes
   # Trigger this stage when docs files are changed
-  condition: or(eq(dependencies.Determine_Changes.outputs['evaluate_changes.DetermineChanges.docsOnly'], 'true'), eq(dependencies.Determine_Changes.outputs['evaluate_changes.DetermineChanges.mixedChanges'], 'true'))
+  condition: and(succeeded(), or(eq(dependencies.Determine_Changes.outputs['evaluate_changes.DetermineChanges.docsOnly'], 'true'), eq(dependencies.Determine_Changes.outputs['evaluate_changes.DetermineChanges.mixedChanges'], 'true')))
   jobs:
   - template: stage-docs-validations.yml
 
@@ -32,7 +32,7 @@ stages:
   displayName: Packages
   dependsOn: Determine_Changes
   # Don't trigger this stage if only docs files are changed
-  condition: ne(dependencies.Determine_Changes.outputs['evaluate_changes.DetermineChanges.docsOnly'], 'true')
+  condition: and(succeeded(), ne(dependencies.Determine_Changes.outputs['evaluate_changes.DetermineChanges.docsOnly'], 'true'))
   jobs:
   - template: stage-build-packages.yml
   - template: stage-build-changelog.yml
@@ -41,7 +41,7 @@ stages:
   displayName: Build Samples
   dependsOn: Determine_Changes
   # Don't trigger this stage if only docs files are changed
-  condition: ne(dependencies.Determine_Changes.outputs['evaluate_changes.DetermineChanges.docsOnly'], 'true')
+  condition: and(succeeded(), ne(dependencies.Determine_Changes.outputs['evaluate_changes.DetermineChanges.docsOnly'], 'true'))
   jobs:
   - template: stage-build-windows.yml
     parameters:
@@ -64,7 +64,7 @@ stages:
   displayName: Build Tests
   dependsOn: Determine_Changes
   # Don't trigger this stage if only docs files are changed
-  condition: ne(dependencies.Determine_Changes.outputs['evaluate_changes.DetermineChanges.docsOnly'], 'true')
+  condition: and(succeeded(), ne(dependencies.Determine_Changes.outputs['evaluate_changes.DetermineChanges.docsOnly'], 'true'))
   jobs:
   - template: stage-build-uitests-wasm.yml
   # Disabled waiting on uno fix: https://github.com/unoplatform/uno/pull/17668

--- a/build/ci/publish/publish-nuget-dev.yml
+++ b/build/ci/publish/publish-nuget-dev.yml
@@ -1,5 +1,6 @@
 jobs:
 - deployment: 'NuGet_Dev'
+  cancelTimeoutInMinutes: 0
   displayName: 'NuGet Publish Dev'
   environment: 'Uno Extensions Development'
 

--- a/build/ci/publish/publish-nuget-prod-dev.yml
+++ b/build/ci/publish/publish-nuget-prod-dev.yml
@@ -1,5 +1,6 @@
 jobs:
 - deployment: 'Nuget_Prod_Dev'
+  cancelTimeoutInMinutes: 0
   displayName: 'Nuget Publish Prod Uno Dev Feed'
   environment: 'Uno Extensions Production'
 

--- a/build/ci/publish/publish-nuget-prod.yml
+++ b/build/ci/publish/publish-nuget-prod.yml
@@ -1,5 +1,6 @@
 jobs:
 - deployment: 'Nuget_Prod_Nuget_Org'
+  cancelTimeoutInMinutes: 0
   displayName: 'Nuget Publish Prod NuGet.org'
   environment: 'Uno Extensions Production'
   pool:
@@ -21,6 +22,7 @@ jobs:
         - template: ../templates/nuget-publish-public.yml
 
 - job: Tag_Release
+  cancelTimeoutInMinutes: 0
   displayName: 'Set git tag'
   dependsOn: 'Nuget_Prod_Nuget_Org'
 

--- a/build/ci/stage-build-changelog.yml
+++ b/build/ci/stage-build-changelog.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: CHANGELOG_generation
+  cancelTimeoutInMinutes: 0
 
   pool:
     vmImage: 'ubuntu-24.04'

--- a/build/ci/stage-build-packages.yml
+++ b/build/ci/stage-build-packages.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: Packages
+  cancelTimeoutInMinutes: 0
   timeoutInMinutes: 90
 
   pool:

--- a/build/ci/stage-build-runtimetests-skia.yml
+++ b/build/ci/stage-build-runtimetests-skia.yml
@@ -1,5 +1,6 @@
 ﻿jobs:
 - job: Skia_Tests
+  cancelTimeoutInMinutes: 0
   displayName: 'Runtime Tests - Skia Desktop'
   timeoutInMinutes: 60
   

--- a/build/ci/stage-build-uitests-wasm.yml
+++ b/build/ci/stage-build-uitests-wasm.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: Wasm_UITests
+  cancelTimeoutInMinutes: 0
   displayName: 'UI Tests - WebAssembly'
   container: unoplatform/wasm-build:3.0
 

--- a/build/ci/stage-build-wasm.yml
+++ b/build/ci/stage-build-wasm.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: Samples_WebAssembly
+  cancelTimeoutInMinutes: 0
   displayName: 'Samples - WebAssembly'
 
   pool:

--- a/build/ci/stage-build-windows.yml
+++ b/build/ci/stage-build-windows.yml
@@ -4,6 +4,7 @@ parameters:
 
 jobs:
 - job: Samples_Windows_${{parameters.solutionName}}
+  cancelTimeoutInMinutes: 0
   displayName: 'Samples - Windows (${{parameters.solutionName}})'
   timeoutInMinutes: 90
 

--- a/build/ci/stage-determine-changes.yml
+++ b/build/ci/stage-determine-changes.yml
@@ -1,5 +1,6 @@
 jobs:
 - job: evaluate_changes
+  cancelTimeoutInMinutes: 0
   displayName: 'Check for Doc Only Changes'
   pool:
     vmImage: 'ubuntu-24.04'

--- a/build/ci/stage-docs-validations.yml
+++ b/build/ci/stage-docs-validations.yml
@@ -1,5 +1,6 @@
 ﻿jobs:
 - job: spell_checking
+  cancelTimeoutInMinutes: 0
   displayName: 'Spell Checking Validation'
 
   pool:
@@ -21,6 +22,7 @@
     displayName: Run Spell Checking
 
 - job: markdown_link
+  cancelTimeoutInMinutes: 0
   displayName: 'Markdown Validation'
 
   pool:


### PR DESCRIPTION
## Summary
- add cancelTimeoutInMinutes: 0 to jobs/deployments
- ensure stage conditions include succeeded() to avoid running after cancellation

## Why
- reduce agent queue usage and stop work promptly on canceled runs