### PR TITLE
fix: Use MVUX code gen tool 3 (HR friendly) by default

### DIFF
--- a/src/Uno.Extensions.Reactive/Config/BindableGenerationToolAttribute.cs
+++ b/src/Uno.Extensions.Reactive/Config/BindableGenerationToolAttribute.cs
@@ -8,8 +8,7 @@ namespace Uno.Extensions.Reactive.Config;
 [AttributeUsage(AttributeTargets.Assembly)]
 public class BindableGenerationToolAttribute : Attribute
 {
-	// Latest version is 3, keeping version 2 as default for backward compatibility
-	private const int DefaultVersion = 2;
+	private const int DefaultVersion = 3;
 
 	/// <summary>
 	/// Creates a new BindableGenerationTool object.


### PR DESCRIPTION
linked https://github.com/unoplatform/private/issues/926

## Bugfix
Use MVUX code gen tool 3 (HR friendly) by default

## What is the current behavior?
Defaults to v2 which has HR support limitations

## What is the new behavior?
Defaults to 3

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
