### PR TITLE
fix reactive tests tool3 naming

### DIFF
--- a/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_BasicViewModel_Then_Generate.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_BasicViewModel_Then_Generate.cs
@@ -16,7 +16,7 @@ public partial class Given_BasicViewModel_Then_Generate
 	[TestMethod]
 	public async Task When_FeedOfKindOfImmutableList_Then_TreatAsListFeed_And_ICollectionView()
 	{
-		await using var bindable = new When_FeedOfKindOfImmutableList_Then_TreatAsListFeed_ViewViewModel();
+		await using var bindable = new When_FeedOfKindOfImmutableList_Then_TreatAsListFeed_ViewModel();
 
 		AssertIsValid(bindable.AFeedOfArray);
 		AssertIsValid(bindable.AFeedOfImmutableList);
@@ -37,7 +37,7 @@ public partial class Given_BasicViewModel_Then_Generate
 		}
 	}
 
-	public partial class When_FeedOfKindOfImmutableList_Then_TreatAsListFeed_ViewModel
+	public partial class When_FeedOfKindOfImmutableList_Then_TreatAsListFeed_Model
 	{
 		public IFeed<string[]> AFeedOfArray { get; } = Feed.Async(async ct => Array.Empty<string>());
 
@@ -63,7 +63,7 @@ public partial class Given_BasicViewModel_Then_Generate
 	[TestMethod]
 	public async Task When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_And_ICollectionView()
 	{
-		await using var bindable = new When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_ViewViewModel();
+		await using var bindable = new When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_ViewModel();
 
 		AssertIsValid(bindable.AFeedOfEnumerable);
 
@@ -74,7 +74,7 @@ public partial class Given_BasicViewModel_Then_Generate
 		}
 	}
 
-	public partial class When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_ViewModel
+	public partial class When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_Model
 	{
 		public IFeed<IEnumerable<string>> AFeedOfEnumerable { get; } = Feed.Async(async ct => Enumerable.Empty<string>());
 	}

--- a/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_BasicViewModel_Then_Generate.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_BasicViewModel_Then_Generate.cs
@@ -16,7 +16,7 @@ public partial class Given_BasicViewModel_Then_Generate
 	[TestMethod]
 	public async Task When_FeedOfKindOfImmutableList_Then_TreatAsListFeed_And_ICollectionView()
 	{
-		await using var bindable = new BindableWhen_FeedOfKindOfImmutableList_Then_TreatAsListFeed_ViewModel();
+		await using var bindable = new When_FeedOfKindOfImmutableList_Then_TreatAsListFeed_ViewViewModel();
 
 		AssertIsValid(bindable.AFeedOfArray);
 		AssertIsValid(bindable.AFeedOfImmutableList);
@@ -63,7 +63,7 @@ public partial class Given_BasicViewModel_Then_Generate
 	[TestMethod]
 	public async Task When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_And_ICollectionView()
 	{
-		await using var bindable = new BindableWhen_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_ViewModel();
+		await using var bindable = new When_FeedOfKindOfRawEnumerable_Then_DoNotTreatAsListFeed_ViewViewModel();
 
 		AssertIsValid(bindable.AFeedOfEnumerable);
 

--- a/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_VMWithCommands.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_VMWithCommands.cs
@@ -30,7 +30,7 @@ public partial class Given_VMWithCommands
 	[TestMethod]
 	public async Task When_ParameterFeed_Then_SubscribedWithSameContext()
 	{
-		var vm = new BindableWhen_ParameterFeed_Then_SubscribedWithSameContext_ViewModel();
+		var vm = new When_ParameterFeed_Then_SubscribedWithSameContext_ViewViewModel();
 
 		await TestHelper.WaitFor(() => vm.MyFeed != 0, default);
 
@@ -48,7 +48,7 @@ public partial class Given_VMWithCommands
 	{
 		FeedView view;
 		Button doSomething;
-		var vm = new BindableWhen_ParameterFeed_Then_SubscribedWithSameContext_ViewModel();
+		var vm = new When_ParameterFeed_Then_SubscribedWithSameContext_ViewViewModel();
 		var ui = new StackPanel
 		{
 			DataContext = vm,

--- a/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_VMWithCommands.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Generator/Given_VMWithCommands.cs
@@ -15,7 +15,7 @@ namespace Uno.Extensions.Reactive.WinUI.Tests.Generator;
 [RunsOnUIThread]
 public partial class Given_VMWithCommands
 {
-	public partial class When_ParameterFeed_Then_SubscribedWithSameContext_ViewModel
+	public partial class When_ParameterFeed_Then_SubscribedWithSameContext_Model
 	{
 		public int FeedInvokeCount { get; private set; }
 
@@ -30,7 +30,7 @@ public partial class Given_VMWithCommands
 	[TestMethod]
 	public async Task When_ParameterFeed_Then_SubscribedWithSameContext()
 	{
-		var vm = new When_ParameterFeed_Then_SubscribedWithSameContext_ViewViewModel();
+		var vm = new When_ParameterFeed_Then_SubscribedWithSameContext_ViewModel();
 
 		await TestHelper.WaitFor(() => vm.MyFeed != 0, default);
 
@@ -48,7 +48,7 @@ public partial class Given_VMWithCommands
 	{
 		FeedView view;
 		Button doSomething;
-		var vm = new When_ParameterFeed_Then_SubscribedWithSameContext_ViewViewModel();
+		var vm = new When_ParameterFeed_Then_SubscribedWithSameContext_ViewModel();
 		var ui = new StackPanel
 		{
 			DataContext = vm,

--- a/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableCollection_Edition.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableCollection_Edition.cs
@@ -26,7 +26,7 @@ public partial class Given_BindableCollection_Edition : FeedTests
 	[InjectedPointer(PointerDeviceType.Touch)]
 	public async Task When_EditFromView()
 	{
-		var vm = new BindableGiven_BindableCollection_Edition_Model();
+		var vm = new Given_BindableCollection_Edition_ViewModel();
 		var collectionView = (await (vm.Items as ISignal<IMessage>).GetSource(Context, CT).FirstAsync()).Current.Data.SomeOrDefault() as ICollectionView;
 
 		Assert.IsNotNull(collectionView);
@@ -43,9 +43,9 @@ public partial class Given_BindableCollection_Edition : FeedTests
 		}, CT);
 	}
 
-	private async Task<(BindableGiven_BindableCollection_Edition_Model, ListView, ListViewItem[])> SetupListView()
+	private async Task<(Given_BindableCollection_Edition_ViewModel, ListView, ListViewItem[])> SetupListView()
 	{
-		var vm = new BindableGiven_BindableCollection_Edition_Model();
+		var vm = new Given_BindableCollection_Edition_ViewModel();
 		var lv = new ListView { ItemsSource = vm.Items, CanDragItems = true, AllowDrop = true, CanReorderItems = true };
 
 		await UIHelper.Load(lv, CT);

--- a/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableCollection_Selection.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableCollection_Selection.cs
@@ -178,9 +178,9 @@ public partial class Given_BindableCollection_Selection : FeedTests
 		await TestHelper.WaitFor(async ct => ((ICollectionView)cb.ItemsSource).CurrentItem is MyItem { Value: 43 }, CT);
 	}
 
-	private async Task<(BindableGiven_BindableCollection_Selection_Model, ListView, ListViewItem[])> SetupListView(ListViewSelectionMode selectionMode)
+	private async Task<(Given_BindableCollection_Selection_ViewModel, ListView, ListViewItem[])> SetupListView(ListViewSelectionMode selectionMode)
 	{
-		var vm = new BindableGiven_BindableCollection_Selection_Model();
+		var vm = new Given_BindableCollection_Selection_ViewModel();
 		var lv = new ListView { ItemsSource = vm.Items, SelectionMode = selectionMode };
 
 		await UIHelper.Load(lv, CT);
@@ -195,9 +195,9 @@ public partial class Given_BindableCollection_Selection : FeedTests
 		return (vm, lv, lvItems);
 	}
 
-	private async Task<(BindableGiven_BindableCollection_Selection_Model, ComboBox)> SetupComboBox()
+	private async Task<(Given_BindableCollection_Selection_ViewModel, ComboBox)> SetupComboBox()
 	{
-		var vm = new BindableGiven_BindableCollection_Selection_Model();
+		var vm = new Given_BindableCollection_Selection_ViewModel();
 		var cb = new ComboBox { ItemsSource = vm.Items };
 
 		await UIHelper.Load(cb, CT);

--- a/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableListFeed.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Presentation/Bindings/Collections/Given_BindableListFeed.cs
@@ -25,7 +25,7 @@ public partial class Given_BindableListFeed : FeedUITests
 	[TestMethod]
 	public async Task When_GetSourceWithDispatcherInSourceContext_Then_GetCollectionViewForUI()
 	{
-		var vm = new BindableGiven_BindableListFeed_Model();
+		var vm = new Given_BindableListFeed_ViewModel();
 		var sut = vm.Items as BindableListFeed<int>;
 
 		sut.Should().NotBeNull();
@@ -44,7 +44,7 @@ public partial class Given_BindableListFeed : FeedUITests
 	[TestMethod]
 	public async Task When_CollectionChanged_Then_CountPropertyChangedRaised()
 	{
-		var vm = new BindableGiven_BindableListFeed_Model();
+		var vm = new Given_BindableListFeed_ViewModel();
 		var sut = vm.Items as BindableListFeed<int>;
 
 		sut.Should().NotBeNull();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3058 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?

main cannot build Uno.Extensions-runtimetests.slnf from a clean checkout. The Uno.Extensions.Reactive.WinUI.Tests project fails with 6 CS0246 errors referencing bindable view-model types that no longer exist.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
