### PR TITLE
fix: Prevent ThemeService from leaking theme across XamlRoot boundary

### DIFF
--- a/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
@@ -133,7 +133,7 @@ internal class ThemeService : IThemeService, IDisposable
 	private bool InternalSetThemeOnUIThread(AppTheme theme)
 	{
 		var existingIsDark = IsDark;
-		var rootElement = RootElement?.XamlRoot?.Content as FrameworkElement;
+		var rootElement = RootElement as FrameworkElement;
 
 		if (rootElement is null)
 		{


### PR DESCRIPTION
## Summary

- `ThemeService.InternalSetThemeOnUIThread` navigated `RootElement?.XamlRoot?.Content` to find the target for `RequestedTheme`. When the `RootElement` is hosted inside another app's visual tree (ALC isolation via `AlcContentHost`), both share the same `XamlRoot`, so `XamlRoot.Content` resolves to the **host's root** — leaking the theme change to the entire host.
- Changed to use `RootElement` directly. For normal apps, `RootElement` (= `window.Content`) and `XamlRoot.Content` (= `WindowChrome.Content`) are the same element — no behavioral change. For ALC-hosted apps, this keeps `RequestedTheme` scoped to the guest's own subtree.

## Root cause analysis

### The visual tree in ALC hosting

```
Host Root  ← XamlRoot.Content resolves HERE
  ├── Host UI elements
  └── AlcContentHost
        └── Guest App Root  ← ThemeService.RootElement
```

Both live in the same `XamlRoot`. `ThemeService` was escaping its boundary by navigating `RootElement.XamlRoot.Content` → host's root.

### Contributing factors

1. **Shared `ISettings`**: Host and guest `ThemeService` instances both use `ApplicationData.Current.LocalSettings` via the `Settings` class. Host saves `"Dark"` to `"CurrentTheme"`, guest reads it — bypassing the `AppTheme.System` early-return in `ElementThemeChanged` and entering the `InternalSetThemeAsync` path.

2. **Stale `ActualTheme` during theme walk**: In Uno Platform's `NotifyThemeChangedCore`, `RaiseActualThemeChanged()` fires before `SetTheme()`, so `sender.ActualTheme` returns the **previous** value. This creates a one-toggle-delayed leak pattern.

### The fix

```diff
-var rootElement = RootElement?.XamlRoot?.Content as FrameworkElement;
+var rootElement = RootElement as FrameworkElement;
```

## Test plan

- [ ] Verify normal (non-ALC) theme switching still works — `RootElement` and `XamlRoot.Content` are the same element, so no behavioral difference
- [ ] Verify ALC-hosted app theme toggle does not leak to the host app
- [ ] Verify `SetThemeAsync(Dark/Light/System)` works correctly in both normal and ALC scenarios

Closes #3061