### PR TITLE
fix: Trigger deferred initial selection in SelectorNavigator after XAML HR

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
@@ -7,11 +7,23 @@ public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
 {
 	private Action? _detachSelectionChanged;
 
+	// Tracks whether Show() has been called by the normal route cascade.
+	// Used to detect when the initial selection was missed during XAML HR.
+	private bool _showCalled;
+
 	public override void ControlInitialize()
 	{
+		_showCalled = false;
 		if (Control is not null)
 		{
 			_detachSelectionChanged = AttachSelectionChanged((sender, selected) => _ = SelectionChanged(sender, selected));
+
+			// Schedule a deferred check for missed initial selection. During XAML HR,
+			// the selector fires SelectionChanged before this navigator is created,
+			// so the event is lost and content stays blank. On normal first load,
+			// Show() is called by the route cascade in the same dispatch cycle,
+			// setting _showCalled=true before this deferred check runs (no-op).
+			_ = DeferredInitialSelectionCheckAsync();
 		}
 		else
 		{
@@ -20,6 +32,27 @@ public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
 				Logger.LogWarningMessage($"Control is null, so unable to attach selection changed handler");
 			}
 		}
+	}
+
+	private async Task DeferredInitialSelectionCheckAsync()
+	{
+		// Yield to the next dispatch cycle. On normal first load, the route cascade
+		// calls Show() in the current cycle, so _showCalled is already true by now.
+		// On XAML HR, no route cascade occurs, so _showCalled stays false.
+		await Dispatcher.ExecuteAsync(async ct =>
+		{
+			if (!_showCalled &&
+				SelectedItem is { } selected &&
+				Region.View is FrameworkElement view)
+			{
+				if (Logger.IsEnabled(LogLevel.Debug))
+				{
+					Logger.LogDebugMessage($"Triggering navigation for missed initial selection (XAML HR)");
+				}
+
+				await SelectionChanged(view, selected);
+			}
+		});
 	}
 
 	protected abstract FrameworkElement? SelectedItem { get; set; }
@@ -59,6 +92,8 @@ public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
 		Type? viewType,
 		object? data)
 	{
+		_showCalled = true;
+
 		if (Control is null)
 		{
 			return null;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2971 

Related to https://github.com/unoplatform/uno.extensions/pull/3063

Related to https://github.com/unoplatform/private/issues/926

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

## What is the new behavior?

During XAML HR page replacement, the selector control (TabBar/NavigationView) fires SelectionChanged before the SelectorNavigator is created, so the event is lost and content stays blank.

Add a deferred check in ControlInitialize that yields one dispatch cycle. On normal first load, Show() is called by the route cascade before the deferred check runs (no-op). On XAML HR, Show() is never called, so the check triggers navigation for the existing selection.

Fixes https://github.com/unoplatform/uno.extensions/issues/#2971

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)