### PR TITLE
fix: Re-evaluate route map after C# hot-reload metadata update

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/NavigationHostedService.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationHostedService.cs
@@ -1,17 +1,41 @@
 ﻿namespace Uno.Extensions.Navigation.UI;
 
-internal record NavigationHostedService(ILogger<NavigationRegion> RegionLogger) : IHostedService, IStartupService
+internal class NavigationHostedService : IHostedService, IStartupService
 {
-	private TaskCompletionSource<bool> _completion = new TaskCompletionSource<bool>();
+	private readonly ILogger<NavigationRegion> _regionLogger;
+	private readonly NavigationRouteContext? _routeContext;
+	private readonly TaskCompletionSource<bool> _completion = new();
+
+	public NavigationHostedService(
+		ILogger<NavigationRegion> regionLogger,
+		NavigationRouteContext? routeContext = null)
+	{
+		_regionLogger = regionLogger;
+		_routeContext = routeContext;
+	}
 
 	public Task StartAsync(CancellationToken cancellationToken)
 	{
-		Region.Logger = RegionLogger;
+		Region.Logger = _regionLogger;
+
+		if (_routeContext is not null)
+		{
+			NavigationRouteUpdateHandler.Register(_routeContext);
+		}
+
 		_completion.SetResult(true);
 		return Task.CompletedTask;
 	}
 
-	public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+	public Task StopAsync(CancellationToken cancellationToken)
+	{
+		if (_routeContext is not null)
+		{
+			NavigationRouteUpdateHandler.Unregister(_routeContext);
+		}
+
+		return Task.CompletedTask;
+	}
 
 	public Task StartupComplete() => _completion.Task;
 }

--- a/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
@@ -5,6 +5,19 @@ using System.Reflection.Metadata;
 namespace Uno.Extensions.Navigation.UI;
 
 /// <summary>
+/// Holds the references needed to refresh navigation routes after a C# hot-reload.
+/// One instance exists per navigation engine (<see cref="ServiceCollectionExtensions.AddNavigation"/>).
+/// Registered/unregistered by <see cref="NavigationHostedService"/> to avoid leaking.
+/// </summary>
+internal sealed class NavigationRouteContext
+{
+	public required Action<IViewRegistry, IRouteRegistry> RouteBuilder { get; init; }
+	public required IViewRegistry Views { get; init; }
+	public required IRouteRegistry Routes { get; init; }
+	public RouteResolver? Resolver { get; set; }
+}
+
+/// <summary>
 /// C# hot-reload handler that re-invokes the <c>viewRouteBuilder</c> delegate
 /// registered via <see cref="ServiceCollectionExtensions.AddNavigation"/> and
 /// rebuilds <see cref="RouteResolver"/> mappings so that newly added routes
@@ -12,45 +25,97 @@ namespace Uno.Extensions.Navigation.UI;
 /// </summary>
 internal static class NavigationRouteUpdateHandler
 {
-	internal static Action<IViewRegistry, IRouteRegistry>? RouteBuilder { get; set; }
-	internal static IViewRegistry? Views { get; set; }
-	internal static IRouteRegistry? Routes { get; set; }
-	internal static RouteResolver? Resolver { get; set; }
+	private static readonly List<NavigationRouteContext> _contexts = new();
+	private static readonly object _lock = new();
+
+	internal static void Register(NavigationRouteContext context)
+	{
+		lock (_lock)
+		{
+			_contexts.Add(context);
+		}
+	}
+
+	internal static void Unregister(NavigationRouteContext context)
+	{
+		lock (_lock)
+		{
+			_contexts.Remove(context);
+		}
+	}
 
 	/// <summary>
 	/// Called by the .NET hot-reload infrastructure after updated types have
-	/// been applied. Re-invokes the route builder delegate (whose method body
-	/// may have been replaced) and rebuilds the resolver's lookup tables.
+	/// been applied. Re-invokes each registered route builder delegate (whose
+	/// method body may have been replaced) and rebuilds the resolver's lookup
+	/// tables.
 	/// </summary>
 #pragma warning disable IDE0051 // Remove unused private members — called by the runtime via MetadataUpdateHandler
 	static void UpdateApplication(Type[]? updatedTypes)
 #pragma warning restore IDE0051
 	{
-		var builder = RouteBuilder;
-		var views = Views;
-		var routes = Routes;
-		var resolver = Resolver;
+		NavigationRouteContext[] snapshot;
+		lock (_lock)
+		{
+			snapshot = _contexts.ToArray();
+		}
 
-		if (builder is null || views is null || routes is null || resolver is null)
+		foreach (var ctx in snapshot)
+		{
+			RebuildRoutes(ctx);
+		}
+	}
+
+	private static void RebuildRoutes(NavigationRouteContext ctx)
+	{
+		var resolver = ctx.Resolver;
+		if (resolver is null)
 		{
 			return;
 		}
 
-		// Clear existing registrations so re-invocation starts fresh.
-		if (views is Registry<ViewMap> viewRegistry)
+		// Snapshot current state so we can restore on failure.
+		ViewMap[]? previousViews = null;
+		RouteMap[]? previousRoutes = null;
+
+		if (ctx.Views is Registry<ViewMap> viewRegistry)
 		{
+			previousViews = viewRegistry.Items.ToArray();
 			viewRegistry.Clear();
 		}
 
-		if (routes is Registry<RouteMap> routeRegistry)
+		if (ctx.Routes is Registry<RouteMap> routeRegistry)
 		{
+			previousRoutes = routeRegistry.Items.ToArray();
 			routeRegistry.Clear();
 		}
 
-		// Re-invoke the (potentially updated) delegate.
-		builder.Invoke(views, routes);
+		try
+		{
+			// Re-invoke the (potentially updated) delegate.
+			ctx.RouteBuilder.Invoke(ctx.Views, ctx.Routes);
 
-		// Rebuild the flat lookup tables from the new route data.
-		resolver.Rebuild();
+			// Rebuild the flat lookup tables from the new route data.
+			resolver.Rebuild();
+		}
+		catch
+		{
+			// The delegate may have been replaced and the old version could
+			// throw (e.g. HotReloadException). Restore the previous state
+			// so the navigation engine remains functional.
+			if (previousViews is not null && ctx.Views is Registry<ViewMap> vr)
+			{
+				vr.Clear();
+				vr.Register(previousViews);
+			}
+
+			if (previousRoutes is not null && ctx.Routes is Registry<RouteMap> rr)
+			{
+				rr.Clear();
+				rr.Register(previousRoutes);
+			}
+
+			resolver.Rebuild();
+		}
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection.Metadata;
 
 [assembly: MetadataUpdateHandler(typeof(Uno.Extensions.Navigation.UI.NavigationRouteUpdateHandler))]
@@ -25,23 +26,16 @@ internal sealed class NavigationRouteContext
 /// </summary>
 internal static class NavigationRouteUpdateHandler
 {
-	private static readonly List<NavigationRouteContext> _contexts = new();
-	private static readonly object _lock = new();
+	private static ImmutableList<NavigationRouteContext> _contexts = ImmutableList<NavigationRouteContext>.Empty;
 
 	internal static void Register(NavigationRouteContext context)
 	{
-		lock (_lock)
-		{
-			_contexts.Add(context);
-		}
+		ImmutableInterlocked.Update(ref _contexts, list => list.Add(context));
 	}
 
 	internal static void Unregister(NavigationRouteContext context)
 	{
-		lock (_lock)
-		{
-			_contexts.Remove(context);
-		}
+		ImmutableInterlocked.Update(ref _contexts, list => list.Remove(context));
 	}
 
 	/// <summary>
@@ -54,13 +48,7 @@ internal static class NavigationRouteUpdateHandler
 	static void UpdateApplication(Type[]? updatedTypes)
 #pragma warning restore IDE0051
 	{
-		NavigationRouteContext[] snapshot;
-		lock (_lock)
-		{
-			snapshot = _contexts.ToArray();
-		}
-
-		foreach (var ctx in snapshot)
+		foreach (var ctx in _contexts)
 		{
 			RebuildRoutes(ctx);
 		}

--- a/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
@@ -1,0 +1,56 @@
+using System.Reflection.Metadata;
+
+[assembly: MetadataUpdateHandler(typeof(Uno.Extensions.Navigation.UI.NavigationRouteUpdateHandler))]
+
+namespace Uno.Extensions.Navigation.UI;
+
+/// <summary>
+/// C# hot-reload handler that re-invokes the <c>viewRouteBuilder</c> delegate
+/// registered via <see cref="ServiceCollectionExtensions.AddNavigation"/> and
+/// rebuilds <see cref="RouteResolver"/> mappings so that newly added routes
+/// become navigable without restarting the app.
+/// </summary>
+internal static class NavigationRouteUpdateHandler
+{
+	internal static Action<IViewRegistry, IRouteRegistry>? RouteBuilder { get; set; }
+	internal static IViewRegistry? Views { get; set; }
+	internal static IRouteRegistry? Routes { get; set; }
+	internal static RouteResolver? Resolver { get; set; }
+
+	/// <summary>
+	/// Called by the .NET hot-reload infrastructure after updated types have
+	/// been applied. Re-invokes the route builder delegate (whose method body
+	/// may have been replaced) and rebuilds the resolver's lookup tables.
+	/// </summary>
+#pragma warning disable IDE0051 // Remove unused private members — called by the runtime via MetadataUpdateHandler
+	static void UpdateApplication(Type[]? updatedTypes)
+#pragma warning restore IDE0051
+	{
+		var builder = RouteBuilder;
+		var views = Views;
+		var routes = Routes;
+		var resolver = Resolver;
+
+		if (builder is null || views is null || routes is null || resolver is null)
+		{
+			return;
+		}
+
+		// Clear existing registrations so re-invocation starts fresh.
+		if (views is Registry<ViewMap> viewRegistry)
+		{
+			viewRegistry.Clear();
+		}
+
+		if (routes is Registry<RouteMap> routeRegistry)
+		{
+			routeRegistry.Clear();
+		}
+
+		// Re-invoke the (potentially updated) delegate.
+		builder.Invoke(views, routes);
+
+		// Rebuild the flat lookup tables from the new route data.
+		resolver.Rebuild();
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
@@ -4,7 +4,7 @@ namespace Uno.Extensions.Navigation;
 
 public class RouteResolver : IRouteResolver
 {
-	private RouteInfo? First { get; }
+	private RouteInfo? First { get; set; }
 	protected IList<RouteInfo> Mappings { get; } = new List<RouteInfo>();
 
 	protected ILogger Logger { get; }
@@ -48,6 +48,33 @@ public class RouteResolver : IRouteResolver
 		);
 		Mappings.Add(messageDialogRoute);
 
+	}
+
+	/// <summary>
+	/// Re-reads the route and view registries and rebuilds the internal mappings.
+	/// Called by the C# hot-reload handler after the route builder delegate is
+	/// re-invoked with updated code.
+	/// </summary>
+	internal void Rebuild()
+	{
+		Mappings.Clear();
+
+		var maps = ResolveViewMaps(RouteMaps.Items);
+		if (maps is not null)
+		{
+			First = maps.FirstOrDefault(x => x.IsDefault) ?? maps.FirstOrDefault();
+			Mappings.AddRange(maps.Flatten());
+		}
+		else
+		{
+			First = null;
+		}
+
+		Mappings.Add(new RouteInfo(
+			Path: RouteConstants.MessageDialogUri,
+			View: () => typeof(MessageDialog),
+			ResultData: typeof(MessageDialog)
+		));
 	}
 
 	private void PrintViewMaps(IEnumerable<RouteInfo> maps, string prefix = "")

--- a/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Uno.Extensions.Navigation.UI;
 
 namespace Uno.Extensions;
 
@@ -20,6 +21,11 @@ public static class ServiceCollectionExtensions
 		var views = createViewRegistry?.Invoke(services) ?? new ViewRegistry(services);
 		var routes = createRouteRegistry?.Invoke(services) ?? new RouteRegistry(services);
 		routeBuilder?.Invoke(views, routes);
+
+		// Store references for C# hot-reload route refresh.
+		NavigationRouteUpdateHandler.RouteBuilder = routeBuilder;
+		NavigationRouteUpdateHandler.Views = views;
+		NavigationRouteUpdateHandler.Routes = routes;
 
 		// Only fall back to the navigation flyout if one hasn't already been registered
 		services.AddTransient<Flyout, NavigationFlyout>();
@@ -84,7 +90,15 @@ public static class ServiceCollectionExtensions
 					.AddSingleton<IRouteResolver>(sp =>
 					{
 						var config = sp.GetRequiredService<NavigationConfiguration>();
-						return (sp.GetRequiredService(config.RouteResolver!) as IRouteResolver)!;
+						var resolver = (sp.GetRequiredService(config.RouteResolver!) as IRouteResolver)!;
+
+						// Store for C# hot-reload route refresh.
+						if (resolver is RouteResolver routeResolver)
+						{
+							NavigationRouteUpdateHandler.Resolver = routeResolver;
+						}
+
+						return resolver;
 					})
 
 					.AddScoped<INavigatorFactory, NavigatorFactory>()

--- a/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/ServiceCollectionExtensions.cs
@@ -22,10 +22,17 @@ public static class ServiceCollectionExtensions
 		var routes = createRouteRegistry?.Invoke(services) ?? new RouteRegistry(services);
 		routeBuilder?.Invoke(views, routes);
 
-		// Store references for C# hot-reload route refresh.
-		NavigationRouteUpdateHandler.RouteBuilder = routeBuilder;
-		NavigationRouteUpdateHandler.Views = views;
-		NavigationRouteUpdateHandler.Routes = routes;
+		// Build context for C# hot-reload route refresh (registered/unregistered
+		// by NavigationHostedService to avoid leaking navigation engine instances).
+		if (routeBuilder is not null)
+		{
+			services.AddSingleton(new NavigationRouteContext
+			{
+				RouteBuilder = routeBuilder,
+				Views = views,
+				Routes = routes,
+			});
+		}
 
 		// Only fall back to the navigation flyout if one hasn't already been registered
 		services.AddTransient<Flyout, NavigationFlyout>();
@@ -92,10 +99,11 @@ public static class ServiceCollectionExtensions
 						var config = sp.GetRequiredService<NavigationConfiguration>();
 						var resolver = (sp.GetRequiredService(config.RouteResolver!) as IRouteResolver)!;
 
-						// Store for C# hot-reload route refresh.
-						if (resolver is RouteResolver routeResolver)
+						// Store resolver reference for C# hot-reload route refresh.
+						if (resolver is RouteResolver routeResolver &&
+							sp.GetService<NavigationRouteContext>() is { } ctx)
 						{
-							NavigationRouteUpdateHandler.Resolver = routeResolver;
+							ctx.Resolver = routeResolver;
 						}
 
 						return resolver;

--- a/src/Uno.Extensions.Navigation/Registry.cs
+++ b/src/Uno.Extensions.Navigation/Registry.cs
@@ -25,4 +25,13 @@ public abstract class Registry<T> : IRegistry<T>
 	{
 		_items.Add(item);
 	}
+
+	/// <summary>
+	/// Removes all registered items. Used by C# hot-reload to allow
+	/// re-invocation of the route builder delegate.
+	/// </summary>
+	internal void Clear()
+	{
+		_items = new List<T>();
+	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable):

Related to https://github.com/unoplatform/uno.extensions/pull/3063

Related to https://github.com/unoplatform/private/issues/926

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Add NavigationRouteUpdateHandler as a standard .NET MetadataUpdateHandler that re-invokes the viewRouteBuilder delegate registered via UseNavigation and rebuilds RouteResolver mappings when C# hot-reload applies a delta.

- Registry<T>: add Clear() to allow re-invocation of route builder
- RouteResolver: add Rebuild() to re-process registries into flat lookups
- ServiceCollectionExtensions: store delegate/registry/resolver references for the hot-reload handler to access

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
