### PR TITLE
feat: Add diagnostic logging to navigation route resolution

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
@@ -45,10 +45,20 @@ public abstract class ControlNavigator<TControl> : ControlNavigator
 		var route = request.Route;
 		var mapping = Resolver.FindByPath(route.Base);
 
+		if (Logger.IsEnabled(LogLevel.Debug))
+		{
+			if (mapping is not null)
+				Logger.LogDebugMessage($"Route '{route.Base}' resolved to mapping: Path='{mapping.Path}', View={mapping.RenderView?.Name ?? "(none)"}");
+			else
+				Logger.LogDebugMessage($"Route '{route.Base}' has no explicit mapping — relying on auto-resolve or panel child lookup");
+		}
+
 		var executedPath = await Show(mapping?.Path ?? route.Base, mapping?.RenderView, route.Data);
 
 		if (executedPath is null)
 		{
+			if (Logger.IsEnabled(LogLevel.Warning))
+				Logger.LogWarningMessage($"Navigation to '{route.Base}' failed: Show() returned null. No matching view was found or created. Ensure a RouteMap is registered or a Page type named '{route.Base}Page' (or similar suffix) exists in the assembly.");
 			return Route.Empty;
 		}
 

--- a/src/Uno.Extensions.Navigation.UI/Navigators/PanelVisiblityNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/PanelVisiblityNavigator.cs
@@ -60,7 +60,18 @@ public class PanelVisiblityNavigator : ControlNavigator<Panel>
 
 		return await Dispatcher.ExecuteAsync(async cancellation =>
 		{
-			return FindByPath(routeMap?.Path ?? route.Base) is not null;
+			var path = routeMap?.Path ?? route.Base;
+			var found = FindByPath(path) is not null;
+			if (Logger.IsEnabled(LogLevel.Debug))
+			{
+				if (found)
+					Logger.LogDebugMessage($"PanelVisibility: Existing child found for path '{path}'");
+				else if (routeMap?.RenderView is not null)
+					Logger.LogDebugMessage($"PanelVisibility: No existing child for '{path}', but view type '{routeMap.RenderView.Name}' will be created");
+				else
+					Logger.LogDebugMessage($"PanelVisibility: No existing child for '{path}' and no view type resolved — a FrameView will be created as fallback");
+			}
+			return found;
 		});
 	}
 

--- a/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
@@ -72,7 +72,16 @@ public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
 
 		return await Dispatcher.ExecuteAsync(async cancellation =>
 		{
-			return FindByPath(routeMap?.Path ?? route.Base) is not null;
+			var path = routeMap?.Path ?? route.Base;
+			var item = FindByPath(path);
+			if (Logger.IsEnabled(LogLevel.Debug))
+			{
+				if (item is not null)
+					Logger.LogDebugMessage($"Selector: Found matching item for path '{path}'");
+				else
+					Logger.LogDebugMessage($"Selector: No item matches path '{path}' — navigation will not proceed through this selector");
+			}
+			return item is not null;
 		});
 	}
 

--- a/src/Uno.Extensions.Navigation.UI/RouteResolverDefault.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteResolverDefault.cs
@@ -175,6 +175,8 @@ public class RouteResolverDefault : RouteResolver
 
 		if (allowMatchExact && TryGetLoadedType(path, out var type))
 		{
+			if (Logger.IsEnabled(LogLevel.Debug))
+				Logger.LogDebugMessage($"Auto-resolve: Exact type match found for path '{path}' → {type.FullName}");
 			return type;
 		}
 
@@ -184,7 +186,13 @@ public class RouteResolverDefault : RouteResolver
 			{
 				if (condition?.Invoke(type) ?? true)
 				{
+					if (Logger.IsEnabled(LogLevel.Debug))
+						Logger.LogDebugMessage($"Auto-resolve: Found type '{path}{suffix}' → {type.FullName} (suffix match)");
 					return type;
+				}
+				else if (Logger.IsEnabled(LogLevel.Trace))
+				{
+					Logger.LogTraceMessage($"Auto-resolve: Type '{path}{suffix}' found but failed condition check (not a FrameworkElement subclass?)");
 				}
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?
- Documentation content changes


## What is the current behavior?

## What is the new behavior?

Add Debug/Warning-level logs to help developers and agents understand why TabBar navigation succeeds or fails for a given route:

- RouteResolverDefault.TypeFromPath: logs when auto-resolve finds a type by exact match or suffix convention (e.g. 'TabThree' -> TabThreePage)
- ControlNavigator.ExecuteRequestAsync: logs whether a route has an explicit mapping or relies on auto-resolve, and warns with actionable guidance when Show() returns null
- PanelVisiblityNavigator.RegionCanNavigate: logs whether an existing child was found or a FrameView will be created
- SelectorNavigator.RegionCanNavigate: logs whether a matching selector item was found for the route path

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)