### PR TITLE
fix: Handle null SelectedItem in SelectorNavigator deferred HR check

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
@@ -51,20 +51,12 @@ public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
 				return;
 			}
 
+			// Only act on an already-selected item. During XAML HR the selector
+			// fires SelectionChanged before this navigator exists, so the item is
+			// selected but the event was lost. On normal first load, SelectedItem
+			// may be null because containers haven't been materialised yet; in that
+			// case the route cascade will handle initial selection — don't interfere.
 			var selected = SelectedItem;
-
-			if (selected is null)
-			{
-				// No item selected — this happens when a brand new selector control
-				// (e.g. TabBar) is added via XAML HR to a page that previously had none.
-				// Pick the first available item to mirror the normal route cascade
-				// behavior where the IsDefault route selects the first matching tab.
-				selected = Items.FirstOrDefault();
-				if (selected is not null)
-				{
-					SelectedItem = selected;
-				}
-			}
 
 			if (selected is not null)
 			{

--- a/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/SelectorNavigator.cs
@@ -46,9 +46,27 @@ public abstract class SelectorNavigator<TControl> : ControlNavigator<TControl>
 		// On XAML HR, no route cascade occurs, so _showCalled stays false.
 		await Dispatcher.ExecuteAsync(async ct =>
 		{
-			if (!_showCalled &&
-				SelectedItem is { } selected &&
-				Region.View is FrameworkElement view)
+			if (_showCalled || Region.View is not FrameworkElement view)
+			{
+				return;
+			}
+
+			var selected = SelectedItem;
+
+			if (selected is null)
+			{
+				// No item selected — this happens when a brand new selector control
+				// (e.g. TabBar) is added via XAML HR to a page that previously had none.
+				// Pick the first available item to mirror the normal route cascade
+				// behavior where the IsDefault route selects the first matching tab.
+				selected = Items.FirstOrDefault();
+				if (selected is not null)
+				{
+					SelectedItem = selected;
+				}
+			}
+
+			if (selected is not null)
 			{
 				if (Logger.IsEnabled(LogLevel.Debug))
 				{


### PR DESCRIPTION
When a brand new selector control (e.g. TabBar) is added to a page via XAML HR, the DeferredInitialSelectionCheckAsync found SelectedItem=null and skipped navigation — leaving the content area empty.

Now falls back to selecting the first available item when no selection exists, mirroring the normal route cascade behavior where the IsDefault route selects the first matching tab.

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
