### PR TITLE
fix: bump Microsoft.Kiota.*

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,12 +8,12 @@
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />
     <PackageVersion Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.21.0" />
-    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.21.0" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Form" Version="1.21.0" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.21.0" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Multipart" Version="1.21.0" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Text" Version="1.21.0" />
+    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.22.2" />
+    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.22.2" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Form" Version="1.22.2" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.22.2" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Multipart" Version="1.22.2" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Text" Version="1.22.2" />
     <PackageVersion Include="MSTest.TestAdapter" Version="2.2.9" />
     <PackageVersion Include="MSTest.TestFramework" Version="2.2.9" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />


### PR DESCRIPTION
## Summary
  Bumps `Microsoft.Kiota.*` from 1.21.0 → 1.22.2 to clear advisory GHSA-7j59-v9qr-6fq9 (high-severity vuln in
  `Microsoft.Kiota.Abstractions` 1.21.0) which fails the CI restore step under `<TreatWarningsAsErrors>`.

  All six packages bumped in lockstep in `src/Directory.Packages.props`.