### PR TITLE
fix: Respect JsonSerializerOptions Singletons

### DIFF
--- a/src/Uno.Extensions.Serialization.Tests/ServiceCollectionExtensionsTests.cs
+++ b/src/Uno.Extensions.Serialization.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,11 @@ public class ServiceCollectionExtensionsTests
 	{
 		var context = new HostBuilderContext(new Dictionary<object,object>());
 		var services = new ServiceCollection();
+		services.AddSingleton(new JsonSerializerOptions
+		{
+			ReadCommentHandling = JsonCommentHandling.Skip,
+		});
+		services.AddSingleton<SimpleClassViewModel>();
 
 #if WITH_AOT_TRIMMING
 		services.AddJsonSerialization(context, TestJsonSerializerContext.Default);
@@ -107,6 +113,21 @@ public class ServiceCollectionExtensionsTests
 			_services = originalServices;
 		}
 	}
+
+	internal const string SimpleClassJsonWithComment = """
+	{
+		// comment
+		"SimpleTextProperty": "Hello World"
+	}
+	""";
+
+	[TestMethod]
+	public void DeserializeJsonWithCommentViaRequiredServices()
+	{
+		var viewModel = _services.GetRequiredService<SimpleClassViewModel>();
+		var entity = viewModel.FromJson(SimpleClassJsonWithComment);
+		Assert.AreEqual(entity.SimpleTextProperty, "Hello World");
+	}
 }
 
 
@@ -116,4 +137,9 @@ public class ServiceCollectionExtensionsTests
 [JsonSerializable(typeof(bool))]
 internal sealed partial class TestJsonSerializerContext : JsonSerializerContext
 {
+}
+
+record SimpleClassViewModel(ISerializer<SimpleClass> Serializer)
+{
+	public SimpleClass FromJson(string json) => Serializer.FromString(json);
 }

--- a/src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using System.Text.Json.Serialization.Metadata;
 
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Uno.Extensions;
 
@@ -33,8 +34,9 @@ public static class ServiceCollectionExtensions
 		{
 			return services;
 		}
+		services.TryAddSingleton(sp => sp.GetJsonSerializationOptions());
+
 		return services
-			.AddSingleton(sp => sp.GetJsonSerializationOptions())
 			.AddSingleton<SystemTextJsonSerializer>()
 			.AddSingleton<ISerializer>(services => services.GetRequiredService<SystemTextJsonSerializer>())
 			.AddSingleton(typeof(ISerializer<>), typeof(SystemTextJsonGeneratedSerializer<>))
@@ -68,8 +70,9 @@ public static class ServiceCollectionExtensions
 			return services;
 		}
 
+		services.TryAddSingleton(sp => new JsonSerializerOptions(JsonSerializationOptions.DefaultSerializerOptions));
+
 		return services
-			.AddSingleton(sp => new JsonSerializerOptions(JsonSerializationOptions.DefaultSerializerOptions))
 			.AddSingleton<SystemTextJsonSerializer>()
 			.AddSingleton<ISerializer>(services => services.GetRequiredService<SystemTextJsonSerializer>())
 			.AddSingleton(typeof(ISerializer<>), typeof(SystemTextJsonGeneratedSerializer<>));

--- a/src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs
+++ b/src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs
@@ -31,8 +31,10 @@ public class SystemTextJsonSerializer : ISerializer
 		_services = services;
 
 		// Need to use `.GetService<…>()` in order for `.ConfigureJsonSerializationOptions()` callbacks to be invoked.
-		_serializerOptions = services.GetJsonSerializationOptions() ??
-			serializerOptions ??
+		// Need to use `.GetService<…>()` in order for `.ConfigureJsonSerializationOptions()` callbacks to be invoked.
+		var configured = services.GetJsonSerializationOptions();
+		_serializerOptions = serializerOptions ??
+			configured ??
 			JsonSerializationOptions.DefaultSerializerOptions;
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/unoplatform/uno.extensions/issues/2845#issuecomment-4399667312

Context: https://github.com/unoplatform/uno.extensions/pull/149

PR #149 "tidy'd up" things and in the process updated `ServiceCollectionExtensions.AddSystemTextJsonSerialization()` to always register a `JsonSerializerOptions` singleton, which is a breaking change for anyone that previously registered their own. Paraphrasing:

	var builder = this.CreateBuilder(args)
	  .Configure(host => host
	    .ConfigureServices((context, services) =>
	    {
	      services.AddSingleton<MainViewModel>();
	    })
	    .UseSerialization(services =>
	    {
	      services.AddJsonTypeInfo(PersonContext.Default.Person);
	      services.AddSingleton(new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip });
	    })
	  );
	var window = builder.Window;
	var host = builder.Build();
	var model = host.Services.GetRequiredService<MainViewModel>();

	// This used to work, but now throws because comments are not being ignored:
	var person = model.LoadPerson("{ /* comment */ \"Name\": \"John Doe\" }");

	// …
	partial record MainViewModel(ISerializer<Person> PersonSerializer) {
	  public Person LoadPerson(string json) => PersonSerializer.FromString<Person>(json);
	}

The expectation and semantic before #149 is that the registered `JsonSerializerOptions` singleton would be used by `SystemTextJsonStreamSerializer<Person>`, which in turn would cause comments within the JSON to be ignored.  #149 broke that.

Two interesting related bits of information:

 1. When [`.AddSingleton<T>()`][0] is invoked multiple times, the *last* registration wins.

	The `.AddSingleton<T>()` within `AddSystemTextJsonSerialization()`
	is (apparently?!) the last.

	(This still confuses me, frankly, because `.UserSerialization()`
	calls `.AddSystemTextJsonSerialization()` *before* invoking the
	callback.  So why is it last?)

 2. There is a [`.TryAddSingleton<T>()`][1] extension method, which only registers the singleton if one has not already been registered.

Which gives us a twofold solution:

 1. Update the `SystemTextJsonSerializer` constructor to prefer the `serializerOptions` parameter when not null, and

 2. Update `ServiceCollectionExtensions` to use `.TryAddSingleton()` when registering the `JsonSerializerOptions`.

This allows user-configured `JsonSerializerOptions` instances to be used by `SystemTextJsonSerializer` when registered.

[0]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.servicecollectionserviceextensions.addsingleton?view=net-10.0-pp#microsoft-extensions-dependencyinjection-servicecollectionserviceextensions-addsingleton-1(microsoft-extensions-dependencyinjection-iservicecollection-system-func((system-iserviceprovider-0)))
[1]: https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.extensions.servicecollectiondescriptorextensions.tryaddsingleton?view=net-10.0-pp#microsoft-extensions-dependencyinjection-extensions-servicecollectiondescriptorextensions-tryaddsingleton-1(microsoft-extensions-dependencyinjection-iservicecollection-system-func((system-iserviceprovider-0)))

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
