### PR TITLE
fix: re-inject ViewModel after XAML HR view swap

### DIFF
--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_HotReloadNavigation.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_HotReloadNavigation.cs
@@ -1025,6 +1025,51 @@ public class Given_NavigationHotReload
 			"Untouched region should remain navigable after rename (#2904)");
 	}
 
+	// ──────────────────────────────────────────────────────────────────────
+	// 12. ViewModel (DataContext) survives XAML HR view swap
+	// ──────────────────────────────────────────────────────────────────────
+
+	/// <summary>
+	/// Proves that when XAML HR replaces a page instance via <c>ReplaceViewInstance</c>,
+	/// the new page's DataContext is re-injected by the navigation framework.
+	/// Without the fix, the new <c>NavigationRegion</c> created by <c>InitializeComponent()</c>
+	/// has <c>_wasUnloaded = false</c>, so <c>HandleLoaded</c> never re-cascades the parent
+	/// route, leaving DataContext null on the new page.
+	/// </summary>
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_XamlHRReplacesPage_Then_ViewModelReinjected(CancellationToken ct)
+	{
+		await using var app = await SetupVmXamlPageAppAsync(ct);
+
+		var hostPage = ResolveCurrentPage<HotReloadVmXamlPage>(app.NavigationRoot);
+		hostPage.Should().NotBeNull();
+
+		// Baseline: ViewModel should be injected as DataContext.
+		hostPage!.DataContext.Should().BeOfType<HotReloadVm>(
+			"ViewMap<HotReloadVmXamlPage, HotReloadVm> should bind the VM as DataContext");
+		hostPage.Label.Text.Should().Be("before-hr");
+
+		// XAML HR: change the TextBlock text to trigger a page swap.
+		await using var _ = await HotReloadHelper.UpdateSourceFile(
+			"../../Uno.Extensions.Navigation.UI.Tests/Pages/HotReloadVmXamlPage.xaml",
+			"""Text="before-hr" """,
+			"""Text="after-hr" """,
+			ct);
+
+		// Wait for XAML HR to replace the page instance.
+		var newPage = await WaitForPageReplacementAsync<HotReloadVmXamlPage>(
+			app.NavigationRoot, hostPage, TimeSpan.FromSeconds(30), ct);
+
+		// The new page should have the updated XAML content.
+		newPage.Label.Text.Should().Be("after-hr",
+			"XAML HR should have swapped in a page with the updated TextBlock text");
+
+		// Critical assertion: ViewModel must be re-injected on the new page.
+		newPage.DataContext.Should().BeOfType<HotReloadVm>(
+			"After XAML HR page swap, the navigation framework should re-inject the ViewModel as DataContext");
+	}
+
 	#region Setup helpers
 
 	/// <summary>
@@ -1136,6 +1181,23 @@ public class Given_NavigationHotReload
 					}));
 			},
 			"HotReloadNavRequestPage",
+			ct);
+
+	/// <summary>XAML page with ViewModel binding for view-swap DataContext test.</summary>
+	private static Task<HotReloadNavTestApp> SetupVmXamlPageAppAsync(CancellationToken ct)
+		=> SetupAppAsync(
+			(views, routes) =>
+			{
+				views.Register(
+					new ViewMap<HotReloadVmXamlPage, HotReloadVm>());
+
+				routes.Register(
+					new RouteMap("", Nested: new RouteMap[]
+					{
+						new RouteMap("HotReloadVmXamlPage", View: views.FindByView<HotReloadVmXamlPage>(), IsDefault: true),
+					}));
+			},
+			"HotReloadVmXamlPage",
 			ct);
 
 	/// <summary>Region.Attached page with nested region routes for #3086 test.</summary>

--- a/src/Uno.Extensions.Navigation.UI.Tests/Pages/HotReloadVmXamlPage.xaml
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Pages/HotReloadVmXamlPage.xaml
@@ -1,0 +1,8 @@
+<Page x:Class="Uno.Extensions.Navigation.UI.Tests.Pages.HotReloadVmXamlPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:uen="using:Uno.Extensions.Navigation.UI">
+	<Grid uen:Region.Attached="True">
+		<TextBlock x:Name="_label" Text="before-hr" />
+	</Grid>
+</Page>

--- a/src/Uno.Extensions.Navigation.UI.Tests/Pages/HotReloadVmXamlPage.xaml.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Pages/HotReloadVmXamlPage.xaml.cs
@@ -1,0 +1,18 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.Extensions.Navigation.UI.Tests.Pages;
+
+/// <summary>
+/// XAML-backed page used to test that ViewModel (DataContext) survives
+/// XAML hot-reload view swap. The XAML is modified at runtime to trigger
+/// ReplaceViewInstance, and the test asserts DataContext is re-injected.
+/// </summary>
+public sealed partial class HotReloadVmXamlPage : Page
+{
+	public HotReloadVmXamlPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public TextBlock Label => (TextBlock)FindName("_label");
+}

--- a/src/Uno.Extensions.Navigation.UI.Tests/Uno.Extensions.Navigation.WinUI.Tests.csproj
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Uno.Extensions.Navigation.WinUI.Tests.csproj
@@ -25,6 +25,7 @@
 		<Page Include="Pages\HotReloadRegionNavigatorPage.xaml" />
 		<Page Include="Pages\HotReloadTabBarXamlPage.xaml" />
 		<Page Include="Pages\HotReloadTabBarCommandPage.xaml" />
+		<Page Include="Pages\HotReloadVmXamlPage.xaml" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Extensions.Navigation.UI/NavigationVisibilityUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationVisibilityUpdateHandler.cs
@@ -1,4 +1,5 @@
 using System.Reflection.Metadata;
+using Uno.Extensions.Navigation.Regions;
 
 [assembly: ElementMetadataUpdateHandlerAttribute(typeof(FrameworkElement), typeof(Uno.Extensions.Navigation.UI.NavigationVisibilityUpdateHandler))]
 
@@ -24,12 +25,26 @@ namespace Uno.Extensions.Navigation.UI;
 internal static class NavigationVisibilityUpdateHandler
 {
 	private const string VisibilityKey = "Visibility";
+	private const string HadActiveNavigationKey = "HadActiveNavigation";
 
 	public static void CaptureState(FrameworkElement element, IDictionary<string, object> stateDictionary, Type[]? updatedTypes)
 	{
 		if (IsNavigationManagedElement(element))
 		{
 			stateDictionary[VisibilityKey] = element.Visibility;
+		}
+
+		// Capture whether this element (or any child) had a region with active navigation.
+		// After HR creates a new element instance, the new NavigationRegion objects won't
+		// have _wasUnloaded set, so HandleLoaded won't re-cascade the parent route.
+		// We mark such elements so RestoreState can flag the new regions for re-cascade.
+		if (element.GetInstance() is NavigationRegion { Parent: not null } region)
+		{
+			var navigator = region.Navigator();
+			if (navigator?.Route is { Base.Length: > 0 } || region.Parent.Navigator()?.Route is { Base.Length: > 0 })
+			{
+				stateDictionary[HadActiveNavigationKey] = true;
+			}
 		}
 	}
 
@@ -41,6 +56,14 @@ internal static class NavigationVisibilityUpdateHandler
 			{
 				element.Visibility = savedVisibility;
 			}
+		}
+
+		// If the old element had active navigation, mark the new region so
+		// HandleLoaded will re-cascade the parent route and re-inject the ViewModel.
+		if (stateDictionary.ContainsKey(HadActiveNavigationKey)
+			&& element.GetInstance() is NavigationRegion newRegion)
+		{
+			newRegion.MarkReplacedByHotReload();
 		}
 
 		return Task.CompletedTask;

--- a/src/Uno.Extensions.Navigation.UI/Regions/NavigationRegion.cs
+++ b/src/Uno.Extensions.Navigation.UI/Regions/NavigationRegion.cs
@@ -17,6 +17,10 @@ public sealed class NavigationRegion : IRegion
 	// unloaded due to navigation (not Hot Reload). When true, HandleLoaded skips the
 	// HR re-cascade because the parent navigator will cascade the correct route itself.
 	internal bool _suppressReCascadeOnReload;
+	// Set by NavigationVisibilityUpdateHandler.RestoreState when this region was created
+	// by HR's ReplaceViewInstance as a replacement for a region that had active navigation.
+	// Treated as equivalent to _wasUnloaded in HandleLoaded's re-cascade check.
+	private bool _replacedByHotReload;
 	public IRegion? Parent
 	{
 		get => _parent;
@@ -290,6 +294,17 @@ public sealed class NavigationRegion : IRegion
 		}
 	}
 
+	/// <summary>
+	/// Called by <see cref="NavigationVisibilityUpdateHandler.RestoreState"/> when this
+	/// region was created by hot-reload's <c>ReplaceViewInstance</c> as a replacement
+	/// for a region that had active navigation. Causes <see cref="HandleLoaded"/> to
+	/// re-cascade the parent route, re-injecting the ViewModel on the new page instance.
+	/// </summary>
+	internal void MarkReplacedByHotReload()
+	{
+		_replacedByHotReload = true;
+	}
+
 	private async Task HandleLoaded()
 	{
 		if (View is null || _isLoaded)
@@ -331,7 +346,7 @@ public sealed class NavigationRegion : IRegion
 			// Skip if this region was unloaded due to navigation (not HR) — the parent
 			// navigator (e.g., FrameNavigator) will cascade the correct route itself
 			// via AdjustRequestForChildNavigation / NavigateChildRegions.
-			if (_wasUnloaded && !_suppressReCascadeOnReload && Parent is not null && navigator.Route is null)
+			if ((_wasUnloaded || _replacedByHotReload) && !_suppressReCascadeOnReload && Parent is not null && navigator.Route is null)
 			{
 				var parentNav = Parent.Navigator();
 				if (parentNav?.Route is { Base.Length: > 0 })
@@ -346,6 +361,7 @@ public sealed class NavigationRegion : IRegion
 				}
 			}
 			_suppressReCascadeOnReload = false;
+			_replacedByHotReload = false;
 		}
 	}
 

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests/App.xaml.cs
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests/App.xaml.cs
@@ -12,6 +12,7 @@ public partial class App : Application
 #if DEBUG // Hot-reload tests are only relevant in debug configuration
 		var reactive_HotReload_Tests = new Uno.Extensions.Reactive.WinUI.Tests.Given_HotReload();
 		var navigation_HotReload_Tests = new Uno.Extensions.Navigation.UI.Tests.Given_HotReload();
+		var navigation_HotReloadNav_Tests = new Uno.Extensions.Navigation.UI.Tests.Given_NavigationHotReload();
 		var tabBar_HotReload_Tests = new Uno.Extensions.Navigation.UI.Tests.Given_TabBarHotReload();
 #endif
 		var navigation_UI_Tests = new Given_RouteNotifier();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

When XAML HR replaces a page via ReplaceViewInstance, the new NavigationRegion has _wasUnloaded=false (brand new object), so HandleLoaded never re-cascades the parent route and the ViewModel is not injected as DataContext on the new page.

Fix: Use NavigationVisibilityUpdateHandler (ElementMetadataUpdateHandler) to detect regions with active navigation before the swap and mark the new region with _replacedByHotReload=true. HandleLoaded then treats this flag the same as _wasUnloaded, triggering the parent route re-cascade and ViewModel injection.

Added runtime test When_XamlHRReplacesPage_Then_ViewModelReinjected that verifies DataContext survives a XAML HR page swap.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)