### PR TITLE
fix: yield to dispatcher in EnsureChildRegionsAreLoaded when children 

### DIFF
--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -882,6 +882,27 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 		// This is required to ensure nested elements (eg Content in a ContentControl)
 		// are loaded. This will ensure the Children collection is correctly populated
 		await CheckLoadedAsync();
+
+		// Child NavigationRegions attach themselves to parent.Children during their
+		// Loaded event handler (HandleLoading → AssignParent). In some hosting
+		// scenarios (e.g., in-process AssemblyLoadContext loading), these Loaded
+		// events may be queued on the dispatcher but not yet processed when this
+		// method returns. Re-schedule on the dispatcher to ensure its queue is
+		// drained and pending attachments complete before the caller checks
+		// Region.Children.
+		if (Region.Children.Count == 0 && Region.View?.IsLoaded == true)
+		{
+			const int maxAttempts = 5;
+			for (var attempt = 0; attempt < maxAttempts && Region.Children.Count == 0; attempt++)
+			{
+				if (Logger.IsEnabled(LogLevel.Trace))
+				{
+					Logger.LogTraceMessage($"Children not yet attached after view loaded (attempt {attempt + 1}/{maxAttempts}), re-scheduling on dispatcher");
+				}
+				await Dispatcher.ExecuteAsync(async ct => true, CancellationToken.None);
+			}
+		}
+
 		PerformanceTimer.Stop(Logger, LogLevel.Trace, loadId);
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix


## What is the current behavior?

In certain hosting scenarios, specifically when an app is loaded in-process via AssemblyLoadContext (as Studio Live does), the initial navigation fails on first load with errors like:
- Navigation to 'Main' failed: Show() returned null. No matching view was found or created.
- Region 'Dashboard' has no children to forward request to

This happens because Navigator.CoreNavigateAsync() calls EnsureChildRegionsAreLoaded(), which waits for the current region's view to load via CheckLoadedAsync(), but child NavigationRegion instances attach to parent.Children during their own Loaded event handler. In ALC hosting, these Loaded events may be queued on the dispatcher but not yet processed when CheckLoadedAsync) returns, so Region.Children.Count is 0 and navigation fails immediately.

On a second Build+Publish cycle the visual tree is already constructed and child regions are attached, so navigation succeeds — making this a first-load-only race condition.

## What is the new behavior?

After CheckLoadedAsync() returns in EnsureChildRegionsAreLoaded(), if Region.Children is still empty despite the view being loaded, the method now yields to the dispatcher (up to 5 times via Task.Yield() to allow pending Loaded events to fire and child regions to complete attachment.

This is zero-cost in normal scenarios — the yield loop only executes when Children.Count == 0 && View.IsLoaded == true, which doesn't occur in standard hosting where children attach synchronously during the view's load cycle.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)