### PR TITLE
chore: rename hr test class

### DIFF
--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_Navigation_HotReload.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_Navigation_HotReload.cs
@@ -42,7 +42,7 @@ namespace Uno.Extensions.Navigation.UI.Tests;
 /// </summary>
 [TestClass]
 [RunsInSecondaryApp(ignoreIfNotSupported: true)]
-public class Given_NavigationHotReload
+public class Given_Navigation_HotReload
 {
 	[TestInitialize]
 	public void Setup()
@@ -1098,7 +1098,7 @@ public class Given_NavigationHotReload
 		{
 			host = await window.InitializeNavigationAsync(
 				buildHost: async () => UnoHost
-					.CreateDefaultBuilder(typeof(Given_NavigationHotReload).Assembly)
+					.CreateDefaultBuilder(typeof(Given_Navigation_HotReload).Assembly)
 					.UseNavigation(viewRouteBuilder: registerViewsAndRoutes)
 					.Build(),
 				navigationRoot: navigationRoot,

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests/App.xaml.cs
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests/App.xaml.cs
@@ -12,7 +12,7 @@ public partial class App : Application
 #if DEBUG // Hot-reload tests are only relevant in debug configuration
 		var reactive_HotReload_Tests = new Uno.Extensions.Reactive.WinUI.Tests.Given_HotReload();
 		var navigation_HotReload_Tests = new Uno.Extensions.Navigation.UI.Tests.Given_HotReload();
-		var navigation_HotReloadNav_Tests = new Uno.Extensions.Navigation.UI.Tests.Given_NavigationHotReload();
+		var navigation_HotReloadNav_Tests = new Uno.Extensions.Navigation.UI.Tests.Given_Navigation_HotReload();
 		var tabBar_HotReload_Tests = new Uno.Extensions.Navigation.UI.Tests.Given_TabBarHotReload();
 #endif
 		var navigation_UI_Tests = new Given_RouteNotifier();

--- a/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests/App.xaml.cs
+++ b/src/Uno.Extensions.RuntimeTests/Uno.Extensions.RuntimeTests/App.xaml.cs
@@ -12,7 +12,7 @@ public partial class App : Application
 #if DEBUG // Hot-reload tests are only relevant in debug configuration
 		var reactive_HotReload_Tests = new Uno.Extensions.Reactive.WinUI.Tests.Given_HotReload();
 		var navigation_HotReload_Tests = new Uno.Extensions.Navigation.UI.Tests.Given_HotReload();
-		var navigation_HotReloadNav_Tests = new Uno.Extensions.Navigation.UI.Tests.Given_NavigationHotReload();
+		var navigation_HotReloadNav_Tests = new Uno.Extensions.Navigation.UI.Tests.Given_Navigation_HotReload();
 		var tabBar_HotReload_Tests = new Uno.Extensions.Navigation.UI.Tests.Given_TabBar_HotReload();
 #endif
 		var navigation_UI_Tests = new Given_RouteNotifier();


### PR DESCRIPTION
This pull request primarily addresses a class renaming for consistency and clarity in the navigation hot reload test suite. The changes update all references to the test class to match the new naming convention.

This is done so the class matches the "_HotReload" filter term used by the Hot Reload Test phase on the CI

**Test class renaming and reference updates:**

* Renamed the test class from `Given_NavigationHotReload` to `Given_Navigation_HotReload` in `Given_Navigation_HotReload.cs` and updated all references accordingly. [[1]](diffhunk://#diff-e491ae646e5b372eda61cf113da25a174911063ea96162c3876224b95c4d4bf9L45-R45) [[2]](diffhunk://#diff-e491ae646e5b372eda61cf113da25a174911063ea96162c3876224b95c4d4bf9L1101-R1101) [[3]](diffhunk://#diff-a6ee3b2fcbb160a619c66c10ccb564baae6ee24882a77c3033aa2aae8496b280L15-R15)