### PR TITLE
fix: skip HR cascade when no route-registered type was updated

### DIFF
--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Navigation;
+using Uno.Extensions.Navigation.UI;
+
+namespace Uno.Extensions.Navigation.UI.Tests;
+
+[TestClass]
+public class Given_NavigationRouteUpdateHandler
+{
+	[TestMethod]
+	public void When_UpdatedTypesAreNull_Then_CascadeIsAllowed()
+	{
+		var resolver = CreateResolver();
+
+		var shouldCascade = NavigationRouteUpdateHandler.ShouldCascadeForUpdatedTypes(null, resolver);
+
+		shouldCascade.Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void When_UpdatedTypeIsNotNavigationRegistered_Then_CascadeIsSkipped()
+	{
+		var resolver = CreateResolver();
+
+		var shouldCascade = NavigationRouteUpdateHandler.ShouldCascadeForUpdatedTypes([typeof(GeneratedXamlPartial)], resolver);
+
+		shouldCascade.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void When_UpdatedTypeIsRegisteredView_Then_CascadeIsAllowed()
+	{
+		var resolver = CreateResolver();
+
+		var shouldCascade = NavigationRouteUpdateHandler.ShouldCascadeForUpdatedTypes([typeof(RegisteredPage)], resolver);
+
+		shouldCascade.Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void When_UpdatedTypeIsRegisteredViewModel_Then_CascadeIsAllowed()
+	{
+		var resolver = CreateResolver();
+
+		var shouldCascade = NavigationRouteUpdateHandler.ShouldCascadeForUpdatedTypes([typeof(RegisteredViewModel)], resolver);
+
+		shouldCascade.Should().BeTrue();
+	}
+
+	private static RouteResolver CreateResolver()
+	{
+		var services = new ServiceCollection();
+		var views = new ViewRegistry(services);
+		var routes = new RouteRegistry(services);
+		var registeredView = new ViewMap<RegisteredPage, RegisteredViewModel>();
+
+		views.Register(registeredView);
+		routes.Register(new RouteMap("Registered", View: registeredView));
+
+		return new RouteResolver(NullLogger<RouteResolver>.Instance, routes, views);
+	}
+
+	private sealed class RegisteredPage
+	{
+	}
+
+	private sealed class RegisteredViewModel
+	{
+	}
+
+	private sealed class GeneratedXamlPartial
+	{
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
@@ -182,7 +182,7 @@ internal static class NavigationRouteUpdateHandler
 			// navigation-registered type.  Cascading unconditionally on every such
 			// cycle re-mounts the page and lets x:Uid overwrite the edited value,
 			// making the edit appear to revert.  See studio.live#2293.
-			if (updatedTypes is null || HasRouteRegisteredType(updatedTypes, resolver))
+			if (ShouldCascadeForUpdatedTypes(updatedTypes, resolver))
 			{
 				ScheduleCascade(root, resolver);
 			}
@@ -192,6 +192,13 @@ internal static class NavigationRouteUpdateHandler
 			}
 		}
 	}
+
+	/// <summary>
+	/// Returns <see langword="true"/> when the hot-reload update should cascade
+	/// through the live region tree.
+	/// </summary>
+	internal static bool ShouldCascadeForUpdatedTypes(Type[]? updatedTypes, RouteResolver resolver)
+		=> updatedTypes is null || HasRouteRegisteredType(updatedTypes, resolver);
 
 	/// <summary>
 	/// Returns <see langword="true"/> if at least one type in <paramref name="types"/>
@@ -248,7 +255,7 @@ internal static class NavigationRouteUpdateHandler
 		{
 			if (ctx.Resolver is { } resolver && ctx.RootRegion is { } root)
 			{
-				if (updatedTypes is null || HasRouteRegisteredType(updatedTypes, resolver))
+				if (ShouldCascadeForUpdatedTypes(updatedTypes, resolver))
 				{
 					ScheduleCascade(root, resolver);
 				}

--- a/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
@@ -72,7 +72,7 @@ internal static class NavigationRouteUpdateHandler
 		{
 			try
 			{
-				RebuildRoutes(ctx);
+				RebuildRoutes(ctx, updatedTypes);
 			}
 			catch (Exception ex)
 			{
@@ -84,7 +84,7 @@ internal static class NavigationRouteUpdateHandler
 		}
 	}
 
-	private static void RebuildRoutes(NavigationRouteContext ctx)
+	private static void RebuildRoutes(NavigationRouteContext ctx, Type[]? updatedTypes)
 	{
 		var resolver = ctx.Resolver;
 		if (resolver is null)
@@ -175,8 +175,48 @@ internal static class NavigationRouteUpdateHandler
 		// runs and lets its async continuations make progress.
 		if (rebuiltSuccessfully && ctx.RootRegion is { } root)
 		{
-			ScheduleCascade(root, resolver);
+			// Only cascade if at least one updated type is registered as a view or
+			// view-model in the (just-rebuilt) route table.  A XAML-only HR cycle
+			// (e.g. a Text change on a page with x:Uid) produces updatedTypes that
+			// contain only the page's generated partial class, which is not a
+			// navigation-registered type.  Cascading unconditionally on every such
+			// cycle re-mounts the page and lets x:Uid overwrite the edited value,
+			// making the edit appear to revert.  See studio.live#2293.
+			if (updatedTypes is null || HasRouteRegisteredType(updatedTypes, resolver))
+			{
+				ScheduleCascade(root, resolver);
+			}
+			else if (Region.Logger.IsEnabled(LogLevel.Debug))
+			{
+				Region.Logger.LogDebugMessage("Hot-reload cascade skipped: none of the updated types are registered navigation routes.");
+			}
 		}
+	}
+
+	/// <summary>
+	/// Returns <see langword="true"/> if at least one type in <paramref name="types"/>
+	/// is registered in the resolver as a view or view-model.
+	/// </summary>
+	private static bool HasRouteRegisteredType(Type[] types, RouteResolver resolver)
+	{
+		foreach (var t in types)
+		{
+			if (resolver.FindByView(t, navigator: null) is not null)
+			{
+				return true;
+			}
+
+			// IL2072: t comes from a Type[] whose elements don't carry DynamicallyAccessedMembers
+			// annotations, but FindByViewModel uses them only for lookup — no construction or
+			// property access is performed. The call is safe for this read-only, type-identity check.
+#pragma warning disable IL2072
+			if (resolver.FindByViewModel(t, navigator: null) is not null)
+#pragma warning restore IL2072
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/// <summary>
@@ -192,6 +232,30 @@ internal static class NavigationRouteUpdateHandler
 			if (ctx.Resolver is { } resolver && ctx.RootRegion is { } root)
 			{
 				ScheduleCascade(root, resolver);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Like <see cref="ScheduleCascadeForAllContexts"/> but skips the cascade
+	/// when <paramref name="updatedTypes"/> contains no navigation-registered type.
+	/// Pass <see langword="null"/> to unconditionally cascade (same behaviour as
+	/// <see cref="ScheduleCascadeForAllContexts"/>).
+	/// </summary>
+	internal static void ScheduleCascadeForAllContextsIfRouteRelevant(Type[]? updatedTypes)
+	{
+		foreach (var ctx in _contexts)
+		{
+			if (ctx.Resolver is { } resolver && ctx.RootRegion is { } root)
+			{
+				if (updatedTypes is null || HasRouteRegisteredType(updatedTypes, resolver))
+				{
+					ScheduleCascade(root, resolver);
+				}
+				else if (Region.Logger.IsEnabled(LogLevel.Debug))
+				{
+					Region.Logger.LogDebugMessage("Hot-reload visibility-restore cascade skipped: none of the updated types are registered navigation routes.");
+				}
 			}
 		}
 	}

--- a/src/Uno.Extensions.Navigation.UI/NavigationVisibilityUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationVisibilityUpdateHandler.cs
@@ -74,7 +74,13 @@ internal static class NavigationVisibilityUpdateHandler
 		{
 			newRegion.MarkReplacedByHotReload();
 
-			NavigationRouteUpdateHandler.ScheduleCascadeForAllContexts();
+			// Only trigger a route cascade when at least one updated type is a
+			// navigation-registered view or view-model.  A XAML-only HR cycle
+			// (e.g. a Text or colour change) replaces the element instance but
+			// does not add new routes; cascading here re-mounts the page and
+			// lets x:Uid resolution overwrite property edits that Hot Design
+			// just wrote, making them appear to revert.  See studio.live#2293.
+			NavigationRouteUpdateHandler.ScheduleCascadeForAllContextsIfRouteRelevant(updatedTypes);
 		}
 
 		return Task.CompletedTask;


### PR DESCRIPTION
GitHub Issue (If applicable): Related to https://github.com/unoplatform/studio.live/issues/2293

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

## What is the new behavior?

When a XAML-only hot-reload cycle fires (e.g. a Text or colour change on a page with x:Uid), NavigationRouteUpdateHandler.UpdateApplication received the updated types but unconditionally scheduled a cascade walk after rebuilding the route table.  That cascade re-mounted the page, causing Uno's x:Uid resolver to fire InitializeComponent and overwrite any property values that Hot Design had just written to XAML literals.

Two guard points added:

1. NavigationRouteUpdateHandler.RebuildRoutes — after a successful rebuild, only call ScheduleCascade when at least one of the updatedTypes is registered in the resolver as a view or view-model. A helper HasRouteRegisteredType() does the lookup via FindByView / FindByViewModel; the IL2072 suppression is justified because the calls are read-only type-identity lookups, not construction.

2. NavigationVisibilityUpdateHandler.RestoreState — replaces the unconditional ScheduleCascadeForAllContexts() call with a new ScheduleCascadeForAllContextsIfRouteRelevant(updatedTypes) that applies the same guard before each context's cascade walk.

A null updatedTypes is treated as 'always cascade' to preserve the existing contract for callers that don't have type information.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features) 
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)