### PR TITLE
fix: gate hot-reload cascade on explicit registrations and route-table changes

### DIFF
--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs
@@ -50,7 +50,92 @@ public class Given_NavigationRouteUpdateHandler
 		shouldCascade.Should().BeTrue();
 	}
 
+	// RouteResolverDefault (the resolver apps actually get) has an implicit-mapping fallback that
+	// must not fool the cascade relevance check into matching arbitrary types (studio.live#2716).
+	[TestMethod]
+	public void When_UpdatedTypeIsNotNavigationRegistered_WithDefaultResolver_Then_CascadeIsSkipped()
+	{
+		var resolver = CreateDefaultResolver();
+
+		var shouldCascade = NavigationRouteUpdateHandler.ShouldCascadeForUpdatedTypes([typeof(GeneratedXamlPartial)], resolver);
+
+		shouldCascade.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void When_UpdatedTypeIsRegisteredView_WithDefaultResolver_Then_CascadeIsAllowed()
+	{
+		var resolver = CreateDefaultResolver();
+
+		var shouldCascade = NavigationRouteUpdateHandler.ShouldCascadeForUpdatedTypes([typeof(RegisteredPage)], resolver);
+
+		shouldCascade.Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void When_UpdatedTypeIsRegisteredViewModel_WithDefaultResolver_Then_CascadeIsAllowed()
+	{
+		var resolver = CreateDefaultResolver();
+
+		var shouldCascade = NavigationRouteUpdateHandler.ShouldCascadeForUpdatedTypes([typeof(RegisteredViewModel)], resolver);
+
+		shouldCascade.Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void When_UpdatedTypeIsNotNavigationRegistered_WithDefaultResolver_Then_MappingsAreNotMutated()
+	{
+		var resolver = CreateDefaultResolver();
+		var mappingCountBefore = resolver.MappingCount;
+
+		NavigationRouteUpdateHandler.ShouldCascadeForUpdatedTypes([typeof(GeneratedXamlPartial)], resolver);
+
+		resolver.MappingCount.Should().Be(mappingCountBefore,
+			"the hot-reload relevance check must be side-effect free and not fabricate implicit mappings for updated types");
+	}
+
+	// The cascade gate also fires on route-table changes — how a route registered behind a
+	// hot-reload-flipped flag cascades even though the flag's declaring type is not registered.
+	[TestMethod]
+	public void When_RouteAddedThenRebuilt_Then_MappingsSignatureChanges()
+	{
+		var (routes, views) = CreateRegistries();
+		var resolver = new RouteResolver(NullLogger<RouteResolver>.Instance, routes, views);
+		var signatureBefore = resolver.GetMappingsSignature();
+
+		routes.Register(new RouteMap("AddedByHotReload"));
+		resolver.Rebuild();
+
+		resolver.GetMappingsSignature().SetEquals(signatureBefore).Should().BeFalse(
+			"adding a route and rebuilding must change the mappings signature so the hot-reload cascade fires");
+	}
+
+	[TestMethod]
+	public void When_RebuiltWithoutChanges_Then_MappingsSignatureUnchanged()
+	{
+		var (routes, views) = CreateRegistries();
+		var resolver = new RouteResolver(NullLogger<RouteResolver>.Instance, routes, views);
+		var signatureBefore = resolver.GetMappingsSignature();
+
+		resolver.Rebuild();
+
+		resolver.GetMappingsSignature().SetEquals(signatureBefore).Should().BeTrue(
+			"rebuilding from unchanged registries must produce the same signature so no spurious cascade fires");
+	}
+
 	private static RouteResolver CreateResolver()
+	{
+		var (routes, views) = CreateRegistries();
+		return new RouteResolver(NullLogger<RouteResolver>.Instance, routes, views);
+	}
+
+	private static InspectableRouteResolverDefault CreateDefaultResolver()
+	{
+		var (routes, views) = CreateRegistries();
+		return new InspectableRouteResolverDefault(routes, views);
+	}
+
+	private static (IRouteRegistry Routes, IViewRegistry Views) CreateRegistries()
 	{
 		var services = new ServiceCollection();
 		var views = new ViewRegistry(services);
@@ -60,7 +145,13 @@ public class Given_NavigationRouteUpdateHandler
 		views.Register(registeredView);
 		routes.Register(new RouteMap("Registered", View: registeredView));
 
-		return new RouteResolver(NullLogger<RouteResolver>.Instance, routes, views);
+		return (routes, views);
+	}
+
+	private sealed class InspectableRouteResolverDefault(IRouteRegistry routes, IViewRegistry views)
+		: RouteResolverDefault(NullLogger<RouteResolverDefault>.Instance, routes, views)
+	{
+		public int MappingCount => Mappings.Count;
 	}
 
 	private sealed class RegisteredPage

--- a/src/Uno.Extensions.Navigation.UI/Controls/NavigationRequestBinder.cs
+++ b/src/Uno.Extensions.Navigation.UI/Controls/NavigationRequestBinder.cs
@@ -1,4 +1,4 @@
-﻿namespace Uno.Extensions.Navigation.UI;
+namespace Uno.Extensions.Navigation.UI;
 
 internal class NavigationRequestBinder
 {
@@ -16,7 +16,8 @@ internal class NavigationRequestBinder
 
 	private async void BindRequestHandler(FrameworkElement? element)
 	{
-
+		// A failed bind means taps never navigate and nothing else logs it,
+		// so every bail-out below warns (studio.live#2716).
 		try
 		{
 			if (element is null)
@@ -34,34 +35,56 @@ internal class NavigationRequestBinder
 
 			var region = element.FindRegion();
 
-			if (region is not null)
+			if (region is null)
 			{
-				await region.View.EnsureLoaded();
-
-				// This picks the last handler so that handlers can be overridden for
-				// specific controls by registering another handler
-				var handler = region.Services?.GetServices<IRequestHandler>().LastOrDefault(x => x.CanBind(element));
-				if (handler is not null)
+				if (Region.Logger.IsEnabled(LogLevel.Warning))
 				{
-					var binding = handler.Bind(element);
-
-
-					// Unbind existing binding if it doesn't match this binding
-					if (element.GetRequestBinding() is { } existing)
-					{
-						existing.Unbind();
-					}
-
-					if (binding is not null)
-					{
-						element.SetRequestBinding(binding);
-					}
+					Region.Logger.LogWarningMessage($"Navigation.Request '{element.GetRequest()}' on {element.GetType().Name} not bound: no region found from the element. The request will not trigger until the element reloads inside a region.");
 				}
+				return;
+			}
+
+			await region.View.EnsureLoaded();
+
+			// This picks the last handler so that handlers can be overridden for
+			// specific controls by registering another handler
+			var handler = region.Services?.GetServices<IRequestHandler>().LastOrDefault(x => x.CanBind(element));
+			if (handler is null)
+			{
+				if (Region.Logger.IsEnabled(LogLevel.Warning))
+				{
+					var reason = region.Services is null
+						? "the region has no service provider (detached or not yet attached to a parent region)"
+						: "no IRequestHandler can bind this element type";
+					Region.Logger.LogWarningMessage($"Navigation.Request '{element.GetRequest()}' on {element.GetType().Name} not bound: {reason}.");
+				}
+				return;
+			}
+
+			var binding = handler.Bind(element);
+
+			// Unbind existing binding if it doesn't match this binding
+			if (element.GetRequestBinding() is { } existing)
+			{
+				existing.Unbind();
+			}
+
+			if (binding is not null)
+			{
+				element.SetRequestBinding(binding);
 			}
 		}
-		catch
+		catch (OperationCanceledException)
+		{
+			// Element/region torn down while awaiting EnsureLoaded; the replacement element gets its own binder.
+		}
+		catch (Exception ex)
 		{
 			// Ensuring no bleeding of exceptions that could tear down app
+			if (Region.Logger.IsEnabled(LogLevel.Warning))
+			{
+				Region.Logger.LogWarningMessage($"Navigation.Request binding failed for {element?.GetType().Name}: {ex.GetType().Name}: {ex.Message}. Taps on this element will not navigate.");
+			}
 		}
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
@@ -103,6 +103,9 @@ internal static class NavigationRouteUpdateHandler
 			return;
 		}
 
+		// Snapshot to detect whether the rebuild actually changes the route table.
+		var previousSignature = resolver.GetMappingsSignature();
+
 		// Snapshot current state so we can restore on failure.
 		ViewMap[]? previousViews = null;
 		RouteMap[]? previousRoutes = null;
@@ -175,20 +178,16 @@ internal static class NavigationRouteUpdateHandler
 		// runs and lets its async continuations make progress.
 		if (rebuiltSuccessfully && ctx.RootRegion is { } root)
 		{
-			// Only cascade if at least one updated type is registered as a view or
-			// view-model in the (just-rebuilt) route table.  A XAML-only HR cycle
-			// (e.g. a Text change on a page with x:Uid) produces updatedTypes that
-			// contain only the page's generated partial class, which is not a
-			// navigation-registered type.  Cascading unconditionally on every such
-			// cycle re-mounts the page and lets x:Uid overwrite the edited value,
-			// making the edit appear to revert.  See studio.live#2293.
-			if (ShouldCascadeForUpdatedTypes(updatedTypes, resolver))
+			// Only cascade when the HR is navigation-relevant: the route table changed or an updated type
+			// is route-registered. Unconditional cascades re-mount pages (studio.live#2293) and race the region tree (studio.live#2716).
+			var routesChanged = !resolver.GetMappingsSignature().SetEquals(previousSignature);
+			if (routesChanged || ShouldCascadeForUpdatedTypes(updatedTypes, resolver))
 			{
 				ScheduleCascade(root, resolver);
 			}
 			else if (Region.Logger.IsEnabled(LogLevel.Debug))
 			{
-				Region.Logger.LogDebugMessage("Hot-reload cascade skipped: none of the updated types are registered navigation routes.");
+				Region.Logger.LogDebugMessage("Hot-reload cascade skipped: route table unchanged and none of the updated types are registered navigation routes.");
 			}
 		}
 	}
@@ -201,24 +200,14 @@ internal static class NavigationRouteUpdateHandler
 		=> updatedTypes is null || HasRouteRegisteredType(updatedTypes, resolver);
 
 	/// <summary>
-	/// Returns <see langword="true"/> if at least one type in <paramref name="types"/>
-	/// is registered in the resolver as a view or view-model.
+	/// True if at least one type is explicitly registered as a view or view-model. Avoids FindByView/
+	/// FindByViewModel, whose implicit-mapping fallback matches almost any class and mutates the route table (studio.live#2716).
 	/// </summary>
 	private static bool HasRouteRegisteredType(Type[] types, RouteResolver resolver)
 	{
 		foreach (var t in types)
 		{
-			if (resolver.FindByView(t, navigator: null) is not null)
-			{
-				return true;
-			}
-
-			// IL2072: t comes from a Type[] whose elements don't carry DynamicallyAccessedMembers
-			// annotations, but FindByViewModel uses them only for lookup — no construction or
-			// property access is performed. The call is safe for this read-only, type-identity check.
-#pragma warning disable IL2072
-			if (resolver.FindByViewModel(t, navigator: null) is not null)
-#pragma warning restore IL2072
+			if (resolver.IsRouteRegisteredType(t))
 			{
 				return true;
 			}

--- a/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
+++ b/src/Uno.Extensions.Navigation.UI/RouteResolver.cs
@@ -311,6 +311,28 @@ public class RouteResolver : IRouteResolver
 		return BestNavigatorRouteInfo(maps, navigator);
 	}
 
+	/// <summary>
+	/// True when <paramref name="type"/> is explicitly registered as a view or view model.
+	/// Unlike FindByView/FindByViewModel, never falls back to implicit mapping (which mutates the mappings table).
+	/// </summary>
+	internal bool IsRouteRegisteredType(Type type)
+		=> FindRouteByType(type, map => map.RenderView).Length > 0 ||
+			FindRouteByType(type, map => map.ViewModel).Length > 0;
+
+	/// <summary>
+	/// Value signature of the current mappings (parent path, path, IsDefault), compared by the
+	/// hot-reload handler before/after a rebuild to detect whether the route table actually changed.
+	/// </summary>
+	internal HashSet<string> GetMappingsSignature()
+	{
+		var signature = new HashSet<string>(StringComparer.Ordinal);
+		foreach (var map in Mappings)
+		{
+			signature.Add($"{map.Parent?.Path}/{map.Path}:{map.IsDefault}");
+		}
+		return signature;
+	}
+
 	/// <inheritdoc />
 	public void InsertRoute(RouteInfo route)
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): related to https://github.com/unoplatform/studio.live/issues/2716

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When a hot-reload update is applied, `NavigationRouteUpdateHandler` decides whether to cascade (re-mount the region tree) by checking whether any updated type resolves via `RouteResolver.FindByView` / `FindByViewModel`. With the resolver apps actually get (`RouteResolverDefault`), those lookups fall back to *implicit mapping*, which matches almost any class — so the relevance check effectively always returns true, and it also mutates the route table as a side effect by fabricating implicit mappings for the updated types.

As a result:

- XAML-only hot-reload cycles (where the updated types are just generated page partials) still trigger a full cascade, re-mounting pages and racing the region tree (studio.live#2716), and re-introducing the `x:Uid` revert symptom previously addressed for studio.live#2293.
- Conversely, a route registered behind a hot-reload-flipped flag would *not* cascade, because the flag's declaring type isn't a navigation-registered type — even though the route table itself changed.
- Separately, when `NavigationRequestBinder` fails to bind a `Navigation.Request` (no region found, no service provider, no compatible `IRequestHandler`, or an exception during binding), it bails out silently. Taps on the element simply never navigate, with nothing in the logs to diagnose why.

## What is the new behavior?

- The cascade gate now fires when the hot reload is genuinely navigation-relevant, based on two explicit signals:
  - **Route-table change**: `RouteResolver.GetMappingsSignature()` snapshots a value signature of the mappings (parent path, path, `IsDefault`) before the rebuild and compares it after — if the rebuilt table differs, the cascade fires regardless of which types were updated.
  - **Explicit registration**: the updated-types check now uses the new `RouteResolver.IsRouteRegisteredType(...)`, which only matches types explicitly registered as a view or view model and never falls back to implicit mapping — so it is side-effect free and no longer matches arbitrary classes under `RouteResolverDefault`.
- XAML-only HR cycles on unregistered types no longer cascade; adding/changing routes during HR still cascades correctly.
- `NavigationRequestBinder` now logs a warning on every bail-out path (no region found, region without service provider, no compatible handler, binding exception) so a non-navigating element is diagnosable, swallows `OperationCanceledException` deliberately (element torn down while awaiting `EnsureLoaded`), and no longer uses a bare `catch`.

Tests added in `Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs`:

- `When_UpdatedTypeIsNotNavigationRegistered_WithDefaultResolver_Then_CascadeIsSkipped`
- `When_UpdatedTypeIsRegisteredView_WithDefaultResolver_Then_CascadeIsAllowed`
- `When_UpdatedTypeIsRegisteredViewModel_WithDefaultResolver_Then_CascadeIsAllowed`
- `When_UpdatedTypeIsNotNavigationRegistered_WithDefaultResolver_Then_MappingsAreNotMutated`
- `When_RouteAddedThenRebuilt_Then_MappingsSignatureChanges`
- `When_RebuiltWithoutChanges_Then_MappingsSignatureUnchanged`

## Other information

- The implicit-mapping fallback in `RouteResolverDefault` remains untouched for normal navigation — only the hot-reload relevance check avoids it.
- Follows up on the cascade gating introduced for studio.live#2293; this extends it to cover the default resolver and route-table changes.
