### PR TITLE
feat(navigation): allow bounding navigation to a portion of the visual tree

### DIFF
--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationBoundary.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationBoundary.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Navigation;
+using Uno.Extensions.Navigation.UI;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Extensions.Navigation.UI.Tests;
+
+/// <summary>
+/// Specs for the navigation boundary: an element with <c>Region.Attached="false"</c> set as a local
+/// value (and not overridden to true) stops the upward service-provider walk (ServiceForControl), so
+/// its subtree is detached from the navigation above it. This lets a host isolate a hosted subtree
+/// without it self-wiring into the surrounding route graph.
+///
+/// The responsive master-detail idiom (local <c>Region.Attached="false"</c> flipped to true by a
+/// VisualState setter for the wide layout) must NOT become a boundary; that exclusion is verified
+/// end-to-end by Given_Responsive in the TestHarness UI tests, and at the predicate level here by
+/// <see cref="When_AttachedExplicitlyTrue_Then_NotABoundary"/>.
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+public class Given_NavigationBoundary
+{
+	// root (holds the service provider) -> mid (the boundary candidate) -> leaf (resolves upward).
+	private async Task<(Grid Root, Grid Mid, Grid Leaf, IServiceProvider? Sp)> BuildLoadedTreeAsync(CancellationToken ct, bool attachServiceProvider = true)
+	{
+		var leaf = new Grid();
+		var mid = new Grid();
+		mid.Children.Add(leaf);
+		var root = new Grid();
+		root.Children.Add(mid);
+
+		IServiceProvider? sp = null;
+		if (attachServiceProvider)
+		{
+			sp = new ServiceCollection().BuildServiceProvider();
+			root.SetServiceProvider(sp);
+		}
+
+		var window = UnitTestsUIContentHelper.CurrentTestWindow!;
+		UnitTestsUIContentHelper.SaveOriginalContent();
+		window.Content = root;
+
+		// Wait until the tree is realized so VisualTreeHelper.GetParent works during resolution.
+		await UIHelper.WaitFor(() => VisualTreeHelper.GetParent(leaf) is not null, ct);
+
+		return (root, mid, leaf, sp);
+	}
+
+	[TestMethod]
+	public async Task When_NoBoundary_Then_LeafResolvesServiceProvider()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+		try
+		{
+			var (_, _, leaf, sp) = await BuildLoadedTreeAsync(ct);
+
+			// Untouched tree: the walk passes through mid up to root and finds the service provider.
+			leaf.FindServiceProvider().Should().BeSameAs(sp);
+		}
+		finally
+		{
+			UnitTestsUIContentHelper.RestoreOriginalContent();
+		}
+	}
+
+	[TestMethod]
+	public async Task When_AttachedExplicitlyFalse_Then_WalkStopsAtBoundary()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+		try
+		{
+			var (_, mid, leaf, _) = await BuildLoadedTreeAsync(ct);
+
+			mid.SetAttached(false); // explicit local false marks mid as a navigation boundary
+
+			// The walk stops at the boundary and does not reach the service provider above it.
+			leaf.FindServiceProvider().Should().BeNull("the walk must stop at the boundary and not reach the service provider above it");
+		}
+		finally
+		{
+			UnitTestsUIContentHelper.RestoreOriginalContent();
+		}
+	}
+
+	[TestMethod]
+	public async Task When_AttachedDefault_Then_NotABoundary()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+		try
+		{
+			var (_, mid, leaf, sp) = await BuildLoadedTreeAsync(ct);
+
+			// Regression guard for the ReadLocalValue subtlety: the default (unset) false that every
+			// element has must NOT be treated as a boundary.
+			mid.GetAttached().Should().BeFalse();
+			leaf.FindServiceProvider().Should().BeSameAs(sp);
+		}
+		finally
+		{
+			UnitTestsUIContentHelper.RestoreOriginalContent();
+		}
+	}
+
+	[TestMethod]
+	public async Task When_AttachedExplicitlyTrue_Then_NotABoundary()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+		try
+		{
+			var (_, mid, leaf, sp) = await BuildLoadedTreeAsync(ct);
+
+			// An effective-true Region.Attached (a real region) is not a boundary, so resolution
+			// still reaches the provider above. (The local-false-but-effective-true VisualState flip
+			// of the wide responsive layout is exercised end-to-end by Given_Responsive.)
+			mid.SetAttached(true);
+
+			leaf.FindServiceProvider().Should().BeSameAs(sp);
+		}
+		finally
+		{
+			UnitTestsUIContentHelper.RestoreOriginalContent();
+		}
+	}
+
+	[TestMethod]
+	public async Task When_NoServiceProviderAndNoBoundary_Then_NotReportedAsBoundary()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+		try
+		{
+			// No service provider anywhere and no boundary: resolution simply returns null (and the
+			// root navigator legitimately warns) - the boundary check must not false-trigger here.
+			var (_, _, leaf, _) = await BuildLoadedTreeAsync(ct, attachServiceProvider: false);
+
+			leaf.FindServiceProvider().Should().BeNull();
+		}
+		finally
+		{
+			UnitTestsUIContentHelper.RestoreOriginalContent();
+		}
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/DependencyObjectExtensions.cs
+++ b/src/Uno.Extensions.Navigation.UI/DependencyObjectExtensions.cs
@@ -68,7 +68,31 @@ public static class DependencyObjectExtensions
             return default;
         }
 
+        // Stop at a navigation boundary: an element with Region.Attached explicitly set to false
+        // detaches its subtree from the navigation above it, so descendants resolve no region/SP.
+        if (element.IsNavigationBoundary())
+        {
+            if (Region.Logger.IsEnabled(LogLevel.Trace))
+            {
+                Region.Logger.LogTraceMessage($"Navigation boundary reached at {element.GetType().Name} (Region.Attached=false); stopping service-provider walk - the subtree below is isolated from the navigation above it.");
+            }
+
+            return default;
+        }
+
         var parent = VisualTreeHelper.GetParent(element);
         return parent.ServiceForControl(searchParent, retrieveFromElement);
     }
+
+    /// <summary>
+    /// True when Region.Attached marks this element as a navigation boundary: its subtree is not
+    /// attached to the navigation above it. Requires a <em>local</em> <c>false</c> (so the default
+    /// unset-false, which every element has, is not a boundary) <em>and</em> an effective value of
+    /// <c>false</c>. The latter excludes the responsive master-detail idiom where a pane is declared
+    /// <c>Region.Attached="false"</c> locally but flipped to <c>true</c> by a VisualState/Style setter
+    /// for the wide layout - that pane is a real region, not a boundary.
+    /// </summary>
+    internal static bool IsNavigationBoundary(this DependencyObject element)
+        => element.ReadLocalValue(Region.AttachedProperty) is bool local && !local
+            && !(bool)element.GetValue(Region.AttachedProperty);
 }


### PR DESCRIPTION
Navigation resolves an element's service provider / parent region by walking **up** the visual tree (`DependencyObjectExtensions.ServiceForControl`), and there is currently no way to tell it to stop at a given element. So an element hosted inside another visual tree (e.g. an embedded or hosted subtree) self-wires into the surrounding navigation and can duplicate the nav host (such as a second TabBar).

This treats `Region.Attached="false"` as a **navigation boundary**: when an element has `Region.Attached` set to an explicit *local* `false` **and** its effective value is also `false`, the upward service-provider walk stops there, so that element's subtree isn't attached to the navigation above it.

Reusing the existing `Region.Attached` property keeps the surface minimal — `Attached="true"` opts a subtree into navigation; `Attached="false"` now bounds it out. Requiring the **effective** value to be false (not just the local value) preserves the responsive master-detail idiom, where a pane is declared `Region.Attached="false"` locally and flipped to `true` by a VisualState/Style setter for the wide layout — that pane stays a real region, not a boundary.

`NavigationRegion` also suppresses the "Unable to find service provider for root navigator" warning when a root region legitimately sits below a boundary (the `IsEnabled` check runs first so the boundary tree-walk only happens when we would actually log; a Trace line records the suppression).

## PR Type

- Feature

## What is the current behavior?

`ServiceForControl` walks unconditionally to the visual root. An element hosted inside a larger visual tree cannot be detached from the navigation above it, so a hosted nav shell finds the outer service provider, self-promotes to a root navigator, default-navigates, and duplicates the nav host (a second TabBar).

## What is the new behavior?

An element with an explicit, effective `Region.Attached="false"` is a navigation boundary: the service-provider walk stops there and its subtree resolves no region/SP from above. The responsive `false`→`true` (VisualState) idiom is unaffected. New `Given_NavigationBoundary` runtime tests cover: walk stops at an explicit-false boundary, default-false is not a boundary, and effective-true is not a boundary.

## PR Checklist

- [x] Unit/UI tests for the changes have been added (`Given_NavigationBoundary`)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (closes studio.live#2740)
