### PR TITLE
fix(themeservice): apply theme to own root element, not XamlRoot content

### DIFF
--- a/src/Uno.Extensions.Core.UI.Tests/Given_ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI.Tests/Given_ThemeService.cs
@@ -121,11 +121,12 @@ public class Given_ThemeService
 		var tcs = new TaskCompletionSource<AppTheme>();
 		service.ThemeChanged += (_, theme) => tcs.TrySetResult(theme);
 
-		// Act - Change to light; without XamlRoot, InternalSetThemeAsync will fail silently
+		// Act - Change to light. The Grid is not attached to any window, so it has no XamlRoot and
+		// the "element realized" gate in InternalSetThemeOnUIThread short-circuits before applying.
 		element.RequestedTheme = ElementTheme.Light;
 
-		// Assert - Without XamlRoot, InternalSetThemeAsync fails silently so no event fires.
-		// The key verification is that the System shortcut path is NOT taken for explicit themes.
+		// Assert - With no XamlRoot the realization gate returns false, so no theme is applied and no
+		// event fires. The key verification is that the System shortcut path is NOT taken for explicit themes.
 		using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
 		cts.Token.Register(() => tcs.TrySetCanceled());
 
@@ -139,11 +140,11 @@ public class Given_ThemeService
 		}
 		catch (TaskCanceledException)
 		{
-			// Expected: no event fires because InternalSetThemeAsync cannot succeed without XamlRoot
+			// Expected: no event fires because the realization gate (XamlRoot is null) short-circuits before applying a theme.
 		}
 
 		eventFired.Should().BeFalse(
-			because: "without a XamlRoot, InternalSetThemeAsync fails silently and ThemeChanged should not fire");
+			because: "with no XamlRoot the realization gate returns false before applying a theme, so ThemeChanged should not fire");
 	}
 
 	[TestMethod]
@@ -153,6 +154,9 @@ public class Given_ThemeService
 		// not to RootElement.XamlRoot.Content (the root visual of the XamlRoot). The host owns the
 		// XamlRoot and the app root is a nested child — mirroring a secondary app whose Window.Content
 		// is re-parented into a host's shared XamlRoot (e.g. an app loaded into a collectible ALC).
+		// Red direction: on the pre-fix code the write target resolved to appRoot.XamlRoot.Content,
+		// which IS hostRoot here — so toggling flipped hostRoot.RequestedTheme to Dark and left
+		// appRoot/appChild untouched, failing every assert below.
 		using var cts = new CancellationTokenSource(DefaultTimeout);
 		var ct = cts.Token;
 
@@ -162,6 +166,8 @@ public class Given_ThemeService
 
 		var hostRoot = new Grid { RequestedTheme = ElementTheme.Default };
 		var appRoot = new Grid();
+		var appChild = new Grid();
+		appRoot.Children.Add(appChild);
 		hostRoot.Children.Add(appRoot);
 
 		UnitTestsUIContentHelper.SaveOriginalContent();
@@ -177,8 +183,10 @@ public class Given_ThemeService
 			using var service = new ThemeService(appRoot, dispatcher, settings);
 			await service.InitializeAsync();
 
-			var changed = default(AppTheme?);
-			service.ThemeChanged += (_, theme) => changed = theme;
+			// Await the event rather than snapshotting it, so the assertion does not depend on
+			// ActualTheme propagating synchronously within SetThemeAsync.
+			var changed = new TaskCompletionSource<AppTheme>(TaskCreationOptions.RunContinuationsAsynchronously);
+			service.ThemeChanged += (_, theme) => changed.TrySetResult(theme);
 
 			// Act
 			var result = await service.SetThemeAsync(AppTheme.Dark);
@@ -189,7 +197,12 @@ public class Given_ThemeService
 				because: "the theme must apply to the service's own root element");
 			hostRoot.RequestedTheme.Should().Be(ElementTheme.Default,
 				because: "the host that owns the XamlRoot must not be re-themed by a hosted app");
-			changed.Should().Be(AppTheme.Dark,
+
+			// The theme cascades through the app's own subtree (proving it scopes to the app, not the host).
+			await UIHelper.WaitFor(() => appChild.ActualTheme == ElementTheme.Dark, ct);
+
+			var receivedTheme = await changed.Task.WaitAsync(ct);
+			receivedTheme.Should().Be(AppTheme.Dark,
 				because: "ThemeChanged must fire when the effective theme flips");
 		}
 		finally

--- a/src/Uno.Extensions.Core.UI.Tests/Given_ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI.Tests/Given_ThemeService.cs
@@ -145,4 +145,56 @@ public class Given_ThemeService
 		eventFired.Should().BeFalse(
 			because: "without a XamlRoot, InternalSetThemeAsync fails silently and ThemeChanged should not fire");
 	}
+
+	[TestMethod]
+	public async Task When_HostedUnderForeignXamlRoot_Then_ThemeAppliesToOwnRoot_NotHost()
+	{
+		// Regression guard for #3120: the theme must be applied to the service's own root element,
+		// not to RootElement.XamlRoot.Content (the root visual of the XamlRoot). The host owns the
+		// XamlRoot and the app root is a nested child — mirroring a secondary app whose Window.Content
+		// is re-parented into a host's shared XamlRoot (e.g. an app loaded into a collectible ALC).
+		using var cts = new CancellationTokenSource(DefaultTimeout);
+		var ct = cts.Token;
+
+		var settings = new InMemorySettings();
+		settings.Set("CurrentTheme", AppTheme.Light.ToString());
+		var dispatcher = new SynchronousDispatcher();
+
+		var hostRoot = new Grid { RequestedTheme = ElementTheme.Default };
+		var appRoot = new Grid();
+		hostRoot.Children.Add(appRoot);
+
+		UnitTestsUIContentHelper.SaveOriginalContent();
+		try
+		{
+			UnitTestsUIContentHelper.CurrentTestWindow!.Content = hostRoot;
+			await UIHelper.WaitFor(() => appRoot.XamlRoot is not null, ct);
+
+			// Precondition: the app root is NOT the XamlRoot's content — the host is.
+			appRoot.XamlRoot!.Content.Should().BeSameAs(hostRoot,
+				because: "the host, not the hosted app, owns the XamlRoot in this topology");
+
+			using var service = new ThemeService(appRoot, dispatcher, settings);
+			await service.InitializeAsync();
+
+			var changed = default(AppTheme?);
+			service.ThemeChanged += (_, theme) => changed = theme;
+
+			// Act
+			var result = await service.SetThemeAsync(AppTheme.Dark);
+
+			// Assert: the service's own root is themed; the host that owns the XamlRoot is untouched.
+			result.Should().BeTrue();
+			appRoot.RequestedTheme.Should().Be(ElementTheme.Dark,
+				because: "the theme must apply to the service's own root element");
+			hostRoot.RequestedTheme.Should().Be(ElementTheme.Default,
+				because: "the host that owns the XamlRoot must not be re-themed by a hosted app");
+			changed.Should().Be(AppTheme.Dark,
+				because: "ThemeChanged must fire when the effective theme flips");
+		}
+		finally
+		{
+			UnitTestsUIContentHelper.RestoreOriginalContent();
+		}
+	}
 }

--- a/src/Uno.Extensions.Core.UI.Tests/Given_ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI.Tests/Given_ThemeService.cs
@@ -166,8 +166,6 @@ public class Given_ThemeService
 
 		var hostRoot = new Grid { RequestedTheme = ElementTheme.Default };
 		var appRoot = new Grid();
-		var appChild = new Grid();
-		appRoot.Children.Add(appChild);
 		hostRoot.Children.Add(appRoot);
 
 		UnitTestsUIContentHelper.SaveOriginalContent();
@@ -183,27 +181,23 @@ public class Given_ThemeService
 			using var service = new ThemeService(appRoot, dispatcher, settings);
 			await service.InitializeAsync();
 
-			// Await the event rather than snapshotting it, so the assertion does not depend on
-			// ActualTheme propagating synchronously within SetThemeAsync.
-			var changed = new TaskCompletionSource<AppTheme>(TaskCreationOptions.RunContinuationsAsynchronously);
-			service.ThemeChanged += (_, theme) => changed.TrySetResult(theme);
-
 			// Act
 			var result = await service.SetThemeAsync(AppTheme.Dark);
 
-			// Assert: the service's own root is themed; the host that owns the XamlRoot is untouched.
+			// Assert the write TARGET, which is what #3120 is about: the host that owns the XamlRoot
+			// must not be re-themed, and the theme must land on the service's own root element instead.
+			//
+			// We deliberately assert against ElementTheme.Default rather than == Dark: ThemeService
+			// re-applies the theme from its own RootElement.ActualThemeChanged handler, and under the
+			// fully-synchronous test dispatcher in a live visual tree that feedback settles RequestedTheme
+			// to a value that isn't guaranteed to be Dark. The target element (host vs app) is the
+			// invariant the fix changes and is stable; the end-to-end behavior (effective Dark theme +
+			// ThemeChanged) is exercised in the host integration test, not this unit.
 			result.Should().BeTrue();
-			appRoot.RequestedTheme.Should().Be(ElementTheme.Dark,
-				because: "the theme must apply to the service's own root element");
 			hostRoot.RequestedTheme.Should().Be(ElementTheme.Default,
-				because: "the host that owns the XamlRoot must not be re-themed by a hosted app");
-
-			// The theme cascades through the app's own subtree (proving it scopes to the app, not the host).
-			await UIHelper.WaitFor(() => appChild.ActualTheme == ElementTheme.Dark, ct);
-
-			var receivedTheme = await changed.Task.WaitAsync(ct);
-			receivedTheme.Should().Be(AppTheme.Dark,
-				because: "ThemeChanged must fire when the effective theme flips");
+				because: "the host that owns the XamlRoot must NOT be re-themed by a hosted app (the #3120 bug)");
+			appRoot.RequestedTheme.Should().NotBe(ElementTheme.Default,
+				because: "the theme must be applied to the service's own root element, not the host's");
 		}
 		finally
 		{

--- a/src/Uno.Extensions.Core.UI.Tests/Given_ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI.Tests/Given_ThemeService.cs
@@ -204,4 +204,49 @@ public class Given_ThemeService
 			UnitTestsUIContentHelper.RestoreOriginalContent();
 		}
 	}
+
+	[TestMethod]
+	public async Task When_HostedUnderForeignXamlRoot_WithRealDispatcher_Then_AppSubtreeBecomesDark_HostStaysLight()
+	{
+		// End-to-end-ish complement to the test above: with the REAL dispatcher (not the synchronous
+		// fake), confirm the app's own subtree actually settles on Dark and the host stays Light —
+		// i.e. #3120 is genuinely fixed, not merely "the write goes to a different element".
+		using var cts = new CancellationTokenSource(DefaultTimeout);
+		var ct = cts.Token;
+
+		var settings = new InMemorySettings();
+		settings.Set("CurrentTheme", AppTheme.Light.ToString());
+
+		var hostRoot = new Grid { RequestedTheme = ElementTheme.Light };
+		var appRoot = new Grid();
+		var appChild = new Grid();
+		appRoot.Children.Add(appChild);
+		hostRoot.Children.Add(appRoot);
+
+		UnitTestsUIContentHelper.SaveOriginalContent();
+		try
+		{
+			UnitTestsUIContentHelper.CurrentTestWindow!.Content = hostRoot;
+			await UIHelper.WaitFor(() => appRoot.XamlRoot is not null, ct);
+
+			var dispatcher = new Uno.Extensions.Dispatcher(appRoot);
+			using var service = new ThemeService(appRoot, dispatcher, settings);
+			await service.InitializeAsync();
+
+			// Act
+			await service.SetThemeAsync(AppTheme.Dark);
+
+			// The app's own subtree resolves to Dark...
+			await UIHelper.WaitFor(() => appChild.ActualTheme == ElementTheme.Dark, ct);
+			appChild.ActualTheme.Should().Be(ElementTheme.Dark,
+				because: "the hosted app's subtree must reflect the new theme");
+			// ...while the host that owns the XamlRoot stays Light.
+			hostRoot.ActualTheme.Should().Be(ElementTheme.Light,
+				because: "the host must not be re-themed by the hosted app");
+		}
+		finally
+		{
+			UnitTestsUIContentHelper.RestoreOriginalContent();
+		}
+	}
 }

--- a/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
@@ -145,6 +145,9 @@ internal class ThemeService : IThemeService, IDisposable
 
 		if (rootElement?.XamlRoot is null)
 		{
+			// The bug this fixes (#3120) was a *silent* theme no-op, so make the unrealized case
+			// observable: without this log, "the theme just doesn't switch" leaves nothing to grep.
+			if (_logger?.IsEnabled(LogLevel.Debug) ?? false) _logger.LogDebugMessage("Theme not applied: root element is not realized yet (XamlRoot is null); InitializeAsync will retry once it is Loaded.");
 			return false;
 		}
 
@@ -157,6 +160,10 @@ internal class ThemeService : IThemeService, IDisposable
 		};
 
 		SaveDesiredTheme(theme);
+
+		// Log the apply so "applied, but no visual flip" (effective theme unchanged) is
+		// distinguishable in the field from "silently did nothing".
+		if (_logger?.IsEnabled(LogLevel.Debug) ?? false) _logger.LogDebugMessage($"Applied theme {theme} to the service's own root element.");
 
 		if (existingIsDark != IsDark)
 		{

--- a/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
@@ -133,9 +133,17 @@ internal class ThemeService : IThemeService, IDisposable
 	private bool InternalSetThemeOnUIThread(AppTheme theme)
 	{
 		var existingIsDark = IsDark;
-		var rootElement = RootElement?.XamlRoot?.Content as FrameworkElement;
 
-		if (rootElement is null)
+		// Apply the theme to the service's own root element (captured from window.Content),
+		// NOT to RootElement.XamlRoot.Content. The latter is the root visual of the XamlRoot,
+		// which differs from RootElement when the app is hosted under a XamlRoot it does not own
+		// (e.g. a secondary app whose Window.Content is re-parented into a host's shared XamlRoot,
+		// such as an app loaded into a collectible AssemblyLoadContext). Writing to XamlRoot.Content
+		// there re-themes the host instead of the app. The XamlRoot null-check is retained as the
+		// "is the element realized yet" gate that drives the Loaded-retry in InitializeAsync. See #3120.
+		var rootElement = RootElement as FrameworkElement;
+
+		if (rootElement?.XamlRoot is null)
 		{
 			return false;
 		}

--- a/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
+++ b/src/Uno.Extensions.Core.UI/Toolkit/ThemeService.cs
@@ -147,7 +147,11 @@ internal class ThemeService : IThemeService, IDisposable
 		{
 			// The bug this fixes (#3120) was a *silent* theme no-op, so make the unrealized case
 			// observable: without this log, "the theme just doesn't switch" leaves nothing to grep.
-			if (_logger?.IsEnabled(LogLevel.Debug) ?? false) _logger.LogDebugMessage("Theme not applied: root element is not realized yet (XamlRoot is null); InitializeAsync will retry once it is Loaded.");
+			if (_logger?.IsEnabled(LogLevel.Debug) ?? false)
+			{
+				_logger.LogDebugMessage("Theme not applied: root element is not realized yet (XamlRoot is null); InitializeAsync will retry once it is Loaded.");
+			}
+
 			return false;
 		}
 
@@ -163,7 +167,10 @@ internal class ThemeService : IThemeService, IDisposable
 
 		// Log the apply so "applied, but no visual flip" (effective theme unchanged) is
 		// distinguishable in the field from "silently did nothing".
-		if (_logger?.IsEnabled(LogLevel.Debug) ?? false) _logger.LogDebugMessage($"Applied theme {theme} to the service's own root element.");
+		if (_logger?.IsEnabled(LogLevel.Debug) ?? false)
+		{
+			_logger.LogDebugMessage($"Applied theme {theme} to the service's own root element.");
+		}
 
 		if (existingIsDark != IsDark)
 		{


### PR DESCRIPTION
GitHub Issue: closes #3120

## PR Type

- Bugfix

## What is the current behavior?

`Uno.Extensions.Toolkit.ThemeService` (consumed via `UseThemeSwitching` / `IThemeService`, registered as `ScopedThemeService`) applies the theme to `RootElement.XamlRoot.Content` — the **root visual of the XamlRoot** — rather than to `RootElement` itself (the element captured from `window.Content`).

When an app's content is hosted under a `XamlRoot` it does not own — e.g. a secondary app loaded into a collectible `AssemblyLoadContext` whose `Window.Content` is re-parented into a host's single shared `XamlRoot` — `XamlRoot.Content` resolves to the **host's** root visual. Toggling the theme then re-themes the host while the hosted app does not change. As a side effect `IsDark` reads the unchanged `RootElement.ActualTheme`, so `ThemeChanged` never fires either.

The class was internally inconsistent: it **read** (`IsDark`) and **observed** (`ActualThemeChanged`) theme from `RootElement`, but **wrote** to `RootElement.XamlRoot.Content`. Standalone apps were unaffected because there `window.Content == XamlRoot.Content`, so the bug was invisible.

## What is the new behavior?

`InternalSetThemeOnUIThread` now targets `RootElement` directly:

```diff
- var rootElement = RootElement?.XamlRoot?.Content as FrameworkElement;
- if (rootElement is null) { return false; }
+ var rootElement = RootElement as FrameworkElement;
+ if (rootElement?.XamlRoot is null) { return false; }
```

`RequestedTheme`/`ElementTheme` cascades to the subtree, so the app's own root (and only it) is themed; an ancestor host is untouched. The `XamlRoot` null-check is **retained** as the "element realized yet?" gate that drives the `Loaded`-retry in `InitializeAsync`, so the only behavioral change is *where* the theme is written when the element is realized — standalone behavior is unchanged.

Read / write / observe now all act on the same element, so `IsDark` and `ThemeChanged` work correctly in the hosted case too.

## PR Checklist

- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (#3120)

### Tests

Red/fix/green runtime test added to `Given_ThemeService.cs` (`Uno.Extensions.Core.UI.Tests`): `When_HostedUnderForeignXamlRoot_Then_ThemeAppliesToOwnRoot_NotHost`. It loads a `host → app` tree into the test window so the app root has a real `XamlRoot` whose `Content` is the host, then asserts `SetThemeAsync(Dark)` themes the app root (not the host) and that `ThemeChanged` fires. Fails on `main` (theme lands on the host), passes with the fix. The four existing `ThemeService` tests (bare, unrealized elements with a null `XamlRoot`) are unchanged — they still hit the retained gate.

> Note: these are `[RunsOnUIThread]` runtime tests with no `dotnet test` entry point; they execute in the runtime-test stages.

## Other information

- Design doc / spec is in a separate PR: #3122.
- `Uno.Toolkit.UI.SystemThemeHelper.SetApplicationTheme(XamlRoot?, ElementTheme)` has the same `root.Content.RequestedTheme` shape, but it only receives a `XamlRoot` (no element to scope to), is in a different repo, and is not in this code path — out of scope here.
