### PR TITLE
fix(canary): pin SkiaSharp to 4.148.0 on canaries/dev samples

### DIFF
--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -11,7 +11,8 @@
 		<UnoUniversalImageLoaderVersion>1.9.37</UnoUniversalImageLoaderVersion>
 		<UnoDspTasksVersion>1.4.0</UnoDspTasksVersion>
 		<UnoResizetizerVersion>1.8.1</UnoResizetizerVersion>
-		<SkiaSharpVersion>3.119.0</SkiaSharpVersion>
+		<!-- Canary-only: pin SkiaSharp to v4 (4.148.0) so the dev Uno.Material / Uno.WinUI.Lottie floor (>=3.119.4) is satisfied without the broken 3.119.4 iOS 26.2 assets. Remove when a fixed 3.119.x ships or the Uno.Sdk moves to v4 (7.0). https://github.com/unoplatform/uno/issues/23680 -->
+		<SkiaSharpVersion>4.148.0</SkiaSharpVersion>
 		<SvgSkiaVersion>3.0.2</SvgSkiaVersion>
 		<WinAppSdkVersion>1.7.250513003</WinAppSdkVersion>
 		<WinAppSdkBuildToolsVersion>10.0.26100.4188</WinAppSdkBuildToolsVersion>


### PR DESCRIPTION
Canary-only workaround on `canaries/dev` (default branch left untouched, per team convention for canary-only adjustments).

Pins SkiaSharp to **4.148.0** for the sample apps so the dev `Uno.Material.WinUI` / `Uno.WinUI.Lottie` floor (`>=3.119.4`) is satisfied, avoiding the `NU1605` downgrade. v4 also ships the corrected `ios26.0` native assets (no `MT0099`). Reverts once SkiaSharp ships a fixed `3.119.x` or the Uno.Sdk moves to v4 in 7.0.

Related to https://github.com/unoplatform/uno/issues/23680