### PR TITLE
ci(canary): bump nuget.updater to 1.3.1

### DIFF
--- a/build/ci/templates/canary-update-template.yml
+++ b/build/ci/templates/canary-update-template.yml
@@ -12,7 +12,7 @@ steps:
       branchToMerge: main
       summaryFile: '$(Build.ArtifactStagingDirectory)/Canary.md'
       resultFile: '$(Build.ArtifactStagingDirectory)/result.json'
-      nugetUpdaterVersion: 1.1.1
+      nugetUpdaterVersion: 1.3.1
       packageAuthor: 'Uno Platform,unoplatform'
       additionalPublicSources: 'https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json'
 


### PR DESCRIPTION
Bumps the canary `nuget.updater` to **1.3.1** for consistency with the other canaries (Themes / Toolkit / Rider / Studio all on 1.3.1), and to pick up the property-package fallback fix.

Single-source-of-truth on the default branch; once merged, `canaries/dev` will be synced with `main` to inherit this (and the rest of the default-branch changes).