### PR TITLE
fix: release process-wide statics that pin previewed-app ALCs (Batch 2)

### DIFF
--- a/Uno.Extensions-packageonly.slnf
+++ b/Uno.Extensions-packageonly.slnf
@@ -7,6 +7,7 @@
       "src\\Uno.Extensions.Authentication.UI\\Uno.Extensions.Authentication.WinUI.csproj",
       "src\\Uno.Extensions.Authentication\\Uno.Extensions.Authentication.csproj",
       "src\\Uno.Extensions.Configuration\\Uno.Extensions.Configuration.csproj",
+      "src\\Uno.Extensions.Configuration.Tests\\Uno.Extensions.Configuration.Tests.csproj",
       "src\\Uno.Extensions.Core.Generators\\Uno.Extensions.Core.Generators.csproj",
       "src\\Uno.Extensions.Core.Tests\\Uno.Extensions.Core.Tests.csproj",
       "src\\Uno.Extensions.Core.UI\\Uno.Extensions.Core.WinUI.csproj",

--- a/Uno.Extensions.sln
+++ b/Uno.Extensions.sln
@@ -147,6 +147,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Serialization.AotTests", "src\Uno.Extensions.Serialization.AotTests\Uno.Extensions.Serialization.AotTests.csproj", "{DF77B943-13C2-4D98-8364-BA0DDC2C156D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Configuration.Tests", "src\Uno.Extensions.Configuration.Tests\Uno.Extensions.Configuration.Tests.csproj", "{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -807,6 +809,22 @@ Global
 		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|x64.Build.0 = Release|Any CPU
 		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|x86.ActiveCfg = Release|Any CPU
 		{DF77B943-13C2-4D98-8364-BA0DDC2C156D}.Release|x86.Build.0 = Release|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Debug|arm64.Build.0 = Debug|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Debug|x64.Build.0 = Debug|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Debug|x86.Build.0 = Debug|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Release|arm64.ActiveCfg = Release|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Release|arm64.Build.0 = Release|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Release|x64.ActiveCfg = Release|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Release|x64.Build.0 = Release|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Release|x86.ActiveCfg = Release|Any CPU
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -857,6 +875,7 @@ Global
 		{C9827C80-312B-4E81-B539-2D305D893A6C} = {45179294-70DC-47E8-AD22-1296F897B594}
 		{76AF6C8E-A738-FF6A-EAB1-FE94DAC56658} = {2197ADCE-59C4-465A-B380-0B06BF68BBBC}
 		{DF77B943-13C2-4D98-8364-BA0DDC2C156D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E7B035D-9A64-4D95-89AA-9D4653F17C42}

--- a/specs/008-alc-pin-managed-sweeps/spec.md
+++ b/specs/008-alc-pin-managed-sweeps/spec.md
@@ -20,15 +20,15 @@ is torn down.
 
 ## Findings
 
-| # | Static | Project | Kind |
-| --- | --- | --- | --- |
-| 1 | `LogExtensions._unoLogger` / `_boundToUnoLogger` (+ `Holder<T>.Logger`); ambient factory reset on shutdown | Reactive / Logging | ALC pin (first `ILoggerFactory` + its `ServiceProvider`) |
-| 2 | `Region.Logger` | Navigation.UI | ALC pin (last host's logger/provider graph) |
-| 3 | `PlatformHelper._appAssembly` | Core | ALC pin (previewed app `Assembly`) |
-| 4 | `EmbeddedAppConfigurationFile.AllFiles<T>()` static cache | Configuration | **Functional bug** + ALC pin |
-| 5 | `NavigationRouteUpdateHandler` context / `RootRegion` / `Resolver` retention | Navigation.UI | ALC pin on non-graceful teardown |
-| 6 | `HotReloadService._latestShadow` | Reactive | ALC pin (previewed-app `Type`s) |
-| 7 | `JsonSerializationOptions.DefaultSerializerOptions` fallbacks | Serialization | ALC pin (cached `JsonTypeInfo` for app `Type`s) |
+| # | Static | Project | Kind | Status |
+| --- | --- | --- | --- | --- |
+| 1 | `LogExtensions._unoLogger` / `_boundToUnoLogger` (+ `Holder<T>.Logger`); ambient factory reset on shutdown | Reactive / Logging | ALC pin (first `ILoggerFactory` + its `ServiceProvider`) | Landed |
+| 2 | `Region.Logger` | Navigation.UI | ALC pin (last host's logger/provider graph) | Landed |
+| 3 | `PlatformHelper._appAssembly` | Core | ALC pin (previewed app `Assembly`) | Landed |
+| 4 | `EmbeddedAppConfigurationFile.AllFiles<T>()` static cache | Configuration | **Functional bug** + ALC pin | Landed |
+| 5 | `NavigationRouteUpdateHandler` context / `RootRegion` / `Resolver` retention | Navigation.UI | ALC pin on non-graceful teardown | Landed |
+| 6 | `HotReloadService._latestShadow` | Reactive | ALC pin (previewed-app `Type`s) | Landed |
+| 7 | `JsonSerializationOptions.DefaultSerializerOptions` fallbacks | Serialization | ALC pin (cached `JsonTypeInfo` for app `Type`s) | Landed |
 
 ## Out of scope (follow-ups)
 
@@ -291,7 +291,69 @@ The `HAS_UNO` ambient-reset in `HostExtensions` compiles on every non-Android TF
 (`net9.0-desktop` verified clean, 0/0); it is exercised by CI runtime heads (there is no headless
 unit path for the `HAS_UNO` block in this environment).
 
-## Remaining (this branch)
+---
 
-Findings 2 (`Region.Logger`) and 5 (`NavigationRouteUpdateHandler` retention) live in the `HAS_UNO`
-`Uno.Extensions.Navigation.UI` project and are covered separately (see below / follow-up).
+## Finding 2 — static `Region.Logger` never cleared
+
+**Files touched:**
+
+- `src/Uno.Extensions.Navigation.UI/Region.cs`
+- `src/Uno.Extensions.Navigation.UI/NavigationHostedService.cs`
+- `src/Uno.Extensions.Navigation.UI.Tests/Given_Region.cs` *(new test)*
+
+### Root cause
+
+`Region.Logger` is a process-wide static `ILogger` set from `NavigationHostedService.StartAsync`
+(`Region.Logger = _regionLogger`) and never reset. After the host stops, the static keeps the host's
+logger — and the service provider behind it — alive.
+
+### Fix
+
+Add `Region.ResetLogger(ILogger expected)` that clears the static back to `NullLogger` **only if it is
+still the expected instance**, and call it from `NavigationHostedService.StopAsync`. The reference
+guard prevents a stopping host from clobbering a concurrently running one that installed its own logger.
+
+### Testing — `Given_Region` (in `Uno.Extensions.Navigation.WinUI.Tests`)
+
+- `When_ResetLogger_WithMatchingInstance_Then_LoggerFallsBackToNull`
+- `When_ResetLogger_WithDifferentInstance_Then_CurrentLoggerKept`
+
+---
+
+## Finding 5 — `NavigationRouteUpdateHandler` retains the region / navigator tree
+
+**Files touched:**
+
+- `src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs`
+- `src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs` *(added tests)*
+
+### Root cause
+
+`NavigationRouteContext` (held in the static `_contexts` list) exposed `RootRegion` as a **strong**
+`IRegion` reference and `Resolver` as a strong `RouteResolver`. `StopAsync` already removes the context
+from `_contexts` on a graceful teardown, but on a **non-graceful** teardown the context could keep the
+whole live region / navigator tree — and its service provider / previewed-app ALC — alive through the
+static list.
+
+### Fix
+
+- `RootRegion` is now held via `WeakReference<IRegion>` (get/set keep the same `IRegion?` API; the HR
+  paths already treat a null root as "nothing to cascade", so a collected root degrades gracefully).
+- `Unregister` now also nulls the context's `RootRegion` and `Resolver`, so a graceful teardown
+  releases the tree even if the context object itself is still referenced (e.g. by the DI container).
+
+### Testing — `Given_NavigationRouteUpdateHandler` (in `Uno.Extensions.Navigation.WinUI.Tests`)
+
+- `When_Unregister_Then_ContextLiveTreeReferencesCleared`
+- `When_RootRegionSet_Then_ItIsHeldWeakly` — assigns a root in a `[NoInlining]` frame, forces GC, and
+  asserts the region is collected and reads back as null.
+
+## Build / test coverage note
+
+Findings 4, 3, 7, 6, 1 (Reactive side) are covered by MSTest `net9.0` projects and were run locally
+(red/fix/green shown per finding). Findings 2, 5, and the `HAS_UNO` half of 1 live in Uno-SDK
+(`HAS_UNO`) projects whose tests run under the Uno runtime-test harness; those source + test files
+compile clean on `net9.0-desktop` here (verified: `Uno.Extensions.Navigation.WinUI`,
+`Uno.Extensions.Navigation.WinUI.Tests`, `Uno.Extensions.Logging.WinUI` desktop TFM all 0 errors) and
+are executed by CI runtime heads. No headless UI runtime is available in this environment, so those
+tests were not run locally.

--- a/specs/008-alc-pin-managed-sweeps/spec.md
+++ b/specs/008-alc-pin-managed-sweeps/spec.md
@@ -109,3 +109,47 @@ must return **none**. This reproduces two apps resolving distinct assemblies.
 **Red (pre-fix):** the first two tests fail — the second assembly wrongly received
 `Uno.Extensions.Configuration.Tests.appsettings.json` (the first caller's file). **Green (post-fix):**
 all three pass. Verified via `dotnet test src/Uno.Extensions.Configuration.Tests`.
+
+---
+
+## Finding 3 — `PlatformHelper._appAssembly` strong reference pins the app assembly
+
+**Files touched:**
+
+- `src/Uno.Extensions.Core/PlatformHelper.cs`
+- `src/Uno.Extensions.Core.Tests/PlatformHelper/Given_PlatformHelper.cs` *(new red/fix/green test)*
+
+### Root cause
+
+`PlatformHelper` cached the app assembly in a strong static field, set either explicitly via
+`SetAppAssembly` or lazily via `GetAppAssembly` (`_appAssembly ??= Assembly.GetCallingAssembly()`):
+
+```csharp
+private static Assembly? _appAssembly;
+public static void SetAppAssembly(Assembly? assembly) => _appAssembly = assembly;
+```
+
+A downstream host calls `SetAppAssembly(previewedAppAssembly)` for each previewed app. The strong
+reference kept that assembly — and therefore its collectible ALC — alive for the process lifetime,
+so no previewed app's ALC could ever be collected.
+
+### Fix
+
+Hold the reference weakly (`WeakReference<Assembly>?`). `SetAppAssembly` wraps the assembly in a
+`WeakReference` (or clears the field on `null`); `GetAppAssembly` returns the target if still alive
+and otherwise re-derives the fallback (`GetEntryAssembly` / `GetCallingAssembly`) and re-caches it
+weakly. Behavior is unchanged while any strong reference to the assembly exists (the host holds one
+while the app is loaded); only the *pin* after the host drops its references is removed.
+
+### Testing (red/fix/green) — `Uno.Extensions.Core.Tests` (MSTest, net9.0)
+
+`When_SetAppAssembly_From_CollectibleAlc_Then_AlcIsCollectible` emits a tiny assembly with Roslyn,
+loads it into a **collectible** `AssemblyLoadContext`, registers it via `SetAppAssembly`, takes a
+`WeakReference` to the ALC, unloads it, and forces GC. The ALC must be collected.
+
+The load/register happens in a `[MethodImpl(NoInlining)]` helper so the ALC and assembly locals do
+not linger on the caller's stack.
+
+**Red (pre-fix):** the strong reference pins the assembly, the ALC stays alive, the test fails.
+**Green (post-fix):** the weak reference lets the ALC collect. Verified via
+`dotnet test src/Uno.Extensions.Core.Tests --filter Given_PlatformHelper`.

--- a/specs/008-alc-pin-managed-sweeps/spec.md
+++ b/specs/008-alc-pin-managed-sweeps/spec.md
@@ -206,8 +206,48 @@ factory so the suite still compiles). **Green (post-fix):** all three pass, and 
 Serialization suite stays green (no regressions). Verified via
 `dotnet test src/Uno.Extensions.Serialization.Tests`.
 
+---
+
+## Finding 6 — `HotReloadService._latestShadow` never released
+
+**Files touched:**
+
+- `src/Uno.Extensions.Reactive/Core/HotReload/HotReloadService.cs`
+- `src/Uno.Extensions.Reactive.Tests/Core/HotReload/Given_HotReloadService.cs` *(new red/fix/green test)*
+
+### Root cause
+
+`_latestShadow` is a `ConcurrentDictionary<Type, Type>` mapping each hot-reloaded model type to its
+latest shadow generation. It is only ever added to (from `UpdateApplication`); the `ClearCache(Type[])`
+callback was a **no-op** and there was no reset. Both key and value are strong `Type` references, so
+every previewed app's model types — and their collectible ALC — were pinned for the process lifetime.
+
+### Fix
+
+- Implement `ClearCache(Type[])` to actually remove the mappings for the supplied types (matched as
+  either the original key or the shadow value).
+- Add a public `Reset()` for the host to call on teardown, clearing the whole map.
+- Add a per-ALC unload sweep: `UpdateApplication` calls `WatchForUnload` for both the original and the
+  shadow type; when either lives in a **collectible** `AssemblyLoadContext`, the service subscribes
+  once (`_watchedContexts`) to `AssemblyLoadContext.Unloading` and drops that ALC's entries on unload —
+  so the map never pins a previewed app's ALC even without an explicit `Reset()`.
+
+### Testing (red/fix/green) — `Uno.Extensions.Reactive.Tests` (MSTest, net9.0, via existing `InternalsVisibleTo`)
+
+Internal test seams `TrackShadowForTest` (mirrors `UpdateApplication`'s map+watch) and
+`TrackedShadowCount` avoid fabricating the runtime metadata-update attributes.
+
+- `When_Reset_Then_ShadowMapIsCleared`
+- `When_ClearCache_Then_OnlyMatchingEntriesRemoved` (clearing by the shadow value drops the entry)
+- `When_TrackedTypeFromCollectibleAlc_Then_AlcIsCollectibleAfterUnload` — loads an on-disk assembly
+  into a collectible ALC, tracks a mapping keyed by a type from it, unloads, and asserts the ALC is
+  collected.
+
+**Red:** with the unload sweep disabled, the ALC test fails (the map pins the ALC). **Green:** with
+the sweep the ALC collects; all three pass. Verified via
+`dotnet test src/Uno.Extensions.Reactive.Tests --filter Given_HotReloadService`.
+
 ## Remaining (this branch)
 
-Findings 1 (`LogExtensions._unoLogger` / `Holder<T>` + ambient reset), 2 (`Region.Logger`),
-5 (`NavigationRouteUpdateHandler` retention), and 6 (`HotReloadService._latestShadow`) are tracked
-here and landed as follow-up commits.
+Findings 1 (`LogExtensions._unoLogger` / `Holder<T>` + ambient reset), 2 (`Region.Logger`), and
+5 (`NavigationRouteUpdateHandler` retention) are tracked here and landed as follow-up commits.

--- a/specs/008-alc-pin-managed-sweeps/spec.md
+++ b/specs/008-alc-pin-managed-sweeps/spec.md
@@ -153,3 +153,61 @@ not linger on the caller's stack.
 **Red (pre-fix):** the strong reference pins the assembly, the ALC stays alive, the test fails.
 **Green (post-fix):** the weak reference lets the ALC collect. Verified via
 `dotnet test src/Uno.Extensions.Core.Tests --filter Given_PlatformHelper`.
+
+---
+
+## Finding 7 — `JsonSerializationOptions.DefaultSerializerOptions` handed out as fallback
+
+**Files touched:**
+
+- `src/Uno.Extensions.Serialization/JsonSerializationOptions.cs`
+- `src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs`
+- `src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs`
+- `src/Uno.Extensions.Serialization/Uno.Extensions.Serialization.csproj` *(`InternalsVisibleTo` for tests)*
+- `src/Uno.Extensions.Serialization.Tests/Given_JsonSerializationOptions.cs` *(new red/fix/green test)*
+
+### Root cause
+
+`DefaultSerializerOptions` is a process-wide `static` `JsonSerializerOptions`. It is *mostly* used as
+a template (copied via `new JsonSerializerOptions(DefaultSerializerOptions)`), but two fallback paths
+returned the static **directly**:
+
+- `ServiceCollectionExtensions.GetJsonSerializationOptions` — when no `IOptions<JsonSerializationOptions>`
+  is registered.
+- `SystemTextJsonSerializer` constructor — final `??` fallback.
+
+`System.Text.Json` caches a `JsonTypeInfo` on the options instance for every type it (de)serializes
+via reflection. A serializer using the shared static therefore accumulates a `JsonTypeInfo` for every
+app type it touches, and each `JsonTypeInfo` holds a `Type`. For a downstream host that loads
+previewed apps into collectible ALCs, that pins the app types — and their ALC — on a process-wide
+object for the process lifetime.
+
+### Fix
+
+Keep `DefaultSerializerOptions` strictly as a template and add an internal
+`CreateSerializerOptions()` factory that returns a fresh `new JsonSerializerOptions(DefaultSerializerOptions)`.
+Both fallback paths now hand out a host-scoped copy, so the per-type cache is confined to the host
+and released with it. The already-copying registrations were normalized to the same factory.
+
+### Testing (red/fix/green) — `Uno.Extensions.Serialization.Tests` (MSTest, net9.0)
+
+`InternalsVisibleTo` was added so the tests can observe the internal template/factory.
+
+- `When_CreateSerializerOptions_Then_ReturnsFreshCopyNotTemplate` — the factory returns a distinct
+  instance (never the template) and preserves the template's configuration.
+- `When_NoOptionsConfigured_Then_FallbackDoesNotReturnTemplate` — the `GetJsonSerializationOptions`
+  fallback returns a copy, not the shared static.
+- `When_TwoHostsRegisterSerialization_Then_EachGetsIndependentOptions` — two hosts each own a distinct
+  options instance and serialization still works off the host-scoped copy.
+
+**Red (pre-fix):** `When_NoOptionsConfigured…` fails — the fallback returned the shared template
+by reference (demonstrated by temporarily reverting the single fallback line while keeping the new
+factory so the suite still compiles). **Green (post-fix):** all three pass, and the full 20-test
+Serialization suite stays green (no regressions). Verified via
+`dotnet test src/Uno.Extensions.Serialization.Tests`.
+
+## Remaining (this branch)
+
+Findings 1 (`LogExtensions._unoLogger` / `Holder<T>` + ambient reset), 2 (`Region.Logger`),
+5 (`NavigationRouteUpdateHandler` retention), and 6 (`HotReloadService._latestShadow`) are tracked
+here and landed as follow-up commits.

--- a/specs/008-alc-pin-managed-sweeps/spec.md
+++ b/specs/008-alc-pin-managed-sweeps/spec.md
@@ -247,7 +247,51 @@ Internal test seams `TrackShadowForTest` (mirrors `UpdateApplication`'s map+watc
 the sweep the ALC collects; all three pass. Verified via
 `dotnet test src/Uno.Extensions.Reactive.Tests --filter Given_HotReloadService`.
 
+---
+
+## Finding 1 — Reactive ambient-logger cache pins the first host's factory
+
+**Files touched:**
+
+- `src/Uno.Extensions.Reactive/Utils/Logging/LogExtensions.cs`
+- `src/Uno.Extensions.Logging/HostExtensions.cs`
+- `src/Uno.Extensions.Reactive.Tests/Core/Logging/Given_LogExtensions.cs` *(new red/fix/green test)*
+
+### Root cause
+
+`LogExtensions` cached the first `LogExtensionPoint.AmbientLoggerFactory` in `_unoLogger` (bound once
+via `_boundToUnoLogger`), and `Holder<T>.Logger` was `= CreateLog(...)` — a logger **snapshotted at
+first touch**. Both retain the first host's `ILoggerFactory`, and through it the whole first host's
+`ServiceProvider`, for the process lifetime. `LogExtensionPoint.AmbientLoggerFactory` itself (external
+package) was set on host start (`HostExtensions.ConnectUnoLogging`) and never reset.
+
+### Fix
+
+- **Reactive (forwarding, in-repo):** `Holder<T>.Logger` is now a `ForwardingLogger` that re-resolves
+  the concrete logger via `CreateLog` on every `Log` / `IsEnabled` / `BeginScope` call, so it never
+  snapshots a factory. Add `LogExtensions.Reset()` to drop `_provider` / `_unoLogger` / the bind flag
+  so the next resolve re-binds — a host-shutdown seam.
+- **Logging (ambient reset):** `ConnectUnoLogging` registers an `IHostApplicationLifetime.ApplicationStopping`
+  callback that resets `AmbientLoggerFactory` to `NullLoggerFactory.Instance` — but only if it is still
+  the factory this host installed (guarded by reference check, so concurrent hosts don't clobber each
+  other). This lives in the `HAS_UNO` UI project.
+
+### Testing (red/fix/green) — `Uno.Extensions.Reactive.Tests` (MSTest, net9.0)
+
+- `When_ProviderChanges_Then_ForwardingLoggerUsesLatest` — a cached `Log<T>()` logger routes to the
+  provider configured **now**, not the one active at first touch.
+- `When_Reset_Then_ProviderIsReleased` — after `Reset`, the forwarder no longer routes to the released
+  provider.
+
+**Red:** with `Holder<T>.Logger` restored to the one-shot `CreateLog(...)` snapshot, the forwarding
+test fails (the cached logger keeps hitting the first provider). **Green:** with the forwarder both
+pass. Verified via `dotnet test src/Uno.Extensions.Reactive.Tests --filter Given_LogExtensions`.
+
+The `HAS_UNO` ambient-reset in `HostExtensions` compiles on every non-Android TFM
+(`net9.0-desktop` verified clean, 0/0); it is exercised by CI runtime heads (there is no headless
+unit path for the `HAS_UNO` block in this environment).
+
 ## Remaining (this branch)
 
-Findings 1 (`LogExtensions._unoLogger` / `Holder<T>` + ambient reset), 2 (`Region.Logger`), and
-5 (`NavigationRouteUpdateHandler` retention) are tracked here and landed as follow-up commits.
+Findings 2 (`Region.Logger`) and 5 (`NavigationRouteUpdateHandler` retention) live in the `HAS_UNO`
+`Uno.Extensions.Navigation.UI` project and are covered separately (see below / follow-up).

--- a/specs/008-alc-pin-managed-sweeps/spec.md
+++ b/specs/008-alc-pin-managed-sweeps/spec.md
@@ -1,0 +1,111 @@
+# Process-wide statics pin previewed-app AssemblyLoadContexts (Batch 2 managed sweeps)
+
+**Status:** In progress (branch `dev/nr/wasm-alc-sweeps-ext`)
+**Issue:** [#3126](https://github.com/unoplatform/uno.extensions/issues/3126)
+**Affects:** `Uno.Extensions.Configuration`, `Uno.Extensions.Core`, `Uno.Extensions.Navigation.UI`, `Uno.Extensions.Reactive`, `Uno.Extensions.Serialization`, `Uno.Extensions.Logging`
+
+## Problem
+
+Several process-wide `static` fields capture the first host's `ILoggerFactory` / `ServiceProvider`
+/ `Assembly` / serializer state at first touch and never release or re-scope it. In a **downstream
+host that loads previewed apps into their own collectible `AssemblyLoadContext`s** (load app, run,
+unload, load the next app into a fresh ALC), these statics keep the *previous* app's object graph
+alive for the whole process lifetime, so the collectible ALC can never be collected. One static
+additionally serves the **wrong app's configuration** to a later load — a functional bug independent
+of the leak.
+
+Standalone (single-app) usage is unaffected: the process only ever hosts one app, so a permanent
+static reference is harmless. The defects only manifest when a second app is loaded after the first
+is torn down.
+
+## Findings
+
+| # | Static | Project | Kind |
+| --- | --- | --- | --- |
+| 1 | `LogExtensions._unoLogger` / `_boundToUnoLogger` (+ `Holder<T>.Logger`); ambient factory reset on shutdown | Reactive / Logging | ALC pin (first `ILoggerFactory` + its `ServiceProvider`) |
+| 2 | `Region.Logger` | Navigation.UI | ALC pin (last host's logger/provider graph) |
+| 3 | `PlatformHelper._appAssembly` | Core | ALC pin (previewed app `Assembly`) |
+| 4 | `EmbeddedAppConfigurationFile.AllFiles<T>()` static cache | Configuration | **Functional bug** + ALC pin |
+| 5 | `NavigationRouteUpdateHandler` context / `RootRegion` / `Resolver` retention | Navigation.UI | ALC pin on non-graceful teardown |
+| 6 | `HotReloadService._latestShadow` | Reactive | ALC pin (previewed-app `Type`s) |
+| 7 | `JsonSerializationOptions.DefaultSerializerOptions` fallbacks | Serialization | ALC pin (cached `JsonTypeInfo` for app `Type`s) |
+
+## Out of scope (follow-ups)
+
+`FeedDependencyRegistry` purge, `ApplicationUpdated` weak subscriptions, `SourceContext`
+deterministic teardown, `RouteResolverDefault` ALC-scoped scan.
+
+---
+
+## Finding 4 — `EmbeddedAppConfigurationFile.AllFiles<T>()` first-caller-wins cache (functional bug)
+
+**Files touched:**
+
+- `src/Uno.Extensions.Configuration/EmbeddedAppConfigurationFile.cs`
+- `src/Uno.Extensions.Configuration.Tests/` *(new MSTest project — red/fix/green + non-regression)*
+
+### Root cause
+
+`AllFiles<TApplicationRoot>()` scans the manifest resources of `typeof(TApplicationRoot).Assembly`
+for `appsettings*` files and caches the result in a single process-wide field:
+
+```csharp
+private static EmbeddedAppConfigurationFile[]? _appConfigurationFiles;
+
+public static EmbeddedAppConfigurationFile[] AllFiles<TApplicationRoot>() where TApplicationRoot : class
+{
+    if (_appConfigurationFiles is null)                       // <-- keyed on "have we run once", not on the assembly
+    {
+        var executingAssembly = typeof(TApplicationRoot).Assembly;
+        _appConfigurationFiles = executingAssembly.GetManifestResourceNames() ... .ToArray();
+    }
+    return _appConfigurationFiles;                            // <-- always the FIRST caller's files
+}
+```
+
+The cache key is "has this method run at all", not the assembly. After the first call the field is
+non-null forever, so every later `AllFiles<TOtherAppRoot>()` returns the **first** app's files and
+ignores its own type argument. Two consequences:
+
+1. **Functional bug:** a second app hosted after the first receives the first app's `appsettings.*`
+   (or, if the first app had none, an empty set) — cross-app configuration bleed.
+2. **ALC pin:** the first `EmbeddedAppConfigurationFile` instances hold a strong `Assembly`
+   reference, keeping the first app's collectible ALC alive for the process lifetime.
+
+### Fix
+
+Rekey the cache per-`Assembly` with a `ConditionalWeakTable<Assembly, EmbeddedAppConfigurationFile[]>`.
+Each assembly gets its own cached array; the `ConditionalWeakTable` holds the key **weakly**, so once
+an app's ALC unloads the entry (and its cached `Assembly`) becomes collectible.
+
+```csharp
+private static readonly ConditionalWeakTable<Assembly, EmbeddedAppConfigurationFile[]> _appConfigurationFiles = new();
+
+public static EmbeddedAppConfigurationFile[] AllFiles<TApplicationRoot>() where TApplicationRoot : class
+{
+    var executingAssembly = typeof(TApplicationRoot).Assembly;
+    return _appConfigurationFiles.GetValue(
+        executingAssembly,
+        static assembly => assembly.GetManifestResourceNames() ... .ToArray());
+}
+```
+
+`GetValue` remains a cache (repeated calls for the same assembly return the identical array), so the
+caching behavior the callers relied on is preserved — only the key is corrected.
+
+### Testing (red/fix/green) — `Uno.Extensions.Configuration.Tests` (new MSTest, net9.0)
+
+The test assembly embeds exactly one `appsettings.json`, so `AllFiles<TypeInThisAssembly>()`
+returns one file while `AllFiles<FrameworkType>()` (an assembly with no `appsettings` resource)
+must return **none**. This reproduces two apps resolving distinct assemblies.
+
+- `When_SecondAssemblyRequested_Then_DoesNotReturnFirstAssemblyFiles` — prime with the assembly that
+  *has* settings, then request a framework type; the second must be empty.
+- `When_FirstRequestedIsWithoutSettings_Then_SecondAssemblyStillGetsItsOwnFiles` — reversed order;
+  each assembly still resolves its own files (order-independent).
+- `When_SameAssemblyRequestedTwice_Then_ReturnsCachedInstance` — the per-assembly cache still returns
+  the identical array instance.
+
+**Red (pre-fix):** the first two tests fail — the second assembly wrongly received
+`Uno.Extensions.Configuration.Tests.appsettings.json` (the first caller's file). **Green (post-fix):**
+all three pass. Verified via `dotnet test src/Uno.Extensions.Configuration.Tests`.

--- a/src/Uno.Extensions.Configuration.Tests/Given_EmbeddedAppConfigurationFile.cs
+++ b/src/Uno.Extensions.Configuration.Tests/Given_EmbeddedAppConfigurationFile.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Configuration;
+
+namespace Uno.Extensions.Configuration.Tests;
+
+/// <summary>
+/// Guards <see cref="EmbeddedAppConfigurationFile.AllFiles{TApplicationRoot}"/> against the
+/// first-caller-wins static cache that served the first application's <c>appsettings.*</c> files
+/// to every later, unrelated assembly.
+/// </summary>
+/// <remarks>
+/// This reproduces the topology of a downstream host that loads previewed apps into their own
+/// collectible <c>AssemblyLoadContext</c>s: distinct application-root types resolve to distinct
+/// assemblies, and each must receive only its own embedded configuration files.
+/// </remarks>
+[TestClass]
+public class Given_EmbeddedAppConfigurationFile
+{
+	// A type in THIS test assembly, which embeds exactly one appsettings.json (see the .csproj).
+	private sealed class AppRootWithSettings
+	{
+	}
+
+	[TestMethod]
+	public void When_SecondAssemblyRequested_Then_DoesNotReturnFirstAssemblyFiles()
+	{
+		// Arrange / Act — prime the cache with the assembly that HAS an appsettings resource first.
+		var withSettings = EmbeddedAppConfigurationFile.AllFiles<AppRootWithSettings>();
+
+		// A framework type resolves to an assembly with no embedded "appsettings" resource.
+		var withoutSettings = EmbeddedAppConfigurationFile.AllFiles<StringBuilder>();
+
+		// Assert — the second, unrelated assembly must NOT inherit the first assembly's files.
+		// On the buggy first-caller-wins cache this returned the AppRootWithSettings file(s).
+		withSettings.Should().NotBeEmpty("this assembly embeds appsettings.json");
+		withSettings.Should().OnlyContain(file => file.FileName.Contains("appsettings"));
+
+		withoutSettings.Should().BeEmpty(
+			"a second application's assembly must resolve its own configuration, not the first caller's");
+	}
+
+	[TestMethod]
+	public void When_FirstRequestedIsWithoutSettings_Then_SecondAssemblyStillGetsItsOwnFiles()
+	{
+		// Arrange / Act — reversed order: prime with the assembly that has NO appsettings first.
+		var withoutSettings = EmbeddedAppConfigurationFile.AllFiles<Uri>();
+
+		// Then request this assembly, which DOES embed appsettings.json.
+		var withSettings = EmbeddedAppConfigurationFile.AllFiles<AppRootWithSettings>();
+
+		// Assert — order must not matter: each assembly resolves its own files.
+		withoutSettings.Should().BeEmpty("the framework assembly embeds no appsettings resource");
+		withSettings.Should().NotBeEmpty("this assembly embeds appsettings.json");
+		withSettings.Should().OnlyContain(file => file.FileName.Contains("appsettings"));
+	}
+
+	[TestMethod]
+	public void When_SameAssemblyRequestedTwice_Then_ReturnsCachedInstance()
+	{
+		// The per-assembly cache must still be a cache: repeated calls for the same assembly
+		// return the identical array instance (no re-scan of manifest resources).
+		var first = EmbeddedAppConfigurationFile.AllFiles<AppRootWithSettings>();
+		var second = EmbeddedAppConfigurationFile.AllFiles<AppRootWithSettings>();
+
+		second.Should().BeSameAs(first);
+	}
+}

--- a/src/Uno.Extensions.Configuration.Tests/Uno.Extensions.Configuration.Tests.csproj
+++ b/src/Uno.Extensions.Configuration.Tests/Uno.Extensions.Configuration.Tests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.Extensions.Configuration\Uno.Extensions.Configuration.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="MSTest.TestAdapter" />
+		<PackageReference Include="MSTest.TestFramework" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="FluentAssertions" />
+	</ItemGroup>
+
+	<!--
+		This test assembly embeds a single appsettings.json so that
+		EmbeddedAppConfigurationFile.AllFiles<TRootInThisAssembly>() returns exactly one file,
+		while a type from another assembly (e.g. a framework type) returns none. That difference
+		is what proves the per-assembly cache no longer serves the first caller's files to a
+		second, unrelated assembly.
+	-->
+	<ItemGroup>
+		<EmbeddedResource Include="appsettings.json" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.Extensions.Configuration.Tests/appsettings.json
+++ b/src/Uno.Extensions.Configuration.Tests/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "Marker": "configuration-tests-assembly"
+}

--- a/src/Uno.Extensions.Configuration/EmbeddedAppConfigurationFile.cs
+++ b/src/Uno.Extensions.Configuration/EmbeddedAppConfigurationFile.cs
@@ -1,4 +1,4 @@
-﻿
+﻿using System.Runtime.CompilerServices;
 
 namespace Uno.Extensions.Configuration;
 
@@ -7,8 +7,18 @@ namespace Uno.Extensions.Configuration;
 /// </summary>
 public class EmbeddedAppConfigurationFile
 {
-
-	private static EmbeddedAppConfigurationFile[]? _appConfigurationFiles;
+	// Cache keyed by the owning assembly rather than a single process-wide array.
+	//
+	// The previous single static array was first-caller-wins: once populated it was returned for
+	// every subsequent AllFiles<T>() call regardless of the type argument. In a downstream host that
+	// loads multiple apps into their own collectible AssemblyLoadContexts, that both (1) served the
+	// FIRST app's appsettings to every later app (a functional bug) and (2) pinned the first app's
+	// Assembly for the process lifetime, preventing its ALC from being collected.
+	//
+	// A ConditionalWeakTable keyed by Assembly gives each app its own entry and holds the key weakly,
+	// so once an app's ALC is unloaded the entry (and the cached Assembly reference) becomes eligible
+	// for collection.
+	private static readonly ConditionalWeakTable<Assembly, EmbeddedAppConfigurationFile[]> _appConfigurationFiles = new();
 
 	private readonly Assembly _assembly;
 
@@ -72,17 +82,14 @@ public class EmbeddedAppConfigurationFile
 	public static EmbeddedAppConfigurationFile[] AllFiles<TApplicationRoot>()
 		 where TApplicationRoot : class
 	{
-		if (_appConfigurationFiles is null)
-		{
-			var executingAssembly = typeof(TApplicationRoot).Assembly;
+		var executingAssembly = typeof(TApplicationRoot).Assembly;
 
-			_appConfigurationFiles = executingAssembly
+		return _appConfigurationFiles.GetValue(
+			executingAssembly,
+			static assembly => assembly
 				.GetManifestResourceNames()
 				.Where(fileName => fileName.ToLowerInvariant().Contains(AppConfiguration.Prefix.ToLowerInvariant()))
-				.Select(fileName => new EmbeddedAppConfigurationFile(fileName, executingAssembly))
-				.ToArray();
-		}
-
-		return _appConfigurationFiles;
+				.Select(fileName => new EmbeddedAppConfigurationFile(fileName, assembly))
+				.ToArray());
 	}
 }

--- a/src/Uno.Extensions.Core.Tests/PlatformHelper/Given_PlatformHelper.cs
+++ b/src/Uno.Extensions.Core.Tests/PlatformHelper/Given_PlatformHelper.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.Extensions.Core.Tests.PlatformHelper;
+
+/// <summary>
+/// Guards that <see cref="global::Uno.Extensions.PlatformHelper.SetAppAssembly"/> does not pin the
+/// supplied assembly for the process lifetime.
+/// </summary>
+/// <remarks>
+/// A downstream host that loads previewed apps into collectible <see cref="AssemblyLoadContext"/>s
+/// calls <c>SetAppAssembly</c> with the previewed app's assembly. If <c>PlatformHelper</c> held that
+/// assembly with a strong reference, the collectible ALC could never be unloaded. The reference is
+/// held weakly instead, so once the ALC drops its own references the assembly (and its ALC) become
+/// collectible.
+/// </remarks>
+[TestClass]
+public class Given_PlatformHelper
+{
+	[TestCleanup]
+	public void Cleanup()
+	{
+		// Do not leak state between tests / suites.
+		global::Uno.Extensions.PlatformHelper.SetAppAssembly(null);
+	}
+
+	[TestMethod]
+	public void When_SetAppAssembly_From_CollectibleAlc_Then_AlcIsCollectible()
+	{
+		// Arrange — emit and load a tiny assembly into a collectible ALC, then register it.
+		var alcReference = LoadAndRegisterInCollectibleAlc();
+
+		// Act — give the runtime a chance to unload the ALC now that no strong reference remains
+		// (only PlatformHelper's internal reference, which must be weak).
+		for (var i = 0; i < 10 && alcReference.IsAlive; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+		}
+
+		// Assert — with a weak internal reference the ALC unloads; with a strong one it stays alive.
+		alcReference.IsAlive.Should().BeFalse(
+			"PlatformHelper must not hold a strong reference that pins the previewed app's collectible ALC");
+	}
+
+	// Kept in a separate non-inlined frame so the ALC + assembly locals are not kept alive by the
+	// caller's stack while we wait for collection.
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static WeakReference LoadAndRegisterInCollectibleAlc()
+	{
+		var image = EmitTinyAssembly();
+
+		var alc = new AssemblyLoadContext(nameof(Given_PlatformHelper), isCollectible: true);
+		using (var stream = new MemoryStream(image))
+		{
+			var assembly = alc.LoadFromStream(stream);
+			global::Uno.Extensions.PlatformHelper.SetAppAssembly(assembly);
+		}
+
+		var reference = new WeakReference(alc, trackResurrection: false);
+		alc.Unload();
+		return reference;
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static byte[] EmitTinyAssembly()
+	{
+		var syntaxTree = CSharpSyntaxTree.ParseText("namespace HostedPreviewApp { public sealed class App { } }");
+		var runtime = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+		var compilation = CSharpCompilation.Create(
+			assemblyName: "HostedPreviewApp",
+			syntaxTrees: new[] { syntaxTree },
+			references: new[] { runtime },
+			options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+		using var peStream = new MemoryStream();
+		var result = compilation.Emit(peStream);
+		result.Success.Should().BeTrue("the test fixture assembly must compile");
+		return peStream.ToArray();
+	}
+}

--- a/src/Uno.Extensions.Core/PlatformHelper.cs
+++ b/src/Uno.Extensions.Core/PlatformHelper.cs
@@ -14,7 +14,12 @@ public static class PlatformHelper
 	private static bool _initialized;
 	private static bool _isWebAssembly;
 
-	private static Assembly? _appAssembly;
+	// Held weakly so an app assembly supplied via SetAppAssembly (e.g. a previewed app loaded into a
+	// collectible AssemblyLoadContext by a downstream host) is not pinned for the process lifetime.
+	// Once the owning ALC unloads and drops its own references, this weak reference no longer keeps
+	// the assembly — and therefore the ALC — alive. GetAppAssembly re-derives a fallback if the
+	// reference has been collected.
+	private static WeakReference<Assembly>? _appAssembly;
 
 	/// <summary>
 	/// Determines if the platform is runnnig WebAssembly
@@ -71,7 +76,8 @@ public static class PlatformHelper
 	///   <see cref="GetAppAssembly"/> will follow its default algorithm.
 	///   </para>
 	/// </remarks>
-	public static void SetAppAssembly(Assembly? assembly) => _appAssembly = assembly;
+	public static void SetAppAssembly(Assembly? assembly)
+		=> _appAssembly = assembly is null ? null : new WeakReference<Assembly>(assembly);
 
 #pragma warning disable RS0030
 	/// <summary>
@@ -116,22 +122,34 @@ public static class PlatformHelper
 	/// </remarks>
 	public static Assembly? GetAppAssembly()
 	{
+		// Return the previously supplied/derived assembly if it is still alive.
+		if (_appAssembly is { } existing && existing.TryGetTarget(out var cached))
+		{
+			return cached;
+		}
+
 		if (!RuntimeFeature.IsDynamicCodeCompiled && !RuntimeFeature.IsDynamicCodeSupported)
 		{
 			// Assume NativeAOT. Might also be iOS+FullAOT…?
-			return _appAssembly ??= Assembly.GetEntryAssembly();
+			return CacheAppAssembly(Assembly.GetEntryAssembly());
 		}
 
 		try
 		{
-			return _appAssembly ??= Assembly.GetCallingAssembly();
+			return CacheAppAssembly(Assembly.GetCallingAssembly());
 		}
 		catch (Exception)
 		{
 			// Log?
-			return _appAssembly ??= Assembly.GetEntryAssembly();
+			return CacheAppAssembly(Assembly.GetEntryAssembly());
 		}
 #pragma warning restore RS0030
+	}
+
+	private static Assembly? CacheAppAssembly(Assembly? assembly)
+	{
+		_appAssembly = assembly is null ? null : new WeakReference<Assembly>(assembly);
+		return assembly;
 	}
 
 	/// <summary>

--- a/src/Uno.Extensions.Logging/HostExtensions.cs
+++ b/src/Uno.Extensions.Logging/HostExtensions.cs
@@ -19,6 +19,21 @@ public static class HostExtensions
 			global::Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory = factory;
 
 			Uno.UI.Adapter.Microsoft.Extensions.Logging.LoggingAdapter.Initialize();
+
+			// The ambient logger factory is a process-wide static that otherwise keeps this host's
+			// ILoggerFactory — and its whole ServiceProvider — alive after the host stops. For a downstream
+			// host that loads previewed apps into their own collectible AssemblyLoadContexts, that pins the
+			// app's ALC forever. Reset it (only if still ours) when the application stops.
+			if (host.Services.GetService<IHostApplicationLifetime>() is { } lifetime)
+			{
+				lifetime.ApplicationStopping.Register(() =>
+				{
+					if (ReferenceEquals(global::Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory, factory))
+					{
+						global::Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory = Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance;
+					}
+				});
+			}
 #endif
 		}
 		return host;

--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs
@@ -1,8 +1,11 @@
+using System;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions.Navigation;
+using Uno.Extensions.Navigation.Regions;
 using Uno.Extensions.Navigation.UI;
 
 namespace Uno.Extensions.Navigation.UI.Tests;
@@ -10,6 +13,68 @@ namespace Uno.Extensions.Navigation.UI.Tests;
 [TestClass]
 public class Given_NavigationRouteUpdateHandler
 {
+	[TestMethod]
+	public void When_Unregister_Then_ContextLiveTreeReferencesCleared()
+	{
+		var resolver = CreateResolver();
+		var context = new NavigationRouteContext
+		{
+			RouteBuilder = (_, _) => { },
+			Views = new ViewRegistry(new ServiceCollection()),
+			Routes = new RouteRegistry(new ServiceCollection()),
+			Resolver = resolver,
+			RootRegion = new FakeRegion(),
+		};
+
+		NavigationRouteUpdateHandler.Register(context);
+		NavigationRouteUpdateHandler.Unregister(context);
+
+		context.Resolver.Should().BeNull("Unregister must drop the resolver so the route tree is released");
+		context.RootRegion.Should().BeNull("Unregister must drop the live region tree reference");
+	}
+
+	[TestMethod]
+	public void When_RootRegionSet_Then_ItIsHeldWeakly()
+	{
+		var context = new NavigationRouteContext
+		{
+			RouteBuilder = (_, _) => { },
+			Views = new ViewRegistry(new ServiceCollection()),
+			Routes = new RouteRegistry(new ServiceCollection()),
+		};
+
+		var reference = AssignRootRegion(context);
+
+		for (var i = 0; i < 10 && reference.IsAlive; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+		}
+
+		reference.IsAlive.Should().BeFalse("RootRegion must be held weakly so it does not pin the region tree");
+		context.RootRegion.Should().BeNull("a collected root region reads back as null");
+	}
+
+	[System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+	private static WeakReference AssignRootRegion(NavigationRouteContext context)
+	{
+		var region = new FakeRegion();
+		context.RootRegion = region;
+		return new WeakReference(region, trackResurrection: false);
+	}
+
+	private sealed class FakeRegion : IRegion
+	{
+		public string? Name => null;
+		public Microsoft.UI.Xaml.FrameworkElement? View => null;
+		public IServiceProvider? Services => null;
+		public IRegion? Parent => null;
+		public System.Collections.Generic.ICollection<IRegion> Children { get; } = new System.Collections.Generic.List<IRegion>();
+		public void ReassignParent() { }
+		public void Detach() { }
+	}
+
 	[TestMethod]
 	public void When_UpdatedTypesAreNull_Then_CascadeIsAllowed()
 	{

--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_Region.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_Region.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Navigation.Regions;
+using Uno.Extensions.Navigation.UI;
+
+namespace Uno.Extensions.Navigation.UI.Tests;
+
+/// <summary>
+/// Guards that the static <see cref="Region.Logger"/> is released on navigation-host shutdown so the
+/// last host's logger (and the service provider behind it) is not retained. In a downstream host that
+/// loads previewed apps into their own collectible AssemblyLoadContexts, a retained logger pins the
+/// app's ALC.
+/// </summary>
+[TestClass]
+public class Given_Region
+{
+	[TestCleanup]
+	public void Cleanup() => Region.ResetLogger(Region.Logger);
+
+	[TestMethod]
+	public void When_ResetLogger_WithMatchingInstance_Then_LoggerFallsBackToNull()
+	{
+		var logger = new NullLoggerFactory().CreateLogger("test");
+		Region.Logger = logger;
+		Region.Logger.Should().BeSameAs(logger);
+
+		Region.ResetLogger(logger);
+
+		Region.Logger.Should().NotBeSameAs(logger, "the matching logger must be cleared on shutdown");
+		Region.Logger.Should().BeOfType<NullLogger<NavigationRegion>>("Region falls back to the null logger");
+	}
+
+	[TestMethod]
+	public void When_ResetLogger_WithDifferentInstance_Then_CurrentLoggerKept()
+	{
+		var running = new NullLoggerFactory().CreateLogger("running-host");
+		Region.Logger = running;
+
+		// A different (already stopped) host tries to reset — it must not clobber the running host's logger.
+		var stopped = new NullLoggerFactory().CreateLogger("stopped-host");
+		Region.ResetLogger(stopped);
+
+		Region.Logger.Should().BeSameAs(running, "a non-matching reset must leave the current logger untouched");
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/NavigationHostedService.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationHostedService.cs
@@ -69,6 +69,11 @@ internal class NavigationHostedService : IHostedService, IStartupService
 			}
 		}
 
+		// Release the static Region.Logger so this host's logger (and its service provider) is not
+		// retained after shutdown. Guarded so we only clear our own logger, not one a concurrently
+		// running host installed after us.
+		Region.ResetLogger(_regionLogger);
+
 		if (_regionLogger.IsEnabled(LogLevel.Information))
 		{
 			_regionLogger.LogInformationMessage("Navigation engine stopped");

--- a/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
@@ -19,13 +19,26 @@ internal sealed class NavigationRouteContext
 	public required IRouteRegistry Routes { get; init; }
 	public RouteResolver? Resolver { get; set; }
 
+	private WeakReference<IRegion>? _rootRegion;
+
 	/// <summary>
 	/// The root <see cref="IRegion"/> of the live navigator tree, populated by
 	/// <see cref="NavigationRegion.InitializeRootRegion"/>. Used by the C# hot-reload
 	/// route refresh to walk the live region tree and re-cascade the current route
 	/// when newly registered nested IsDefault routes become available.
 	/// </summary>
-	public IRegion? RootRegion { get; set; }
+	/// <remarks>
+	/// Held via a <see cref="WeakReference{T}"/>: on a non-graceful teardown (where
+	/// <see cref="NavigationRouteUpdateHandler.Unregister"/> is not called) this context could
+	/// otherwise keep the entire region / navigator tree — and its service provider and previewed-app
+	/// ALC — alive through the static handler list. The hot-reload paths already treat a null root as
+	/// "nothing to cascade", so a collected root simply degrades to no cascade.
+	/// </remarks>
+	public IRegion? RootRegion
+	{
+		get => _rootRegion is not null && _rootRegion.TryGetTarget(out var region) ? region : null;
+		set => _rootRegion = value is null ? null : new WeakReference<IRegion>(value);
+	}
 }
 
 /// <summary>
@@ -46,6 +59,12 @@ internal static class NavigationRouteUpdateHandler
 	internal static void Unregister(NavigationRouteContext context)
 	{
 		ImmutableInterlocked.Update(ref _contexts, l => l.Remove(context));
+
+		// Proactively drop the live-tree references so a graceful teardown releases the region /
+		// navigator tree and its resolver even if the context object itself is still referenced
+		// elsewhere (e.g. captured by the DI container until the provider is disposed).
+		context.RootRegion = null;
+		context.Resolver = null;
 	}
 
 	/// <summary>

--- a/src/Uno.Extensions.Navigation.UI/Region.cs
+++ b/src/Uno.Extensions.Navigation.UI/Region.cs
@@ -17,6 +17,20 @@ public static class Region
 		set => _logger = value;
 	}
 
+	/// <summary>
+	/// Clears the static logger back to the null logger, but only if it is still the
+	/// <paramref name="expected"/> instance. Called on navigation-host shutdown so the last host's
+	/// logger (and the service provider behind it) is not retained; the reference guard avoids a
+	/// stopping host clobbering a still-running one that installed its own logger.
+	/// </summary>
+	internal static void ResetLogger(ILogger expected)
+	{
+		if (ReferenceEquals(_logger, expected))
+		{
+			_logger = null;
+		}
+	}
+
 	public static readonly DependencyProperty InstanceProperty =
 	   DependencyProperty.RegisterAttached(
 		   "Instance",

--- a/src/Uno.Extensions.Reactive.Tests/Core/HotReload/Given_HotReloadService.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/HotReload/Given_HotReloadService.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Core.HotReload;
+
+namespace Uno.Extensions.Reactive.Tests.Core.HotReload;
+
+/// <summary>
+/// Guards that <see cref="HotReloadService"/> does not retain hot-reloaded model types (and their
+/// collectible <see cref="AssemblyLoadContext"/>s) forever.
+/// </summary>
+/// <remarks>
+/// The shadow map is only ever added to by the metadata-update pipeline, so without release it keeps
+/// every previewed app's model types — and their ALC — alive for the process lifetime in a downstream
+/// host that loads previewed apps into their own collectible ALCs.
+/// </remarks>
+[TestClass]
+public class Given_HotReloadService
+{
+	[TestCleanup]
+	public void Cleanup() => HotReloadService.Reset();
+
+	[TestMethod]
+	public void When_Reset_Then_ShadowMapIsCleared()
+	{
+		HotReloadService.TrackShadowForTest(typeof(OriginalStub), typeof(ShadowStub));
+		HotReloadService.TrackedShadowCount.Should().BeGreaterThan(0);
+
+		HotReloadService.Reset();
+
+		HotReloadService.TrackedShadowCount.Should().Be(0);
+	}
+
+	[TestMethod]
+	public void When_ClearCache_Then_OnlyMatchingEntriesRemoved()
+	{
+		HotReloadService.TrackShadowForTest(typeof(OriginalStub), typeof(ShadowStub));
+		HotReloadService.TrackShadowForTest(typeof(OtherOriginalStub), typeof(OtherShadowStub));
+		HotReloadService.TrackedShadowCount.Should().Be(2);
+
+		// Clearing by the shadow value must drop the whole entry.
+		HotReloadService.ClearCache(new[] { typeof(ShadowStub) });
+
+		HotReloadService.TrackedShadowCount.Should().Be(1);
+	}
+
+	[TestMethod]
+	public void When_TrackedTypeFromCollectibleAlc_Then_AlcIsCollectibleAfterUnload()
+	{
+		var alcReference = TrackTypeFromCollectibleAlc();
+
+		for (var i = 0; i < 10 && alcReference.IsAlive; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+		}
+
+		alcReference.IsAlive.Should().BeFalse(
+			"HotReloadService must not keep a previewed app's collectible ALC alive via the shadow map");
+	}
+
+	// Separate non-inlined frame so the ALC + type locals do not linger on the caller's stack.
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static WeakReference TrackTypeFromCollectibleAlc()
+	{
+		// Load an on-disk assembly into a fresh collectible ALC. This produces a distinct Type identity
+		// scoped to that ALC — the shape a downstream host sees for a previewed app's model type.
+		var probePath = typeof(HotReloadService).Assembly.Location;
+
+		var alc = new AssemblyLoadContext(nameof(Given_HotReloadService), isCollectible: true);
+		var assembly = alc.LoadFromAssemblyPath(probePath);
+		var appType = assembly.GetType(typeof(HotReloadService).FullName!, throwOnError: true)!;
+
+		// Sanity: the type must belong to the collectible ALC, not the default one.
+		AssemblyLoadContext.GetLoadContext(appType.Assembly).Should().BeSameAs(alc);
+
+		// Track a mapping keyed by a type from the collectible ALC.
+		HotReloadService.TrackShadowForTest(appType, appType);
+
+		var reference = new WeakReference(alc, trackResurrection: false);
+
+		// The host tears the app down: unload the ALC. The service's unload handler must drop the entry.
+		appType = null;
+		assembly = null;
+		alc.Unload();
+		return reference;
+	}
+
+	private sealed class OriginalStub { }
+	private sealed class ShadowStub { }
+	private sealed class OtherOriginalStub { }
+	private sealed class OtherShadowStub { }
+}

--- a/src/Uno.Extensions.Reactive.Tests/Core/Logging/Given_LogExtensions.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Logging/Given_LogExtensions.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Logging;
+
+namespace Uno.Extensions.Reactive.Tests.Core.Logging;
+
+/// <summary>
+/// Guards that the Reactive logging helpers do not permanently snapshot the first host's logging
+/// provider / ambient factory.
+/// </summary>
+/// <remarks>
+/// A snapshot pins that host's whole <c>ServiceProvider</c> for the process lifetime. In a downstream
+/// host that loads previewed apps into their own collectible <c>AssemblyLoadContext</c>s the first
+/// previewed app's ALC would then never collect. The <c>Log&lt;T&gt;</c> loggers must forward to the
+/// currently-configured provider, and <c>Reset</c> must drop it.
+/// </remarks>
+[TestClass]
+public class Given_LogExtensions
+{
+	[TestCleanup]
+	public void Cleanup() => LogExtensions.Reset();
+
+	[TestMethod]
+	public void When_ProviderChanges_Then_ForwardingLoggerUsesLatest()
+	{
+		// The cached Log<T>() logger is obtained once...
+		var logger = LogExtensions.Log<Given_LogExtensions>();
+
+		var first = new RecordingProvider();
+		LogExtensions.SetProvider(first);
+		logger.LogInformation("one");
+
+		// ...then the provider is swapped (as it would be for a second host).
+		var second = new RecordingProvider();
+		LogExtensions.SetProvider(second);
+		logger.LogInformation("two");
+
+		first.Messages.Should().ContainSingle().Which.Should().Be("one");
+		second.Messages.Should().ContainSingle().Which.Should().Be("two",
+			"the forwarding logger must resolve the current provider, not a snapshot of the first");
+	}
+
+	[TestMethod]
+	public void When_Reset_Then_ProviderIsReleased()
+	{
+		var provider = new RecordingProvider();
+		LogExtensions.SetProvider(provider);
+
+		LogExtensions.Reset();
+
+		// After reset the forwarder no longer routes to the released provider.
+		LogExtensions.Log<Given_LogExtensions>().LogInformation("after-reset");
+		provider.Messages.Should().BeEmpty("Reset must drop the previously-configured provider");
+	}
+
+	private sealed class RecordingProvider : ILoggerProvider
+	{
+		public List<string> Messages { get; } = new();
+
+		public ILogger CreateLogger(string categoryName) => new RecordingLogger(Messages);
+
+		public void Dispose() { }
+
+		private sealed class RecordingLogger : ILogger
+		{
+			private readonly List<string> _messages;
+
+			public RecordingLogger(List<string> messages) => _messages = messages;
+
+			public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+			public bool IsEnabled(LogLevel logLevel) => true;
+
+			public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+				=> _messages.Add(formatter(state, exception));
+		}
+	}
+}

--- a/src/Uno.Extensions.Reactive/Core/HotReload/HotReloadService.cs
+++ b/src/Uno.Extensions.Reactive/Core/HotReload/HotReloadService.cs
@@ -84,7 +84,7 @@ public static class HotReloadService
 		{
 			if (targets.Contains(entry.Key) || targets.Contains(entry.Value))
 			{
-				((IDictionary<Type, Type>)_latestShadow).Remove(entry.Key);
+				_latestShadow.TryRemove(entry.Key, out _);
 			}
 		}
 	}
@@ -111,7 +111,7 @@ public static class HotReloadService
 			if (AssemblyLoadContext.GetLoadContext(entry.Key.Assembly) == context ||
 				AssemblyLoadContext.GetLoadContext(entry.Value.Assembly) == context)
 			{
-				((IDictionary<Type, Type>)_latestShadow).Remove(entry.Key);
+				_latestShadow.TryRemove(entry.Key, out _);
 			}
 		}
 

--- a/src/Uno.Extensions.Reactive/Core/HotReload/HotReloadService.cs
+++ b/src/Uno.Extensions.Reactive/Core/HotReload/HotReloadService.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions.Reactive.Bindings;
 using Uno.Extensions.Reactive.Logging;
@@ -32,10 +34,89 @@ public static class HotReloadService
 	// pick up the original type's stale lambdas / cached delegates) can be redirected to the
 	// freshest generation. Populated from `UpdateApplication` for every type that carries
 	// `MetadataUpdateOriginalTypeAttribute`.
+	//
+	// Both key and value are strong `Type` references. The map is only ever added to, so on its own
+	// it would keep every hot-reloaded model type — and therefore that type's (collectible)
+	// AssemblyLoadContext — alive for the process lifetime. A downstream host that loads previewed
+	// apps into their own collectible ALCs would leak the entire type graph of every app it ever
+	// previewed. `ClearCache`/`Reset` and the per-ALC unload sweep below release those entries.
 	private static readonly ConcurrentDictionary<Type, Type> _latestShadow = new();
 
+	// Collectible ALCs we have already subscribed to, so a single unload handler is attached per ALC.
+	private static readonly ConcurrentDictionary<AssemblyLoadContext, byte> _watchedContexts = new();
+
+	/// <summary>
+	/// Removes every tracked shadow mapping. Intended to be called when the host that owns the
+	/// previewed app is torn down, so no app type is retained past its lifetime.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static void Reset()
+	{
+		_latestShadow.Clear();
+		_watchedContexts.Clear();
+		if (_trace) _log.Trace("Cleared all MVUX hot-patch shadow mappings.");
+	}
+
+	// Number of tracked shadow mappings. Exposed to tests so they can observe release without
+	// reaching into the private field.
+	internal static int TrackedShadowCount => _latestShadow.Count;
+
+	// Registers a shadow mapping exactly as `UpdateApplication` does (map entry + collectible-ALC
+	// unload watch), without requiring the runtime metadata-update attributes. Test seam only.
+	internal static void TrackShadowForTest(Type originalType, Type shadowType)
+	{
+		_latestShadow[originalType] = shadowType;
+		WatchForUnload(originalType);
+		WatchForUnload(shadowType);
+	}
+
+	// Invoked by the runtime's metadata-update pipeline. Drop the shadow mappings for the supplied
+	// types (both as original keys and as shadow values) so stale generations are not retained.
 	internal static void ClearCache(Type[]? types)
 	{
+		if (types is null or { Length: 0 })
+		{
+			return;
+		}
+
+		var targets = new HashSet<Type>(types);
+		foreach (var entry in _latestShadow)
+		{
+			if (targets.Contains(entry.Key) || targets.Contains(entry.Value))
+			{
+				((IDictionary<Type, Type>)_latestShadow).Remove(entry.Key);
+			}
+		}
+	}
+
+	// Ensure the shadow entries keyed/valued by types from a collectible ALC are dropped when that
+	// ALC unloads, so the map never pins a previewed app's ALC.
+	private static void WatchForUnload(Type type)
+	{
+		if (AssemblyLoadContext.GetLoadContext(type.Assembly) is not { IsCollectible: true } context)
+		{
+			return;
+		}
+
+		if (_watchedContexts.TryAdd(context, 0))
+		{
+			context.Unloading += OnContextUnloading;
+		}
+	}
+
+	private static void OnContextUnloading(AssemblyLoadContext context)
+	{
+		foreach (var entry in _latestShadow)
+		{
+			if (AssemblyLoadContext.GetLoadContext(entry.Key.Assembly) == context ||
+				AssemblyLoadContext.GetLoadContext(entry.Value.Assembly) == context)
+			{
+				((IDictionary<Type, Type>)_latestShadow).Remove(entry.Key);
+			}
+		}
+
+		_watchedContexts.TryRemove(context, out _);
+		context.Unloading -= OnContextUnloading;
 	}
 
 	[RequiresUnreferencedCode("`MetadataUpdateOriginalTypeAttribute` may be a per-assembly type, so it cannot be statically known.")]
@@ -67,6 +148,11 @@ public static class HotReloadService
 			// after this update can self-patch its (otherwise stale-lambda-bound) model to the
 			// freshest type. Cf. `TryHotPatch`.
 			_latestShadow[originalType] = type;
+
+			// If either type lives in a collectible ALC, make sure the mapping is dropped when that
+			// ALC unloads, so we never keep a previewed app's ALC alive.
+			WatchForUnload(originalType);
+			WatchForUnload(type);
 
 			if (_log.IsEnabled(LogLevel.Information)) _log.Info($"Hot-patching bindables of {originalType} to use the updated {type}.");
 

--- a/src/Uno.Extensions.Reactive/Utils/Logging/LogExtensions.cs
+++ b/src/Uno.Extensions.Reactive/Utils/Logging/LogExtensions.cs
@@ -11,8 +11,14 @@ namespace Uno.Extensions.Reactive.Logging;
 internal static class LogExtensions
 {
 	private static ILoggerProvider? _provider;
-	private static bool _boundToUnoLogger;
+
+	// The ambient Uno logger factory is resolved on demand and re-resolved after `Reset`, rather than
+	// bound once for the process lifetime. Caching the FIRST host's factory permanently pinned that
+	// host's whole `ServiceProvider` — and in a downstream host that loads previewed apps into their
+	// own collectible AssemblyLoadContexts, the first previewed app's ALC — forever. The `Log<T>`
+	// loggers below are forwarders that re-resolve on each call, so they never snapshot a stale factory.
 	private static ILoggerFactory? _unoLogger;
+	private static bool _boundToUnoLogger;
 
 	private static ILoggerFactory? FindUnoAmbientLogger()
 	{
@@ -37,6 +43,18 @@ internal static class LogExtensions
 
 	public static void SetProvider(ILoggerProvider provider)
 		=> _provider = provider;
+
+	/// <summary>
+	/// Drops the cached provider and ambient logger factory so the next <see cref="CreateLog(string)"/>
+	/// re-resolves. Intended to be called on host shutdown so the previous host's logger factory (and its
+	/// service provider) is not retained.
+	/// </summary>
+	public static void Reset()
+	{
+		_provider = null;
+		_unoLogger = null;
+		_boundToUnoLogger = false;
+	}
 
 	public static ILogger CreateLog(string categoryName)
 		=> _provider?.CreateLogger(categoryName)
@@ -78,6 +96,31 @@ internal static class LogExtensions
 
 	private static class Holder<T>
 	{
-		public static ILogger Logger { get; } = CreateLog(typeof(T).FullName!);
+		// A forwarding logger that re-resolves the concrete logger on each call instead of snapshotting
+		// one at first touch. A snapshot would capture (and pin) the ambient factory of whichever host
+		// happened to be active when this generic was first used.
+		public static ILogger Logger { get; } = new ForwardingLogger(typeof(T).FullName!);
+	}
+
+	/// <summary>
+	/// An <see cref="ILogger"/> that resolves the underlying logger via <see cref="CreateLog(string)"/> on
+	/// every call, so it always uses the current provider / ambient factory and never retains a stale one.
+	/// </summary>
+	private sealed class ForwardingLogger : ILogger
+	{
+		private readonly string _categoryName;
+
+		public ForwardingLogger(string categoryName)
+			=> _categoryName = categoryName;
+
+		public IDisposable? BeginScope<TState>(TState state)
+			where TState : notnull
+			=> CreateLog(_categoryName).BeginScope(state);
+
+		public bool IsEnabled(LogLevel logLevel)
+			=> CreateLog(_categoryName).IsEnabled(logLevel);
+
+		public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+			=> CreateLog(_categoryName).Log(logLevel, eventId, state, exception, formatter);
 	}
 }

--- a/src/Uno.Extensions.Serialization.Tests/Given_JsonSerializationOptions.cs
+++ b/src/Uno.Extensions.Serialization.Tests/Given_JsonSerializationOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -73,12 +74,26 @@ public class Given_JsonSerializationOptions
 	{
 		var context = new HostBuilderContext(new System.Collections.Generic.Dictionary<object, object>());
 		var services = new ServiceCollection();
+
+		// Register HostedType through source generation so the serializer sanity check below still works
+		// when System.Text.Json reflection is disabled (the AOT/trimming test config), matching the repo
+		// rule to always use generated serializers. Mirrors the split in ServiceCollectionExtensionsTests.
+#if WITH_AOT_TRIMMING
+		services.AddJsonSerialization(context, HostedTypeContext.Default);
+#else
 		services.AddSystemTextJsonSerialization(context);
+#endif
 		return services.BuildServiceProvider();
 	}
+}
 
-	public sealed class HostedType
-	{
-		public int Value { get; set; }
-	}
+public sealed class HostedType
+{
+	public int Value { get; set; }
+}
+
+[JsonSourceGenerationOptions]
+[JsonSerializable(typeof(HostedType))]
+internal sealed partial class HostedTypeContext : JsonSerializerContext
+{
 }

--- a/src/Uno.Extensions.Serialization.Tests/Given_JsonSerializationOptions.cs
+++ b/src/Uno.Extensions.Serialization.Tests/Given_JsonSerializationOptions.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.Extensions.Serialization.Tests;
+
+/// <summary>
+/// Guards that the process-wide <see cref="JsonSerializationOptions.DefaultSerializerOptions"/> template
+/// is never handed to a serializer directly.
+/// </summary>
+/// <remarks>
+/// <c>System.Text.Json</c> caches a <c>JsonTypeInfo</c> per (de)serialized type on the options instance.
+/// A downstream host that loads previewed apps into their own collectible <c>AssemblyLoadContext</c>s
+/// would otherwise accumulate every app type's metadata on the shared static, pinning those types (and
+/// their ALCs) for the process lifetime. Callers must receive a host-scoped copy instead.
+/// </remarks>
+[TestClass]
+public class Given_JsonSerializationOptions
+{
+	[TestMethod]
+	public void When_CreateSerializerOptions_Then_ReturnsFreshCopyNotTemplate()
+	{
+		var first = JsonSerializationOptions.CreateSerializerOptions();
+		var second = JsonSerializationOptions.CreateSerializerOptions();
+
+		first.Should().NotBeSameAs(JsonSerializationOptions.DefaultSerializerOptions,
+			"the shared template must never be handed out directly");
+		second.Should().NotBeSameAs(first, "each caller must get its own instance");
+
+		// The copy carries the template's configuration.
+		first.AllowTrailingCommas.Should().Be(JsonSerializationOptions.DefaultSerializerOptions.AllowTrailingCommas);
+		first.NumberHandling.Should().Be(JsonSerializationOptions.DefaultSerializerOptions.NumberHandling);
+	}
+
+	[TestMethod]
+	public void When_NoOptionsConfigured_Then_FallbackDoesNotReturnTemplate()
+	{
+		var services = new ServiceCollection().BuildServiceProvider();
+
+		var options = services.GetJsonSerializationOptions();
+
+		options.Should().NotBeSameAs(JsonSerializationOptions.DefaultSerializerOptions,
+			"the fallback must be a host-scoped copy so reflection-based JsonTypeInfo caching " +
+			"does not accumulate app types on the shared template");
+	}
+
+	[TestMethod]
+	public void When_TwoHostsRegisterSerialization_Then_EachGetsIndependentOptions()
+	{
+		// Two independent hosts (as a downstream host creates per previewed app).
+		var firstHost = BuildSerializerServices();
+		var secondHost = BuildSerializerServices();
+
+		var firstOptions = firstHost.GetRequiredService<JsonSerializerOptions>();
+		var secondOptions = secondHost.GetRequiredService<JsonSerializerOptions>();
+
+		// Each host has its own options, and neither is the shared template. This is what confines
+		// System.Text.Json's per-type JsonTypeInfo cache to a host, so serializing one app's types
+		// cannot pin them (or their ALC) via the process-wide template.
+		firstOptions.Should().NotBeSameAs(JsonSerializationOptions.DefaultSerializerOptions);
+		secondOptions.Should().NotBeSameAs(JsonSerializationOptions.DefaultSerializerOptions);
+		firstOptions.Should().NotBeSameAs(secondOptions, "each host must own its serializer options");
+
+		// Serializing through one host must still work off its own copy.
+		var serializer = firstHost.GetRequiredService<ISerializer>();
+		serializer.ToString(new HostedType { Value = 42 }, typeof(HostedType)).Should().Contain("42");
+	}
+
+	private static IServiceProvider BuildSerializerServices()
+	{
+		var context = new HostBuilderContext(new System.Collections.Generic.Dictionary<object, object>());
+		var services = new ServiceCollection();
+		services.AddSystemTextJsonSerialization(context);
+		return services.BuildServiceProvider();
+	}
+
+	public sealed class HostedType
+	{
+		public int Value { get; set; }
+	}
+}

--- a/src/Uno.Extensions.Serialization/AssemblyInfo.cs
+++ b/src/Uno.Extensions.Serialization/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Uno.Extensions.Serialization.Tests")]

--- a/src/Uno.Extensions.Serialization/AssemblyInfo.cs
+++ b/src/Uno.Extensions.Serialization/AssemblyInfo.cs
@@ -1,3 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Uno.Extensions.Serialization.Tests")]
+// The AOT test project compiles the same test .cs files (Compile Include from ...Serialization.Tests),
+// so it also needs access to the internal serializer-options template/factory.
+[assembly: InternalsVisibleTo("Uno.Extensions.Serialization.AotTests")]

--- a/src/Uno.Extensions.Serialization/JsonSerializationOptions.cs
+++ b/src/Uno.Extensions.Serialization/JsonSerializationOptions.cs
@@ -9,6 +9,13 @@ namespace Uno.Extensions.Serialization;
 /// </summary>
 public class JsonSerializationOptions
 {
+	// Template only — never handed to a serializer directly.
+	//
+	// `System.Text.Json` caches a `JsonTypeInfo` on the options instance for every type it (de)serializes
+	// via reflection. If this shared static were handed to a serializer, it would accumulate `JsonTypeInfo`
+	// for every app type across every host, pinning those types — and, for a downstream host that loads
+	// previewed apps into their own collectible AssemblyLoadContexts, the app's ALC — for the process
+	// lifetime. Callers must obtain a host-scoped copy via <see cref="CreateSerializerOptions"/>.
 	internal static readonly JsonSerializerOptions DefaultSerializerOptions = new JsonSerializerOptions()
 	{
 		AllowTrailingCommas     = true,
@@ -24,9 +31,21 @@ public class JsonSerializationOptions
 	};
 
 	/// <summary>
+	/// Creates a fresh, host-scoped copy of the default serializer options.
+	/// </summary>
+	/// <remarks>
+	/// Each caller receives its own instance so the reflection-based `JsonTypeInfo` cache that
+	/// <c>System.Text.Json</c> builds up while (de)serializing app types is confined to that host
+	/// and released with it, rather than accumulating on the shared <see cref="DefaultSerializerOptions"/>
+	/// template.
+	/// </remarks>
+	internal static JsonSerializerOptions CreateSerializerOptions()
+		=> new JsonSerializerOptions(DefaultSerializerOptions);
+
+	/// <summary>
 	/// Gets the <see cref="JsonSerializerOptions"/>.
 	/// </summary>
-	public JsonSerializerOptions SerializerOptions { get; } = new JsonSerializerOptions(DefaultSerializerOptions);
+	public JsonSerializerOptions SerializerOptions { get; } = CreateSerializerOptions();
 
 	[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Only used when JsonSerializer.IsReflectionEnabledByDefault=true.")]
 	[UnconditionalSuppressMessage("Trimming", "IL3050", Justification = "Only used when JsonSerializer.IsReflectionEnabledByDefault=true.")]

--- a/src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs
+++ b/src/Uno.Extensions.Serialization/ServiceCollectionExtensions.cs
@@ -43,7 +43,7 @@ public static class ServiceCollectionExtensions
 
 	internal static JsonSerializerOptions GetJsonSerializationOptions(this IServiceProvider services)
 		=> services.GetService<IOptions<JsonSerializationOptions>>()?.Value?.SerializerOptions ??
-			JsonSerializationOptions.DefaultSerializerOptions;
+			JsonSerializationOptions.CreateSerializerOptions();
 
 
 	/// <summary>
@@ -69,7 +69,7 @@ public static class ServiceCollectionExtensions
 		}
 
 		return services
-			.AddSingleton(sp => new JsonSerializerOptions(JsonSerializationOptions.DefaultSerializerOptions))
+			.AddSingleton(sp => JsonSerializationOptions.CreateSerializerOptions())
 			.AddSingleton<SystemTextJsonSerializer>()
 			.AddSingleton<ISerializer>(services => services.GetRequiredService<SystemTextJsonSerializer>())
 			.AddSingleton(typeof(ISerializer<>), typeof(SystemTextJsonGeneratedSerializer<>));

--- a/src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs
+++ b/src/Uno.Extensions.Serialization/SystemTextJsonSerializer.cs
@@ -31,9 +31,12 @@ public class SystemTextJsonSerializer : ISerializer
 		_services = services;
 
 		// Need to use `.GetService<…>()` in order for `.ConfigureJsonSerializationOptions()` callbacks to be invoked.
+		// Never fall back to the shared `DefaultSerializerOptions` template: reflection-based (de)serialization
+		// caches a `JsonTypeInfo` per type on the options instance, so using the static would accumulate app
+		// types on a process-wide object and pin their (collectible) AssemblyLoadContexts. Use a host-scoped copy.
 		_serializerOptions = services.GetJsonSerializationOptions() ??
 			serializerOptions ??
-			JsonSerializationOptions.DefaultSerializerOptions;
+			JsonSerializationOptions.CreateSerializerOptions();
 	}
 
 	private bool TryGetJsonTypeInfo(Type type, [NotNullWhen(true)] out JsonTypeInfo? info)

--- a/src/Uno.Extensions.Serialization/Uno.Extensions.Serialization.csproj
+++ b/src/Uno.Extensions.Serialization/Uno.Extensions.Serialization.csproj
@@ -23,8 +23,4 @@
 		<ProjectReference Include="..\Uno.Extensions.Hosting\Uno.Extensions.Hosting.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<InternalsVisibleTo Include="Uno.Extensions.Serialization.Tests" />
-	</ItemGroup>
-
 </Project>

--- a/src/Uno.Extensions.Serialization/Uno.Extensions.Serialization.csproj
+++ b/src/Uno.Extensions.Serialization/Uno.Extensions.Serialization.csproj
@@ -23,4 +23,8 @@
 		<ProjectReference Include="..\Uno.Extensions.Hosting\Uno.Extensions.Hosting.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="Uno.Extensions.Serialization.Tests" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Batch 2 of the process-wide static sweeps that keep a **downstream host that loads previewed apps
into their own collectible `AssemblyLoadContext`s** from ever collecting the previous app's object
graph. Each finding is a `static` field that captures the first/last host's `ILoggerFactory` /
`ServiceProvider` / `Assembly` / serializer state and never releases or re-scopes it; one also serves
the wrong app's configuration to a later load.

Standalone (single-app) usage is unaffected — a permanent static reference is harmless when the
process only ever hosts one app. The defects only manifest when a second app is loaded after the
first is torn down.

Spec: `specs/008-alc-pin-managed-sweeps/spec.md`. Closes #3126.

## Findings — all landed

| # | Static | Project | Fix |
| --- | --- | --- | --- |
| 4 | `EmbeddedAppConfigurationFile.AllFiles<T>()` first-caller-wins cache | Configuration | Rekey per-`Assembly` via `ConditionalWeakTable` (also a **functional bug**: second app got the first app's appsettings) |
| 3 | `PlatformHelper._appAssembly` strong ref | Core | `WeakReference<Assembly>`; re-derive fallback if collected |
| 7 | `JsonSerializationOptions.DefaultSerializerOptions` handed out as fallback | Serialization | Keep static as template; fallbacks return a host-scoped copy via `CreateSerializerOptions()` |
| 6 | `HotReloadService._latestShadow` never released | Reactive | Real `ClearCache`, public `Reset()`, per-ALC `Unloading` sweep |
| 1 | Reactive ambient-logger cache (`_unoLogger` / `Holder<T>`) | Reactive / Logging | Forwarding logger (no snapshot) + `Reset()`; `ConnectUnoLogging` resets ambient factory on `ApplicationStopping` |
| 2 | `Region.Logger` never cleared | Navigation.UI | `Region.ResetLogger(expected)` (reference-guarded) from `StopAsync` |
| 5 | `NavigationRouteUpdateHandler` context / `RootRegion` / `Resolver` retention | Navigation.UI | `WeakReference<IRegion>` root + null-out on `Unregister` |

Out of scope (follow-ups): `FeedDependencyRegistry` purge, `ApplicationUpdated` weak subscriptions,
`SourceContext` deterministic teardown, `RouteResolverDefault` ALC-scoped scan.

## Tests (red/fix/green)

New/extended tests per finding; each has a demonstrated red on the pre-fix code:

- `Given_EmbeddedAppConfigurationFile` (new `Uno.Extensions.Configuration.Tests`) — a second, unrelated
  assembly no longer inherits the first caller's appsettings. **Red:** the second assembly received
  `…Configuration.Tests.appsettings.json`.
- `Given_PlatformHelper` (`Core.Tests`) — a collectible ALC registered via `SetAppAssembly` is collected
  after unload. **Red:** the strong reference pinned the ALC.
- `Given_JsonSerializationOptions` (`Serialization.Tests`, via `InternalsVisibleTo`) — the fallback
  returns a copy, not the shared template; two hosts get independent options. **Red:** the fallback
  returned the template by reference.
- `Given_HotReloadService` (`Reactive.Tests`) — `Reset`/`ClearCache` release entries; a tracked type
  from a collectible ALC is collected after unload. **Red:** with the sweep disabled the ALC stayed alive.
- `Given_LogExtensions` (`Reactive.Tests`) — the cached `Log<T>()` logger tracks the current provider;
  `Reset` releases it. **Red:** the one-shot snapshot kept hitting the first provider.
- `Given_Region` + extended `Given_NavigationRouteUpdateHandler` (`Navigation.WinUI.Tests`) — logger
  reset is reference-guarded; `Unregister` clears the tree; `RootRegion` is weak.

### What was run locally

- MSTest `net9.0` suites (findings 4, 3, 7, 6, and the Reactive half of 1): **green**, red demonstrated
  per finding.
  - Configuration.Tests 3/3, Core.Tests 61/61, Serialization.Tests 20/20, Reactive.Tests 1419 passed /
    19 pre-existing skips / 0 failed.
- Findings 2, 5, and the `HAS_UNO` half of 1 live in Uno-SDK (`HAS_UNO`) projects whose tests run under
  the Uno runtime-test harness. Source + test files compile clean on `net9.0-desktop`
  (`Uno.Extensions.Navigation.WinUI`, `Uno.Extensions.Navigation.WinUI.Tests`,
  `Uno.Extensions.Logging.WinUI` — all 0 errors); no headless UI runtime is available in this
  environment, so those tests are validated by CI.

Draft: kept as draft so CI validates the `HAS_UNO` runtime tests before review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
