### PR TITLE
chore: bump private sdk and 6.7 dependencies

### DIFF
--- a/build/ci/stage-build-runtimetests-skia-hotreload.yml
+++ b/build/ci/stage-build-runtimetests-skia-hotreload.yml
@@ -24,6 +24,21 @@ jobs:
 
     displayName: 'Run uno-check'
 
+  - script: |
+        cat > DebugPlatforms.props <<'EOF'
+        <Project>
+          <PropertyGroup>
+            <Build_Android>false</Build_Android>
+            <Build_iOS>false</Build_iOS>
+            <Build_MacCatalyst>false</Build_MacCatalyst>
+            <Build_Windows>false</Build_Windows>
+            <Build_Web>false</Build_Web>
+          </PropertyGroup>
+        </Project>
+        EOF
+    displayName: 'Restrict target platforms (DebugPlatforms.props)'
+    workingDirectory: $(Build.SourcesDirectory)
+
   - script: dotnet build Uno.Extensions-runtimetests.slnf /p:Build_Android=false /p:Build_iOS=false /p:Build_Windows=false /p:Build_MacCatalyst=false /p:Build_Web=false -c Debug -p:GeneratePackageOnBuild=false -bl:$(Build.ArtifactStagingDirectory)/skia-hotreload-test-build.binlog
     displayName: 'Build Runtime Tests app (Debug)'
     workingDirectory: $(Build.SourcesDirectory)

--- a/build/ci/stage-build-uitests-wasm.yml
+++ b/build/ci/stage-build-uitests-wasm.yml
@@ -19,7 +19,13 @@ jobs:
   - template: templates/dotnet-install.yml
 
   - template: templates/canary-updater.yml
-  
+
+  # SkiaSharp 3.x (pulled in by Uno 6.7+) ships native WebAssembly assets, which makes
+  # the bootstrapper relink the runtime — that requires the wasm-tools workload (UNOWA0001).
+  - script: dotnet workload install wasm-tools
+    displayName: 'Install wasm-tools workload'
+    retryCountOnTaskFailure: 3
+
   - task: NodeTool@0
     inputs:
       versionSpec: '18.x'

--- a/build/ci/stage-build-uitests-wasm.yml
+++ b/build/ci/stage-build-uitests-wasm.yml
@@ -20,8 +20,6 @@ jobs:
 
   - template: templates/canary-updater.yml
 
-  # SkiaSharp 3.x (pulled in by Uno 6.7+) ships native WebAssembly assets, which makes
-  # the bootstrapper relink the runtime — that requires the wasm-tools workload (UNOWA0001).
   - script: dotnet workload install wasm-tools
     displayName: 'Install wasm-tools workload'
     retryCountOnTaskFailure: 3

--- a/build/ci/stage-build-wasm.yml
+++ b/build/ci/stage-build-wasm.yml
@@ -16,6 +16,12 @@ jobs:
   - template: templates/canary-updater.yml
   - template: templates/gitversion.yml
 
+  # SkiaSharp 3.x (pulled in by Uno 6.7+) ships native WebAssembly assets, which makes
+  # the bootstrapper relink the runtime — that requires the wasm-tools workload (UNOWA0001).
+  - script: dotnet workload install wasm-tools
+    displayName: 'Install wasm-tools workload'
+    retryCountOnTaskFailure: 3
+
   - script: |
       dotnet build "testing/TestHarness/TestHarness.sln" /p:Build_Web=true /p:Build_Android=false /p:Build_MacCatalyst=false /p:Build_iOS=false /p:Build_Windows=false /p:Build_Desktop=false /p:Configuration=Release "/p:InformationalVersion=$(NBGV_InformationalVersion)" /p:GeneratePackageOnBuild=false /detailedsummary "/bl:$(build.artifactstagingdirectory)/testharness-wasm.binlog"
 

--- a/build/ci/stage-build-wasm.yml
+++ b/build/ci/stage-build-wasm.yml
@@ -16,8 +16,6 @@ jobs:
   - template: templates/canary-updater.yml
   - template: templates/gitversion.yml
 
-  # SkiaSharp 3.x (pulled in by Uno 6.7+) ships native WebAssembly assets, which makes
-  # the bootstrapper relink the runtime — that requires the wasm-tools workload (UNOWA0001).
   - script: dotnet workload install wasm-tools
     displayName: 'Install wasm-tools workload'
     retryCountOnTaskFailure: 3

--- a/build/ci/stage-build-windows.yml
+++ b/build/ci/stage-build-windows.yml
@@ -22,6 +22,10 @@ jobs:
   - template: templates/canary-updater.yml
   - template: templates/gitversion.yml
 
+  - script: dotnet workload install wasm-tools-net9
+    displayName: 'Install wasm-tools workload'
+    retryCountOnTaskFailure: 3
+
   - powershell: |
       dotnet tool update -g dotnet-vs
       $MSBUILDPATH="$(vs where release --prop=InstallationPath)\MSBuild\Current\Bin"

--- a/build/ci/stage-build-windows.yml
+++ b/build/ci/stage-build-windows.yml
@@ -22,7 +22,7 @@ jobs:
   - template: templates/canary-updater.yml
   - template: templates/gitversion.yml
 
-  - script: dotnet workload install wasm-tools-net9
+  - script: dotnet workload install wasm-tools
     displayName: 'Install wasm-tools workload'
     retryCountOnTaskFailure: 3
 

--- a/build/ci/templates/dotnet-install-windows.yml
+++ b/build/ci/templates/dotnet-install-windows.yml
@@ -1,11 +1,6 @@
 parameters:
-  # Kept installed so test assemblies targeting the previous TFM keep a matching runtime for VSTest.
-  PreviousDotNetVersion: '9.0.200'
-  # Keep aligned with unoplatform/uno master (.vsts-ci.yml: DotNetSdkVersion /
-  # GlobalUnoCheckVersion) so the installed workloads match what the Uno dev packages
-  # resolved through the Uno.Sdk are built against.
   DotNetVersion: '10.0.105'
-  UnoCheck_Version: '1.34.0-dev.23'
+  UnoCheck_Version: '1.34.1'
   # UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/3b250f49b719d1cf5ab205f997c3959b5e9fed1d/manifests/uno.ui.manifest.json'
 
 steps:
@@ -21,14 +16,6 @@ steps:
   #  errorActionPreference: stop
   #  retryCountOnTaskFailure: 3
   - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK ${{ parameters.PreviousDotNetVersion }}'
-    retryCountOnTaskFailure: 3
-    inputs:
-      packageType: sdk
-      version: ${{ parameters.PreviousDotNetVersion }}
-      includePreviewVersions: false
-
-  - task: UseDotNet@2
     displayName: 'Use .NET Core SDK ${{ parameters.DotNetVersion }}'
     retryCountOnTaskFailure: 3
     inputs:
@@ -36,11 +23,18 @@ steps:
       version: ${{ parameters.DotNetVersion }}
       includePreviewVersions: false
 
+  - task: UseDotNet@2
+    displayName: 'Use .NET 9 Runtime (for net9.0 test targets)'
+    retryCountOnTaskFailure: 3
+    inputs:
+      packageType: runtime
+      version: 9.x
+
   - template: jdk-setup.yml
 
   - powershell: |
       & dotnet tool update --global uno.check --version ${{ parameters.UnoCheck_Version }} --add-source https://api.nuget.org/v3/index.json
-      & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vsmac --skip androidsdk --skip androidemulator --pre-major
+      & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vswinworkloads --skip unosdk --skip dotnetnewunotemplates --skip vsmac --skip androidsdk --skip androidemulator
     displayName: Install .NET Workloads
     errorActionPreference: continue
     ignoreLASTEXITCODE: true

--- a/build/ci/templates/dotnet-install-windows.yml
+++ b/build/ci/templates/dotnet-install-windows.yml
@@ -1,6 +1,6 @@
 parameters:
-  DotNetVersion: '10.0.105'
-  UnoCheck_Version: '1.34.1'
+  DotNetVersion: '9.0.200'
+  UnoCheck_Version: '1.30.1'
   # UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/3b250f49b719d1cf5ab205f997c3959b5e9fed1d/manifests/uno.ui.manifest.json'
 
 steps:
@@ -23,18 +23,11 @@ steps:
       version: ${{ parameters.DotNetVersion }}
       includePreviewVersions: false
 
-  - task: UseDotNet@2
-    displayName: 'Use .NET 9 Runtime (for net9.0 test targets)'
-    retryCountOnTaskFailure: 3
-    inputs:
-      packageType: runtime
-      version: 9.x
-
   - template: jdk-setup.yml
 
   - powershell: |
       & dotnet tool update --global uno.check --version ${{ parameters.UnoCheck_Version }} --add-source https://api.nuget.org/v3/index.json
-      & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vswinworkloads --skip unosdk --skip dotnetnewunotemplates --skip vsmac --skip androidsdk --skip androidemulator
+      & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vsmac --skip androidsdk --skip androidemulator
     displayName: Install .NET Workloads
     errorActionPreference: continue
     ignoreLASTEXITCODE: true

--- a/build/ci/templates/dotnet-install-windows.yml
+++ b/build/ci/templates/dotnet-install-windows.yml
@@ -1,6 +1,11 @@
 parameters:
-  DotNetVersion: '9.0.200'
-  UnoCheck_Version: '1.30.1'
+  # Kept installed so test assemblies targeting the previous TFM keep a matching runtime for VSTest.
+  PreviousDotNetVersion: '9.0.200'
+  # Keep aligned with unoplatform/uno master (.vsts-ci.yml: DotNetSdkVersion /
+  # GlobalUnoCheckVersion) so the installed workloads match what the Uno dev packages
+  # resolved through the Uno.Sdk are built against.
+  DotNetVersion: '10.0.105'
+  UnoCheck_Version: '1.34.0-dev.23'
   # UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/3b250f49b719d1cf5ab205f997c3959b5e9fed1d/manifests/uno.ui.manifest.json'
 
 steps:
@@ -16,6 +21,14 @@ steps:
   #  errorActionPreference: stop
   #  retryCountOnTaskFailure: 3
   - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK ${{ parameters.PreviousDotNetVersion }}'
+    retryCountOnTaskFailure: 3
+    inputs:
+      packageType: sdk
+      version: ${{ parameters.PreviousDotNetVersion }}
+      includePreviewVersions: false
+
+  - task: UseDotNet@2
     displayName: 'Use .NET Core SDK ${{ parameters.DotNetVersion }}'
     retryCountOnTaskFailure: 3
     inputs:
@@ -27,7 +40,7 @@ steps:
 
   - powershell: |
       & dotnet tool update --global uno.check --version ${{ parameters.UnoCheck_Version }} --add-source https://api.nuget.org/v3/index.json
-      & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vsmac --skip androidsdk --skip androidemulator
+      & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vsmac --skip androidsdk --skip androidemulator --pre-major
     displayName: Install .NET Workloads
     errorActionPreference: continue
     ignoreLASTEXITCODE: true

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.44",
     "Uno.Sdk": "6.0.67",
-    "Uno.Sdk.Private": "6.6.0-dev.982"
+    "Uno.Sdk.Private": "6.7.0-dev.870"
   }
 }

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -1,13 +1,13 @@
 <Project ToolsVersion="15.0">
 	<PropertyGroup>
-		<SkiaSharpVersion>3.119.1</SkiaSharpVersion>
+		<SkiaSharpVersion>3.119.2</SkiaSharpVersion>
 		<SvgSkiaVersion>3.0.2</SvgSkiaVersion>
 		<WinAppSdkVersion>1.7.250909003</WinAppSdkVersion>
-		<WinAppSdkBuildToolsVersion>10.0.26100.7463</WinAppSdkBuildToolsVersion>
-		<MicrosoftLoggingVersion>9.0.14</MicrosoftLoggingVersion>
+		<WinAppSdkBuildToolsVersion>10.0.28000.1721</WinAppSdkBuildToolsVersion>
+		<MicrosoftLoggingVersion>9.0.18</MicrosoftLoggingVersion>
 		<WindowsCompatibilityVersion>8.0.15</WindowsCompatibilityVersion>
 		<MicrosoftIdentityClientVersion>4.72.1</MicrosoftIdentityClientVersion>
-		<CommunityToolkitMvvmVersion>8.4.0</CommunityToolkitMvvmVersion>
+		<CommunityToolkitMvvmVersion>8.4.2</CommunityToolkitMvvmVersion>
 		<PrismVersion>9.0.537</PrismVersion>
 		<AndroidMaterialVersion>1.12.0.3</AndroidMaterialVersion>
 		<AndroidXLegacySupportV4Version>1.0.0.33</AndroidXLegacySupportV4Version>

--- a/samples/Playground/Directory.Build.props
+++ b/samples/Playground/Directory.Build.props
@@ -13,5 +13,7 @@
       PRI257: Ignore default language (en) not being one of the included resources (eg en-us, en-uk)
     -->
 		<NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
+
+		<UnoToolkitVersion>8.4.2</UnoToolkitVersion>
 	</PropertyGroup>
 </Project>

--- a/samples/Playground/Directory.Build.props
+++ b/samples/Playground/Directory.Build.props
@@ -15,5 +15,6 @@
 		<NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
 
 		<UnoToolkitVersion>8.4.2</UnoToolkitVersion>
+		<UnoThemesVersion>6.1.1</UnoThemesVersion>
 	</PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.1.1" />
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />
     <PackageVersion Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.18" />
     <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.22.2" />
     <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.22.2" />
     <PackageVersion Include="Microsoft.Kiota.Serialization.Form" Version="1.22.2" />
@@ -18,13 +18,13 @@
     <PackageVersion Include="MSTest.TestFramework" Version="2.2.9" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.18" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.18" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.18" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.18" />
+    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.18" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.18" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.18" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.72.1" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.72.1" />
     <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.72.1" />

--- a/testing/TestHarness/Directory.Build.props
+++ b/testing/TestHarness/Directory.Build.props
@@ -30,6 +30,7 @@
 
   <PropertyGroup>
     <UnoToolkitVersion>8.4.2</UnoToolkitVersion>
+    <UnoThemesVersion>6.1.1</UnoThemesVersion>
   </PropertyGroup>
 	<PropertyGroup>
 		<DebugType>portable</DebugType>

--- a/testing/TestHarness/Directory.Build.props
+++ b/testing/TestHarness/Directory.Build.props
@@ -25,9 +25,12 @@
 
   <!-- See https://aka.platform.uno/using-uno-sdk#implicit-packages for more information regarding the Implicit Packages version properties. -->
   <!-- <PropertyGroup>
-    <UnoToolkitVersion>6.0.24</UnoToolkitVersion>
     <UnoThemesVersion>5.0.13</UnoThemesVersion>
   </PropertyGroup> -->
+
+  <PropertyGroup>
+    <UnoToolkitVersion>8.4.2</UnoToolkitVersion>
+  </PropertyGroup>
 	<PropertyGroup>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
GitHub Issue (If applicable): for #3131 (related to #3130)

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

The repo pins `Uno.Sdk.Private` at `6.6.0-dev.982`, which predates the Uno-side stranded
`Frame.Content` hot-reload fix (unoplatform/uno#23804). The Navigation HR regression test
introduced in #3131 (`When_PageXamlUpdatedWhileUnmaterialized_Then_RevealShowsUpdatedContent`)
is red until that fix ships in the pinned Uno version.

Additionally, the centrally-managed package pins predate what the Uno 6.7 toolchain requires,
so bumping Uno alone breaks restore/build across the repo (NU1109/NU1605 downgrades, and
`UNOWA0001` on WASM heads).

## What is the new behavior?

`Uno.Sdk.Private` is bumped to `6.7.0-dev.870` — the CI build of the unoplatform/uno#23804
merge commit — together with the pin alignments its dependency chain requires:

| Pin | Was | Now | Forced by |
| --- | --- | --- | --- |
| `Microsoft.Extensions.*` (`src` + `samples` CPM) | 9.0.14 | 9.0.18 | `Microsoft.Extensions.Hosting` 9.0.18 chain in Uno 6.7 |
| `SkiaSharpVersion` (`samples` CPM) | 3.119.1 | 3.119.2 | `Uno.UI.HotDesign 1.19.175` → `SkiaSharp.Views.Uno.WinUI >= 3.119.2` |
| `CommunityToolkitMvvmVersion` (`samples` CPM) | 8.4.0 | 8.4.2 | `Uno.UI.HotDesign 1.19.175` |
| `WinAppSdkBuildToolsVersion` (`samples` CPM) | 10.0.26100.7463 | 10.0.28000.1721 | `Uno.UI.HotDesign 1.19.175` |

CI: the `Samples - WebAssembly` and `UI Tests - WebAssembly` stages now install the
`wasm-tools` workload before building. SkiaSharp 3.x ships native WebAssembly assets, which
makes `Uno.Wasm.Bootstrap` (9.0.23, pulled in by Uno 6.7) relink the runtime — a step that
hard-fails with `UNOWA0001` when the workload is missing. Older bootstraps tolerated the
missing workload silently, which is why these stages never needed it before.

Validation performed locally:
- Release build of the package surface and Debug build of `Uno.Extensions-runtimetests.slnf`
  against 6.7.0-dev.870: zero errors.
- `TestHarness.sln` WASM build (the exact `Samples - WebAssembly` CI command) and
  `Playground.sln` / `TestHarness.sln` Windows-TFM restores: zero errors.
- Navigation runtime tests (`Given_FrameContentRehook`, non-HR navigation suites) and unit
  tests: green under the new versions.

## Other information

Sequencing with #3131: this PR should land first. #3131 then rebases on `main` to pick up
the new Uno version, which flips its stranded-content HR regression test red → green in the
CI hot-reload stage and resolves the open review thread about the missing version bump.

Note: the `Samples - Windows` jobs also compile the `net9.0-browserwasm` TFM (`Build_Web`
defaults to `true`). If they hit `UNOWA0001` on the `windows-2022` image, the same
`dotnet workload install wasm-tools` step can be added to `stage-build-windows.yml`.

Internal Issue (If applicable):
