### PR TITLE
Version bump after 7.3 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "7.3-dev.{height}",
+  "version": "7.3",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "7.3-dev.{height}",
+  "version": "7.4-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
GitHub Issue (If applicable): related to #3130

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

In a multi-tab app whose pages are filled by an external Hot Reload (agent/IDE) while the app's view has not had a layout pass, the default tab keeps showing its scaffolded placeholder (#3130). The investigation showed the live default page is **never replaced**: it was created while its host panel could not lay out, so it exists only as `Frame.Content` — never as a materialized visual child — and Uno's HR visual-tree walk cannot see it. Navigation then declines to refresh it by design (the keep-active-instance cascade skip, and `no segments to navigate` on re-selection), so the stale placeholder is what appears once the view finally lays out.

Additionally, even when the page instance is replaced outside navigation, `FrameNavigator` keeps tracking the dead instance (no `Frame.Navigated` is raised), and the new instance carries a copied, stale `DataContext` — so bound content renders empty.

## What is the new behavior?

Together with the Uno-side fix (Uno's `FrameElementMetadataUpdateHandler` now re-creates unmaterialized frame content — PR link TBD), navigation now fully recovers:

- New `NavigationFrameContentUpdateHandler` (element-update pipeline, `AfterVisualTreeUpdate`): after each HR visual-tree phase, every `FrameNavigator` in the live region trees re-hooks onto its frame's actual content. Empty-type-list cycles are ignored.
- `FrameNavigator.RehookCurrentViewAfterHotReload`: updates `CurrentView`, re-applies the region name, re-parents nested regions, and rebuilds the view model through the standard pipeline (`InitializeCurrentView` with `refresh: true` — required because an in-place EnC update keeps the type identity, which the default "wrong VM type" check treats as still valid). Bindings then target a view model built from the updated types instead of the stale copied `DataContext`.
- Deterministic regression test: `Given_HotReload.When_PageXamlUpdatedWhileUnmaterialized_Then_RevealShowsUpdatedContent` reproduces the stranded-page state on Skia desktop by collapsing the host panel before populating it. Red on current Uno packages; green once the Uno-side fix ships in the pinned Uno version. `HotReload.Spec.md` documents the scenario and harness constraints.
- No regressions: full navigation HR suite (6) and TabBar HR suite (23) pass with both fixes applied.

## Other information

The new runtime test is expected to fail until the Uno-side fix (unoplatform/uno/pull/23804) is available in the Uno version this repo pins — sequence the two PRs accordingly (land the Uno fix first, or merge this one together with the version bump that includes it). The temporary `[NAV-HR-DIAG]` diagnostic logging added earlier on this branch is kept for now to help validate the fix in real runs; it can be removed or downgraded to Debug in a follow-up.

This is an automated version bump of the  **main** branch after the creation of the release branch release/stable/7.3, based on #3131