### PR TITLE
fix: surface view-model creation failures instead of silently faulting navigation

### DIFF
--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_Navigation_VmCreationFailure.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_Navigation_VmCreationFailure.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Hosting;
+using Uno.Extensions.Navigation.UI.Controls;
+using Uno.Extensions.Navigation.UI.Tests.Pages;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Extensions.Navigation.UI.Tests;
+
+/// <summary>
+/// Tests for how navigation surfaces a view model whose constructor (or DI
+/// dependency chain) throws (#3136). The failure must:
+/// - fault the navigation task with the original exception (not hang),
+/// - be logged at Error level (previously nothing was logged at any level),
+/// - leave the navigator usable for subsequent navigations
+///   (RouteUpdater.EndNavigation must run even when navigation faults).
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+public class Given_Navigation_VmCreationFailure
+{
+	private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(15);
+
+	public sealed class ThrowingCtorViewModel
+	{
+		public const string FailureMessage = "ThrowingCtorViewModel: constructor failure";
+
+		public ThrowingCtorViewModel()
+		{
+			throw new InvalidOperationException(FailureMessage);
+		}
+	}
+
+	private sealed class CapturingLoggerProvider : ILoggerProvider
+	{
+		public ConcurrentQueue<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = new();
+
+		public ILogger CreateLogger(string categoryName) => new CapturingLogger(this);
+
+		public void Dispose()
+		{
+		}
+
+		private sealed class CapturingLogger : ILogger
+		{
+			private readonly CapturingLoggerProvider _owner;
+
+			public CapturingLogger(CapturingLoggerProvider owner)
+			{
+				_owner = owner;
+			}
+
+			public IDisposable? BeginScope<TState>(TState state) where TState : notnull => default;
+
+			public bool IsEnabled(LogLevel logLevel) => true;
+
+			public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+				=> _owner.Entries.Enqueue((logLevel, formatter(state, exception), exception));
+		}
+	}
+
+	private sealed class TestApp : IAsyncDisposable
+	{
+		private readonly IHost _host;
+
+		public TestApp(ContentControl navigationRoot, INavigator frameNavigator, IHost host, CapturingLoggerProvider logs)
+		{
+			NavigationRoot = navigationRoot;
+			FrameNavigator = frameNavigator;
+			Logs = logs;
+			_host = host;
+		}
+
+		public ContentControl NavigationRoot { get; }
+
+		public INavigator FrameNavigator { get; }
+
+		public CapturingLoggerProvider Logs { get; }
+
+		public async ValueTask DisposeAsync()
+		{
+			try
+			{
+				await _host.StopAsync();
+			}
+			finally
+			{
+				UnitTestsUIContentHelper.RestoreOriginalContent();
+			}
+		}
+	}
+
+	/// <summary>
+	/// Boots an Uno host with navigation, hosted in the runtime-tests engine's
+	/// already-displayed test window (a fresh <c>new Window()</c> never fires
+	/// Loaded/Activate in this harness — see Given_HotReload.SetupAppAsync), and
+	/// navigates to TestPageOne. Navigation targets the FrameView's inner
+	/// navigator because a Page navigated into a ContentControl root is wrapped
+	/// in a FrameView (see ContentControlNavigator.Show).
+	/// </summary>
+	private static async Task<TestApp> SetupAppAsync(CancellationToken ct)
+	{
+		var window = UnitTestsUIContentHelper.CurrentTestWindow!;
+		var navigationRoot = new ContentControl
+		{
+			HorizontalAlignment = HorizontalAlignment.Stretch,
+			VerticalAlignment = VerticalAlignment.Stretch,
+			HorizontalContentAlignment = HorizontalAlignment.Stretch,
+			VerticalContentAlignment = VerticalAlignment.Stretch,
+		};
+
+		UnitTestsUIContentHelper.SaveOriginalContent();
+		window.Content = navigationRoot;
+
+		var logs = new CapturingLoggerProvider();
+		IHost? host = null;
+		try
+		{
+			host = await window.InitializeNavigationAsync(
+				buildHost: async () => UnoHost
+					.CreateDefaultBuilder(typeof(Given_Navigation_VmCreationFailure).Assembly)
+					.ConfigureServices(services => services.AddLogging(logging => logging.AddProvider(logs)))
+					.UseNavigation(
+						viewRouteBuilder: (views, routes) =>
+						{
+							views.Register(
+								new ViewMap<TestPageOne>(),
+								new ViewMap<TestPageTwo, ThrowingCtorViewModel>(),
+								new ViewMap<TestPageThree>());
+
+							routes.Register(
+								new RouteMap("", Nested: new RouteMap[]
+								{
+									new RouteMap("TestPageOne", View: views.FindByView<TestPageOne>()),
+									new RouteMap("TestPageTwo", View: views.FindByView<TestPageTwo>()),
+									new RouteMap("TestPageThree", View: views.FindByView<TestPageThree>()),
+								}));
+						})
+					.Build(),
+				navigationRoot: navigationRoot,
+				initialRoute: "TestPageOne");
+
+			var frameNav = await WaitForFrameNavigatorAsync(navigationRoot, Timeout, ct);
+			await WaitForRouteAsync(frameNav, "TestPageOne", Timeout, ct);
+
+			return new TestApp(navigationRoot, frameNav, host, logs);
+		}
+		catch
+		{
+			if (host is not null)
+			{
+				await host.StopAsync();
+			}
+			UnitTestsUIContentHelper.RestoreOriginalContent();
+			throw;
+		}
+	}
+
+	[TestMethod]
+	public async Task When_VmCtorThrows_Then_NavigationFaults_And_ErrorIsLogged()
+	{
+		using var cts = new CancellationTokenSource(Timeout);
+		await using var app = await SetupAppAsync(cts.Token);
+
+		var navigation = app.FrameNavigator.NavigateRouteAsync(this, "TestPageTwo");
+
+		// The navigation must complete (faulted), not hang — the hang is the
+		// original #3136 symptom.
+		var completed = await Task.WhenAny(navigation, Task.Delay(Timeout));
+		completed.Should().Be(navigation, "a failing view-model constructor must fault the navigation, not hang it");
+
+		var exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => navigation);
+		exception.Message.Should().Be(ThrowingCtorViewModel.FailureMessage, "the original constructor exception must propagate unwrapped");
+
+		var errors = app.Logs.Entries.Where(e => e.Level == LogLevel.Error).ToArray();
+		errors.Should().Contain(
+			e => e.Exception is InvalidOperationException && e.Message.Contains(nameof(ThrowingCtorViewModel)),
+			"the view-model construction failure must be logged at Error with the view-model type");
+	}
+
+	[TestMethod]
+	public async Task When_VmCtorThrows_Then_SubsequentNavigationStillWorks()
+	{
+		using var cts = new CancellationTokenSource(Timeout);
+		await using var app = await SetupAppAsync(cts.Token);
+
+		var navigation = app.FrameNavigator.NavigateRouteAsync(this, "TestPageTwo");
+		await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => navigation);
+
+		// The faulted navigation must not wedge the pipeline: EndNavigation ran,
+		// so a follow-up navigation on the same navigator succeeds.
+		await app.FrameNavigator.NavigateRouteAsync(this, "TestPageThree");
+
+		using var routeCts = new CancellationTokenSource(Timeout);
+		await WaitForRouteAsync(app.FrameNavigator, "TestPageThree", Timeout, routeCts.Token);
+
+		app.FrameNavigator.Route?.Base.Should().Be("TestPageThree");
+	}
+
+	private static async Task<INavigator> WaitForFrameNavigatorAsync(ContentControl root, TimeSpan timeout, CancellationToken ct)
+	{
+		var sw = System.Diagnostics.Stopwatch.StartNew();
+		while (sw.Elapsed < timeout)
+		{
+			ct.ThrowIfCancellationRequested();
+			if (root.Content is FrameView fv && fv.Navigator is { } nav)
+			{
+				return nav;
+			}
+			await Task.Delay(50, ct);
+		}
+
+		throw new TimeoutException(
+			$"FrameView navigator did not become available within {timeout.TotalSeconds:F0}s. " +
+			$"root.Content={root.Content?.GetType().FullName ?? "<null>"}.");
+	}
+
+	private static async Task WaitForRouteAsync(INavigator nav, string expectedBase, TimeSpan timeout, CancellationToken ct)
+	{
+		var sw = System.Diagnostics.Stopwatch.StartNew();
+		while (sw.Elapsed < timeout)
+		{
+			ct.ThrowIfCancellationRequested();
+			if (nav.Route?.Base == expectedBase)
+			{
+				return;
+			}
+			await Task.Delay(50, ct);
+		}
+
+		throw new TimeoutException(
+			$"Navigation did not reach Base='{expectedBase}' within {timeout.TotalSeconds:F0}s. " +
+			$"Last state: Route='{nav.Route?.Base ?? "<null>"}'.");
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -53,49 +53,70 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 	public async Task<NavigationResponse?> NavigateAsync(NavigationRequest request)
 	{
 		RouteUpdater.StartNavigation(this, Region, request);
-		NavigationResponse? response;
+		NavigationResponse? response = default;
+		var isNavigationEntryPoint = request.Source is null;
 
-		if (request.Source is null)
+		try
 		{
-			if (Logger.IsEnabled(LogLevel.Information)) Logger.LogInformationMessage($"Starting Navigation - Navigator: {this.GetType().Name} Request: {request.Route}");
-			request = request with { Source = this };
-		}
-
-		if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($" Navigator: {this.GetType().Name} Request: {request.Route}");
-
-		// Do any initialisation logic that may be
-		// defined for the route - allows for
-		// routes to be redirected
-		request = InitializeRequest(request);
-
-		// Redirect navigation if required
-		// eg route that matches a child, should be routed to that child
-		// eg route that doesn't match a page for frame nav should be sent to parent
-		var redirection = await RedirectNavigateAsync(request);
-		if (redirection is not null)
-		{
-			response = await redirection;
-		}
-		else
-		{
-
-			// Append Internal qualifier to avoid requests being sent back to parent
-			request = request.AsInternal();
-
-			if (request.Route.IsDialog())
+			if (request.Source is null)
 			{
-				// Dialogs will load a separate navigation hierarchy
-				// so there's no need to route the request to child regions
-				response = await DialogNavigateAsync(request);
+				if (Logger.IsEnabled(LogLevel.Information)) Logger.LogInformationMessage($"Starting Navigation - Navigator: {this.GetType().Name} Request: {request.Route}");
+				request = request with { Source = this };
+			}
+
+			if (Logger.IsEnabled(LogLevel.Debug)) Logger.LogDebugMessage($" Navigator: {this.GetType().Name} Request: {request.Route}");
+
+			// Do any initialisation logic that may be
+			// defined for the route - allows for
+			// routes to be redirected
+			request = InitializeRequest(request);
+
+			// Redirect navigation if required
+			// eg route that matches a child, should be routed to that child
+			// eg route that doesn't match a page for frame nav should be sent to parent
+			var redirection = await RedirectNavigateAsync(request);
+			if (redirection is not null)
+			{
+				response = await redirection;
 			}
 			else
 			{
-				// Invoke the region specific navigation
-				response = await RegionNavigateAsync(request);
+
+				// Append Internal qualifier to avoid requests being sent back to parent
+				request = request.AsInternal();
+
+				if (request.Route.IsDialog())
+				{
+					// Dialogs will load a separate navigation hierarchy
+					// so there's no need to route the request to child regions
+					response = await DialogNavigateAsync(request);
+				}
+				else
+				{
+					// Invoke the region specific navigation
+					response = await RegionNavigateAsync(request);
+				}
 			}
+			return response;
 		}
-		RouteUpdater.EndNavigation(this, Region, request, response);
-		return response;
+		catch (Exception ex)
+		{
+			// Log at the request's entry navigator only — nested navigators rethrow
+			// through here too and would repeat the same exception at every level.
+			// Log Route.Base (not the full Route) to keep Data/query values, which
+			// can carry tokens or PII, out of Uno.Extensions.* log output.
+			if (isNavigationEntryPoint && Logger.IsEnabled(LogLevel.Error))
+			{
+				Logger.LogErrorMessage(ex, $"Navigation failed for route '{request.Route.Base}'");
+			}
+			throw;
+		}
+		finally
+		{
+			// Must run even when navigation faults: skipping it leaks the notifier's
+			// per-request tracking state and drops the RouteChanged notification.
+			RouteUpdater.EndNavigation(this, Region, request, response);
+		}
 	}
 
 	private async Task<Task<NavigationResponse?>?> RedirectNavigateAsync(NavigationRequest request)

--- a/src/Uno.Extensions.Navigation.UI/Navigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigator.cs
@@ -85,17 +85,12 @@ public class Navigator : INavigator, IInstance<IServiceProvider>
 				// Append Internal qualifier to avoid requests being sent back to parent
 				request = request.AsInternal();
 
-				if (request.Route.IsDialog())
-				{
-					// Dialogs will load a separate navigation hierarchy
-					// so there's no need to route the request to child regions
-					response = await DialogNavigateAsync(request);
-				}
-				else
-				{
-					// Invoke the region specific navigation
-					response = await RegionNavigateAsync(request);
-				}
+				// Dialogs will load a separate navigation hierarchy
+				// so there's no need to route the request to child regions;
+				// otherwise invoke the region specific navigation
+				response = request.Route.IsDialog() ?
+					await DialogNavigateAsync(request) :
+					await RegionNavigateAsync(request);
 			}
 			return response;
 		}

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
@@ -422,7 +422,23 @@ public abstract class ControlNavigator : Navigator
 
 					services.AddScopedInstance(request);
 
-					var created = services.GetService(mapping!.ViewModel);
+					object? created;
+					try
+					{
+						created = services.GetService(mapping!.ViewModel);
+					}
+					catch (Exception ex)
+					{
+						// A view-model constructor (or one of its DI dependencies) throwing
+						// here is app code failing, not a missing registration — don't fall
+						// through to the reflection path, which would run the same failing
+						// constructor again. Log before the fault propagates: no caller up
+						// the navigation chain logs it, and at startup the faulted task is
+						// typically unobserved, so this is the only diagnostic the app
+						// author ever gets (see #3136).
+						if (Logger.IsEnabled(LogLevel.Error)) Logger.LogErrorMessage(ex, $"Failed to create view model '{mapping!.ViewModel.Name}': the service provider threw while constructing it");
+						throw;
+					}
 
 					if (created is not null)
 					{
@@ -437,9 +453,9 @@ public abstract class ControlNavigator : Navigator
 							return ctr.Invoke(args);
 						}
 					}
-					catch
+					catch (Exception ex)
 					{
-						if (Logger.IsEnabled(LogLevel.Information)) Logger.LogInformationMessage("ViewModel not included in RouteMap, and unable to instance using Activator instead of ServiceProvider");
+						if (Logger.IsEnabled(LogLevel.Error)) Logger.LogErrorMessage(ex, $"Failed to create view model '{mapping.ViewModel.Name}' via the reflection fallback (type isn't registered with the service provider)");
 					}
 					return default;
 				});


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3136

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When a view model constructor (or anything in its DI dependency chain) throws during navigation:

- `ControlNavigator.CreateViewModel` resolves the VM with `services.GetService(...)` outside its `try/catch`, so the exception faults the navigation task with **no log at any level**. At startup, that faulted task is typically unobserved — the app sits on the splash screen forever with zero diagnostics (this is how the Uno Platform Studio iOS TestFlight hang stayed undiagnosable; see #3136).
- The reflection-fallback `catch` discards the exception detail and logs at `Information`.
- `Navigator.NavigateAsync` has no `try/finally`, so a faulted navigation skips `RouteUpdater.EndNavigation`, leaking the `RouteNotifier` per-request tracking state (`runningNavigations`/`navigationSegments`/`rootRegions`) and dropping the `RouteChanged` notification.

## What is the new behavior?

- `CreateViewModel` wraps the DI resolution in `try/catch`: the failure is logged at `Error` with the view-model type and full exception, then rethrown (the original exception still propagates unwrapped — no behavior change for callers that observe the fault). The reflection fallback no longer runs after a DI throw, since that would re-run the same failing constructor.
- The reflection-fallback catch now logs the actual exception at `Error` instead of a generic `Information` message.
- `Navigator.NavigateAsync` runs `RouteUpdater.EndNavigation` in a `finally`, and logs the failure at `Error` once, at the request's entry navigator only (nested navigators rethrough don't repeat it). Only `Route.Base` is logged to keep query/data values (potential tokens/PII) out of logs.

### Tests

`Given_Navigation_VmCreationFailure` (runtime tests) covers:
- a throwing VM ctor faults the navigation task with the original exception (no hang) and produces an `Error` log naming the VM type — this test fails without the fix (no error was logged);
- a subsequent navigation on the same navigator still succeeds after the fault.

Verified locally on Skia desktop (macOS): both tests pass with the fix, and the error-log test fails without it (it detects the exact bug). Full `!_HotReload` runtime-suite comparison against `main` shows no regressions — the failure sets are identical apart from `When_ContentDetachedDuringInitialNavigation_Then_RouteResumesOnReattach`, which fails its own scenario precondition in full-suite context on **unmodified `main`** as well (2 of 3 runs; passes consistently in isolation on both builds) — a pre-existing suite-order flake in the local macOS harness, unrelated to this change.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
