### PR TITLE
fix(tests): remove three timing races that flake CI

### DIFF
--- a/src/Uno.Extensions.Reactive.Testing/FeedRecorder.cs
+++ b/src/Uno.Extensions.Reactive.Testing/FeedRecorder.cs
@@ -11,5 +11,12 @@ public class FeedRecorder
 	/// <summary>
 	/// Gets the default timeout, in ms, used for <see cref="IFeedRecorder{T}.WaitForMessages"/> and <see cref="IFeedRecorder{T}.WaitForEnd"/>.
 	/// </summary>
-	public const int DefaultTimeout = 1000;
+	/// <remarks>
+	/// A passing test waits only as long as its feed actually takes, so this bound costs nothing
+	/// when things work - it only decides how much scheduling delay counts as a failure. At 1s a
+	/// contended CI agent produced spurious timeouts (<c>Given_PaginatedListFeed</c>
+	/// <c>When_Async_Then_FlagIsLoading</c> reported 2 of 3 expected messages), so genuine failures
+	/// were indistinguishable from a busy machine.
+	/// </remarks>
+	public const int DefaultTimeout = 5000;
 }

--- a/src/Uno.Extensions.Reactive.Tests/Core/Given_FeedSubscription.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Core/Given_FeedSubscription.cs
@@ -31,25 +31,37 @@ public class Given_FeedSubscription : FeedTests
 	[TestMethod]
 	public async Task When_SubscribeTwice_Then_Replay()
 	{
+		// Both halves of this test are about *which* value a subscriber sees, so the source must be
+		// held at a known position rather than merely nudged with a delay. The original version used
+		// `await Task.Yield()` to give the first subscriber a chance to observe 1 and `Task.Delay(10)`
+		// to let 2 and 3 flow; a loaded CI agent lost the first race regularly, and the subscriber then
+		// read the latest value instead ("expected 1, but found 3").
+		var firstValueObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var allValuesProduced = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
 		async IAsyncEnumerable<int> Source([EnumeratorCancellation] CancellationToken ct = default)
 		{
 			yield return 1;
 
-			await Task.Yield(); // Make sure to run async, so listener will receive 1 message.
+			await firstValueObserved.Task; // Not a delay: 2 cannot exist until 1 has been read.
 
 			yield return 2;
 			yield return 3;
+
+			// Reached only once the consumer has pulled past 3, so 3 is already published by then.
+			allValuesProduced.SetResult();
 		}
 		var src = Feed<int>.AsyncEnumerable(Source);
 		var sut = new FeedSubscription<int>(src, Context.SourceContext);
 
 		var sub1Message = await sut.GetMessages(Context.SourceContext, CT).FirstAsync(CT);
 
-		await Task.Delay(10); // Make sure to run async, so listener will receive next messages.
+		firstValueObserved.SetResult();
+		await allValuesProduced.Task;
 
 		var sub2Message = await sut.GetMessages(Context.SourceContext, CT).FirstAsync(CT);
 
-		sub1Message.Current.Data.SomeOrDefault().Should().Be(1, "We added a delay before the second value");
+		sub1Message.Current.Data.SomeOrDefault().Should().Be(1, "the source was held until the first value had been read");
 		sub2Message.Current.Data.SomeOrDefault().Should().Be(3, "the subscription should have stay active");
 	}
 

--- a/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Apps/Regions/Given_Apps_Regions.cs
+++ b/testing/TestHarness/TestHarness.UITest/Ext/Navigation/Apps/Regions/Given_Apps_Regions.cs
@@ -35,11 +35,20 @@ public class Given_Apps_Regions : NavigationTestBase
 
 		App.WaitThenTap("RegionsTbDataPageTabOne");
 
+		// Wait for each tab's content before touching it. Tapping a TabBarItem returns as soon as the
+		// tap lands, not when the region has finished materializing the page, so SetText/GetText could
+		// run against a tree that does not contain the TextBox yet - which surfaced as
+		// "InvalidOperationException: The query returned no results" on the WebAssembly lane. The
+		// NavView test above already waits this way.
+		App.WaitElement("RegionsFirstTbiDataPageTextBox");
+
 		var textToSet = "Hello, World!";
 
 		App.SetText("RegionsFirstTbiDataPageTextBox", textToSet);
 
 		App.WaitThenTap("RegionsTbDataPageTabTwo");
+
+		App.WaitElement("RegionsSecondTbiDataPageTextBox");
 
 		var textFromTb = App.GetText("RegionsSecondTbiDataPageTextBox");
 


### PR DESCRIPTION
GitHub Issue (If applicable): none — found while getting #3139 through CI

## PR Type

- Bugfix
- Build or CI related changes

## What is the current behavior?

Three tests fail intermittently on `main`. All three failed during CI runs for #3139 while the code under test was untouched by that branch, and all three passed on retry:

| Test | Project | Observed |
| --- | --- | --- |
| `Given_FeedSubscription.When_SubscribeTwice_Then_Replay` | `Uno.Extensions.Reactive.Tests` | `Expected sub1Message.Current.Data.SomeOrDefault() to be 1 … but found 3` |
| `Given_PaginatedListFeed.When_Async_Then_FlagIsLoading` | `Uno.Extensions.Reactive.Tests` | `TimeoutException: … did not produced the expected 3 messages (got only 2) within the given delay of 0:00:01` |
| `Given_Apps_Regions.When_Regions_Send_Data_TabBar` | `TestHarness.UITest` | `InvalidOperationException: The query returned no results` |

The `Packages` job failed in **2 of 7** builds on one PR, twice for the same test. This matters more than the per-test rate suggests: `Runtime_Tests_Devices` has `dependsOn: Build_Tests` with the default `succeeded()` condition, so one flaky Selenium assertion in `UI Tests - WebAssembly` **skips the whole device stage** — the iOS and Desktop runtime lanes never run, and the build is inconclusive rather than red.

## What is the new behavior?

Each race is removed at its cause rather than papered over with a longer sleep.

**`When_SubscribeTwice_Then_Replay` — hold the source instead of nudging it.** The test asserts *which* value each subscriber sees, but only gave the first subscriber a single `await Task.Yield()` to observe `1` before `2` and `3` overwrote it, then a fixed `Task.Delay(10)` for the rest to flow. The source now awaits a `TaskCompletionSource` the test releases after the first read, so `2` cannot exist until `1` has been observed, and the second read waits for a signal raised once the consumer has pulled past `3` rather than for an arbitrary 10 ms.

**`FeedRecorder.DefaultTimeout` 1s → 5s.** The feed was slow, not broken. A passing test waits only as long as its feed actually takes, so this bound costs nothing when things work — it only decides how much scheduling delay counts as a failure, and at 1s a contended agent made genuine failures indistinguishable from a busy machine. This is a latent flake in every test in the suite that uses the default, not just the one that tripped.

**`When_Regions_Send_Data_TabBar` — wait for the tab content.** `App.WaitThenTap` on a `TabBarItem` returns when the tap lands, not when the region has materialized the page, so `SetText`/`GetText` could query a tree that does not contain the `TextBox` yet. Added the `WaitElement` calls that the sibling `When_Regions_Send_Data_NavView` test in the same file already uses.

### Verification

Red/green, not assumed. Under 12-way CPU contention on the same machine:

- **Original** `When_SubscribeTwice_Then_Replay`: **2 of 12 runs failed** — reproducing the CI symptom exactly, and consistent with the ~29% job-level rate observed in CI.
- **Fixed**, identical load: **0 of 12 failed**.
- Full `Uno.Extensions.Reactive.Tests`: **1419 passed, 19 skipped, 0 failed**.
- `Uno.Extensions.Reactive.WinUI.Tests` and `TestHarness.UITest` both still compile (the two other consumers of the changed helper).

The Selenium fix cannot be stress-tested locally — it needs the WebAssembly lane — but it is the same wait the sibling test in the same file already performs before its `GetText`.

## PR Checklist

- [x] Tested code with current supported SDKs
- [ ] Docs have been added/updated which fit documentation template — n/a, no public behavior change
- [x] Unit Tests and/or UI Tests for the changes have been added — these *are* the tests; no new cases, the existing ones are made deterministic
- [ ] Wasm UI Tests are not showing any unexpected differences — the WebAssembly lane in this PR is the check for that
- [x] Contains **NO** breaking changes — see the note below on `DefaultTimeout`
- [ ] Updated the Release Notes — n/a, test-only
- [ ] Associated with an issue (GitHub or internal)

## Other information

`FeedRecorder.DefaultTimeout` is a `public const` in the shipped `Uno.Extensions.Reactive.Testing` package, so consumers already compiled against it keep the inlined `1000` until they rebuild. That is benign for a test-helper timeout — it only affects how long *their* recorder waits before declaring a timeout — but it is a value change on a public surface and reviewers should be aware rather than surprised. If you would rather not touch the public constant, the alternative is passing an explicit timeout at the single flaky call site, which fixes one test and leaves the same latent flake in every other test using the default.

Not addressed here, but worth a follow-up: the `Runtime_Tests_Devices` → `Build_Tests` stage dependency described above. Those lanes consume pipeline artifacts from the build jobs and have no dependency on `UI Tests - WebAssembly`, so an unrelated Selenium flake should not be able to void the runtime-test results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
