### PR TITLE
fix: re-instantiate the active route's view model on hot reload

### DIFF
--- a/specs/009-hr-active-route-vm-refresh/progress.md
+++ b/specs/009-hr-active-route-vm-refresh/progress.md
@@ -1,0 +1,45 @@
+# Progress — HR refresh of the active route's view model (#3142)
+
+Branch: `dev/mara/fix-routes-hr` (no commit/push in this session — per request)
+
+## Plan
+
+- [x] Read issue #3142, the downstream consumer report that surfaced it, and the existing HR machinery
+      (`NavigationRouteUpdateHandler`, `FrameNavigator` rehook, `Given_FrameContentRehook`,
+      spec 003, `HotReload.Spec.md`)
+- [x] Write spec (`spec.md` in this folder)
+- [x] RED: harness-free UI test `Given_ActiveRouteVmRefresh` (VM delta → rebuilt; view-only delta →
+      preserved) — fails on current code
+- [x] RED: runtime HR test `Given_HotReload.When_ActiveRouteViewModelUpdated_Then_ActiveRegionVmReinstantiated`
+      + ctor-seeded property on `HotReloadRegionVm`
+- [x] FIX: `ControlNavigator.RefreshActiveRouteViewModelAsync` (internal virtual + generic override)
+- [x] FIX: `NavigationRouteUpdateHandler` — thread `updatedTypes` into `ScheduleCascade`, add
+      `CollectUpdatedViewModels` + `RefreshUpdatedActiveRoutesFromRoot`
+- [x] Unit tests for `CollectUpdatedViewModels` in `Given_NavigationRouteUpdateHandler`
+- [x] GREEN: build + run the new tests (and the neighboring HR/rehook tests) locally
+- [x] Update living spec `src/Uno.Extensions.Navigation.UI.Tests/HotReload.Spec.md`
+- [x] Baseline-diff the neighboring navigation suites (stash fix → rebuild → rerun) to attribute
+      any failures
+
+## Review
+
+- Verified locally on Skia desktop (net9.0-desktop runtime-test host):
+  - `Given_ActiveRouteVmRefresh` — RED before fix (`When_ActiveRouteViewModelInDelta_...` timed
+    out: nothing re-instantiated the VM), GREEN after; the view-only control test passed in both
+    states.
+  - `Given_NavigationRouteUpdateHandler` — 11/11 green (incl. 5 new `CollectUpdatedViewModels`
+    cases: null, unregistered, registered VM, registered view-only, MVUX mapped-model).
+  - `Given_FrameContentRehook` — 4/4 green (state-preservation behavior unchanged).
+  - Release build of `Uno.Extensions.Navigation.WinUI.csproj`: 0 errors.
+  - `Given_HotReload` secondary-app tests require the dev-server HR harness (not available in
+    this environment — the RC connection has no listener); the new test compiles and follows the
+    existing harness patterns and runs in CI's `stage-build-runtimetests-skia-hotreload.yml`
+    (filter `_HotReload` matches `Given_HotReload`).
+- Neighboring suites: `Given_NavigationBoundary`, `Given_Navigation_VmCreationFailure`,
+  `Given_TabNavigation`, `Given_NestedNavReloadRecovery` green. `Given_ChainedGetDataAsync` (8),
+  `Given_NavigatorStartup` (1), `Given_Region` (1), `Given_RouteNotifier` (1) failed identically
+  on the UNMODIFIED baseline (stash → rebuild → rerun) — pre-existing/environmental, not caused
+  by this change; none of them exercise any HR entry point.
+- Design decision worth keeping in mind: the refresh triggers on **view-model** membership only —
+  view deltas are owned by Uno's element walk, and including them would regress the
+  state-preservation behavior pinned by `Given_FrameContentRehook`.

--- a/specs/009-hr-active-route-vm-refresh/spec.md
+++ b/specs/009-hr-active-route-vm-refresh/spec.md
@@ -1,0 +1,105 @@
+# Hot-Reload Refresh of the Active Route's View Model
+
+**Status:** Implemented (branch `dev/mara/fix-routes-hr`)
+**Issue:** [#3142](https://github.com/unoplatform/uno.extensions/issues/3142) — `[HR][Navigation]
+CascadeNewDefaultsFromRoot suppresses the refresh of the active route, so the displayed page is
+never re-instantiated` (surfaced by a downstream hosted-app consumer)
+**Affects:** `Uno.Extensions.Navigation.UI`
+**Files touched:**
+
+- `src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs`
+- `src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs`
+
+## Problem
+
+A C# hot-reload delta that updates the view model of the **currently displayed** route never
+re-instantiates that view model, so edits that only run at construction time (constructor bodies,
+property initializers) stay invisible until a full rebuild:
+
+```csharp
+public ISeries[] DeploymentSeries { get; } = new ISeries[]
+{
+    new ColumnSeries<double> { ... },  // HR edit -> LineSeries<double>: invisible on the active page
+};
+```
+
+Why every existing HR path declines to handle it:
+
+- `NavigationRouteUpdateHandler.UpdateApplication` rebuilds the route table and
+  `ShouldCascadeForUpdatedTypes` correctly classifies the delta as navigation-relevant — but
+  `CascadeNewDefaultsFromRoot` suppresses the `IsDefault` dispatch because the descendant region is
+  *already* on that route (`FindActiveDescendantNestedRoute`). That suppression is intentional and
+  correct for its own case (don't yank the user's selection back to the default) — but it is the
+  only walk that could have touched the region, and it never receives `updatedTypes`.
+- `NavigationFrameContentUpdateHandler` → `FrameNavigator.RehookCurrentViewAfterHotReload` only acts
+  when Uno's element-update walk **replaced** `Frame.Content`. A metadata-only edit to a plain C#
+  view-model class replaces no element, so the re-hook early-outs on `ReferenceEquals`.
+- `RetryPendingFailedRequestsFromRoot` only re-issues *failed* requests; a region that navigated
+  successfully has none.
+
+Net effect: the one page guaranteed not to refresh is the page the user is looking at.
+
+## Design
+
+Two situations were sharing one branch; they are now handled by two **orthogonal walks** instead of
+entangling `updatedTypes` into the cascade's conflict check:
+
+| Situation | Correct action | Owner |
+|---|---|---|
+| Cascade wants a *different* default than the region's active route | suppress — don't move the user | `CascadeNewDefaultsFromRoot` (unchanged) |
+| The active route's own **view model** was just updated | re-create that view model in place | `RefreshUpdatedActiveRoutesFromRoot` (new) |
+
+`ScheduleCascade` now receives `updatedTypes` and, in the same dispatcher-deferred lambda as the
+cascade and retry walks, runs a third walk:
+
+1. `CollectUpdatedViewModels(updatedTypes, resolver)` maps each updated type to the view-model type
+   the (just-rebuilt) route table associates with it, via `RouteResolver.FindByViewModel`. Going
+   through the resolver — instead of comparing raw types — makes the MVUX case work:
+   `MappedRouteResolver.InternalFindByViewModel` translates a model type (`OverviewModel`, which is
+   what the delta contains) to its generated bindable view model (which is what
+   `RouteInfo.ViewModel` holds).
+2. `RefreshUpdatedActiveRoutesFromRoot` walks the live region tree; every region whose navigator's
+   active `Route.Base` resolves (`FindByPath`) to a mapping whose `ViewModel` is in that set gets
+   `ControlNavigator.RefreshActiveRouteViewModelAsync()` — a new internal entry point that re-runs
+   `InitializeCurrentView(request, route, mapping, refresh: true)`, i.e. the standard
+   `CreateViewModel` + `InjectServicesAndSetDataContextAsync` pipeline, for the route the navigator
+   is already on. No navigation is issued, so the user's selection can't move.
+
+### Why "re-create the view model" and not "re-navigate the route"
+
+Re-issuing the same route is a no-op end to end: `FrameNavigator.NavigateForwardAsync` computes
+0 forward segments for the route it is already on, and its HR bypass only fires when
+`SourcePageType` differs from the mapping's `RenderView` — which it doesn't for an in-place (EnC)
+update. The refresh entry point sidesteps the pipeline's already-there short-circuits and does
+exactly the missing piece.
+
+### Why view types do NOT trigger the refresh
+
+Updated **views** are already owned by Uno's element-update walk (materialized instances) and
+`FrameElementMetadataUpdateHandler` + `RehookCurrentViewAfterHotReload` (unmaterialized ones).
+Triggering the view-model rebuild on a view-only delta would discard un-persisted view-model state
+on every XAML/code-behind page edit — the exact state-preservation behavior
+`Given_FrameContentRehook.When_XamlOnlyDelta_Then_CopiedViewModelIsPreserved` pins.
+
+### Scope / known limitations
+
+- A view model **replaced** via `CreateNewOnMetadataUpdate` (rude edit) whose registration
+  delegate body was not itself updated resolves to the old type in the rebuilt route table and is
+  not matched — same pre-existing limitation as the route table itself (#3072). The demonstrated
+  scenario (EnC in-place constructor/initializer edit, type identity preserved) is fully covered.
+- `updatedTypes == null` (unknown delta) refreshes nothing — conservative, mirrors the
+  pre-existing x:Uid-revert guard on the cascade.
+
+## Verification
+
+- `Given_NavigationRouteUpdateHandler` (unit): `CollectUpdatedViewModels` for null / unregistered /
+  registered-VM / registered-view-only / MVUX-mapped-model deltas.
+- `Given_ActiveRouteVmRefresh` (UI, no HR harness — same technique as `Given_FrameContentRehook`):
+  drives `ScheduleCascadeForAllContextsIfRouteRelevant` with a synthetic delta against a live
+  navigation tree; asserts the VM is rebuilt in place (view instance untouched) for a VM delta and
+  preserved for a view-only delta. Red on main, green with the fix.
+- `Given_HotReload.When_ActiveRouteViewModelUpdated_Then_ActiveRegionVmReinstantiated` (runtime,
+  real HR delta, secondary app): navigates a visibility region to a non-default route, edits a
+  constructor-seeded property initializer on the active route's VM file, asserts the VM is
+  re-instantiated with the post-HR seed AND the selection is not yanked back to the `IsDefault`
+  route.

--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_ActiveRouteVmRefresh.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_ActiveRouteVmRefresh.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Hosting;
+using Uno.Extensions.Navigation;
+using Uno.Extensions.Navigation.UI.Controls;
+using Uno.Extensions.Navigation.UI.Tests.Pages;
+using Uno.Extensions.Navigation.UI.Tests.ViewModels;
+using Uno.UI.RuntimeTests;
+
+namespace Uno.Extensions.Navigation.UI.Tests;
+
+/// <summary>
+/// Tests for the hot-reload refresh of the ACTIVE route's view model
+/// (uno.extensions#3142). A C# delta that updates the view model of the route a region is
+/// currently on must re-create that view model in place: a metadata update never re-runs
+/// constructors or property initializers on live instances, the IsDefault cascade deliberately
+/// suppresses regions that are already on their route, and the frame-content re-hook only reacts
+/// to element replacement — so before the fix, nothing refreshed the one page the user is
+/// looking at.
+/// <para>
+/// Same technique as <see cref="Given_FrameContentRehook"/>: the delta is synthesized by invoking
+/// the internal hot-reload entry point directly, so these tests run without the HR harness and
+/// pin the refresh decision deterministically. The full-fidelity delta is covered by
+/// <c>Given_HotReload.When_ActiveRouteViewModelUpdated_Then_ActiveRegionVmReinstantiated</c>.
+/// </para>
+/// </summary>
+[TestClass]
+[RunsOnUIThread]
+public class Given_ActiveRouteVmRefresh
+{
+	private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+	private async Task<(IHost Host, Frame Frame)> SetupNavigationAsync()
+	{
+		var window = new Window();
+
+		var host = await window.InitializeNavigationAsync(
+			buildHost: async () => UnoHost
+				.CreateDefaultBuilder(typeof(Given_ActiveRouteVmRefresh).Assembly)
+				.UseNavigation(viewRouteBuilder: (views, routes) =>
+				{
+					views.Register(
+						new ViewMap<HotReloadVmPage, HotReloadVm>());
+
+					routes.Register(
+						new RouteMap("", Nested: new RouteMap[]
+						{
+							new RouteMap("HotReloadVmPage", View: views.FindByView<HotReloadVmPage>(), IsDefault: true),
+						}));
+				})
+				.Build(),
+			initialRoute: "HotReloadVmPage");
+
+		var root = (ContentControl)window.Content!;
+
+		using var cts = new CancellationTokenSource(Timeout);
+		await UIHelper.WaitFor(
+			() => root.Content is FrameView fv &&
+				fv.FindName("NavigationFrame") is Frame frame &&
+				frame.Content is HotReloadVmPage page &&
+				page.DataContext is HotReloadVm,
+			cts.Token);
+
+		var frameView = (FrameView)root.Content!;
+		var frame = (Frame)frameView.FindName("NavigationFrame");
+
+		// Precondition for every test in this class: the navigation context must be registered
+		// with a live root region and resolver, otherwise the refresh walk has nothing to visit
+		// and a "view model preserved" assertion would pass vacuously.
+		NavigationRouteUpdateHandler.ActiveContexts
+			.Should().Contain(
+				ctx => ctx.Resolver != null && ctx.RootRegion != null,
+				"the hot-reload walk operates on registered contexts with a live region tree");
+
+		return (host, frame);
+	}
+
+	[TestMethod]
+	public async Task When_ActiveRouteViewModelInDelta_Then_ViewModelRebuiltInPlace()
+	{
+		var (host, frame) = await SetupNavigationAsync();
+
+		try
+		{
+			var page = (HotReloadVmPage)frame.Content;
+			var originalVm = (HotReloadVm)page.DataContext;
+
+			// The delta contains the view model mapped to the route the frame is currently on
+			// (an in-place EnC update keeps the type identity). #3142: the region is already on
+			// 'HotReloadVmPage', so no cascade or navigation will ever touch it — the refresh
+			// walk is the only path that can re-run the view model's constructor.
+			NavigationRouteUpdateHandler.ScheduleCascadeForAllContextsIfRouteRelevant(new[] { typeof(HotReloadVm) });
+
+			using var cts = new CancellationTokenSource(Timeout);
+			await UIHelper.WaitFor(
+				() => page.DataContext is HotReloadVm vm && !ReferenceEquals(vm, originalVm),
+				cts.Token);
+
+			page.DataContext.Should().BeOfType<HotReloadVm>(
+				"the active route's view model must be re-instantiated so constructor and " +
+				"property-initializer edits become visible (#3142)");
+			frame.Content.Should().BeSameAs(page,
+				"the refresh re-creates the view model only — replacing the view is owned by " +
+				"Uno's element-update walk");
+		}
+		finally
+		{
+			await host.StopAsync();
+		}
+	}
+
+	[TestMethod]
+	public async Task When_DeltaContainsOnlyViewTypes_Then_ViewModelPreserved()
+	{
+		var (host, frame) = await SetupNavigationAsync();
+
+		try
+		{
+			var page = (HotReloadVmPage)frame.Content;
+			var originalVm = (HotReloadVm)page.DataContext;
+
+			// A view-only delta (XAML or code-behind edit on the page type) must NOT rebuild the
+			// view model: updated views are owned by Uno's element-update walk, and re-creating
+			// the view model here would discard its un-persisted state on every page edit — the
+			// same behavior Given_FrameContentRehook pins for the re-hook path.
+			NavigationRouteUpdateHandler.ScheduleCascadeForAllContextsIfRouteRelevant(new[] { typeof(HotReloadVmPage) });
+
+			// Nothing observable should change; give the dispatched walk time to run.
+			await Task.Delay(500);
+
+			page.DataContext.Should().BeSameAs(originalVm,
+				"a delta without the mapped view-model type must preserve the live view model " +
+				"and any un-persisted state it holds");
+		}
+		finally
+		{
+			await host.StopAsync();
+		}
+	}
+}

--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_ActiveRouteVmRefresh.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_ActiveRouteVmRefresh.cs
@@ -138,6 +138,20 @@ public class Given_ActiveRouteVmRefresh
 			page.DataContext.Should().BeSameAs(originalVm,
 				"a delta without the mapped view-model type must preserve the live view model " +
 				"and any un-persisted state it holds");
+
+			// The walk must not probe FindByViewModel with view types: on a miss,
+			// RouteResolverDefault's convention fallback derives the view's own route path
+			// from the type name and REPLACES the registered mapping with one whose
+			// ViewModel is the view type itself — corrupting every later navigation on
+			// that route (the CI regression across the XAML TabBar HR tests).
+			var context = NavigationRouteUpdateHandler.ActiveContexts.First(ctx => ctx.Resolver is not null);
+			var mapping = context.Resolver!.FindByPath("HotReloadVmPage");
+			mapping.Should().NotBeNull();
+			mapping!.RenderView.Should().Be(typeof(HotReloadVmPage),
+				"the registered route's view must survive a view-only delta");
+			mapping.ViewModel.Should().Be(typeof(HotReloadVm),
+				"the registered route's view model must survive a view-only delta — a " +
+				"view-typed ViewModel here means the convention fallback clobbered the mapping");
 		}
 		finally
 		{

--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_HotReload.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_HotReload.cs
@@ -348,6 +348,79 @@ public class Given_HotReload
 	}
 
 	/// <summary>
+	/// Regression test for uno.extensions#3142: a hot-reload delta that updates the view model
+	/// of a region's ACTIVE route must re-instantiate that view model in place. Constructor /
+	/// property-initializer edits are only visible on a fresh instance, and before the fix no HR
+	/// path created one: the IsDefault cascade deliberately suppresses regions already on their
+	/// route (<c>FindActiveDescendantNestedRoute</c>), and the frame-content re-hook only reacts
+	/// to element replacement — so the one page guaranteed not to refresh was the page the user
+	/// was looking at. The refresh must also NOT disturb the user's selection: RegionTwo
+	/// (non-default) stays active, guarding the same no-yank behavior as
+	/// <see cref="When_HRCascadeAfterUserSelection_Then_ActiveRegionPreserved"/>.
+	/// </summary>
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_ActiveRouteViewModelUpdated_Then_ActiveRegionVmReinstantiated(CancellationToken ct)
+	{
+		await using var app = await SetupAppAsync(
+			registerViewsAndRoutes: (views, routes) =>
+			{
+				views.Register(
+					new ViewMap<HotReloadRegionPage>(),
+					new ViewMap<HotReloadRegionContentPage, HotReloadRegionVm>());
+
+				routes.Register(
+					new RouteMap("", Nested: new RouteMap[]
+					{
+						new RouteMap(
+							"HotReloadRegionPage",
+							View: views.FindByView<HotReloadRegionPage>(),
+							IsDefault: true,
+							Nested: new RouteMap[]
+							{
+								new RouteMap("RegionOne", View: views.FindByView<HotReloadRegionContentPage>(), IsDefault: true),
+								new RouteMap("RegionTwo", View: views.FindByView<HotReloadRegionContentPage>()),
+							}),
+					}));
+			},
+			initialRoute: "HotReloadRegionPage",
+			ct);
+
+		var hostPage = ResolveCurrentPage<HotReloadRegionPage>(app.NavigationRoot);
+		hostPage.Should().NotBeNull("Frame should have navigated to HotReloadRegionPage");
+
+		// Move off the IsDefault route so the test also proves the refresh does not re-issue
+		// the IsDefault cascade (RegionTwo must stay active throughout).
+		var panelNavigator = await WaitForPanelNavigatorAsync(hostPage!.ContentGrid, TimeSpan.FromSeconds(30), ct);
+		await panelNavigator.NavigateRouteAsync(hostPage, "RegionTwo");
+		var vmBefore = await WaitForRegionVmAsync(hostPage.ContentGrid, "RegionTwo", TimeSpan.FromSeconds(30), ct);
+		vmBefore.CtorSeededValue.Should().Be("ctor-original",
+			"precondition: the pre-HR view model must carry the pre-HR constructor seed");
+
+		// HR: edit the ACTIVE route's view-model type itself (not a helper class), so the delta
+		// contains a navigation-registered view-model type. The edited method only runs from the
+		// property initializer, so the change is invisible unless a new instance is created.
+		// Disposal reverts the file on scope exit.
+		await using var _ = await HotReloadHelper.UpdateSourceFile(
+			"../../Uno.Extensions.Navigation.UI.Tests/ViewModels/HotReloadRegionVm.cs",
+			"""return "ctor-original";""",
+			"""return "ctor-updated";""",
+			ct);
+
+		// The refresh is dispatched onto the dispatcher and applied fire-and-forget; poll for
+		// the re-created view model on the active region.
+		var refreshedVm = await WaitForReinstantiatedRegionVmAsync(
+			hostPage.ContentGrid, "RegionTwo", vmBefore, TimeSpan.FromSeconds(30), ct);
+		refreshedVm.CtorSeededValue.Should().Be("ctor-updated",
+			"the active route's view model must be re-instantiated so constructor and " +
+			"property-initializer edits become visible (#3142)");
+
+		GetActiveRegionName(hostPage.ContentGrid).Should().Be("RegionTwo",
+			"the refresh must re-create the view model in place without yanking the selection " +
+			"back to the IsDefault RegionOne");
+	}
+
+	/// <summary>
 	/// Deterministic repro for unoplatform/uno.extensions#3130 (RED until the stranded-page
 	/// fix lands). A page that is live but NOT materialized — its host panel is Collapsed,
 	/// the deterministic stand-in for "the hosted app's view gets no layout pass while an
@@ -561,6 +634,41 @@ public class Given_HotReload
 		throw new TimeoutException(
 			$"Region '{regionName}' did not populate a HotReloadRegionContentPage within {timeout.TotalSeconds:F0}s. " +
 			$"ContentGrid children: [{children}].");
+	}
+
+	/// <summary>
+	/// Like <see cref="WaitForRegionVmAsync"/>, but only returns once the region's view model is
+	/// a DIFFERENT instance than <paramref name="previousVm"/> — the hot-reload refresh replaces
+	/// the DataContext asynchronously, so polling for type alone would return the stale instance.
+	/// </summary>
+	private static async Task<HotReloadRegionVm> WaitForReinstantiatedRegionVmAsync(
+		Grid contentGrid,
+		string regionName,
+		HotReloadRegionVm previousVm,
+		TimeSpan timeout,
+		CancellationToken ct)
+	{
+		var sw = System.Diagnostics.Stopwatch.StartNew();
+		while (sw.Elapsed < timeout)
+		{
+			ct.ThrowIfCancellationRequested();
+			var regionView = contentGrid.Children
+				.OfType<FrameworkElement>()
+				.FirstOrDefault(c => Uno.Extensions.Navigation.UI.Region.GetName(c) == regionName);
+			if (regionView is FrameView fv &&
+				fv.FindName("NavigationFrame") is Frame frame &&
+				frame.Content is HotReloadRegionContentPage page &&
+				page.DataContext is HotReloadRegionVm vm &&
+				!ReferenceEquals(vm, previousVm))
+			{
+				return vm;
+			}
+			await Task.Delay(50, ct);
+		}
+
+		throw new TimeoutException(
+			$"Region '{regionName}' still exposes the pre-HR view model instance after {timeout.TotalSeconds:F0}s — " +
+			"the active route's view model was not re-instantiated (#3142).");
 	}
 
 	/// <summary>

--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs
@@ -172,6 +172,32 @@ public class Given_NavigationRouteUpdateHandler
 				"(bindable) view model — the MVUX shape from #3142");
 	}
 
+	[TestMethod]
+	public void When_CollectUpdatedViewModels_WithViewTypeOnDefaultResolver_Then_EmptyAndRouteTableIntact()
+	{
+		var services = new ServiceCollection();
+		var views = new ViewRegistry(services);
+		var routes = new RouteRegistry(services);
+		var viewMap = new ViewMap<FrameworkElementPage>();
+		views.Register(viewMap);
+		// Route registered at the view type's full name — the same shape as the TabBar HR
+		// tests, where RouteResolverDefault's convention fallback derives that exact path
+		// from the type name on a FindByViewModel miss and would REPLACE the real mapping.
+		routes.Register(new RouteMap("FrameworkElementPage", View: viewMap));
+		var resolver = new RouteResolverDefault(NullLogger<RouteResolverDefault>.Instance, routes, views);
+
+		var collected = NavigationRouteUpdateHandler.CollectUpdatedViewModels([typeof(FrameworkElementPage)], resolver);
+
+		collected.Should().BeEmpty(
+			"view types are owned by the element-update walk and must not trigger view-model refreshes");
+		var mapping = resolver.FindByPath("FrameworkElementPage");
+		mapping.Should().NotBeNull();
+		mapping!.RenderView.Should().Be(typeof(FrameworkElementPage),
+			"the lookup must not let the convention fallback replace the registered mapping");
+		mapping.ViewModel.Should().BeNull(
+			"the registered route has no view model; a view-typed ViewModel here is route-table corruption");
+	}
+
 	private static RouteResolver CreateResolver()
 	{
 		var services = new ServiceCollection();
@@ -194,6 +220,10 @@ public class Given_NavigationRouteUpdateHandler
 	}
 
 	private sealed class GeneratedXamlPartial
+	{
+	}
+
+	private sealed partial class FrameworkElementPage : Microsoft.UI.Xaml.FrameworkElement
 	{
 	}
 

--- a/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/Given_NavigationRouteUpdateHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -115,6 +116,62 @@ public class Given_NavigationRouteUpdateHandler
 		shouldCascade.Should().BeTrue();
 	}
 
+	[TestMethod]
+	public void When_CollectUpdatedViewModels_WithNullTypes_Then_Empty()
+	{
+		var resolver = CreateResolver();
+
+		NavigationRouteUpdateHandler.CollectUpdatedViewModels(null, resolver).Should().BeEmpty(
+			"an unknown delta must refresh nothing — conservative default");
+	}
+
+	[TestMethod]
+	public void When_CollectUpdatedViewModels_WithUnregisteredType_Then_Empty()
+	{
+		var resolver = CreateResolver();
+
+		NavigationRouteUpdateHandler.CollectUpdatedViewModels([typeof(GeneratedXamlPartial)], resolver).Should().BeEmpty();
+	}
+
+	[TestMethod]
+	public void When_CollectUpdatedViewModels_WithRegisteredViewModel_Then_ContainsViewModel()
+	{
+		var resolver = CreateResolver();
+
+		NavigationRouteUpdateHandler.CollectUpdatedViewModels([typeof(RegisteredViewModel)], resolver)
+			.Should().BeEquivalentTo(new[] { typeof(RegisteredViewModel) });
+	}
+
+	[TestMethod]
+	public void When_CollectUpdatedViewModels_WithRegisteredViewOnly_Then_Empty()
+	{
+		var resolver = CreateResolver();
+
+		// Updated views are owned by Uno's element-update walk; a view-only delta must not
+		// trigger a view-model rebuild (it would discard un-persisted view-model state on
+		// every page edit — the behavior Given_FrameContentRehook pins).
+		NavigationRouteUpdateHandler.CollectUpdatedViewModels([typeof(RegisteredPage)], resolver).Should().BeEmpty();
+	}
+
+	[TestMethod]
+	public void When_CollectUpdatedViewModels_WithMappedModel_Then_ContainsBindableViewModel()
+	{
+		var services = new ServiceCollection();
+		var views = new MappedViewRegistry(services, new Dictionary<Type, Type>
+		{
+			[typeof(MappedModel)] = typeof(BindableMappedModel),
+		});
+		var routes = new RouteRegistry(services);
+		views.Register(new ViewMap<RegisteredPage, MappedModel>());
+		routes.Register(new RouteMap("Mapped", View: views.FindByViewModel<MappedModel>()));
+		var resolver = new MappedRouteResolver(NullLogger<MappedRouteResolver>.Instance, routes, views);
+
+		NavigationRouteUpdateHandler.CollectUpdatedViewModels([typeof(MappedModel)], resolver)
+			.Should().BeEquivalentTo(new[] { typeof(BindableMappedModel) },
+				"the delta contains the model type, but the route table holds the mapped " +
+				"(bindable) view model — the MVUX shape from #3142");
+	}
+
 	private static RouteResolver CreateResolver()
 	{
 		var services = new ServiceCollection();
@@ -137,6 +194,14 @@ public class Given_NavigationRouteUpdateHandler
 	}
 
 	private sealed class GeneratedXamlPartial
+	{
+	}
+
+	private sealed class MappedModel
+	{
+	}
+
+	private sealed class BindableMappedModel
 	{
 	}
 }

--- a/src/Uno.Extensions.Navigation.UI.Tests/HotReload.Spec.md
+++ b/src/Uno.Extensions.Navigation.UI.Tests/HotReload.Spec.md
@@ -267,6 +267,31 @@ Each child `Region.Name` is a selectable target. See docs:
   HR delta is applied. The refresh itself is deferred onto the dispatcher and guarded by
   a token + content-identity check so a navigation that lands first wins.
 
+- **ID**: `When_ActiveRouteViewModelUpdated_Then_ActiveRegionVmReinstantiated`
+- **Goal**: Regression guard for uno.extensions#3142 — a C# delta that updates the view model of
+  a region's **active** route must re-instantiate that view model in place. Constructor /
+  property-initializer edits are only visible on a fresh instance, and before the fix no HR path
+  created one: the IsDefault cascade deliberately suppresses regions already on their route, and
+  the frame-content re-hook only reacts to element replacement.
+- **Layout**: Same visibility-region shape as the preserved-selection test (`HotReloadRegionPage`
+  with `RegionOne` IsDefault / `RegionTwo`); the test navigates to `RegionTwo` so it also proves
+  the refresh does not re-issue the IsDefault cascade.
+- **HR change**: `HotReloadRegionVm.ComputeCtorSeed()` — the VM's **own file**, so the delta
+  contains a navigation-registered view-model type (editing a helper class would not exercise
+  the refresh gate). The edited method only runs from a property initializer.
+- **Trigger**: none — the refresh must happen with no navigation at all; the test polls for the
+  region's DataContext to become a *different* `HotReloadRegionVm` instance.
+- **Assertion**: new VM instance with `CtorSeededValue == "ctor-updated"` AND the active region
+  is still `RegionTwo`.
+- **Risk**: the refresh triggers on **view-model** membership only — view deltas stay owned by
+  Uno's element walk; including them would regress the state preservation pinned by
+  `Given_FrameContentRehook.When_XamlOnlyDelta_Then_CopiedViewModelIsPreserved`.
+- **Status (2026-08-20)**: Implemented alongside the fix (spec `specs/009-hr-active-route-vm-refresh`).
+  The harness-free companion `Given_ActiveRouteVmRefresh` (primary app, synthetic delta via
+  `ScheduleCascadeForAllContextsIfRouteRelevant`) was verified red/fix/green locally on Skia
+  desktop; unit coverage for the type→view-model mapping (incl. the MVUX mapped-model shape)
+  lives in `Given_NavigationRouteUpdateHandler`.
+
 - **ID**: `When_UpdateStackPanelChildAfterHR_Then_NewlyShownChildReflectsUpdate`
 - **Goal**: Same as above but with a `StackPanel` instead of `Grid`.
 - **Risk**: `StackPanel` doesn't have rows/columns but the region mechanism is identical

--- a/src/Uno.Extensions.Navigation.UI.Tests/ViewModels/HotReloadRegionVm.cs
+++ b/src/Uno.Extensions.Navigation.UI.Tests/ViewModels/HotReloadRegionVm.cs
@@ -3,4 +3,17 @@ namespace Uno.Extensions.Navigation.UI.Tests.ViewModels;
 public sealed class HotReloadRegionVm
 {
 	public string DisplayedValue => HotReloadRegionTarget.GetValue();
+
+	/// <summary>
+	/// Captured once at construction. The #3142 HR test edits <see cref="ComputeCtorSeed"/> and
+	/// asserts the active route's view model was RE-INSTANTIATED — a metadata update never
+	/// re-runs property initializers on live instances, so only a fresh instance can observe
+	/// the post-HR value.
+	/// </summary>
+	public string CtorSeededValue { get; } = ComputeCtorSeed();
+
+	private static string ComputeCtorSeed()
+	{
+		return "ctor-original";
+	}
 }

--- a/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
@@ -354,10 +354,17 @@ internal static class NavigationRouteUpdateHandler
 			return [];
 		}
 
+		// View types must never reach FindByViewModel — not merely because updated views are
+		// owned by the element-update walk: on a lookup miss, RouteResolverDefault's convention
+		// fallback derives the view's own route path from the type name and REPLACES the
+		// registered mapping with one whose ViewModel is the view type itself, corrupting every
+		// later navigation on that route (and making this walk "refresh" pages with a page
+		// instance as DataContext).
 		// IL2067: same read-only, type-identity lookup as HasRouteRegisteredType above (the
 		// lambda parameter shifts the trim diagnostic from IL2072 to IL2067).
 #pragma warning disable IL2067
 		return updatedTypes
+			.Where(t => !typeof(FrameworkElement).IsAssignableFrom(t))
 			.Select(t => resolver.FindByViewModel(t, navigator: null)?.ViewModel)
 			.OfType<Type>()
 			.ToHashSet();

--- a/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
@@ -209,7 +209,7 @@ internal static class NavigationRouteUpdateHandler
 			// making the edit appear to revert.  See studio.live#2293.
 			if (ShouldCascadeForUpdatedTypes(updatedTypes, resolver))
 			{
-				ScheduleCascade(root, resolver);
+				ScheduleCascade(root, resolver, updatedTypes);
 			}
 			else if (Region.Logger.IsEnabled(LogLevel.Debug))
 			{
@@ -263,7 +263,7 @@ internal static class NavigationRouteUpdateHandler
 		{
 			if (ctx.Resolver is { } resolver && ctx.RootRegion is { } root)
 			{
-				ScheduleCascade(root, resolver);
+				ScheduleCascade(root, resolver, updatedTypes: null);
 			}
 		}
 	}
@@ -282,7 +282,7 @@ internal static class NavigationRouteUpdateHandler
 			{
 				if (ShouldCascadeForUpdatedTypes(updatedTypes, resolver))
 				{
-					ScheduleCascade(root, resolver);
+					ScheduleCascade(root, resolver, updatedTypes);
 				}
 				else if (Region.Logger.IsEnabled(LogLevel.Debug))
 				{
@@ -292,7 +292,7 @@ internal static class NavigationRouteUpdateHandler
 		}
 	}
 
-	private static void ScheduleCascade(IRegion root, RouteResolver resolver)
+	private static void ScheduleCascade(IRegion root, RouteResolver resolver, Type[]? updatedTypes)
 	{
 		var dispatcher = root.Services?.GetService<IDispatcher>();
 		if (dispatcher is null)
@@ -313,6 +313,19 @@ internal static class NavigationRouteUpdateHandler
 		{
 			CascadeNewDefaultsFromRoot(root, resolver);
 
+			// A region already ON the route an updated type maps to is deliberately left
+			// alone by the cascade above (its suppression preserves the user's selection),
+			// and the frame-content re-hook only reacts to element replacement — so a
+			// metadata-only edit to the ACTIVE route's view model would otherwise never
+			// re-run its constructor or property initializers (#3142). Re-create just the
+			// view model, in place, for every region whose active route maps to an updated
+			// view-model type.
+			var updatedViewModels = CollectUpdatedViewModels(updatedTypes, resolver);
+			if (updatedViewModels.Count > 0)
+			{
+				RefreshUpdatedActiveRoutesFromRoot(root, resolver, updatedViewModels);
+			}
+
 			// Re-issue any navigation requests that were dropped earlier because
 			// their target view type was not yet present in the assembly. The
 			// resolver has now been rebuilt with the latest route table, so a
@@ -322,6 +335,65 @@ internal static class NavigationRouteUpdateHandler
 			// is given a chance to recover.
 			RetryPendingFailedRequestsFromRoot(root);
 		});
+	}
+
+	/// <summary>
+	/// Maps each updated type to the view-model type the (just-rebuilt) route table associates
+	/// with it. Resolving through <see cref="RouteResolver.FindByViewModel"/> — rather than
+	/// comparing raw types — makes the MVUX case work: <see cref="MappedRouteResolver"/>
+	/// translates a model type (which is what the delta contains) to its generated bindable view
+	/// model (which is what <see cref="RouteInfo.ViewModel"/> holds). View types are deliberately
+	/// NOT collected: updated views are owned by Uno's element-update walk (plus the
+	/// frame-content re-hook), and rebuilding view models on a view-only delta would discard
+	/// un-persisted view-model state on every page edit.
+	/// </summary>
+	internal static HashSet<Type> CollectUpdatedViewModels(Type[]? updatedTypes, RouteResolver resolver)
+	{
+		var viewModels = new HashSet<Type>();
+		if (updatedTypes is null)
+		{
+			return viewModels;
+		}
+
+		foreach (var t in updatedTypes)
+		{
+			// IL2072: same read-only, type-identity lookup as HasRouteRegisteredType above.
+#pragma warning disable IL2072
+			if (resolver.FindByViewModel(t, navigator: null)?.ViewModel is { } viewModel)
+#pragma warning restore IL2072
+			{
+				viewModels.Add(viewModel);
+			}
+		}
+
+		return viewModels;
+	}
+
+	/// <summary>
+	/// Walks the live region tree and, for every region whose navigator's ACTIVE route maps to
+	/// one of <paramref name="updatedViewModels"/>, re-creates that view model in place via
+	/// <see cref="ControlNavigator.RefreshActiveRouteViewModelAsync"/>. No navigation is issued,
+	/// so the user's selection cannot move (#3142).
+	/// </summary>
+	private static void RefreshUpdatedActiveRoutesFromRoot(IRegion region, RouteResolver resolver, HashSet<Type> updatedViewModels)
+	{
+		if (region.Navigator() is ControlNavigator cn &&
+			cn.Route?.Base is { Length: > 0 } activeBase &&
+			resolver.FindByPath(activeBase) is { ViewModel: { } viewModel } &&
+			updatedViewModels.Contains(viewModel))
+		{
+			if (Region.Logger.IsEnabled(LogLevel.Information))
+			{
+				Region.Logger.LogInformationMessage($"Hot-reload refresh: active route '{activeBase}' on region '{region.Name ?? string.Empty}' maps to updated view model '{viewModel.Name}'; re-creating it in place");
+			}
+
+			SafeFireAndForget(cn.RefreshActiveRouteViewModelAsync(), $"view-model refresh for active route '{activeBase}'");
+		}
+
+		foreach (var child in region.Children.ToArray())
+		{
+			RefreshUpdatedActiveRoutesFromRoot(child, resolver, updatedViewModels);
+		}
 	}
 
 	private static void RetryPendingFailedRequestsFromRoot(IRegion region)

--- a/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
@@ -349,24 +349,18 @@ internal static class NavigationRouteUpdateHandler
 	/// </summary>
 	internal static HashSet<Type> CollectUpdatedViewModels(Type[]? updatedTypes, RouteResolver resolver)
 	{
-		var viewModels = new HashSet<Type>();
 		if (updatedTypes is null)
 		{
-			return viewModels;
+			return [];
 		}
 
-		foreach (var t in updatedTypes)
-		{
-			// IL2072: same read-only, type-identity lookup as HasRouteRegisteredType above.
+		// IL2072: same read-only, type-identity lookup as HasRouteRegisteredType above.
 #pragma warning disable IL2072
-			if (resolver.FindByViewModel(t, navigator: null)?.ViewModel is { } viewModel)
+		return updatedTypes
+			.Select(t => resolver.FindByViewModel(t, navigator: null)?.ViewModel)
+			.OfType<Type>()
+			.ToHashSet();
 #pragma warning restore IL2072
-			{
-				viewModels.Add(viewModel);
-			}
-		}
-
-		return viewModels;
 	}
 
 	/// <summary>

--- a/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
+++ b/src/Uno.Extensions.Navigation.UI/NavigationRouteUpdateHandler.cs
@@ -354,13 +354,14 @@ internal static class NavigationRouteUpdateHandler
 			return [];
 		}
 
-		// IL2072: same read-only, type-identity lookup as HasRouteRegisteredType above.
-#pragma warning disable IL2072
+		// IL2067: same read-only, type-identity lookup as HasRouteRegisteredType above (the
+		// lambda parameter shifts the trim diagnostic from IL2072 to IL2067).
+#pragma warning disable IL2067
 		return updatedTypes
 			.Select(t => resolver.FindByViewModel(t, navigator: null)?.ViewModel)
 			.OfType<Type>()
 			.ToHashSet();
-#pragma warning restore IL2072
+#pragma warning restore IL2067
 	}
 
 	/// <summary>

--- a/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
+++ b/src/Uno.Extensions.Navigation.UI/Navigators/ControlNavigator.cs
@@ -145,6 +145,19 @@ public abstract class ControlNavigator<TControl> : ControlNavigator
 		return executedRoute;
 	}
 
+	/// <inheritdoc />
+	internal override async Task RefreshActiveRouteViewModelAsync()
+	{
+		var route = Route;
+		if (route is null || string.IsNullOrEmpty(route.Base))
+		{
+			return;
+		}
+
+		var mapping = Resolver.FindByPath(route.Base);
+		await InitializeCurrentView(new NavigationRequest(this, route), route, mapping, refresh: true);
+	}
+
 	protected async Task<object?> InitializeCurrentView(NavigationRequest request, Route route, RouteInfo? mapping, bool refresh = false)
 	{
 		var view = CurrentView;
@@ -301,6 +314,18 @@ public abstract class ControlNavigator : Navigator
 
 		return NavigateAsync(pending);
 	}
+
+	/// <summary>
+	/// Re-creates the view model of the route this navigator is currently on and rebinds it to
+	/// the current view, without issuing a navigation. Called by
+	/// <see cref="UI.NavigationRouteUpdateHandler"/> after a C# hot-reload delta updated the view
+	/// model mapped to the ACTIVE route (#3142): a metadata update never re-runs constructors or
+	/// property initializers on live instances, and no navigation-based path re-instantiates the
+	/// route the user is already on — the IsDefault cascade deliberately suppresses regions that
+	/// are already on their route, and re-issuing the same route short-circuits to a no-op
+	/// (0 forward segments, unchanged SourcePageType).
+	/// </summary>
+	internal virtual Task RefreshActiveRouteViewModelAsync() => Task.CompletedTask;
 
 	protected ControlNavigator(
 		ILogger logger,


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3142

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

A C# hot-reload delta that updates the view model of the **currently displayed** route never
re-instantiates that view model, so edits that only run at construction time (constructor bodies,
property initializers) stay invisible until a full rebuild — the one page guaranteed not to
refresh is the page the user is looking at.

Every existing HR path declines to handle it:

- `NavigationRouteUpdateHandler.UpdateApplication` rebuilds the route table and correctly
  classifies the delta as navigation-relevant, but `CascadeNewDefaultsFromRoot` suppresses the
  walk because the region is *already* on that route (the suppression itself is correct — it
  preserves the user's selection).
- `FrameNavigator.RehookCurrentViewAfterHotReload` only reacts when the frame's content element
  was replaced; a metadata-only edit to a plain C# view-model class replaces no element.
- `RetryPendingFailedRequestsFromRoot` only re-issues *failed* requests.

Re-issuing the same route is also a no-op end to end: `FrameNavigator.NavigateForwardAsync`
computes 0 forward segments for the route it is already on, and its HR bypass only fires when
`SourcePageType` differs from the mapping's `RenderView` — which it doesn't for an in-place
(EnC) update.

## What is the new behavior?

When a hot-reload delta updates the view model mapped to a region's **active** route, that view
model is re-created in place and rebound — no navigation is issued, so the user's selection
cannot move.

Implementation (two orthogonal walks instead of entangling `updatedTypes` into the cascade's
conflict check — `CascadeNewDefaultsFromRoot` is unchanged):

- `NavigationRouteUpdateHandler.ScheduleCascade` now receives `updatedTypes`.
  `CollectUpdatedViewModels` maps each updated type to the view-model type the just-rebuilt route
  table associates with it, resolved through `RouteResolver.FindByViewModel` so the MVUX case
  works (`MappedRouteResolver` translates a model type — what the delta contains — to its
  generated bindable view model — what `RouteInfo.ViewModel` holds).
- `RefreshUpdatedActiveRoutesFromRoot` walks the live region tree; every region whose navigator's
  active `Route.Base` resolves to a mapping whose `ViewModel` is in that set gets the new
  `ControlNavigator.RefreshActiveRouteViewModelAsync()`, which re-runs the standard
  `InitializeCurrentView(refresh: true)` pipeline (`CreateViewModel` +
  `InjectServicesAndSetDataContextAsync`) for the route the navigator is already on.
- **View types deliberately do not trigger the refresh**: updated views are owned by Uno's
  element-update walk (plus the frame-content re-hook), and rebuilding view models on a view-only
  delta would discard un-persisted view-model state on every page edit — the behavior
  `Given_FrameContentRehook.When_XamlOnlyDelta_Then_CopiedViewModelIsPreserved` pins.
- `updatedTypes == null` (unknown delta) refreshes nothing — conservative, mirrors the existing
  x:Uid-revert guard on the cascade.

Known limitation (documented in `specs/009-hr-active-route-vm-refresh/spec.md`): a view model
replaced via `CreateNewOnMetadataUpdate` (rude edit / some partial-class deltas) resolves to the
old type in the rebuilt route table and is not matched — same pre-existing limitation as the
route table itself (#3072). The in-place EnC case (type identity preserved) is fully covered.

## Other information

**Tests added** (red/fix/green — the repro tests fail on `main`):

- `Given_ActiveRouteVmRefresh` (UI test, no HR harness — same technique as
  `Given_FrameContentRehook`): drives the internal HR entry point with a synthetic delta against
  a live navigation tree. Asserts the VM is rebuilt in place (view instance untouched) for a
  VM delta, and preserved for a view-only delta. Verified red before the fix (timeout — nothing
  re-instantiates the VM) and green after, on Skia desktop.
- `Given_HotReload.When_ActiveRouteViewModelUpdated_Then_ActiveRegionVmReinstantiated` (runtime
  test, real HR delta, secondary app): edits a constructor-seeded property initializer on the
  active route's own VM file while sitting on a **non-default** visibility-region route; asserts
  the VM is re-instantiated with the post-HR seed AND the selection is not yanked back to the
  `IsDefault` route. Runs in the hot-reload runtime-test CI stage.
- `Given_NavigationRouteUpdateHandler`: 5 unit tests for `CollectUpdatedViewModels`
  (null / unregistered / registered VM / registered view-only / MVUX mapped-model).
- Existing guard suites verified green: `Given_FrameContentRehook` (state preservation
  unchanged), `Given_NavigationRouteUpdateHandler`, neighboring navigation suites.

Also validated end-to-end in a downstream consumer: with this assembly, editing a chart series
property initializer on the displayed page's model (`ColumnSeries<double>` →
`LineSeries<double>`) renders live on the active page in one hot-reload pass — previously it
required breaking hot reload badly enough to force a full rebuild.

Design doc: `specs/009-hr-active-route-vm-refresh/spec.md` (+ scenario entry in
`src/Uno.Extensions.Navigation.UI.Tests/HotReload.Spec.md`).

Internal Issue (If applicable):
