### PR TITLE
[POC] feat(reactive): mock data sources for FeedView (POCO / JSON envelopes)

### DIFF
--- a/doc/Learn/Mvux/FeedView.md
+++ b/doc/Learn/Mvux/FeedView.md
@@ -55,6 +55,50 @@ The `Source` property of the `FeedView` is data bound to the `CurrentContact` pr
 
 In the above example, [`Data`](#data) is a property of the `FeedViewState` instance that the `FeedView` creates from the `IFeed` and sets as the `DataContext` for the various templates.
 
+#### Mock data and design-time sources
+
+The `Source` property also accepts values which are not feeds, making it easy to preview a page with mock data without writing a Model. A plain object (a POCO, an anonymous object, or an `ExpandoObject`/dictionary created from JSON) is wrapped as a single-message feed whose value is the object, rendered by the [`ValueTemplate`](#valuetemplate-default-template):
+
+```xml
+<mvux:FeedView>
+    <mvux:FeedView.Source>
+        <models:Person Age="34" />
+    </mvux:FeedView.Source>
+    <DataTemplate>
+        <TextBlock Text="{Binding Data.Age}"/>
+    </DataTemplate>
+</mvux:FeedView>
+```
+
+To mock the other states of the `FeedView` (loading, error, empty), provide a mock *envelope*: an object whose members are limited to the following (matched case-insensitively, so camelCase JSON works):
+
+| Member | Aliases | Effect |
+| ------ | ------- | ------ |
+| `Data` | — | `null` renders the [`NoneTemplate`](#nonetemplate); any other value renders the `ValueTemplate` with that value. If the value is itself a feed, that feed is used directly. |
+| `Progress` | `IsProgress`, `InProgress` | `true` renders the [`ProgressTemplate`](#progresstemplate), mocking an in-flight load. |
+| `Error` | `Exception` | A non-null value renders the [`ErrorTemplate`](#errortemplate). An `Exception` is used as-is; any other value (such as a string coming from JSON) is wrapped in an exception carrying its text as the message. |
+
+An object is only treated as an envelope when **all** of its public properties (or dictionary keys) belong to the list above and at least one is present — a business object which merely happens to expose a `Data` property (alongside other properties) is still rendered as a plain value.
+
+```xml
+<!-- Mock the loading state -->
+<mvux:FeedView>
+    <mvux:FeedView.Source>
+        <models:FeedMock Progress="True" />
+    </mvux:FeedView.Source>
+    ...
+</mvux:FeedView>
+```
+
+> [!NOTE]
+> Envelope detection on POCOs relies on reflection over the object's public properties. On trimmed/AOT targets prefer `IDictionary<string, object?>`/`ExpandoObject` sources (e.g. converted from JSON), which are inspected without reflection. If property metadata has been trimmed, the object safely degrades to being rendered whole as a plain value.
+
+A constant feed can also be created explicitly with `Feed.Value(...)`:
+
+```csharp
+public IFeed<Person> CurrentContact => Feed.Value(new Person("Mock Mary", 34));
+```
+
 ### State
 
 The `State` property returns a `FeedViewState`, which exposes the current state of the `FeedView`'s underlying data Feed. It's unlikely that you'll need to access the `State` property directly since the `FeedViewState` is automatically set as the `DataContext` of the various templates.

--- a/samples/Playground/Playground/AppHost.cs
+++ b/samples/Playground/Playground/AppHost.cs
@@ -125,6 +125,7 @@ internal static class AppHost
 			new ViewMap<ComplexDialogSecondPage>(),
 			new ViewMap<PanelVisibilityPage>(),
 			new ViewMap<VisualStatesPage>(),
+			new ViewMap<FeedViewMockPage>(),
 			new ViewMap<AdHocPage, AdHocViewModel>(),
 			new ViewMap<ListPage, ListViewModel>(),
 			new ViewMap<ItemDetailsPage, ItemDetailsViewModel>(),
@@ -141,7 +142,8 @@ internal static class AppHost
 			new RouteMap("", View: views.FindByViewModel<ShellViewModel>(),
 			Nested: new[]
 			{
-					new RouteMap("Home",View: views.FindByView<HomePage>()),
+					// IsDefault ensures the shell can resolve an initial route when the empty route is requested
+					new RouteMap("Home",View: views.FindByView<HomePage>(), IsDefault: true),
 					new RouteMap("CodeBehind",View: views.FindByView<CodeBehindPage>(), DependsOn: "Home"),
 					new RouteMap("VM",View: views.FindByView<VMPage>(), DependsOn: "Home"),
 					new RouteMap("Xaml",View: views.FindByView<XamlPage>(), DependsOn: "Home"),
@@ -179,6 +181,7 @@ internal static class AppHost
 					}),
 					new RouteMap("PanelVisibility",View: views.FindByView<PanelVisibilityPage>()),
 					new RouteMap("VisualStates",View: views.FindByView<VisualStatesPage>()),
+					new RouteMap("FeedViewMock",View: views.FindByView<FeedViewMockPage>(), DependsOn: "Home"),
 					new RouteMap("AdHoc",View: views.FindByViewModel<AdHocViewModel>(),
 					Nested: new[]
 					{

--- a/samples/Playground/Playground/Models/FeedMock.cs
+++ b/samples/Playground/Playground/Models/FeedMock.cs
@@ -1,0 +1,18 @@
+namespace Playground.Models;
+
+/// <summary>
+/// A XAML-friendly FeedView mock envelope, exposing exactly the members recognized by the
+/// FeedView mock source convention (Data / Progress / Error) so the FeedView can render
+/// each of its states from design-time data.
+/// </summary>
+public class FeedMock
+{
+	/// <summary>The mocked value: non-null renders the value template, null renders the None state.</summary>
+	public object? Data { get; set; }
+
+	/// <summary>When true, the FeedView renders its progress (loading) state.</summary>
+	public bool Progress { get; set; }
+
+	/// <summary>The mocked error: an Exception, or any value (e.g. a string) used as the error message.</summary>
+	public object? Error { get; set; }
+}

--- a/samples/Playground/Playground/Models/JsonDataContext.cs
+++ b/samples/Playground/Playground/Models/JsonDataContext.cs
@@ -1,0 +1,76 @@
+using System.Dynamic;
+using System.Text.Json;
+
+namespace Playground.Models;
+
+/// <summary>
+/// Converts a raw JSON string (typically declared inline in XAML) into an <see cref="ExpandoObject"/>
+/// graph exposed via <see cref="Value"/>, so it can be used as a mock DataContext / FeedView source.
+/// </summary>
+/// <remarks>
+/// This deliberately deviates from the repo rule of typed JSON deserialization: the whole point of a
+/// JSON mock is an unknown-at-compile-time shape, so no typed model can exist. Sample-only code —
+/// see specs/009-feedview-mock-source/spec.md (Spec deviations).
+/// </remarks>
+public class JsonDataContext
+{
+	private string? _json;
+
+	/// <summary>The raw JSON to convert.</summary>
+	public string? Json
+	{
+		get => _json;
+		set
+		{
+			_json = value;
+			Value = Parse(value);
+		}
+	}
+
+	/// <summary>The converted object graph (ExpandoObject for JSON objects, List for arrays, CLR primitives otherwise).</summary>
+	public object? Value { get; private set; }
+
+	private static object? Parse(string? json)
+	{
+		if (string.IsNullOrWhiteSpace(json))
+		{
+			return null;
+		}
+
+		try
+		{
+			using var document = JsonDocument.Parse(json);
+			// The graph is fully materialized into CLR objects before the document is disposed.
+			return ToClr(document.RootElement);
+		}
+		catch (JsonException error)
+		{
+			// Surface the parsing failure through the FeedView error state instead of crashing the page.
+			return new Dictionary<string, object?> { ["Error"] = error };
+		}
+	}
+
+	private static object? ToClr(JsonElement element)
+		=> element.ValueKind switch
+		{
+			JsonValueKind.Object => ToExpando(element),
+			JsonValueKind.Array => element.EnumerateArray().Select(ToClr).ToList(),
+			JsonValueKind.String => element.GetString(),
+			JsonValueKind.Number => element.TryGetInt64(out var integer) ? integer : element.GetDouble(),
+			JsonValueKind.True => true,
+			JsonValueKind.False => false,
+			_ => null,
+		};
+
+	private static ExpandoObject ToExpando(JsonElement element)
+	{
+		var expando = new ExpandoObject();
+		var members = (IDictionary<string, object?>)expando;
+		foreach (var property in element.EnumerateObject())
+		{
+			members[property.Name] = ToClr(property.Value);
+		}
+
+		return expando;
+	}
+}

--- a/samples/Playground/Playground/Views/FeedViewMockPage.xaml
+++ b/samples/Playground/Playground/Views/FeedViewMockPage.xaml
@@ -1,0 +1,412 @@
+﻿<Page x:Class="Playground.Views.FeedViewMockPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Playground.Views"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:ui="using:Uno.Toolkit.UI"
+	  xmlns:uer="using:Uno.Extensions.Reactive.UI"
+	  xmlns:models="using:Playground.Models"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+		<DataTemplate x:Key="MockProgressTemplate">
+			<StackPanel Orientation="Horizontal"
+						Spacing="8">
+				<ProgressRing IsActive="True"
+							  Width="24"
+							  Height="24" />
+				<TextBlock Text="Loading (mocked)…"
+						   VerticalAlignment="Center" />
+			</StackPanel>
+		</DataTemplate>
+		<DataTemplate x:Key="MockErrorTemplate">
+			<TextBlock Text="{Binding Message}"
+					   Foreground="Red" />
+		</DataTemplate>
+		<DataTemplate x:Key="MockNoneTemplate">
+			<TextBlock Text="No data (mocked empty state)" />
+		</DataTemplate>
+
+		<Style x:Key="SectionHeaderStyle"
+			   TargetType="TextBlock">
+			<Setter Property="FontSize"
+					Value="18" />
+			<Setter Property="FontWeight"
+					Value="SemiBold" />
+			<Setter Property="Margin"
+					Value="0,12,0,0" />
+		</Style>
+		<Style x:Key="CodeBorderStyle"
+			   TargetType="Border">
+			<Setter Property="BorderBrush"
+					Value="Gray" />
+			<Setter Property="BorderThickness"
+					Value="1" />
+			<Setter Property="CornerRadius"
+					Value="4" />
+			<Setter Property="Padding"
+					Value="8" />
+			<Setter Property="VerticalAlignment"
+					Value="Top" />
+		</Style>
+		<Style x:Key="CodeTextStyle"
+			   TargetType="TextBlock">
+			<Setter Property="FontFamily"
+					Value="Consolas" />
+			<Setter Property="FontSize"
+					Value="11" />
+			<Setter Property="IsTextSelectionEnabled"
+					Value="True" />
+		</Style>
+	</Page.Resources>
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<ui:NavigationBar Content="FeedView Mock Data"
+						  Style="{StaticResource MaterialNavigationBarStyle}" />
+		<ScrollViewer Grid.Row="1">
+			<StackPanel Spacing="8"
+						Margin="12">
+
+				<!-- 1. A plain POCO as Source: wrapped as a single-value feed (Some state). -->
+				<TextBlock Text="POCO value"
+						   Style="{StaticResource SectionHeaderStyle}" />
+				<Grid ColumnSpacing="12">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+					<uer:FeedView VerticalAlignment="Top">
+						<uer:FeedView.Source>
+							<!-- Note: Person.Name is set via a property element because a `Name` attribute
+								 is treated as x:Name by the XAML compiler. -->
+							<models:Person Age="34"
+										   Height="1.65"
+										   Weight="62">
+								<models:Person.Name>
+									<x:String>Poco Polly</x:String>
+								</models:Person.Name>
+							</models:Person>
+						</uer:FeedView.Source>
+						<DataTemplate>
+							<StackPanel>
+								<TextBlock Text="{Binding Data.Name}" />
+								<TextBlock Text="{Binding Data.Age}" />
+							</StackPanel>
+						</DataTemplate>
+					</uer:FeedView>
+					<Border Grid.Column="1"
+							Style="{StaticResource CodeBorderStyle}">
+						<TextBlock Style="{StaticResource CodeTextStyle}">
+							<TextBlock.Text>
+								<x:String xml:space="preserve">&lt;uer:FeedView>
+  &lt;uer:FeedView.Source>
+    &lt;!-- `Name` attribute = x:Name, so use a property element -->
+    &lt;models:Person Age="34" Height="1.65" Weight="62">
+      &lt;models:Person.Name>
+        &lt;x:String>Poco Polly&lt;/x:String>
+      &lt;/models:Person.Name>
+    &lt;/models:Person>
+  &lt;/uer:FeedView.Source>
+  &lt;DataTemplate>
+    &lt;StackPanel>
+      &lt;TextBlock Text="{Binding Data.Name}" />
+      &lt;TextBlock Text="{Binding Data.Age}" />
+    &lt;/StackPanel>
+  &lt;/DataTemplate>
+&lt;/uer:FeedView></x:String>
+							</TextBlock.Text>
+						</TextBlock>
+					</Border>
+				</Grid>
+
+				<!-- 2. A POCO envelope driving the progress (loading) state. -->
+				<TextBlock Text="POCO envelope — Progress"
+						   Style="{StaticResource SectionHeaderStyle}" />
+				<Grid ColumnSpacing="12">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+					<uer:FeedView ProgressTemplate="{StaticResource MockProgressTemplate}"
+								  VerticalAlignment="Top">
+						<uer:FeedView.Source>
+							<models:FeedMock Progress="True" />
+						</uer:FeedView.Source>
+						<DataTemplate>
+							<TextBlock Text="{Binding Data}" />
+						</DataTemplate>
+					</uer:FeedView>
+					<Border Grid.Column="1"
+							Style="{StaticResource CodeBorderStyle}">
+						<TextBlock Style="{StaticResource CodeTextStyle}">
+							<TextBlock.Text>
+								<x:String xml:space="preserve">&lt;uer:FeedView ProgressTemplate="{StaticResource MockProgressTemplate}">
+  &lt;uer:FeedView.Source>
+    &lt;models:FeedMock Progress="True" />
+  &lt;/uer:FeedView.Source>
+  &lt;DataTemplate>
+    &lt;TextBlock Text="{Binding Data}" />
+  &lt;/DataTemplate>
+&lt;/uer:FeedView></x:String>
+							</TextBlock.Text>
+						</TextBlock>
+					</Border>
+				</Grid>
+
+				<!-- 3. A POCO envelope driving the error state (a string is wrapped as the error message). -->
+				<TextBlock Text="POCO envelope — Error"
+						   Style="{StaticResource SectionHeaderStyle}" />
+				<Grid ColumnSpacing="12">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+					<uer:FeedView ErrorTemplate="{StaticResource MockErrorTemplate}"
+								  VerticalAlignment="Top">
+						<uer:FeedView.Source>
+							<models:FeedMock Error="Something went wrong (mocked)" />
+						</uer:FeedView.Source>
+						<DataTemplate>
+							<TextBlock Text="{Binding Data}" />
+						</DataTemplate>
+					</uer:FeedView>
+					<Border Grid.Column="1"
+							Style="{StaticResource CodeBorderStyle}">
+						<TextBlock Style="{StaticResource CodeTextStyle}">
+							<TextBlock.Text>
+								<x:String xml:space="preserve">&lt;uer:FeedView ErrorTemplate="{StaticResource MockErrorTemplate}">
+  &lt;uer:FeedView.Source>
+    &lt;!-- A string Error is wrapped as the exception message -->
+    &lt;models:FeedMock Error="Something went wrong (mocked)" />
+  &lt;/uer:FeedView.Source>
+  &lt;DataTemplate>
+    &lt;TextBlock Text="{Binding Data}" />
+  &lt;/DataTemplate>
+&lt;/uer:FeedView></x:String>
+							</TextBlock.Text>
+						</TextBlock>
+					</Border>
+				</Grid>
+
+				<!-- 4. A POCO envelope with null Data: the None (empty) state. -->
+				<TextBlock Text="POCO envelope — None (empty)"
+						   Style="{StaticResource SectionHeaderStyle}" />
+				<Grid ColumnSpacing="12">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+					<uer:FeedView NoneTemplate="{StaticResource MockNoneTemplate}"
+								  VerticalAlignment="Top">
+						<uer:FeedView.Source>
+							<models:FeedMock />
+						</uer:FeedView.Source>
+						<DataTemplate>
+							<TextBlock Text="{Binding Data}" />
+						</DataTemplate>
+					</uer:FeedView>
+					<Border Grid.Column="1"
+							Style="{StaticResource CodeBorderStyle}">
+						<TextBlock Style="{StaticResource CodeTextStyle}">
+							<TextBlock.Text>
+								<x:String xml:space="preserve">&lt;uer:FeedView NoneTemplate="{StaticResource MockNoneTemplate}">
+  &lt;uer:FeedView.Source>
+    &lt;!-- Data is null: renders the None (empty) state -->
+    &lt;models:FeedMock />
+  &lt;/uer:FeedView.Source>
+  &lt;DataTemplate>
+    &lt;TextBlock Text="{Binding Data}" />
+  &lt;/DataTemplate>
+&lt;/uer:FeedView></x:String>
+							</TextBlock.Text>
+						</TextBlock>
+					</Border>
+				</Grid>
+
+				<!-- 5. Raw JSON set as the DataContext in XAML: the JSON envelope keys (case-insensitive)
+					 drive the feed axes, and the Data object is rendered by the value template. -->
+				<TextBlock Text="JSON envelope — Value"
+						   Style="{StaticResource SectionHeaderStyle}" />
+				<Grid ColumnSpacing="12">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+					<StackPanel>
+						<StackPanel.DataContext>
+							<models:JsonDataContext>
+								<models:JsonDataContext.Json>
+									<x:String xml:space="preserve">
+									{
+										"data": { "Name": "Json Jane", "Company": "Contoso" },
+										"progress": false
+									}
+									</x:String>
+								</models:JsonDataContext.Json>
+							</models:JsonDataContext>
+						</StackPanel.DataContext>
+						<uer:FeedView Source="{Binding Value}">
+							<DataTemplate>
+								<StackPanel>
+									<TextBlock Text="{Binding Data.Name}" />
+									<TextBlock Text="{Binding Data.Company}" />
+								</StackPanel>
+							</DataTemplate>
+						</uer:FeedView>
+					</StackPanel>
+					<Border Grid.Column="1"
+							Style="{StaticResource CodeBorderStyle}">
+						<TextBlock Style="{StaticResource CodeTextStyle}">
+							<TextBlock.Text>
+								<x:String xml:space="preserve">&lt;StackPanel>
+  &lt;StackPanel.DataContext>
+    &lt;models:JsonDataContext>
+      &lt;models:JsonDataContext.Json>
+        &lt;x:String xml:space="preserve">
+        {
+          "data": { "Name": "Json Jane", "Company": "Contoso" },
+          "progress": false
+        }
+        &lt;/x:String>
+      &lt;/models:JsonDataContext.Json>
+    &lt;/models:JsonDataContext>
+  &lt;/StackPanel.DataContext>
+  &lt;uer:FeedView Source="{Binding Value}">
+    &lt;DataTemplate>
+      &lt;StackPanel>
+        &lt;TextBlock Text="{Binding Data.Name}" />
+        &lt;TextBlock Text="{Binding Data.Company}" />
+      &lt;/StackPanel>
+    &lt;/DataTemplate>
+  &lt;/uer:FeedView>
+&lt;/StackPanel></x:String>
+							</TextBlock.Text>
+						</TextBlock>
+					</Border>
+				</Grid>
+
+				<!-- 6. Raw JSON envelope mocking the error state. -->
+				<TextBlock Text="JSON envelope — Error"
+						   Style="{StaticResource SectionHeaderStyle}" />
+				<Grid ColumnSpacing="12">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+					<StackPanel>
+						<StackPanel.DataContext>
+							<models:JsonDataContext>
+								<models:JsonDataContext.Json>
+									<x:String xml:space="preserve">
+									{
+										"data": null,
+										"error": "Failed to load data (from JSON)"
+									}
+									</x:String>
+								</models:JsonDataContext.Json>
+							</models:JsonDataContext>
+						</StackPanel.DataContext>
+						<uer:FeedView Source="{Binding Value}"
+									  ErrorTemplate="{StaticResource MockErrorTemplate}"
+									  NoneTemplate="{StaticResource MockNoneTemplate}">
+							<DataTemplate>
+								<TextBlock Text="{Binding Data}" />
+							</DataTemplate>
+						</uer:FeedView>
+					</StackPanel>
+					<Border Grid.Column="1"
+							Style="{StaticResource CodeBorderStyle}">
+						<TextBlock Style="{StaticResource CodeTextStyle}">
+							<TextBlock.Text>
+								<x:String xml:space="preserve">&lt;StackPanel>
+  &lt;StackPanel.DataContext>
+    &lt;models:JsonDataContext>
+      &lt;models:JsonDataContext.Json>
+        &lt;x:String xml:space="preserve">
+        {
+          "data": null,
+          "error": "Failed to load data (from JSON)"
+        }
+        &lt;/x:String>
+      &lt;/models:JsonDataContext.Json>
+    &lt;/models:JsonDataContext>
+  &lt;/StackPanel.DataContext>
+  &lt;uer:FeedView Source="{Binding Value}"
+                ErrorTemplate="{StaticResource MockErrorTemplate}"
+                NoneTemplate="{StaticResource MockNoneTemplate}">
+    &lt;DataTemplate>
+      &lt;TextBlock Text="{Binding Data}" />
+    &lt;/DataTemplate>
+  &lt;/uer:FeedView>
+&lt;/StackPanel></x:String>
+							</TextBlock.Text>
+						</TextBlock>
+					</Border>
+				</Grid>
+
+				<!-- 7. Raw JSON that is NOT an envelope: the whole object becomes the feed value. -->
+				<TextBlock Text="JSON plain object"
+						   Style="{StaticResource SectionHeaderStyle}" />
+				<Grid ColumnSpacing="12">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+					<StackPanel>
+						<StackPanel.DataContext>
+							<models:JsonDataContext>
+								<models:JsonDataContext.Json>
+									<x:String xml:space="preserve">
+									{ "Name": "Raw Ray", "Role": "Not an envelope" }
+									</x:String>
+								</models:JsonDataContext.Json>
+							</models:JsonDataContext>
+						</StackPanel.DataContext>
+						<uer:FeedView Source="{Binding Value}">
+							<DataTemplate>
+								<StackPanel>
+									<TextBlock Text="{Binding Data.Name}" />
+									<TextBlock Text="{Binding Data.Role}" />
+								</StackPanel>
+							</DataTemplate>
+						</uer:FeedView>
+					</StackPanel>
+					<Border Grid.Column="1"
+							Style="{StaticResource CodeBorderStyle}">
+						<TextBlock Style="{StaticResource CodeTextStyle}">
+							<TextBlock.Text>
+								<x:String xml:space="preserve">&lt;StackPanel>
+  &lt;StackPanel.DataContext>
+    &lt;models:JsonDataContext>
+      &lt;models:JsonDataContext.Json>
+        &lt;!-- Not an envelope: whole object becomes the feed value -->
+        &lt;x:String xml:space="preserve">
+        { "Name": "Raw Ray", "Role": "Not an envelope" }
+        &lt;/x:String>
+      &lt;/models:JsonDataContext.Json>
+    &lt;/models:JsonDataContext>
+  &lt;/StackPanel.DataContext>
+  &lt;uer:FeedView Source="{Binding Value}">
+    &lt;DataTemplate>
+      &lt;StackPanel>
+        &lt;TextBlock Text="{Binding Data.Name}" />
+        &lt;TextBlock Text="{Binding Data.Role}" />
+      &lt;/StackPanel>
+    &lt;/DataTemplate>
+  &lt;/uer:FeedView>
+&lt;/StackPanel></x:String>
+							</TextBlock.Text>
+						</TextBlock>
+					</Border>
+				</Grid>
+
+			</StackPanel>
+		</ScrollViewer>
+	</Grid>
+</Page>

--- a/samples/Playground/Playground/Views/FeedViewMockPage.xaml.cs
+++ b/samples/Playground/Playground/Views/FeedViewMockPage.xaml.cs
@@ -1,0 +1,9 @@
+﻿namespace Playground.Views;
+
+public sealed partial class FeedViewMockPage : Page
+{
+	public FeedViewMockPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/samples/Playground/Playground/Views/HomePage.xaml
+++ b/samples/Playground/Playground/Views/HomePage.xaml
@@ -68,6 +68,8 @@
 						Content="Flyouts Popups and Drawer page" />
 				<Button uen:Navigation.Request="VisualStates"
 						Content="Visual States" />
+				<Button uen:Navigation.Request="FeedViewMock"
+						Content="FeedView Mock Data" />
 				<Button uen:Navigation.Request="PanelVisibility"
 						Content="Visibility" />
 				<Button uen:Navigation.Request="AdHoc"

--- a/specs/009-feedview-mock-source/progress.md
+++ b/specs/009-feedview-mock-source/progress.md
@@ -1,0 +1,46 @@
+# Progress — FeedView mock sources
+
+Branch: `dev/nr/feedview-mock-source`
+
+- [x] Spec written (`spec.md`)
+- [x] Core: `Feed.Value<T>` public factory over `ValueFeed<T>` (`Core/Feed.cs`)
+- [x] Core: `MockFeed` (envelope detection, dictionary + reflection readers, refresh handling) (`Sources/MockFeed.cs`, `Sources/MockFeedException.cs`)
+- [x] UI: `FeedView` source coercion (cached `_coercedSource` field, `OnSourceChanged`/`Enable`/`OnApplyTemplate`)
+- [x] Unit tests: `Given_MockFeed` — 22 cases (package CI surface), all passing
+- [x] Unit tests: `Given_Feed.When_Value*` for `Feed.Value`, passing
+- [x] UI tests: `Given_FeedView` mock-source cases (7 cases; compile-verified — run by runtime-test stages)
+- [x] Playground: `FeedViewMockPage` + `JsonDataContext` + `FeedMock` + route + home button + FeedView.xaml merge in App.xaml
+- [x] Docs: `doc/Learn/Mvux/FeedView.md` — "Mock data and design-time sources" section
+- [x] Release build (net9.0) of `Uno.Extensions.Reactive` and `Uno.Extensions.Reactive.WinUI`: zero warnings
+- [x] `dotnet test Uno.Extensions.Reactive.Tests`: full suite green (1443 passed / 19 pre-existing skips)
+
+## Notes / decisions
+
+- The coercion surface is `ISignal<IMessage>` (internal `MockFeed.Create`), not `IFeed<object>` as first
+  planned: `IFeed<T>` is invariant, so a typed feed passthrough cannot be typed `IFeed<object>`.
+  Public API additions are limited to `Feed.Value<T>(T)`.
+- Playground desktop currently only builds with `-p:UnoDisableHotDesign=true`: the Uno.UI.HotDesign
+  source generator fails on this machine (pre-existing, reproduced on a clean tree — 100 errors on main).
+- `Person Name="..."` in XAML generates an `x:Name` member — set POCO `Name` properties via property
+  elements in mock XAML (documented with a comment in `FeedViewMockPage.xaml`).
+- Pre-existing on `main` (verified on a clean tree): Playground desktop starts with a blank window —
+  initial navigation fails with "Route '' has 19 nested route(s) but none marked IsDefault" even though
+  `initialViewModel: typeof(HomeViewModel)` is passed. Worked around in this branch by marking the
+  `Home` route `IsDefault: true` in `AppHost.cs`. The underlying resolver behavior (initialViewModel
+  not resolving the initial route) is a candidate separate issue.
+
+## Review
+
+Verified live on Playground (net9.0-desktop, 2026-08-22) — all seven demo sections render correctly:
+
+1. POCO value → "Poco Polly / 34" via ValueTemplate
+2. POCO envelope Progress=true → ProgressRing + custom ProgressTemplate
+3. POCO envelope Error (string) → ErrorTemplate showing the coerced exception message
+4. POCO envelope Data=null → NoneTemplate
+5. JSON envelope (camelCase keys) → ValueTemplate binding into the ExpandoObject data ("Json Jane / Contoso") —
+   confirms Uno's binding engine resolves ExpandoObject members on Skia desktop
+6. JSON envelope with "error" string → ErrorTemplate
+7. JSON plain object (not an envelope) → whole object as value ("Raw Ray / Not an envelope")
+
+Unit suite: 1443 passed / 0 failed / 19 pre-existing skips.
+Release (net9.0) builds of Reactive + Reactive.WinUI: zero warnings.

--- a/specs/009-feedview-mock-source/spec.md
+++ b/specs/009-feedview-mock-source/spec.md
@@ -1,0 +1,163 @@
+# FeedView mock sources (POCO / JSON envelopes)
+
+## Problem
+
+`FeedView.Source` is declared as `object` but every consumption site casts with `Source as ISignal<IMessage>`
+(`FeedView.cs` — `OnSourceChanged`, `Enable`, `OnApplyTemplate`). Any value that is not an `IFeed<T>` /
+`IState<T>` is silently discarded: the control stays in its loading state and nothing renders.
+
+This makes it needlessly hard to prototype a page: a designer or developer should be able to hand a
+`FeedView` a plain POCO, an anonymous object, or a dictionary produced from a JSON document, and see the
+page render — including the *non-Value* states (progress, error, empty) — without writing a view model.
+
+## Goals
+
+1. A non-feed `Source` is wrapped as a single-message feed instead of being discarded.
+2. A lightweight "envelope" convention lets the mock drive the `FeedView` state machine
+   (Value / None / Error / Indeterminate) — not just the happy path.
+3. Both strongly-typed objects (POCO, anonymous types) and loosely-typed objects
+   (`IDictionary<string, object?>`, `ExpandoObject`, JSON-derived graphs) are supported.
+4. `Refresh` on a mocked source completes instead of hanging `IAsyncCommand.IsExecuting`.
+5. No breaking change: any `Source` that is already an `ISignal<IMessage>` behaves exactly as today.
+
+## Non-goals
+
+- Overlaying envelope axes on top of a *real* feed (an envelope whose `Data` is a feed returns that feed
+  unchanged; other envelope members are ignored).
+- Making arbitrary JSON graphs bindable on every platform. Envelope *detection* is handled by this
+  feature; binding *into* the `Data` value from a template relies on the platform binding engine
+  (Uno's binding engine supports `ExpandoObject` / `IDictionary<string, object>`; WinAppSDK on Windows
+  does not guarantee reflection binding into dynamic objects). The Playground sample converts JSON to
+  `ExpandoObject` graphs for this reason.
+
+## Design
+
+### Envelope convention
+
+The envelope mirrors the three values `FeedViewState` exposes to template bindings (`Data`, `Progress`,
+`Error`). Property/key matching is **case-insensitive** (JSON is typically camelCase):
+
+| Canonical | Aliases                    | Effect on the mocked feed message                                     |
+| --------- | -------------------------- | --------------------------------------------------------------------- |
+| `Data`    | —                          | `null` → `Option.None` (None state); otherwise `Option.Some(value)` (Some state). If the value is itself an `ISignal<IMessage>`, that feed is returned directly. |
+| `Progress`| `IsProgress`, `InProgress` | `true` → message is transient (`MessageAxis.Progress`) → Indeterminate state; `FeedView` keeps reporting `ILoadable.IsExecuting == true` (by design: it mocks an in-flight load). |
+| `Error`   | `Exception`                | non-null → `MessageAxis.Error` → Error state. A `string` value is wrapped in an exception carrying that message (JSON cannot carry an `Exception`). |
+
+**Detection rule** — an object is an envelope iff:
+
+- at least one recognized name is present, **and**
+- every public readable instance property (or dictionary key) is within the recognized set.
+
+This keeps real POCOs that happen to expose a `Data` property (e.g. `Report { Data, Title, Author }`)
+out of the envelope path: they degrade to "wrap the whole object as the value" instead of being mangled.
+An object with no public properties is not an envelope.
+
+Two readers implement the property lookup:
+
+- `IDictionary<string, object?>` (covers `ExpandoObject` and JSON-derived dictionaries) — key lookup is
+  `OrdinalIgnoreCase`. This path is trim/AOT-safe.
+- Reflection over public instance properties (POCO, anonymous types) — annotated for trimming (see below).
+
+**Value coercion** (loosely-typed path):
+
+- `Progress`: `bool` used as-is; anything else goes through `bool.TryParse(value.ToString(), ...)`,
+  defaulting to `false`. This covers JSON `true`, `"true"`, and `JsonElement` without the core package
+  referencing `System.Text.Json`.
+- `Error` / `Exception`: an `Exception` instance passes through; any other non-null value is wrapped as
+  `MockFeedException(value.ToString())` (internal type; travels as `Exception` so consumers are unaffected).
+
+### Coercion pipeline
+
+`object?` → `ISignal<IMessage>?`, applied by `FeedView` when `Source` changes:
+
+1. `null` → no feed (unchanged behavior).
+2. Already `ISignal<IMessage>` (any `IFeed<T>` / `IState<T>` / `IListFeed<T>` via `ISignal`'s covariance)
+   → passthrough, untouched.
+3. Envelope (per rule above) → `MockFeed` with the three axes set. If `Data` is a feed → that feed.
+4. Anything else (POCO, string, list, `ExpandoObject` without envelope keys) → `MockFeed` in the
+   Some state wrapping the object.
+
+Note: the coerced feed cannot be typed `IFeed<object>` for the passthrough case — `IFeed<T>` is invariant
+in `T` (`IFeed<int>` is not `IFeed<object>`), while `ISignal<out T>` covariance makes every `IFeed<T>` an
+`ISignal<IMessage>`. The coercion surface is therefore `ISignal<IMessage>`, which is exactly what
+`FeedView` consumes.
+
+### New / changed surface
+
+**`Uno.Extensions.Reactive` (core, net9.0 — unit-testable by package CI):**
+
+- `Sources/MockFeed.cs` — `internal sealed class MockFeed : IFeed<object>`. Emits one message carrying
+  the mocked `Data` / `Error` / `Progress` axes. Honors `RefreshRequest` by re-emitting the same message
+  with the requested `RefreshToken` (`MessageAxis.Refresh`) so `FeedView.Refresh` completes; completes
+  its enumeration on `EndRequest` (feeds must be completable — WASM subscriber-leak rule).
+  Static `MockFeed.TryCreateEnvelope(object)` / `MockFeed.Create(object)` implement the coercion.
+- `Core/Feed.cs` — new public factory `Feed.Value<T>(T value)`: a constant feed over the existing
+  internal `ValueFeed<T>` (single message, then completes). Additive; useful beyond mocking (there is
+  currently no public factory for a constant feed).
+
+**`Uno.Extensions.Reactive.UI`:**
+
+- `FeedView` caches the coerced source in a private field assigned in `OnSourceChanged`; `Enable` and
+  `OnApplyTemplate` read the field instead of re-casting `Source`. Caching preserves feed identity so
+  `Subscribe`'s `_subscription?.Feed == feed` short-circuit keeps working (no re-subscription on every
+  load/template pass). The public `Source` property is unchanged and still returns the raw object.
+
+### Refresh semantics on a mock
+
+`RefreshCommand.Execute` clears `IsExecuting` only when a message arrives carrying the requested
+`RefreshToken` and the message is non-transient. `MockFeed` therefore:
+
+- registers the token on the request and re-emits its message with `MessageAxis.Refresh` set → refresh
+  completes for Value / None / Error mocks;
+- for a `Progress = true` mock the re-emitted message is still transient, so `IsExecuting` remains true —
+  consistent with refreshing a feed whose load never finishes (that is what the mock models).
+
+### Trimming / AOT
+
+The reflection reader is annotated `[RequiresUnreferencedCode]`; the single call site inside the coercion
+carries a scoped `#pragma warning disable IL2026` with justification (same precedent as
+`AsyncFeed.BuildDependentTypeSet`). Under aggressive trimming, envelope detection on a POCO can fail
+soft: the object falls back to being wrapped whole as a value — never a crash. The dictionary /
+`ExpandoObject` path is reflection-free and is the documented trim-safe option.
+
+## Spec deviations (Exceptions process)
+
+- **JSON→object conversion in the Playground sample** traverses `JsonElement` rather than using a typed,
+  source-generated deserializer (repo rule §2/§12). Constraint: the entire point of the JSON mock path is
+  an *unknown-at-compile-time* shape, so no typed model can exist. Impact: sample-only code
+  (`samples/Playground`), never shipped in a package. Mitigation: conversion is isolated in one small
+  helper (`JsonDataContext`) and the library itself never parses JSON.
+
+## Test plan
+
+`src/Uno.Extensions.Reactive.Tests/Sources/Given_MockFeed.cs` (package CI):
+
+- passthrough: a real feed / an envelope whose `Data` is a feed → same instance returned;
+- raw POCO / string / list → one Some message, then completes on `EndRequest`;
+- envelope: `Data` set → Some; `Data = null` → None; `Progress = true` → transient;
+  `Error` non-null → error axis; combinations (error + data, progress + data);
+- false-positive guard: POCO with `Data` plus unrecognized properties → treated as raw value;
+- dictionary/`ExpandoObject` path: camelCase keys, string `error` value, string `"true"` progress;
+- refresh: `RequestRefresh` → second message carrying the refresh token.
+
+`src/Uno.Extensions.Reactive.UI.Tests/Given_FeedView.cs` (runtime-test stages):
+
+- POCO `Source` → `ValueTemplate` renders / `FeedViewState.Data` exposes the POCO;
+- envelope `Progress = true` → `ILoadable.IsExecuting` stays true;
+- envelope `Error` → `FeedViewState.Error` set; `Data = null` → None state;
+- re-applying template / reloading with same `Source` object → no re-subscription;
+- `Refresh` on a mock completes (`IsExecuting` returns to false).
+
+## Documentation
+
+- `doc/Learn/Mvux/FeedView.md`: new "Mock data and design-time sources" section — envelope table,
+  detection rule, POCO + JSON examples, trim-safe note, `Feed.Value` mention.
+
+## Playground demo
+
+`samples/Playground` gets a `FeedViewMockPage` (route `FeedViewMock`, button on `HomePage`) showing:
+
+- a `FeedView` whose `Source` is a POCO (`Person`) declared in XAML;
+- a `FeedView` bound to envelope objects declared in XAML (data / progress / error variants);
+- a `FeedView` whose `DataContext` is set in XAML from a raw JSON string via a small `JsonDataContext`
+  helper (JSON → `ExpandoObject` graph), with `Source="{Binding Value}"`.

--- a/src/Uno.Extensions.Reactive.Tests/Given_Feed.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Given_Feed.cs
@@ -24,6 +24,28 @@ public class Given_Feed : FeedTests
 		result.Should().Be(42);
 	}
 
+	[TestMethod]
+	public async Task When_Value()
+	{
+		var sut = Feed.Value(42);
+		var result = await sut;
+
+		result.Should().Be(42);
+	}
+
+	[TestMethod]
+	public async Task When_Value_Then_SingleMessageAndCompletes()
+	{
+		var sut = Feed.Value(42);
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(42)
+		);
+	}
+
 		[TestMethod]
 		public async Task When_Async()
 		{

--- a/src/Uno.Extensions.Reactive.Tests/Sources/Given_MockFeed.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Sources/Given_MockFeed.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Sources;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.Extensions.Reactive.Tests.Sources;
+
+[TestClass]
+public class Given_MockFeed : FeedTests
+{
+	private record MyValue(string Name);
+
+	private record MyEnvelope
+	{
+		public object? Data { get; init; }
+		public bool Progress { get; init; }
+		public object? Error { get; init; }
+	}
+
+	private record NotAnEnvelope
+	{
+		public object? Data { get; init; }
+		public string? Title { get; init; }
+	}
+
+	#region Coercion
+	[TestMethod]
+	public void When_SourceIsFeed_Then_Passthrough()
+	{
+		var feed = Feed.Value(42);
+
+		var result = MockFeed.Create(feed);
+
+		result.Should().BeSameAs(feed);
+	}
+
+	[TestMethod]
+	public void When_EnvelopeDataIsFeed_Then_Passthrough()
+	{
+		var feed = Feed.Value(42);
+
+		var result = MockFeed.Create(new { Data = feed });
+
+		result.Should().BeSameAs(feed);
+	}
+
+	[TestMethod]
+	public void When_SameSource_Then_SameFeedInstance()
+	{
+		var source = new MyValue("42");
+
+		var first = MockFeed.Create(source);
+		var second = MockFeed.Create(source);
+
+		second.Should().BeSameAs(first, "coercing the same object twice must preserve feed identity");
+	}
+	#endregion
+
+	#region Raw values (non-envelope)
+	[TestMethod]
+	public async Task When_RawPoco_Then_SomeValueAndCompletes()
+	{
+		var source = new MyValue("42");
+		var sut = (IFeed<object>)MockFeed.Create(source);
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Count.Should().Be(1);
+		result.First().Current.Data.SomeOrDefault().Should().BeSameAs(source);
+		result.First().Current.Error.Should().BeNull();
+		result.First().Current.IsTransient.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public async Task When_RawString_Then_SomeValue()
+	{
+		var sut = (IFeed<object>)MockFeed.Create("hello");
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Data.SomeOrDefault().Should().Be("hello");
+	}
+
+	[TestMethod]
+	public async Task When_RawList_Then_SomeValue()
+	{
+		var source = new List<int> { 1, 2, 3 };
+		var sut = (IFeed<object>)MockFeed.Create(source);
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Data.SomeOrDefault().Should().BeSameAs(source);
+	}
+
+	[TestMethod]
+	public async Task When_PocoWithDataAndOtherProperties_Then_TreatedAsRawValue()
+	{
+		var source = new NotAnEnvelope { Data = new MyValue("42"), Title = "report" };
+		var sut = (IFeed<object>)MockFeed.Create(source);
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Data.SomeOrDefault().Should().BeSameAs(source, "an object with unrecognized members is not an envelope");
+	}
+	#endregion
+
+	#region Envelopes (typed)
+	[TestMethod]
+	public async Task When_EnvelopeWithData_Then_SomeValue()
+	{
+		var data = new MyValue("42");
+		var sut = (IFeed<object>)MockFeed.Create(new MyEnvelope { Data = data });
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Data.SomeOrDefault().Should().BeSameAs(data, "the envelope's Data must be unwrapped as the feed value");
+		result.First().Current.Error.Should().BeNull();
+		result.First().Current.IsTransient.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public async Task When_EnvelopeWithNullData_Then_None()
+	{
+		var sut = (IFeed<object>)MockFeed.Create(new MyEnvelope { Data = null });
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Data.Type.Should().Be(OptionType.None);
+	}
+
+	[TestMethod]
+	public async Task When_EnvelopeWithProgress_Then_Transient()
+	{
+		var sut = (IFeed<object>)MockFeed.Create(new MyEnvelope { Progress = true });
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.IsTransient.Should().BeTrue();
+		result.First().Current.Data.Type.Should().Be(OptionType.None, "the typed envelope exposes a Data member whose value is null");
+	}
+
+	[TestMethod]
+	public async Task When_EnvelopeWithoutDataMember_Then_Undefined()
+	{
+		var sut = (IFeed<object>)MockFeed.Create(new { Progress = true });
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.IsTransient.Should().BeTrue();
+		result.First().Current.Data.Type.Should().Be(OptionType.Undefined, "an envelope without a Data member must not force a data state");
+	}
+
+	[TestMethod]
+	public async Task When_EnvelopeWithProgressAndData_Then_TransientWithValue()
+	{
+		var data = new MyValue("42");
+		var sut = (IFeed<object>)MockFeed.Create(new MyEnvelope { Data = data, Progress = true });
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.IsTransient.Should().BeTrue();
+		result.First().Current.Data.SomeOrDefault().Should().BeSameAs(data);
+	}
+
+	[TestMethod]
+	public async Task When_EnvelopeWithError_Then_ErrorAxisSet()
+	{
+		var error = new TestException();
+		var sut = (IFeed<object>)MockFeed.Create(new MyEnvelope { Error = error });
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Error.Should().BeSameAs(error);
+	}
+
+	[TestMethod]
+	public async Task When_EnvelopeWithErrorAndData_Then_ErrorWithValue()
+	{
+		var data = new MyValue("42");
+		var error = new TestException();
+		var sut = (IFeed<object>)MockFeed.Create(new MyEnvelope { Data = data, Error = error });
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Error.Should().BeSameAs(error);
+		result.First().Current.Data.SomeOrDefault().Should().BeSameAs(data);
+	}
+
+	[TestMethod]
+	public async Task When_AnonymousEnvelopeWithAliases_Then_Recognized()
+	{
+		var sut = (IFeed<object>)MockFeed.Create(new { IsProgress = true });
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.IsTransient.Should().BeTrue();
+
+		sut = (IFeed<object>)MockFeed.Create(new { InProgress = true });
+		result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.IsTransient.Should().BeTrue();
+
+		var error = new TestException();
+		sut = (IFeed<object>)MockFeed.Create(new { Exception = error });
+		result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Error.Should().BeSameAs(error);
+	}
+	#endregion
+
+	#region Envelopes (dictionary / expando, i.e. JSON-shaped)
+	[TestMethod]
+	public async Task When_DictionaryEnvelopeWithCamelCaseKeys_Then_Recognized()
+	{
+		var data = new MyValue("42");
+		var source = new Dictionary<string, object?>
+		{
+			["data"] = data,
+			["progress"] = false,
+		};
+		var sut = (IFeed<object>)MockFeed.Create(source);
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Data.SomeOrDefault().Should().BeSameAs(data);
+		result.First().Current.IsTransient.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public async Task When_DictionaryWithUnrecognizedKey_Then_TreatedAsRawValue()
+	{
+		var source = new Dictionary<string, object?>
+		{
+			["data"] = new MyValue("42"),
+			["title"] = "report",
+		};
+		var sut = (IFeed<object>)MockFeed.Create(source);
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Data.SomeOrDefault().Should().BeSameAs(source);
+	}
+
+	[TestMethod]
+	public async Task When_ExpandoEnvelope_Then_Recognized()
+	{
+		var source = new ExpandoObject();
+		var members = (IDictionary<string, object?>)source;
+		members["data"] = new MyValue("42");
+		members["error"] = "something went wrong";
+
+		var sut = (IFeed<object>)MockFeed.Create(source);
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Error.Should().NotBeNull();
+		result.First().Current.Error!.Message.Should().Be("something went wrong", "a non-Exception error member must be wrapped as an exception carrying its text");
+	}
+
+	[TestMethod]
+	public async Task When_StringProgress_Then_Parsed()
+	{
+		var source = new Dictionary<string, object?> { ["progress"] = "true" };
+		var sut = (IFeed<object>)MockFeed.Create(source);
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.IsTransient.Should().BeTrue();
+	}
+
+	[TestMethod]
+	public async Task When_EmptyDictionary_Then_TreatedAsRawValue()
+	{
+		var source = new Dictionary<string, object?>();
+		var sut = (IFeed<object>)MockFeed.Create(source);
+		var result = sut.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.First().Current.Data.SomeOrDefault().Should().BeSameAs(source, "an object without any envelope member is not an envelope");
+	}
+	#endregion
+
+	#region Refresh
+	[TestMethod]
+	public async Task When_RefreshRequested_Then_ReEmitsWithRefreshToken()
+	{
+		var data = new MyValue("42");
+		var sut = (IFeed<object>)MockFeed.Create(new MyEnvelope { Data = data });
+		var requests = new RequestSource();
+		await using var ctx = Context.SourceContext.CreateChild(requests);
+		using var result = sut.Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+
+		requests.RequestRefresh();
+
+		await result.WaitForMessages(2, CT);
+
+		result.Count.Should().Be(2);
+		result.Last().Current.Data.SomeOrDefault().Should().BeSameAs(data, "refresh must re-emit the mocked value");
+		result.Last().Current.Get(MessageAxis.Refresh).Should().NotBeNull("the refresh message must carry the requested token");
+	}
+
+	[TestMethod]
+	public async Task When_RefreshRequestedOnProgressMock_Then_StaysTransient()
+	{
+		var sut = (IFeed<object>)MockFeed.Create(new MyEnvelope { Progress = true });
+		var requests = new RequestSource();
+		await using var ctx = Context.SourceContext.CreateChild(requests);
+		using var result = sut.Record(ctx);
+
+		await result.WaitForMessages(1, CT);
+
+		requests.RequestRefresh();
+
+		await result.WaitForMessages(2, CT);
+
+		result.Last().Current.IsTransient.Should().BeTrue("a progress mock models a load that never completes");
+	}
+	#endregion
+}

--- a/src/Uno.Extensions.Reactive.UI.Tests/Given_FeedView.cs
+++ b/src/Uno.Extensions.Reactive.UI.Tests/Given_FeedView.cs
@@ -77,4 +77,107 @@ public class Given_FeedView : FeedTests
 
 		(await result.Task).Should().BeTrue();
 	}
+
+	#region Mock (non-feed) sources
+	private record MockValue(string Name);
+
+	private record MockEnvelope
+	{
+		public object? Data { get; init; }
+		public bool Progress { get; init; }
+		public object? Error { get; init; }
+	}
+
+	[TestMethod]
+	public async Task When_SourceIsPoco_Then_RendersValue()
+	{
+		var value = new MockValue("42");
+		var sut = new FeedView { Source = value };
+
+		await UIHelper.Load(sut, CT);
+
+		await TestHelper.WaitFor(() => ReferenceEquals(sut.State.Data, value), CT);
+		(sut as ILoadable).IsExecuting.Should().BeFalse("a mocked value is not loading");
+	}
+
+	[TestMethod]
+	public async Task When_SourceIsEnvelopeWithData_Then_RendersDataValue()
+	{
+		var value = new MockValue("42");
+		var sut = new FeedView { Source = new MockEnvelope { Data = value } };
+
+		await UIHelper.Load(sut, CT);
+
+		await TestHelper.WaitFor(() => ReferenceEquals(sut.State.Data, value), CT);
+	}
+
+	[TestMethod]
+	public async Task When_SourceIsEnvelopeWithProgress_Then_StaysLoading()
+	{
+		var sut = new FeedView { Source = new MockEnvelope { Progress = true } };
+
+		await UIHelper.Load(sut, CT);
+
+		await TestHelper.WaitFor(() => sut.State.Progress, CT);
+		(sut as ILoadable).IsExecuting.Should().BeTrue("a progress mock models an in-flight load");
+	}
+
+	[TestMethod]
+	public async Task When_SourceIsEnvelopeWithError_Then_ExposesError()
+	{
+		var error = new InvalidOperationException("mocked failure");
+		var sut = new FeedView { Source = new MockEnvelope { Error = error } };
+
+		await UIHelper.Load(sut, CT);
+
+		await TestHelper.WaitFor(() => sut.State.Error == error, CT);
+	}
+
+	[TestMethod]
+	public async Task When_SourceIsEnvelopeWithNullData_Then_None()
+	{
+		var sut = new FeedView { Source = new MockEnvelope { Data = null } };
+		var sutAsLoadable = sut as ILoadable;
+
+		await UIHelper.Load(sut, CT);
+
+		await TestHelper.WaitFor(() => !sutAsLoadable.IsExecuting, CT);
+		sut.State.Data.Should().BeNull("a null Data member mocks the None state");
+		sut.State.Error.Should().BeNull();
+	}
+
+	[TestMethod]
+	public async Task When_MockSourceAndReloaded_Then_StillRenders()
+	{
+		var value = new MockValue("42");
+		var sut = new FeedView { Source = value };
+		var root = new Grid { Children = { sut } };
+
+		await UIHelper.Load(root, CT);
+		await TestHelper.WaitFor(() => ReferenceEquals(sut.State.Data, value), CT);
+
+		// Unload and reload the view: Enable must re-subscribe using the cached coerced source.
+		root.Children.Remove(sut);
+		await TestHelper.WaitFor(() => !sut.IsLoaded, CT);
+		root.Children.Add(sut);
+
+		await TestHelper.WaitFor(() => ReferenceEquals(sut.State.Data, value), CT);
+		(sut as ILoadable).IsExecuting.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public async Task When_MockSourceAndRefresh_Then_RefreshCompletes()
+	{
+		var value = new MockValue("42");
+		var sut = new FeedView { Source = new MockEnvelope { Data = value } };
+
+		await UIHelper.Load(sut, CT);
+		await TestHelper.WaitFor(() => ReferenceEquals(sut.State.Data, value), CT);
+
+		sut.Refresh.Execute(null);
+
+		await TestHelper.WaitFor(() => !sut.Refresh.IsExecuting, CT);
+		sut.State.Data.Should().Be(value, "refreshing a mock re-emits the mocked value");
+	}
+	#endregion
 }

--- a/src/Uno.Extensions.Reactive.UI/View/FeedView.cs
+++ b/src/Uno.Extensions.Reactive.UI/View/FeedView.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using Uno.Extensions.Reactive.Sources;
 
 namespace Uno.Extensions.Reactive.UI;
 
@@ -18,16 +19,38 @@ public partial class FeedView : Control
 		"Source", typeof(object), typeof(FeedView), new PropertyMetadata(default(object), OnSourceChanged));
 
 	private static void OnSourceChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args)
-		=> (obj as FeedView)?.Subscribe(args.NewValue as ISignal<IMessage>);
+	{
+		if (obj is FeedView that)
+		{
+			// The coerced feed is cached so Enable / OnApplyTemplate re-use the same instance,
+			// preserving the Subscribe identity short-circuit (no re-subscription on each load).
+			that._coercedSource = CoerceSource(args.NewValue);
+			that.Subscribe(that._coercedSource);
+		}
+	}
 
 	/// <summary>
 	/// Gets or sets the <see cref="IFeed{T}"/> displayed by this control.
 	/// </summary>
+	/// <remarks>
+	/// A value which is not a feed is not discarded: it's wrapped as a single-message feed,
+	/// enabling mock/design-time data. An object exposing only Data / Progress / Error members
+	/// (a mock "envelope") drives the corresponding visual states of this control; any other
+	/// object is rendered as the value of the feed.
+	/// </remarks>
 	public object? Source
 	{
 		get => GetValue(SourceProperty);
 		set => SetValue(SourceProperty, value);
 	}
+
+	private static ISignal<IMessage>? CoerceSource(object? source)
+		=> source switch
+		{
+			null => null,
+			ISignal<IMessage> feed => feed,
+			_ => MockFeed.Create(source),
+		};
 	#endregion
 
 	#region VisualStateSelector DP
@@ -202,6 +225,7 @@ public partial class FeedView : Control
 
 	private ControlState _state;
 	private Subscription? _subscription;
+	private ISignal<IMessage>? _coercedSource;
 
 	[Flags]
 	private enum ControlState
@@ -246,7 +270,7 @@ public partial class FeedView : Control
 		if (snd is FeedView that)
 		{
 			that._state |= ControlState.IsLoaded;
-			if (that.Source is ISignal<IMessage> feed)
+			if (that._coercedSource is { } feed)
 			{
 				that.Subscribe(feed);
 			}
@@ -268,7 +292,7 @@ public partial class FeedView : Control
 		base.OnApplyTemplate();
 
 		_state |= ControlState.HasTemplate;
-		if (Source is ISignal<IMessage> feed)
+		if (_coercedSource is { } feed)
 		{
 			Subscribe(feed);
 		}

--- a/src/Uno.Extensions.Reactive/Core/Feed.cs
+++ b/src/Uno.Extensions.Reactive/Core/Feed.cs
@@ -49,6 +49,20 @@ public static partial class Feed
 		=> Feed<T>.Create(sourceProvider);
 
 	/// <summary>
+	/// Creates a feed which produces a single message with a constant value, then completes.
+	/// </summary>
+	/// <typeparam name="T">The type of the value of the resulting feed.</typeparam>
+	/// <param name="value">The value of the resulting feed.</param>
+	/// <returns>A feed which encapsulates the given value.</returns>
+	/// <remarks>
+	/// Unlike <see cref="Async{T}(AsyncFunc{T},Signal?)"/>, the resulting feed does not support refresh:
+	/// it completes immediately after emitting its value. This is designed for constant and mock/design-time data.
+	/// </remarks>
+	public static IFeed<T> Value<T>(T value)
+		where T : notnull
+		=> new ValueFeed<T>(Uno.Extensions.Option.Some(value));
+
+	/// <summary>
 	/// Gets or create a custom feed from an async method.
 	/// </summary>
 	/// <typeparam name="T">The type of the value of the resulting feed.</typeparam>

--- a/src/Uno.Extensions.Reactive/Sources/MockFeed.cs
+++ b/src/Uno.Extensions.Reactive/Sources/MockFeed.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Threading;
+using Uno.Extensions.Reactive.Core;
+using Uno.Extensions.Reactive.Utils;
+
+namespace Uno.Extensions.Reactive.Sources;
+
+/// <summary>
+/// A feed which renders a plain object as a single feed message — used by the FeedView to accept
+/// mock data (POCOs, anonymous objects, dictionaries built from JSON) as its Source.
+/// </summary>
+/// <remarks>
+/// The source object can either be a raw value (wrapped as-is in the Some state), or a mock "envelope"
+/// which drives the feed axes explicitly. An object is an envelope only when at least one of its public
+/// readable properties (or dictionary keys) is a recognized envelope member — <c>Data</c>,
+/// <c>Progress</c> (aliases <c>IsProgress</c> / <c>InProgress</c>), <c>Error</c> (alias
+/// <c>Exception</c>) — and **all** of its members are within that set. Matching is case-insensitive.
+/// See specs/009-feedview-mock-source/spec.md.
+/// </remarks>
+internal sealed class MockFeed : IFeed<object>
+{
+	private readonly Option<object> _data;
+	private readonly Exception? _error;
+	private readonly bool _isTransient;
+
+	/// <summary>
+	/// Coerces an arbitrary object into a feed suitable for the FeedView.
+	/// </summary>
+	/// <param name="source">The object to coerce.</param>
+	/// <returns>
+	/// The <paramref name="source"/> itself when it is already a feed, the feed found in an envelope's
+	/// <c>Data</c> member, or a <see cref="MockFeed"/> wrapping the object.
+	/// </returns>
+	public static ISignal<IMessage> Create(object source)
+		=> source as ISignal<IMessage>
+			?? AttachedProperty.GetOrCreate(source, typeof(MockFeed), static (src, _) => CreateCore(src));
+
+	private static ISignal<IMessage> CreateCore(object source)
+		=> TryCreateFromEnvelope(source) ?? new MockFeed(Option.Some(source), error: null, isTransient: false);
+
+	private MockFeed(Option<object> data, Exception? error, bool isTransient)
+	{
+		_data = data;
+		_error = error;
+		_isTransient = isTransient;
+	}
+
+	/// <inheritdoc />
+	public IAsyncEnumerable<Message<object>> GetSource(SourceContext context, CancellationToken ct = default)
+	{
+		var subject = new AsyncEnumerableSubject<Message<object>>(ReplayMode.EnabledForFirstEnumeratorOnly);
+		var refreshGate = new object();
+		var refreshToken = RefreshToken.Initial(this, context);
+
+		var current = (Message<object>)Message<object>.Initial
+			.With()
+			.Data(_data)
+			.Error(_error)
+			.IsTransient(_isTransient);
+		subject.SetNext(current);
+
+		// A mock has nothing to reload, but we still have to honor refresh requests: the FeedView's
+		// Refresh command completes only once a message carrying the requested token is received.
+		// We re-emit the same mocked axes stamped with the token.
+		context.Requests<RefreshRequest>(
+			request =>
+			{
+				lock (refreshGate)
+				{
+					var token = RefreshToken.InterlockedIncrement(ref refreshToken);
+					request.Register(token);
+					current = current
+						.With()
+						.Data(_data)
+						.Error(_error)
+						.IsTransient(_isTransient) // Transient axes are cleared by With(), re-apply the mocked progress.
+						.Refreshed(token);
+					subject.TrySetNext(current);
+				}
+			},
+			ct);
+
+		// Registered last so that, on a request-less (None) context which raises EndRequest at
+		// subscription, the initial message above is already enqueued before we complete.
+		context.Requests<EndRequest>(_ => subject.TryComplete(), ct);
+
+		return subject;
+	}
+
+	private static ISignal<IMessage>? TryCreateFromEnvelope(object source)
+	{
+		if (source is IDictionary<string, object?> dictionary)
+		{
+			return TryCreateFromDictionary(dictionary);
+		}
+
+#pragma warning disable IL2026 // Envelope detection degrades gracefully: if property metadata was trimmed, the object is wrapped whole as a plain value (documented; dictionary sources are the trim-safe path).
+		return TryCreateFromProperties(source);
+#pragma warning restore IL2026
+	}
+
+	private static ISignal<IMessage>? TryCreateFromDictionary(IDictionary<string, object?> source)
+	{
+		var envelope = new Envelope();
+		foreach (var member in source)
+		{
+			if (!envelope.TryAdd(member.Key, member.Value))
+			{
+				return null;
+			}
+		}
+
+		return envelope.TryBuild();
+	}
+
+	[RequiresUnreferencedCode("Inspects the public properties of the mock source object; under trimming their metadata may have been removed, in which case the object is treated as a plain value. Prefer IDictionary<string, object?> sources for trimmed apps.")]
+	private static ISignal<IMessage>? TryCreateFromProperties(object source)
+	{
+		var envelope = new Envelope();
+		foreach (var property in source.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+		{
+			if (!property.CanRead || property.GetIndexParameters().Length > 0)
+			{
+				continue;
+			}
+
+			if (!envelope.TryAdd(property.Name, property.GetValue(source)))
+			{
+				return null;
+			}
+		}
+
+		return envelope.TryBuild();
+	}
+
+	/// <summary>
+	/// Accumulates recognized envelope members; a single unrecognized member disqualifies the source.
+	/// </summary>
+	private struct Envelope
+	{
+		private bool _hasAny;
+		private bool _hasData;
+		private object? _data;
+		private object? _progress;
+		private object? _error;
+
+		public bool TryAdd(string name, object? value)
+		{
+			if (name.Equals("Data", StringComparison.OrdinalIgnoreCase))
+			{
+				_hasData = true;
+				_data = value;
+			}
+			else if (name.Equals("Progress", StringComparison.OrdinalIgnoreCase)
+				|| name.Equals("IsProgress", StringComparison.OrdinalIgnoreCase)
+				|| name.Equals("InProgress", StringComparison.OrdinalIgnoreCase))
+			{
+				_progress = value;
+			}
+			else if (name.Equals("Error", StringComparison.OrdinalIgnoreCase)
+				|| name.Equals("Exception", StringComparison.OrdinalIgnoreCase))
+			{
+				_error = value;
+			}
+			else
+			{
+				return false; // Unrecognized member: this is a plain object, not an envelope.
+			}
+
+			_hasAny = true;
+			return true;
+		}
+
+		public readonly ISignal<IMessage>? TryBuild()
+		{
+			if (!_hasAny)
+			{
+				return null;
+			}
+
+			// An envelope whose Data is itself a feed is a passthrough: the feed drives the view directly.
+			if (_data is ISignal<IMessage> feed)
+			{
+				return feed;
+			}
+
+			var data = _hasData
+				? _data is null ? Option<object>.None() : Option.Some(_data)
+				: Option<object>.Undefined();
+
+			return new MockFeed(data, CoerceError(_error), CoerceProgress(_progress));
+		}
+
+		private static Exception? CoerceError(object? value)
+			=> value switch
+			{
+				null => null,
+				Exception error => error,
+				// JSON cannot carry an Exception: any other value (typically a string) becomes the error message.
+				_ => new MockFeedException(value.ToString() ?? value.GetType().Name),
+			};
+
+		private static bool CoerceProgress(object? value)
+			=> value switch
+			{
+				null => false,
+				bool isInProgress => isInProgress,
+				// Covers "true" strings and JSON booleans surfaced as JsonElement, without a System.Text.Json dependency.
+				_ => bool.TryParse(value.ToString(), out var parsed) && parsed,
+			};
+	}
+}

--- a/src/Uno.Extensions.Reactive/Sources/MockFeedException.cs
+++ b/src/Uno.Extensions.Reactive/Sources/MockFeedException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Uno.Extensions.Reactive.Sources;
+
+/// <summary>
+/// The exception surfaced by a <see cref="MockFeed"/> when the mock envelope's error member
+/// is not an <see cref="Exception"/> instance (e.g. an error message string coming from JSON).
+/// </summary>
+internal sealed class MockFeedException : Exception
+{
+	public MockFeedException(string message)
+		: base(message)
+	{
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): none — **this is a proof of concept**; no issue exists yet. If the approach is validated, an issue will be created before this graduates from POC.

> [!IMPORTANT]
> **🧪 PROOF OF CONCEPT** — opened as a draft to validate the approach and the envelope convention. Not intended to merge as-is.

## PR Type

- Feature (POC)

## Initial requirements (as provided)

The goal is to make it easy to supply a mock DataContext to a page that uses a `FeedView`, using either a set of raw POCO objects, or an Expando object created from JSON:

- Currently, if a plain object is passed into a `FeedView` it's just discarded. The simple solution is to wrap the object as a feed with an initial value.
- However, that doesn't help mock different states. As part of creating the feed from an initial value, the object should be checked for `Data`, `InProgress`/`IsProgress` and `Exception` properties:
  - If a `Data` property exists, its value is used as the value of the feed in the **Value** state — unless the value is `null`, in which case the feed is in the **Empty (None)** state.
  - If a progress property exists and is `true`, the feed is in the **in-progress** state.
  - If an `Exception` property exists and is not `null`, the feed is in the **Error** state.
- A demo page in the Playground app showing both POCO objects and raw JSON data (DataContext set from JSON in XAML).

## What is the current behavior?

`FeedView.Source` silently discards any value that is not an `ISignal<IMessage>` (`IFeed<T>` / `IState<T>`): the control stays in its loading state and renders nothing.

## What is the new behavior?

- A non-feed `Source` is coerced into a single-message feed (internal `MockFeed`) instead of being discarded.
- A mock **envelope** — an object whose public members are limited to `Data`, `Progress` (aliases `IsProgress`/`InProgress`), `Error` (alias `Exception`), matched case-insensitively — drives the FeedView states: Value / None / Indeterminate / Error. A string error value is wrapped as the exception message (so JSON can mock errors).
- Works with POCOs/anonymous objects (reflection) and `IDictionary<string, object?>`/`ExpandoObject` (trim-safe, no reflection) — the latter is how JSON-shaped data flows in.
- An envelope whose `Data` is itself a feed passes that feed through untouched; objects with unrecognized members are rendered whole as the feed value (no false envelope detection).
- Mocked sources honor refresh requests, so `FeedView.Refresh` completes instead of hanging `IsExecuting`.
- New public API: `Feed.Value<T>(T)` — a constant single-message feed (the only public surface addition; the coercion itself is internal).
- Playground: new **FeedView Mock Data** page showing seven scenarios (POCO value, envelope progress/error/none, JSON envelope value/error, JSON plain object), each with its XAML displayed alongside the live control. Verified running on `net9.0-desktop`.

Design details and decisions are captured in `specs/009-feedview-mock-source/spec.md` (+ `progress.md`).

### Notes / known issues surfaced while building the POC

- **Pre-existing on `main`:** Playground desktop started with a blank window — initial navigation resolves no route ("Route '' has 19 nested route(s) but none marked IsDefault") despite `initialViewModel: typeof(HomeViewModel)`. Worked around here by marking the `Home` route `IsDefault: true` (isolated commit, easy to drop). The resolver behavior deserves its own issue.
- The Playground `JsonDataContext` helper deliberately deviates from the typed-deserialization rule (unknown-at-compile-time shape is the point of a JSON mock); sample-only, documented in the spec's exceptions section.
- Envelope detection on POCOs relies on reflection; under trimming it degrades safely to wrapping the object whole. Dictionary/Expando is the documented trim-safe path.

## PR Checklist

- [x] Tested code with current supported SDKs (net9.0; Playground on `net9.0-desktop`)
- [x] Docs added: `doc/Learn/Mvux/FeedView.md` — "Mock data and design-time sources"
- [x] Unit tests (`Given_MockFeed`, `Feed.Value` cases — full Reactive suite green: 1443 passed) and UI-host tests (`Given_FeedView`, run by runtime-test stages)
- [ ] Wasm UI Tests screenshots compare — to validate on CI
- [x] Contains **NO** breaking changes (additive only; previously-discarded sources now render)
- [ ] Release Notes — deferred until this graduates from POC
- [ ] Associated with an issue — **none yet (POC)**, see note at top

## Other information

Internal Issue (If applicable): none (POC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)