### PR TITLE
fix(auth): stop logging tokens and fix the refresh, sign-out and provider-build paths

### DIFF
--- a/Uno.Extensions-packageonly.slnf
+++ b/Uno.Extensions-packageonly.slnf
@@ -4,6 +4,7 @@
     "projects": [
       "src\\Uno.Extensions.Authentication.MSAL\\Uno.Extensions.Authentication.MSAL.WinUI.csproj",
       "src\\Uno.Extensions.Authentication.Oidc\\Uno.Extensions.Authentication.Oidc.WinUI.csproj",
+      "src\\Uno.Extensions.Authentication.Tests\\Uno.Extensions.Authentication.Tests.csproj",
       "src\\Uno.Extensions.Authentication.UI\\Uno.Extensions.Authentication.WinUI.csproj",
       "src\\Uno.Extensions.Authentication\\Uno.Extensions.Authentication.csproj",
       "src\\Uno.Extensions.Configuration\\Uno.Extensions.Configuration.csproj",

--- a/Uno.Extensions.sln
+++ b/Uno.Extensions.sln
@@ -149,6 +149,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Serializatio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Configuration.Tests", "src\Uno.Extensions.Configuration.Tests\Uno.Extensions.Configuration.Tests.csproj", "{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Authentication.Tests", "src\Uno.Extensions.Authentication.Tests\Uno.Extensions.Authentication.Tests.csproj", "{7AD671A6-E401-4C16-803B-C9554673FD19}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -825,6 +827,22 @@ Global
 		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Release|x64.Build.0 = Release|Any CPU
 		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Release|x86.ActiveCfg = Release|Any CPU
 		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B}.Release|x86.Build.0 = Release|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Debug|arm64.Build.0 = Debug|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Debug|x64.Build.0 = Debug|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Debug|x86.Build.0 = Debug|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Release|arm64.ActiveCfg = Release|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Release|arm64.Build.0 = Release|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Release|x64.ActiveCfg = Release|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Release|x64.Build.0 = Release|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Release|x86.ActiveCfg = Release|Any CPU
+		{7AD671A6-E401-4C16-803B-C9554673FD19}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -876,6 +894,7 @@ Global
 		{76AF6C8E-A738-FF6A-EAB1-FE94DAC56658} = {2197ADCE-59C4-465A-B380-0B06BF68BBBC}
 		{DF77B943-13C2-4D98-8364-BA0DDC2C156D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{7AD671A6-E401-4C16-803B-C9554673FD19} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E7B035D-9A64-4D95-89AA-9D4653F17C42}

--- a/src/Uno.Extensions.Authentication.Tests/CapturingLogger.cs
+++ b/src/Uno.Extensions.Authentication.Tests/CapturingLogger.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Uno.Extensions.Authentication;
+
+/// <summary>
+/// Records every message at every level so a test can assert on what a logging pipeline would
+/// have seen. Trace is the worst case for leaks, so nothing is filtered.
+/// </summary>
+internal sealed class CapturingLogger<T> : ILogger<T>
+{
+	private readonly StringBuilder _text = new();
+
+	public string Text => _text.ToString();
+
+	public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+	public bool IsEnabled(LogLevel logLevel) => true;
+
+	public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+		_text.Append(logLevel).Append(' ').AppendLine(formatter(state, exception));
+}

--- a/src/Uno.Extensions.Authentication.Tests/FakeAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.Tests/FakeAuthenticationProvider.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Uno.Extensions.Authentication;
+
+/// <summary>
+/// Scripted <see cref="IAuthenticationProvider"/>: each call answers with whatever the test set up.
+/// </summary>
+internal sealed class FakeAuthenticationProvider : IAuthenticationProvider
+{
+	public FakeAuthenticationProvider(string name = "Fake") => Name = name;
+
+	public string Name { get; }
+
+	/// <summary>What <see cref="RefreshAsync"/> returns; <c>null</c> means "could not refresh".</summary>
+	public Func<IDictionary<string, string>?> OnRefresh { get; set; } = () => null;
+
+	/// <summary>What <see cref="LogoutAsync"/> does; throw to simulate a provider failing part-way.</summary>
+	public Func<bool> OnLogout { get; set; } = () => true;
+
+	public int RefreshCount { get; private set; }
+
+	public ValueTask<IDictionary<string, string>?> LoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials, CancellationToken cancellationToken) =>
+		new(credentials);
+
+	public ValueTask<bool> LogoutAsync(IDispatcher? dispatcher, CancellationToken cancellationToken) =>
+		new(OnLogout());
+
+	public ValueTask<IDictionary<string, string>?> RefreshAsync(CancellationToken cancellationToken)
+	{
+		RefreshCount++;
+		return new(OnRefresh());
+	}
+}
+
+/// <summary>
+/// <see cref="IProviderFactory"/> that counts how many times its provider is read, so a test can
+/// prove the service builds its provider table exactly once.
+/// </summary>
+internal sealed class CountingProviderFactory : IProviderFactory
+{
+	private readonly IAuthenticationProvider _provider;
+	private int _reads;
+
+	public CountingProviderFactory(IAuthenticationProvider provider) => _provider = provider;
+
+	public string Name => _provider.Name;
+
+	public int Reads => _reads;
+
+	public IAuthenticationProvider AuthenticationProvider
+	{
+		get
+		{
+			Interlocked.Increment(ref _reads);
+			return _provider;
+		}
+	}
+}

--- a/src/Uno.Extensions.Authentication.Tests/FakeKeyValueStorage.cs
+++ b/src/Uno.Extensions.Authentication.Tests/FakeKeyValueStorage.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions.Storage.KeyValueStorage;
+
+namespace Uno.Extensions.Authentication;
+
+/// <summary>
+/// Minimal in-memory <see cref="IKeyValueStorage"/> for exercising <see cref="MsalTokenCacheStore"/>.
+/// </summary>
+/// <remarks>
+/// Hand-rolled rather than mocked: the surface is four methods, and a mock would pin the exact call
+/// sequence the store makes instead of the observable storage state (AGENTS.md section 5).
+/// <see cref="Values"/> is exposed so tests can assert on - and corrupt - the stored representation.
+/// </remarks>
+internal sealed class FakeKeyValueStorage : IKeyValueStorage
+{
+	public bool IsEncrypted => false;
+
+	/// <summary>
+	/// The backing store, keyed exactly as the caller wrote it.
+	/// </summary>
+	public Dictionary<string, object> Values { get; } = new();
+
+	/// <summary>
+	/// Number of <see cref="SetAsync"/> calls, so tests can assert that a no-op path wrote nothing.
+	/// </summary>
+	public int WriteCount { get; private set; }
+
+	public ValueTask ClearAsync(string key, CancellationToken ct)
+	{
+		Values.Remove(key);
+		return default;
+	}
+
+	public ValueTask<TValue?> GetAsync<TValue>(string key, CancellationToken ct) =>
+		new(Values.TryGetValue(key, out var value) ? (TValue)value : default);
+
+	public ValueTask<string[]> GetKeysAsync(CancellationToken ct) =>
+		new(Values.Keys.ToArray());
+
+	public ValueTask SetAsync<TValue>(string key, TValue value, CancellationToken ct)
+		where TValue : notnull
+	{
+		WriteCount++;
+		Values[key] = value;
+		return default;
+	}
+}

--- a/src/Uno.Extensions.Authentication.Tests/Given_AuthenticationService.cs
+++ b/src/Uno.Extensions.Authentication.Tests/Given_AuthenticationService.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.Extensions.Authentication;
+
+[TestClass]
+public class Given_AuthenticationService
+{
+	private static readonly IDictionary<string, string> SomeTokens =
+		new Dictionary<string, string> { { TokenCacheExtensions.AccessTokenKey, "access-1" } };
+
+	private static (AuthenticationService Service, TokenCache Tokens, FakeAuthenticationProvider Provider, CountingProviderFactory Factory) Create()
+	{
+		var tokens = new TokenCache(NullLogger<TokenCache>.Instance, new FakeKeyValueStorage());
+		var provider = new FakeAuthenticationProvider();
+		var factory = new CountingProviderFactory(provider);
+		var service = new AuthenticationService(NullLogger<AuthenticationService>.Instance, new[] { factory }, tokens);
+		return (service, tokens, provider, factory);
+	}
+
+	[TestMethod]
+	public async Task When_RefreshReturnsNoTokens_Then_SignedOutAndLoggedOutRaised()
+	{
+		// The provider could not renew the session - an expired or revoked refresh token. The user
+		// was authenticated and now is not, which is exactly what LoggedOut exists to announce; an
+		// app that navigates on it must not be left on a signed-in page with nothing to send.
+		var (service, tokens, provider, _) = Create();
+		await tokens.SaveAsync(provider.Name, SomeTokens, CancellationToken.None);
+		var loggedOut = 0;
+		service.LoggedOut += (_, _) => loggedOut++;
+
+		provider.OnRefresh = () => null;
+		var refreshed = await service.RefreshAsync(CancellationToken.None);
+
+		refreshed.Should().BeFalse();
+		(await service.IsAuthenticated(CancellationToken.None)).Should().BeFalse();
+		(await tokens.GetAsync(CancellationToken.None)).Should().BeEmpty();
+		loggedOut.Should().Be(1, "a refresh that ends the session is a sign-out");
+	}
+
+	[TestMethod]
+	public async Task When_RefreshReturnsEmptyTokens_Then_SignedOut()
+	{
+		// An empty dictionary is "no tokens" too: saving it would leave no keys, but only ClearAsync
+		// raises Cleared, so the two must be treated alike.
+		var (service, tokens, provider, _) = Create();
+		await tokens.SaveAsync(provider.Name, SomeTokens, CancellationToken.None);
+		var loggedOut = 0;
+		service.LoggedOut += (_, _) => loggedOut++;
+
+		provider.OnRefresh = () => new Dictionary<string, string>();
+		var refreshed = await service.RefreshAsync(CancellationToken.None);
+
+		refreshed.Should().BeFalse();
+		loggedOut.Should().Be(1);
+	}
+
+	[TestMethod]
+	public async Task When_RefreshReturnsTokens_Then_SavedAndStillAuthenticated()
+	{
+		var (service, tokens, provider, _) = Create();
+		await tokens.SaveAsync(provider.Name, SomeTokens, CancellationToken.None);
+		var loggedOut = 0;
+		service.LoggedOut += (_, _) => loggedOut++;
+
+		provider.OnRefresh = () => new Dictionary<string, string> { { TokenCacheExtensions.AccessTokenKey, "access-2" } };
+		var refreshed = await service.RefreshAsync(CancellationToken.None);
+
+		refreshed.Should().BeTrue();
+		(await tokens.GetAsync(CancellationToken.None))[TokenCacheExtensions.AccessTokenKey].Should().Be("access-2");
+		loggedOut.Should().Be(0);
+	}
+
+	[TestMethod]
+	public async Task When_ProviderLogoutThrows_Then_TokensClearedAndLoggedOutRaised()
+	{
+		// A keychain or cache-file error part-way through the provider's sign-out must not leave the
+		// user signed in: the access token would survive, IsAuthenticated would stay true and the HTTP
+		// handlers would keep sending the bearer. The failure still surfaces to the caller.
+		var (service, tokens, provider, _) = Create();
+		await tokens.SaveAsync(provider.Name, SomeTokens, CancellationToken.None);
+		var loggedOut = 0;
+		service.LoggedOut += (_, _) => loggedOut++;
+		provider.OnLogout = () => throw new InvalidOperationException("keychain locked");
+
+		var act = async () => await service.LogoutAsync(dispatcher: null, CancellationToken.None);
+
+		await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("keychain locked");
+		(await service.IsAuthenticated(CancellationToken.None)).Should().BeFalse();
+		(await tokens.GetAsync(CancellationToken.None)).Should().BeEmpty();
+		loggedOut.Should().Be(1);
+	}
+
+	[TestMethod]
+	public async Task When_ProviderLogoutThrowsWithCancelledToken_Then_TokensStillCleared()
+	{
+		// The clear must not itself be skipped because the caller's token was already cancelled.
+		var (service, tokens, provider, _) = Create();
+		await tokens.SaveAsync(provider.Name, SomeTokens, CancellationToken.None);
+		provider.OnLogout = () => throw new OperationCanceledException();
+		using var cancelled = new CancellationTokenSource();
+		cancelled.Cancel();
+
+		var act = async () => await service.LogoutAsync(dispatcher: null, cancelled.Token);
+
+		await act.Should().ThrowAsync<OperationCanceledException>();
+		(await tokens.GetAsync(CancellationToken.None)).Should().BeEmpty();
+	}
+
+	[TestMethod]
+	public async Task When_ProviderDeclinesLogout_Then_TokensKept()
+	{
+		// `false` is the provider saying the sign-out did not happen (the user dismissed a prompt,
+		// say) - not a failure; the session stands.
+		var (service, tokens, provider, _) = Create();
+		await tokens.SaveAsync(provider.Name, SomeTokens, CancellationToken.None);
+		var loggedOut = 0;
+		service.LoggedOut += (_, _) => loggedOut++;
+		provider.OnLogout = () => false;
+
+		var result = await service.LogoutAsync(dispatcher: null, CancellationToken.None);
+
+		result.Should().BeFalse();
+		(await service.IsAuthenticated(CancellationToken.None)).Should().BeTrue();
+		loggedOut.Should().Be(0);
+	}
+
+	[TestMethod]
+	public async Task When_NotAuthenticated_Then_RefreshDoesNotCallProvider()
+	{
+		var (service, _, provider, _) = Create();
+
+		var refreshed = await service.RefreshAsync(CancellationToken.None);
+
+		refreshed.Should().BeFalse();
+		provider.RefreshCount.Should().Be(0);
+	}
+
+	[TestMethod]
+	public async Task When_CalledConcurrently_Then_ProvidersBuiltOnce()
+	{
+		// Regression guard for the Count == 0 check this replaced: two concurrent callers could both
+		// see an empty table and both populate it. The factory counts reads of its provider, which
+		// happens once per build of the table.
+		var (service, tokens, provider, factory) = Create();
+		await tokens.SaveAsync(provider.Name, SomeTokens, CancellationToken.None);
+		provider.OnRefresh = () => SomeTokens;
+
+		await Task.WhenAll(Enumerable.Range(0, 32).Select(_ => Task.Run(() => service.RefreshAsync(CancellationToken.None).AsTask())));
+
+		factory.Reads.Should().Be(1);
+		service.Providers.Should().Equal(provider.Name);
+	}
+
+	[TestMethod]
+	public void When_NothingResolvedYet_Then_ProvidersIsEmptyWithoutBuilding()
+	{
+		// Reading the property must not construct providers (MSAL builds a client application in
+		// its factory); it reports what has been built so far.
+		var (service, _, _, factory) = Create();
+
+		service.Providers.Should().BeEmpty();
+		factory.Reads.Should().Be(0);
+	}
+}

--- a/src/Uno.Extensions.Authentication.Tests/Given_ProviderFactory.cs
+++ b/src/Uno.Extensions.Authentication.Tests/Given_ProviderFactory.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.Extensions.Authentication;
+
+[TestClass]
+public class Given_ProviderFactory
+{
+	[TestMethod]
+	public async Task When_ResolvedConcurrently_Then_ConfiguredOnceAndSameInstance()
+	{
+		// ConfigureProvider is where MSAL builds its client application and subscribes to
+		// ITokenCache.Cleared; a bare `??=` let concurrent resolves run it more than once, with the
+		// losing copies left subscribed and unreachable.
+		var configured = 0;
+		var factory = new ProviderFactory<FakeAuthenticationProvider, object>(
+			"Fake",
+			new FakeAuthenticationProvider(),
+			new object(),
+			(provider, _) =>
+			{
+				Interlocked.Increment(ref configured);
+				return new FakeAuthenticationProvider(provider.Name);
+			});
+
+		var resolved = await Task.WhenAll(Enumerable.Range(0, 32).Select(_ => Task.Run(() => factory.AuthenticationProvider)));
+
+		configured.Should().Be(1);
+		resolved.Distinct().Should().ContainSingle("every caller must get the one configured instance");
+	}
+}

--- a/src/Uno.Extensions.Authentication.Tests/Given_TokenLogging.cs
+++ b/src/Uno.Extensions.Authentication.Tests/Given_TokenLogging.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Authentication.Handlers;
+
+namespace Uno.Extensions.Authentication;
+
+/// <summary>
+/// AGENTS.md section 7: tokens must never reach Uno.Extensions log output. Both cases here log at
+/// the level the code actually uses - Trace for the cache, Debug for the handler - on a logger
+/// that records everything, which is what a consumer's pipeline sees once those levels are on.
+/// </summary>
+[TestClass]
+public class Given_TokenLogging
+{
+	private const string AccessToken = "eyJ-access-token-value-that-must-not-be-logged";
+	private const string RefreshToken = "refresh-token-value-that-must-not-be-logged";
+
+	private static async Task<(TokenCache Cache, CapturingLogger<TokenCache> Log)> SeededCache()
+	{
+		var log = new CapturingLogger<TokenCache>();
+		var cache = new TokenCache(log, new FakeKeyValueStorage());
+		await cache.SaveAsync("Fake", new Dictionary<string, string>
+		{
+			{ TokenCacheExtensions.AccessTokenKey, AccessToken },
+			{ TokenCacheExtensions.RefreshTokenKey, RefreshToken },
+		}, CancellationToken.None);
+		return (cache, log);
+	}
+
+	[TestMethod]
+	public async Task When_KeysLoggedAtTrace_Then_TokenValuesAbsent()
+	{
+		// HasTokenAsync enumerates the cache at Trace, which used to print every value.
+		var (cache, log) = await SeededCache();
+
+		(await cache.HasTokenAsync(CancellationToken.None)).Should().BeTrue("the diagnostic only runs when there are keys to list");
+
+		log.Text.Should().Contain(TokenCacheExtensions.AccessTokenKey, "the key is the useful part of the diagnostic");
+		log.Text.Should().NotContain(AccessToken);
+		log.Text.Should().NotContain(RefreshToken);
+	}
+
+	[TestMethod]
+	public async Task When_HeaderApplied_Then_TokenNotLogged()
+	{
+		// HeaderHandler runs on every outbound request and used to log the bearer at Debug.
+		var (cache, _) = await SeededCache();
+		var log = new CapturingLogger<HeaderHandler>();
+		var handler = new HeaderHandler(log, new FakeAuthenticationService(), cache, new HandlerSettings())
+		{
+			InnerHandler = new OkHandler(),
+		};
+		using var invoker = new HttpMessageInvoker(handler);
+		using var request = new HttpRequestMessage(HttpMethod.Get, "https://api.example/resource");
+
+		using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+		request.Headers.Authorization!.Parameter.Should().Be(AccessToken, "the header itself must still carry the token");
+		log.Text.Should().Contain("Bearer", "the scheme is safe to log");
+		log.Text.Should().NotContain(AccessToken);
+	}
+
+	private sealed class OkHandler : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = request });
+	}
+
+	private sealed class FakeAuthenticationService : IAuthenticationService
+	{
+		public event EventHandler? LoggedOut { add { } remove { } }
+		public string[] Providers => new[] { "Fake" };
+		public ValueTask<bool> LoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials = null, string? provider = null, CancellationToken? cancellationToken = null) => new(true);
+		public ValueTask<bool> RefreshAsync(CancellationToken? cancellationToken = null) => new(true);
+		public ValueTask<bool> LogoutAsync(IDispatcher? dispatcher, CancellationToken? cancellationToken = null) => new(true);
+		public ValueTask<bool> IsAuthenticated(CancellationToken? cancellationToken = null) => new(true);
+	}
+}

--- a/src/Uno.Extensions.Authentication.Tests/Uno.Extensions.Authentication.Tests.csproj
+++ b/src/Uno.Extensions.Authentication.Tests/Uno.Extensions.Authentication.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Uno.Extensions.Authentication\Uno.Extensions.Authentication.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Uno.Extensions.Authentication/AuthenticationService.cs
+++ b/src/Uno.Extensions.Authentication/AuthenticationService.cs
@@ -7,7 +7,19 @@ internal class AuthenticationService : IAuthenticationService
 	private readonly ILogger _logger;
 	private readonly IEnumerable<IProviderFactory> _providerFactories;
 	private readonly ITokenCache _tokens;
-	private readonly IDictionary<string, IAuthenticationProvider> _providers = new Dictionary<string, IAuthenticationProvider>();
+
+	/// <summary>
+	/// The providers, built once on first use and never mutated afterwards.
+	/// </summary>
+	/// <remarks>
+	/// Was a plain <see cref="Dictionary{TKey, TValue}"/> populated by a <c>Count == 0</c> check.
+	/// Two concurrent authentication calls - an HTTP handler refreshing while the UI asks
+	/// <c>IsAuthenticated</c>, say - could both see it empty, both populate it, and corrupt it
+	/// mid-write; the <c>_providers.First()</c> fallback could throw on a dictionary being written
+	/// concurrently. <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/> builds it exactly
+	/// once, and nothing writes to it after that.
+	/// </remarks>
+	private readonly Lazy<IDictionary<string, IAuthenticationProvider>> _providers;
 
 	public AuthenticationService
 	(
@@ -20,9 +32,23 @@ internal class AuthenticationService : IAuthenticationService
 		_providerFactories = providerFactories;
 		_tokens = tokens;
 		_tokens.Cleared += TokensCleared;
+		_providers = new Lazy<IDictionary<string, IAuthenticationProvider>>(
+			BuildProviders,
+			LazyThreadSafetyMode.ExecutionAndPublication);
 	}
 
-	public string[] Providers => _providers.Keys.ToArray();
+	/// <inheritdoc />
+	/// <remarks>
+	/// Deliberately does not force the providers to be built: it reports them only once something
+	/// else has. Building constructs real clients - MSAL builds an
+	/// <c>IPublicClientApplication</c> - and reading a property should not have that side effect,
+	/// nor start throwing where it used to return empty. Consumers bind to this during page
+	/// construction (see <c>MsalAuthenticationWelcomeViewModel</c>), so this preserves the previous
+	/// observable behaviour exactly; making it build on read would be a separate, deliberate change.
+	/// </remarks>
+	public string[] Providers => _providers.IsValueCreated
+		? _providers.Value.Keys.ToArray()
+		: Array.Empty<string>();
 
 	public async ValueTask<bool> LoginAsync(IDispatcher? dispatcher, IDictionary<string, string>? credentials = default, string? provider = null, CancellationToken? cancellationToken = default)
 	{
@@ -45,7 +71,24 @@ internal class AuthenticationService : IAuthenticationService
 		var authProvider = await AuthenticationProvider(default, ct);
 
 		if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTraceMessage($"Attempting to logout");
-		if (!await authProvider.LogoutAsync(dispatcher, ct))
+		bool loggedOut;
+		try
+		{
+			loggedOut = await authProvider.LogoutAsync(dispatcher, ct);
+		}
+		catch (Exception ex)
+		{
+			// The provider failed part-way (a keychain or cache-file error, say). The user asked to
+			// sign out, so nothing this service holds may keep the session alive: clear the tokens
+			// before surfacing the failure, or IsAuthenticated stays true and the HTTP handlers keep
+			// sending the bearer. CancellationToken.None so a cancelled token cannot turn the clear
+			// into a no-op - that is the one outcome this guards.
+			if (_logger.IsEnabled(LogLevel.Warning)) _logger.LogWarning(ex, "Logout failed; clearing the token cache regardless so the user is not left signed in");
+			await _tokens.ClearAsync(CancellationToken.None);
+			throw;
+		}
+
+		if (!loggedOut)
 		{
 			if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTraceMessage($"Logout failed (for example logout cancelled)");
 			return false;
@@ -67,6 +110,17 @@ internal class AuthenticationService : IAuthenticationService
 		{
 			if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTraceMessage($"Attempting to refresh");
 			var tokens = await authProvider.RefreshAsync(ct);
+
+			if (tokens is not { Count: > 0 })
+			{
+				// The provider could not renew the session (an expired or revoked refresh token, say).
+				// Clear rather than save-empty so ITokenCache.Cleared fires: that is what raises
+				// LoggedOut and lets providers drop their own persisted state, exactly as an explicit
+				// sign-out would. The user was authenticated a moment ago and now is not.
+				if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTraceMessage($"Refresh produced no tokens, clearing token cache");
+				await _tokens.ClearAsync(ct);
+				return false;
+			}
 
 			if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTraceMessage($"Refresh complete, saving new tokens");
 			await _tokens.SaveAsync(authProvider.Name, tokens, ct);
@@ -106,27 +160,27 @@ internal class AuthenticationService : IAuthenticationService
 			if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTraceMessage($"No provider specified, so retrieving current provider from token cache '{provider}'");
 		}
 
-		if (_providers.Count == 0)
-		{
-			BuildProviders();
-		}
+		var providers = _providers.Value;
 
-		if (_providers.Count == 0 &&
+		if (providers.Count == 0 &&
 			_logger.IsEnabled(LogLevel.Error))
 		{
 			_logger.LogErrorMessage($"No providers specified for the application");
 		}
 
-		return _providers.TryGetValue(provider ?? string.Empty, out var authProvider) ? authProvider : _providers.First().Value;
+		return providers.TryGetValue(provider ?? string.Empty, out var authProvider) ? authProvider : providers.First().Value;
 	}
 
-	private void BuildProviders()
+	private IDictionary<string, IAuthenticationProvider> BuildProviders()
 	{
 		if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTraceMessage($"Building authentication providers");
+		var providers = new Dictionary<string, IAuthenticationProvider>();
 		foreach (var factory in _providerFactories)
 		{
-			_providers[factory.Name] = factory.AuthenticationProvider;
+			providers[factory.Name] = factory.AuthenticationProvider;
 			if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTraceMessage($"Authentication provider '{factory.Name}' created");
 		}
+
+		return providers;
 	}
 }

--- a/src/Uno.Extensions.Authentication/AuthenticationServiceExtensions.cs
+++ b/src/Uno.Extensions.Authentication/AuthenticationServiceExtensions.cs
@@ -8,6 +8,19 @@ public static class AuthenticationServiceExtensions
 	/// <summary>
 	/// Logs in the user using the specified credentials.
 	/// </summary>
+	/// <remarks>
+	/// This overload passes no <see cref="IDispatcher"/>, so it only suits providers that never need
+	/// one. <c>MsalAuthenticationProvider</c> requires one and throws
+	/// <see cref="ArgumentNullException"/> here — use
+	/// <see cref="IAuthenticationService.LoginAsync(IDispatcher?, IDictionary{string, string}?, string?, CancellationToken?)"/>
+	/// and hand it the dispatcher instead.
+	/// <para>
+	/// MSAL rejects the call up front, even when the sign-in would have completed silently from a
+	/// cached account and shown no UI at all — its dispatcher is only used by the interactive leg.
+	/// Narrowing that guard to the interactive path would be a behaviour change to a published
+	/// package, so it is not done as a drive-by.
+	/// </para>
+	/// </remarks>
 	/// <param name="auth">
 	/// The <see cref="IAuthenticationService"/> to use.
 	/// </param>

--- a/src/Uno.Extensions.Authentication/BaseAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication/BaseAuthenticationProvider.cs
@@ -173,8 +173,19 @@ public abstract record BaseAuthenticationProvider(ILogger Logger, string Name, I
 internal record ProviderFactory<TProvider, TSettings>(string Name, TProvider Provider, TSettings Settings, Func<TProvider, TSettings, TProvider> ConfigureProvider) : IProviderFactory
 	where TProvider : IAuthenticationProvider
 {
-	private IAuthenticationProvider? configuredProvider;
-	public IAuthenticationProvider AuthenticationProvider => configuredProvider ??= ConfigureProvider(Provider, Settings);
+	/// <remarks>
+	/// <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/> rather than the bare
+	/// <c>??=</c> this replaces: two concurrent resolves could both see null and both run
+	/// <see cref="ConfigureProvider"/>. That callback builds the provider - for MSAL it constructs an
+	/// <c>IPublicClientApplication</c> and subscribes to <c>ITokenCache.Cleared</c> - and it returns
+	/// a *copy* of the record each time, so the losing instance stays subscribed for the host's
+	/// lifetime with no reference left to unsubscribe it. Cheap to get wrong, invisible when it
+	/// happens.
+	/// </remarks>
+	private readonly Lazy<IAuthenticationProvider> _configuredProvider =
+		new(() => ConfigureProvider(Provider, Settings), LazyThreadSafetyMode.ExecutionAndPublication);
+
+	public IAuthenticationProvider AuthenticationProvider => _configuredProvider.Value;
 }
 
 internal interface IProviderFactory

--- a/src/Uno.Extensions.Authentication/Handlers/HeaderHandler.cs
+++ b/src/Uno.Extensions.Authentication/Handlers/HeaderHandler.cs
@@ -23,7 +23,9 @@ internal class HeaderHandler : BaseAuthorizationHandler
 			!string.IsNullOrWhiteSpace(_settings.AuthorizationHeaderScheme))
 		{
 			request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(_settings.AuthorizationHeaderScheme, accessToken);
-			if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogDebugMessage($"Set Authorization header with scheme {_settings.AuthorizationHeaderScheme} and token {accessToken}");
+			// The scheme is safe to log; the token is not (AGENTS.md §7). Debug is a level
+			// consumers routinely enable, and this runs on every outbound request.
+			if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogDebugMessage($"Set Authorization header with scheme {_settings.AuthorizationHeaderScheme}");
 			return true;
 		}
 

--- a/src/Uno.Extensions.Authentication/TokenCache.cs
+++ b/src/Uno.Extensions.Authentication/TokenCache.cs
@@ -111,11 +111,16 @@ internal record TokenCache : ITokenCache
 			try
 			{
 				var value = await _secureCache.GetAsync<string>(key, cancellation);
-				_logger.LogTraceMessage($">{key}{value}");
+
+				// Log the shape, never the value: every entry here is an access, refresh or id
+				// token, and this runs at Trace on a consumer's configured logging pipeline
+				// (AGENTS.md §7). The length still distinguishes "present" from "empty", which is
+				// all this diagnostic was ever useful for.
+				_logger.LogTraceMessage($">{key} ({(value is null ? "no value" : $"{value.Length} chars")})");
 			}
-			catch
+			catch (Exception ex)
 			{
-				_logger.LogTraceMessage($">Unable to log {key} (it may not be a string value)");
+				_logger.LogTraceMessage($">Unable to log {key} ({ex.GetType().Name}; it may not be a string value)");
 			}
 		}
 

--- a/src/Uno.Extensions.Authentication/Uno.Extensions.Authentication.csproj
+++ b/src/Uno.Extensions.Authentication/Uno.Extensions.Authentication.csproj
@@ -31,5 +31,6 @@
 		<InternalsVisibleTo Include="$(AssemblyName).MSAL.WinUI" />
 		<InternalsVisibleTo Include="$(AssemblyName).Oidc.UI" />
 		<InternalsVisibleTo Include="$(AssemblyName).Oidc.WinUI" />
+		<InternalsVisibleTo Include="$(AssemblyName).Tests" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): split out of #3139

## PR Type

- Bugfix

## What is the current behavior?

Five defects in `Uno.Extensions.Authentication`, all provider-independent, none covered by a test:

- **Tokens reach the logs.** `TokenCache` prints every cached *value* at Trace when it enumerates keys, and `HeaderHandler` logs the bearer token at Debug on every outbound request. Both go to the consumer's configured logging pipeline (AGENTS.md §7 forbids exactly this).
- **A refresh that cannot renew the session leaves the user "authenticated".** `RefreshAsync` saves whatever the provider returns; a provider that returns nothing (expired or revoked refresh token) leaves the cache with no tokens but never raises `ITokenCache.Cleared`, so `LoggedOut` is not raised and an app that navigates on it sits on a signed-in page with nothing to send.
- **A sign-out that throws leaves the user signed in.** If the provider fails part-way through `LogoutAsync` (a locked keychain, a cache-file error), the exception escapes before `_tokens.ClearAsync` runs: the access token survives, `IsAuthenticated` stays true, and the HTTP handlers keep sending the bearer for a user who asked to sign out.
- **Providers can be built more than once.** `AuthenticationService` populated its provider table behind a `Count == 0` check and `ProviderFactory` configured its provider with a bare `??=`; two concurrent callers - an HTTP handler refreshing while the UI asks `IsAuthenticated`, say - could both build. `ConfigureProvider` returns a record copy, so the losing instance stayed alive, subscribed to `ITokenCache.Cleared`, with nothing left to unsubscribe it.
- `IAuthenticationService.LoginAsync(CancellationToken)`'s docs did not say that it passes no `IDispatcher`, which some providers require.

## What is the new behavior?

- `TokenCache` logs key + value length; `HeaderHandler` logs the scheme only.
- `RefreshAsync` clears the token cache when the provider returns no tokens, so `Cleared` and `LoggedOut` fire - the same as an explicit sign-out. A provider that keeps its tokens on a transient failure is unaffected.
- `LogoutAsync` clears the token cache (`CancellationToken.None`, so a cancelled token cannot skip it) and rethrows when the provider throws. A provider returning `false` is unchanged: that is "the sign-out did not happen", and the session stands.
- The provider table and each configured provider are built exactly once (`Lazy`, `ExecutionAndPublication`). `Providers` still reports only what has been built - reading a property must not construct MSAL's client application.
- The `LoginAsync(CancellationToken)` remarks say what the overload cannot do.

New `Uno.Extensions.Authentication.Tests` (plain `net9.0` MSTest, in the package-CI VSTest filter): 12 tests - refresh returns nothing / empty / tokens, logout throws / throws with a cancelled token / declines, concurrent calls build once, `Providers` does not build, `ProviderFactory` configures once, and two log-leak guards. Every fix was verified red before it: the two leak guards fail against `main`'s `TokenCache` and `HeaderHandler`, the refresh and logout cases against `main`'s `AuthenticationService`.

## PR Checklist

- [x] Tested code with current supported SDKs
- [x] Docs have been added/updated which fit documentation template - XML docs on the changed overload; behavior changes are listed in `UpdatingExtensions.md` on #3139, to land with the MSAL layer that depends on them
- [x] Unit Tests and/or UI Tests for the changes have been added
- [ ] Wasm UI Tests are not showing any unexpected differences
- [x] Contains **NO** breaking changes - binary-compatible; `LoggedOut` now fires in one more situation (an unrenewable session), which is the documented meaning of the event
- [ ] Updated the Release Notes
- [x] Associated with an issue (GitHub or internal)

## Other information

Verified locally: `Uno.Extensions.Authentication.Tests` 12/12 (2/12 red with `main`'s `TokenCache` + `HeaderHandler`); `Uno.Extensions-packageonly.slnf` Release build 0 errors, which covers the MSAL, OIDC and `Authentication.WinUI` consumers of the changed internals.

Reviewer note: this is the auth-core layer of #3139's split. The MSAL provider changes that build on it (`TokensOrNull`, keeping tokens on transient refresh failures, sign-out removing every account) come in a later PR with their end-to-end tests; nothing here depends on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqfQh5ovrPEvFGcERLiLhH
