### PR TITLE
feat(reactive): add Uno.HotTesting.Reactive handwritten feed mocks (#3149)

### DIFF
--- a/Uno.Extensions-packageonly.slnf
+++ b/Uno.Extensions-packageonly.slnf
@@ -7,8 +7,8 @@
       "src\\Uno.Extensions.Authentication.Tests\\Uno.Extensions.Authentication.Tests.csproj",
       "src\\Uno.Extensions.Authentication.UI\\Uno.Extensions.Authentication.WinUI.csproj",
       "src\\Uno.Extensions.Authentication\\Uno.Extensions.Authentication.csproj",
-      "src\\Uno.Extensions.Configuration\\Uno.Extensions.Configuration.csproj",
       "src\\Uno.Extensions.Configuration.Tests\\Uno.Extensions.Configuration.Tests.csproj",
+      "src\\Uno.Extensions.Configuration\\Uno.Extensions.Configuration.csproj",
       "src\\Uno.Extensions.Core.Generators\\Uno.Extensions.Core.Generators.csproj",
       "src\\Uno.Extensions.Core.Tests\\Uno.Extensions.Core.Tests.csproj",
       "src\\Uno.Extensions.Core.UI\\Uno.Extensions.Core.WinUI.csproj",
@@ -38,9 +38,9 @@
       "src\\Uno.Extensions.Reactive.UI.Markup\\Uno.Extensions.Reactive.WinUI.Markup.csproj",
       "src\\Uno.Extensions.Reactive.UI\\Uno.Extensions.Reactive.WinUI.csproj",
       "src\\Uno.Extensions.Reactive\\Uno.Extensions.Reactive.csproj",
+      "src\\Uno.Extensions.Serialization.AotTests\\Uno.Extensions.Serialization.AotTests.csproj",
       "src\\Uno.Extensions.Serialization.Http\\Uno.Extensions.Serialization.Http.csproj",
       "src\\Uno.Extensions.Serialization.Refit\\Uno.Extensions.Serialization.Refit.csproj",
-      "src\\Uno.Extensions.Serialization.AotTests\\Uno.Extensions.Serialization.AotTests.csproj",
       "src\\Uno.Extensions.Serialization.Tests\\Uno.Extensions.Serialization.Tests.csproj",
       "src\\Uno.Extensions.Serialization\\Uno.Extensions.Serialization.csproj",
       "src\\Uno.Extensions.Storage.UI\\Uno.Extensions.Storage.WinUI.csproj",
@@ -48,7 +48,9 @@
       "src\\Uno.Extensions.Toolkit.UI\\Uno.Extensions.Toolkit.WinUI.csproj",
       "src\\Uno.Extensions.Toolkit\\Uno.Extensions.Toolkit.csproj",
       "src\\Uno.Extensions.Validation.Fluent\\Uno.Extensions.Validation.Fluent.csproj",
-      "src\\Uno.Extensions.Validation\\Uno.Extensions.Validation.csproj"
+      "src\\Uno.Extensions.Validation\\Uno.Extensions.Validation.csproj",
+      "src\\Uno.HotTesting.Reactive.Tests\\Uno.HotTesting.Reactive.Tests.csproj",
+      "src\\Uno.HotTesting.Reactive\\Uno.HotTesting.Reactive.csproj"
     ]
   }
 }

--- a/Uno.Extensions.Reactive.slnf
+++ b/Uno.Extensions.Reactive.slnf
@@ -20,7 +20,9 @@
       "src\\Uno.Extensions.RuntimeTests\\Uno.Extensions.RuntimeTests.Skia.Gtk\\Uno.Extensions.RuntimeTests.Skia.Gtk.csproj",
       "src\\Uno.Extensions.RuntimeTests\\Uno.Extensions.RuntimeTests.Skia.Wpf\\Uno.Extensions.RuntimeTests.Skia.Wpf.csproj",
       "src\\Uno.Extensions.RuntimeTests\\Uno.Extensions.RuntimeTests.Wasm\\Uno.Extensions.RuntimeTests.Wasm.csproj",
-      "src\\Uno.Extensions.RuntimeTests\\Uno.Extensions.RuntimeTests.Windows\\Uno.Extensions.RuntimeTests.Windows.csproj"
+      "src\\Uno.Extensions.RuntimeTests\\Uno.Extensions.RuntimeTests.Windows\\Uno.Extensions.RuntimeTests.Windows.csproj",
+      "src\\Uno.HotTesting.Reactive.Tests\\Uno.HotTesting.Reactive.Tests.csproj",
+      "src\\Uno.HotTesting.Reactive\\Uno.HotTesting.Reactive.csproj"
     ]
   }
 }

--- a/Uno.Extensions.sln
+++ b/Uno.Extensions.sln
@@ -152,6 +152,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Authentication.Tests", "src\Uno.Extensions.Authentication.Tests\Uno.Extensions.Authentication.Tests.csproj", "{7AD671A6-E401-4C16-803B-C9554673FD19}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Extensions.Storage.WinUI.Tests", "src\Uno.Extensions.Storage.UI.Tests\Uno.Extensions.Storage.WinUI.Tests.csproj", "{26DA9186-8DD8-4623-A455-0F0B9DA2E79A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.HotTesting.Reactive", "src\Uno.HotTesting.Reactive\Uno.HotTesting.Reactive.csproj", "{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.HotTesting.Reactive.Tests", "src\Uno.HotTesting.Reactive.Tests\Uno.HotTesting.Reactive.Tests.csproj", "{2347B2F1-002C-4165-B523-D4D236A13CEC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -861,6 +864,38 @@ Global
 		{26DA9186-8DD8-4623-A455-0F0B9DA2E79A}.Release|x64.Build.0 = Release|Any CPU
 		{26DA9186-8DD8-4623-A455-0F0B9DA2E79A}.Release|x86.ActiveCfg = Release|Any CPU
 		{26DA9186-8DD8-4623-A455-0F0B9DA2E79A}.Release|x86.Build.0 = Release|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Debug|arm64.Build.0 = Debug|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Debug|x86.Build.0 = Debug|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Release|arm64.ActiveCfg = Release|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Release|arm64.Build.0 = Release|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Release|x64.Build.0 = Release|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF}.Release|x86.Build.0 = Release|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Debug|arm64.Build.0 = Debug|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Debug|x64.Build.0 = Debug|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Debug|x86.Build.0 = Debug|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Release|arm64.ActiveCfg = Release|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Release|arm64.Build.0 = Release|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Release|x64.ActiveCfg = Release|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Release|x64.Build.0 = Release|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Release|x86.ActiveCfg = Release|Any CPU
+		{2347B2F1-002C-4165-B523-D4D236A13CEC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -914,6 +949,8 @@ Global
 		{457C6DC1-BDCA-4C07-B797-48A4465D5C5B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{7AD671A6-E401-4C16-803B-C9554673FD19} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{26DA9186-8DD8-4623-A455-0F0B9DA2E79A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{A1A08FE3-19D4-4EB2-B228-10187E2C4CDF} = {6B956AB1-06A6-4BEC-9467-E7B593A89E34}
+		{2347B2F1-002C-4165-B523-D4D236A13CEC} = {6B956AB1-06A6-4BEC-9467-E7B593A89E34}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E7B035D-9A64-4D95-89AA-9D4653F17C42}

--- a/build/ci/cspell.json
+++ b/build/ci/cspell.json
@@ -2,6 +2,9 @@
 	"version": "0.2",
 	"language": "en",
 	"words": [
+		"refreshable",
+		"rehook",
+		"synchronise",
 		"nuspecs",
 		"unmaterialized",
 		"Avalonia",

--- a/doc/Reference/Reactive/testing.md
+++ b/doc/Reference/Reactive/testing.md
@@ -30,3 +30,83 @@ You define each axis (`Data` / `Error` / `Progress`) in the `Message` you want t
 
 > [!NOTE]
 > When developing a new _feed_, we recommend that you systematically validate all axes.
+
+## Provide handwritten feed mocks to a page
+
+Install the `Uno.HotTesting.Reactive` package in the project that provides the
+mock page. Its `FeedMock` and `ListFeedMock` factories create feeds pinned to
+common MVUX states for previews and UI testing.
+
+In this initial scope, no view-model mock is generated. Write the record or class
+yourself, give its properties exactly the names and feed types expected by the
+page bindings, and assign an instance to the page's `DataContext`.
+
+For example, these bindings expect properties named `MyFeed` and `MyItems`:
+
+```xml
+<Page
+    x:Class="MyApp.MySuperPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mvux="using:Uno.Extensions.Reactive.UI">
+    <StackPanel>
+        <mvux:FeedView Source="{Binding MyFeed}">
+            <DataTemplate>
+                <TextBlock Text="{Binding Data}" />
+            </DataTemplate>
+        </mvux:FeedView>
+
+        <mvux:FeedView Source="{Binding MyItems}">
+            <DataTemplate>
+                <ListView ItemsSource="{Binding Data}">
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Name}" />
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </DataTemplate>
+        </mvux:FeedView>
+    </StackPanel>
+</Page>
+```
+
+The handwritten mock and page initialization can then be:
+
+```csharp
+using Microsoft.UI.Xaml.Controls;
+using Uno.Extensions.Reactive;
+using Uno.HotTesting.Reactive;
+
+namespace MyApp;
+
+public sealed record Product(string Name);
+
+public sealed record MySuperPageViewModelMock
+{
+    public IFeed<string> MyFeed { get; init; } = FeedMock.Undefined<string>();
+
+    public IListFeed<Product> MyItems { get; init; } = ListFeedMock.Empty<Product>();
+}
+
+public sealed partial class MySuperPage : Page
+{
+    public MySuperPage()
+    {
+        InitializeComponent();
+
+        DataContext = new MySuperPageViewModelMock
+        {
+            MyFeed = FeedMock.Value("Ready"),
+            MyItems = ListFeedMock.Value(
+                new Product("First item"),
+                new Product("Second item"))
+        };
+    }
+}
+```
+
+The developer remains responsible for the property names, feed shapes, and
+`DataContext` injection. These factories are the reusable runtime base for the
+longer-term Hot Testing direction; this initial API does not promise or require a
+generator.

--- a/specs/009-hot-testing-reactive-feed-mocks/spec.md
+++ b/specs/009-hot-testing-reactive-feed-mocks/spec.md
@@ -1,0 +1,97 @@
+# Spec 009: Hot Testing Reactive feed mocks
+
+Status: Implemented for issue #3149
+
+## Product direction
+
+This is the deliberately small runtime foundation requested for
+[uno.extensions #3149](https://github.com/unoplatform/uno.extensions/issues/3149).
+
+- The assembly, package, and namespace are exactly Uno.HotTesting.Reactive, even
+  though the project lives in the uno.extensions repository for now.
+- The public vocabulary is FeedMock and ListFeedMock.
+- There is no generated code.
+- Users hand-write a view-model-shaped record or class, make its property names and
+  feed shapes match their XAML bindings, and assign that object to Page.DataContext.
+- Name matching, binding shape correctness, and DataContext injection are the user's
+  responsibility.
+- This runtime layer must remain reusable by the fuller spec 013 generation and
+  architecture work later.
+
+The name ListFeedMock is authoritative. An earlier conversation used ListViewMock once,
+but the issue and the proven runtime work in PR #3147 both refer to a list feed rather
+than a view.
+
+## Public API
+
+FeedMock and ListFeedMock expose the same small state vocabulary:
+
+- Undefined<T>()
+- Loading<T>()
+- Empty<T>()
+- Value<T>(...)
+- Error<T>(Exception)
+- Refreshing<T>(...)
+- Message<T>(...)
+
+Message is retained as the low-level escape hatch because MVUX messages have
+independent data, error, progress, and other axes. It keeps this runtime usable by
+future generated factories without adding state scripting or generator policy now.
+
+There is intentionally no public state enum in this first slice. The factories are
+the reusable primitive; an enum would add a second abstraction before there is a
+consumer that needs it.
+
+## Semantics
+
+Every factory returns a cold, finite feed. Each subscription receives its pinned
+message state and completes. Loading and refreshing therefore remain visually pinned
+without a never-ending task, timer, or background operation. A later subscription
+(such as a view being unloaded and reparented) receives the same state again.
+
+Undefined<T>() emits a None data message followed by Undefined. MVUX's initial message
+is already undefined, so this transition is required for the final undefined value to
+remain an observable data-axis change through state replay.
+
+Refreshing sets data plus transient progress. It does not set the internal refresh
+axis, which cannot be produced outside a refreshable source feed.
+
+Scalar FeedMock.Empty<T>() means Option<T>.None.
+
+ListFeedMock.Empty<T>() means a present empty immutable list (Some(empty)). The list
+adapter forwards the message rather than using the normal list-feed adapter, which
+would coerce Some(empty) to None. Empty Value and Refreshing inputs preserve the same
+Some(empty) behavior. Callers that need None for a list can express it explicitly
+through ListFeedMock.Message.
+
+## Reuse boundary
+
+Future generator or Hot Design work may consume these factories, but must not fork
+their message construction semantics. The runtime has no dependency on a generated
+view model, UI framework, reflection, naming convention, or source generator.
+
+## Explicitly rejected scope
+
+The following are not part of issue #3149:
+
+- source generators or generated view-model factories;
+- generated user records or automatic property-name matching;
+- MockCommand;
+- timed scripts or selection helpers;
+- gallery, marketing, or broad documentation work.
+
+These exclusions keep this commit a reusable runtime foundation rather than a partial
+implementation of the full spec 013 system.
+
+## Verification
+
+Focused tests cover scalar and list common states, all configured message axes, finite
+completion, repeated subscriptions, undefined replay through state, Some(empty) list
+behavior, assembly/namespace naming, and the public API shape.
+
+Validation on the issue branch:
+
+- Release test build and execution: 22 passed, 0 failed. The uno-dev image has only
+  the .NET 10 runtime, so the net9.0 test host was run with DOTNET_ROLL_FORWARD=Major.
+- Release package creation succeeded for Uno.HotTesting.Reactive, including its net9.0
+  assembly, XML documentation, symbols, and Uno.Extensions.Reactive dependency.

--- a/specs/009-hot-testing-reactive-feed-mocks/spec.md
+++ b/specs/009-hot-testing-reactive-feed-mocks/spec.md
@@ -115,3 +115,22 @@ Validation on the issue branch:
   the .NET 10 runtime, so the net9.0 test host was run with DOTNET_ROLL_FORWARD=Major.
 - Release package creation succeeded for Uno.HotTesting.Reactive, including its net9.0
   assembly, XML documentation, symbols, and Uno.Extensions.Reactive dependency.
+
+## Delivery to origin (decision)
+
+David's decision: the change reaches the canonical GitHub repository
+(unoplatform/uno.extensions) exclusively through the Agent Outbox (ABO), and the outbox
+must do two things, not one. It must:
+
+1. synchronise/push the task branch to origin (never force-pushed), and
+2. open the corresponding GitHub pull request, filled according to the repository pull
+   request template at `.github/pull_request_template.md`.
+
+The worker never writes to origin directly. Every origin Git operation goes through ABO:
+`abo-git sync` performs the branch mirror, and `gh api` creates or updates the pull
+request. The submitted ABO script is declarative and idempotent: it re-syncs the branch,
+checks whether an origin PR already exists for this head/base, creates it as a draft when
+absent, and otherwise updates its title/body. The PR targets base `main` from head
+`dev/devid/issue-3149-feed-mocks` and follows the repository template. Origin PR creation
+is therefore an outbox responsibility, gated by ABO human approval, not a direct worker
+action.

--- a/specs/009-hot-testing-reactive-feed-mocks/spec.md
+++ b/specs/009-hot-testing-reactive-feed-mocks/spec.md
@@ -22,6 +22,25 @@ The name ListFeedMock is authoritative. An earlier conversation used ListViewMoc
 but the issue and the proven runtime work in PR #3147 both refer to a list feed rather
 than a view.
 
+## Handwritten page-mock contract
+
+For this first scope there is no generation. The developer:
+
+1. writes a record or class shaped like the view model the page expects;
+2. declares `IFeed<T>` and `IListFeed<T>` properties whose names exactly match
+   the page bindings;
+3. initializes those properties with `FeedMock` and `ListFeedMock`; and
+4. assigns the handwritten instance directly to `Page.DataContext`.
+
+Property naming, feed-shape compatibility, and injection remain explicit user
+responsibilities. The official user example is maintained in
+`doc/Reference/Reactive/testing.md`, the existing MVUX testing reference page,
+and shows both scalar and list feeds.
+
+This API is the reusable runtime base for the longer-term Hot Testing direction.
+That compatibility boundary does not promise, schedule, or require a generator,
+and documentation must not imply that handwritten mocks are generated.
+
 ## Public API
 
 FeedMock and ListFeedMock expose the same small state vocabulary:
@@ -72,13 +91,14 @@ view model, UI framework, reflection, naming convention, or source generator.
 
 ## Explicitly rejected scope
 
-The following are not part of issue #3149:
+Focused user documentation of the handwritten workflow is part of issue #3149.
+The following remain outside its scope:
 
 - source generators or generated view-model factories;
 - generated user records or automatic property-name matching;
 - MockCommand;
 - timed scripts or selection helpers;
-- gallery, marketing, or broad documentation work.
+- gallery, marketing, or unrelated broad documentation work.
 
 These exclusions keep this commit a reusable runtime foundation rather than a partial
 implementation of the full spec 013 system.

--- a/src/Uno.HotTesting.Reactive.Tests/Given_FeedMock.cs
+++ b/src/Uno.HotTesting.Reactive.Tests/Given_FeedMock.cs
@@ -1,0 +1,133 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions;
+using Uno.Extensions.Reactive;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.HotTesting.Reactive.Tests;
+
+[TestClass]
+public class Given_FeedMock : FeedTests
+{
+	[TestMethod]
+	public async Task When_Undefined_Then_DataAxisIsUndefined_AndFeedCompletes()
+	{
+		var result = FeedMock.Undefined<int>().Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Data, Data.None, Error.No, Progress.Final)
+			.Message(Changed.Data, Data.Undefined, Error.No, Progress.Final));
+	}
+
+	[TestMethod]
+	public void When_UndefinedTwice_Then_FeedsAreIndependent()
+		=> FeedMock.Undefined<int>().Should().NotBeSameAs(FeedMock.Undefined<int>());
+
+	[TestMethod]
+	public async Task When_Loading_Then_ProgressIsTransient_AndFeedCompletes()
+	{
+		var result = FeedMock.Loading<int>().Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Progress, Data.Undefined, Error.No, Progress.Transient));
+	}
+
+	[TestMethod]
+	public async Task When_Empty_Then_DataIsNone()
+	{
+		var result = FeedMock.Empty<int>().Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Data, Data.None, Error.No, Progress.Final));
+	}
+
+	[TestMethod]
+	public async Task When_Value_Then_DataIsSome()
+	{
+		var result = FeedMock.Value(42).Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Data, 42, Error.No, Progress.Final));
+	}
+
+	[TestMethod]
+	public async Task When_Error_Then_ErrorAxisIsSet()
+	{
+		var error = new TestException();
+		var result = FeedMock.Error<int>(error).Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Error, Data.Undefined, error, Progress.Final));
+	}
+
+	[TestMethod]
+	public async Task When_Refreshing_Then_DataAndTransientProgressAreSet()
+	{
+		var result = FeedMock.Refreshing(42).Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Data & Changed.Progress, 42, Error.No, Progress.Transient));
+	}
+
+	[TestMethod]
+	public async Task When_Message_Then_AllConfiguredAxesArePreserved()
+	{
+		var error = new TestException();
+		var result = FeedMock.Message<int>(message => message
+			.Data(42)
+			.Error(error)
+			.IsTransient(true))
+			.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(
+				Changed.Data & Changed.Error & Changed.Progress,
+				42,
+				error,
+				Progress.Transient));
+	}
+
+	[TestMethod]
+	public async Task When_SubscribedAgain_Then_PinnedStateIsReplayedAndCompletes()
+	{
+		var feed = FeedMock.Loading<int>();
+		var first = feed.Record();
+		await first.WaitForEnd(CT);
+
+		var second = feed.Record();
+		await second.WaitForEnd(CT);
+
+		first.Should().Be(r => r
+			.Message(Changed.Progress, Data.Undefined, Error.No, Progress.Transient));
+		second.Should().Be(r => r
+			.Message(Changed.Progress, Data.Undefined, Error.No, Progress.Transient));
+	}
+
+	[TestMethod]
+	public async Task When_UndefinedPassesThroughState_Then_ReplayConvergesToUndefined()
+	{
+		var state = Context.SourceContext.GetOrCreateState(FeedMock.Undefined<int>());
+
+		var data = await state.DataSet(ct: CT)
+			.Where(value => value.Type == OptionType.Undefined)
+			.FirstAsync(CT);
+
+		data.Type.Should().Be(OptionType.Undefined);
+	}
+}

--- a/src/Uno.HotTesting.Reactive.Tests/Given_ListFeedMock.cs
+++ b/src/Uno.HotTesting.Reactive.Tests/Given_ListFeedMock.cs
@@ -1,0 +1,128 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions;
+using Uno.Extensions.Reactive;
+using Uno.Extensions.Reactive.Testing;
+
+namespace Uno.HotTesting.Reactive.Tests;
+
+[TestClass]
+public class Given_ListFeedMock : FeedTests
+{
+	[TestMethod]
+	public async Task When_Undefined_Then_DataAxisIsUndefined_AndFeedCompletes()
+	{
+		var result = ListFeedMock.Undefined<int>().Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Data, Data.None, Error.No, Progress.Final)
+			.Message(Changed.Data, Data.Undefined, Error.No, Progress.Final));
+	}
+
+	[TestMethod]
+	public async Task When_Loading_Then_ProgressIsTransient_AndFeedCompletes()
+	{
+		var result = ListFeedMock.Loading<int>().Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Progress, Data.Undefined, Error.No, Progress.Transient));
+	}
+
+	[TestMethod]
+	public async Task When_Empty_Then_DataIsSomeEmptyList()
+	{
+		var result = ListFeedMock.Empty<int>().Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Data, Data.Some, Error.No, Progress.Final));
+		result.Single().Current.Data.SomeOrDefault().Should().BeEmpty();
+	}
+
+	[TestMethod]
+	public async Task When_ValueHasItems_Then_DataContainsItems()
+	{
+		var result = ListFeedMock.Value(1, 2, 3).Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Data, Items.Some(1, 2, 3), Error.No, Progress.Final));
+	}
+
+	[TestMethod]
+	public async Task When_ValueHasNoItems_Then_DataRemainsSomeEmptyList()
+	{
+		var result = ListFeedMock.Value<int>().Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Data, Data.Some, Error.No, Progress.Final));
+		result.Single().Current.Data.SomeOrDefault().Should().BeEmpty();
+	}
+
+	[TestMethod]
+	public async Task When_Error_Then_ErrorAxisIsSet()
+	{
+		var error = new TestException();
+		var result = ListFeedMock.Error<int>(error).Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Error, Data.Undefined, error, Progress.Final));
+	}
+
+	[TestMethod]
+	public async Task When_RefreshingWithItems_Then_DataAndTransientProgressAreSet()
+	{
+		var result = ListFeedMock.Refreshing(1, 2, 3).Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(
+				Changed.Data & Changed.Progress,
+				Items.Some(1, 2, 3),
+				Error.No,
+				Progress.Transient));
+	}
+
+	[TestMethod]
+	public async Task When_RefreshingWithoutItems_Then_DataRemainsSomeEmptyList()
+	{
+		var result = ListFeedMock.Refreshing<int>().Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(
+				Changed.Data & Changed.Progress,
+				Data.Some,
+				Error.No,
+				Progress.Transient));
+		result.Single().Current.Data.SomeOrDefault().Should().BeEmpty();
+	}
+
+	[TestMethod]
+	public async Task When_MessageSetsNone_Then_ExplicitAxisIsPreserved()
+	{
+		var result = ListFeedMock.Message<int>(message =>
+			message.Data(Option<IImmutableList<int>>.None()))
+			.Record();
+
+		await result.WaitForEnd(CT);
+
+		result.Should().Be(r => r
+			.Message(Changed.Data, Data.None, Error.No, Progress.Final));
+	}
+}

--- a/src/Uno.HotTesting.Reactive.Tests/Given_PublicApi.cs
+++ b/src/Uno.HotTesting.Reactive.Tests/Given_PublicApi.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions.Reactive;
+
+namespace Uno.HotTesting.Reactive.Tests;
+
+[TestClass]
+public class Given_PublicApi
+{
+	[TestMethod]
+	public void When_AssemblyIsLoaded_Then_NameAndNamespaceMatchProductContract()
+	{
+		typeof(FeedMock).Assembly.GetName().Name.Should().Be("Uno.HotTesting.Reactive");
+		typeof(FeedMock).Namespace.Should().Be("Uno.HotTesting.Reactive");
+		typeof(ListFeedMock).Namespace.Should().Be("Uno.HotTesting.Reactive");
+	}
+
+	[TestMethod]
+	public void When_FactorySurfaceIsInspected_Then_OnlyPinnedStatePrimitivesArePresent()
+	{
+		var expected = new[]
+		{
+			"Empty",
+			"Error",
+			"Loading",
+			"Message",
+			"Refreshing",
+			"Undefined",
+			"Value",
+		};
+
+		typeof(FeedMock).GetMethods()
+			.Where(method => method.DeclaringType == typeof(FeedMock))
+			.Select(method => method.Name)
+			.Distinct()
+			.Should()
+			.BeEquivalentTo(expected);
+		typeof(ListFeedMock).GetMethods()
+			.Where(method => method.DeclaringType == typeof(ListFeedMock))
+			.Select(method => method.Name)
+			.Distinct()
+			.Should()
+			.BeEquivalentTo(expected);
+	}
+
+	[TestMethod]
+	public void When_UserBuildsNamedRecord_Then_FeedsCanBeInjectedDirectly()
+		=> new PreviewModel(FeedMock.Empty<int>(), ListFeedMock.Empty<string>())
+			.Should().BeAssignableTo<PreviewModel>();
+
+	private sealed record PreviewModel(IFeed<int> Count, IListFeed<string> Items);
+}

--- a/src/Uno.HotTesting.Reactive.Tests/Uno.HotTesting.Reactive.Tests.csproj
+++ b/src/Uno.HotTesting.Reactive.Tests/Uno.HotTesting.Reactive.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="MSTest.TestAdapter" />
+		<PackageReference Include="MSTest.TestFramework" />
+		<PackageReference Include="coverlet.collector" />
+		<PackageReference Include="System.Collections.Immutable" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.Extensions.Reactive.Testing\Uno.Extensions.Reactive.Testing.csproj" />
+		<ProjectReference Include="..\Uno.HotTesting.Reactive\Uno.HotTesting.Reactive.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/Uno.HotTesting.Reactive/FeedMock.cs
+++ b/src/Uno.HotTesting.Reactive/FeedMock.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Uno.Extensions;
+using Uno.Extensions.Reactive;
+
+namespace Uno.HotTesting.Reactive;
+
+/// <summary>
+/// Creates finite <see cref="IFeed{T}"/> instances pinned to common MVUX message states.
+/// </summary>
+/// <remarks>
+/// Each subscription receives the configured state and then completes. This keeps loading
+/// and refreshing previews pinned without leaving background work running.
+/// </remarks>
+public static class FeedMock
+{
+	/// <summary>Creates a feed pinned before its first value.</summary>
+	/// <typeparam name="T">The feed value type.</typeparam>
+	/// <returns>A feed whose data axis is undefined.</returns>
+	public static IFeed<T> Undefined<T>()
+	{
+		// Feed.Create caches by delegate identity. Capturing a fresh identity keeps two mock
+		// properties of the same type independent when a future factory consumes this API.
+		var identity = new object();
+		return Feed.Create<T>(ct => FeedMockMessageSource.Undefined<T>(identity, ct));
+	}
+
+	/// <summary>Creates a feed pinned in an indefinite loading state.</summary>
+	/// <typeparam name="T">The feed value type.</typeparam>
+	/// <returns>A transient feed which completes after its loading message.</returns>
+	public static IFeed<T> Loading<T>()
+		=> Message<T>(message => message.IsTransient(true));
+
+	/// <summary>Creates a feed with no value.</summary>
+	/// <typeparam name="T">The feed value type.</typeparam>
+	/// <returns>A feed whose data axis is <see cref="Option{T}.None"/>.</returns>
+	public static IFeed<T> Empty<T>()
+		=> Message<T>(message => message.Data(Option<T>.None()));
+
+	/// <summary>Creates a feed pinned to a value.</summary>
+	/// <typeparam name="T">The feed value type.</typeparam>
+	/// <param name="value">The value to expose.</param>
+	/// <returns>A feed whose data axis contains <paramref name="value"/>.</returns>
+	public static IFeed<T> Value<T>(T value)
+		=> Message<T>(message => message.Data(value));
+
+	/// <summary>Creates a feed pinned to an error.</summary>
+	/// <typeparam name="T">The feed value type.</typeparam>
+	/// <param name="error">The error to expose.</param>
+	/// <returns>A feed whose error axis contains <paramref name="error"/>.</returns>
+	public static IFeed<T> Error<T>(Exception error)
+	{
+		if (error is null)
+		{
+			throw new ArgumentNullException(nameof(error));
+		}
+
+		return Message<T>(message => message.Error(error));
+	}
+
+	/// <summary>Creates a feed pinned to stale data while a refresh is in progress.</summary>
+	/// <typeparam name="T">The feed value type.</typeparam>
+	/// <param name="staleValue">The stale value to expose.</param>
+	/// <returns>A transient feed with data.</returns>
+	/// <remarks>
+	/// This models the public message axes used by views: data is present and progress is
+	/// transient. The internal refresh axis can only be raised by a refreshable source feed.
+	/// </remarks>
+	public static IFeed<T> Refreshing<T>(T staleValue)
+		=> Message<T>(message => message.Data(staleValue).IsTransient(true));
+
+	/// <summary>Creates a feed pinned to an arbitrary message.</summary>
+	/// <typeparam name="T">The feed value type.</typeparam>
+	/// <param name="configure">Configures the message axes.</param>
+	/// <returns>A feed which emits the configured message and completes.</returns>
+	public static IFeed<T> Message<T>(Action<MessageBuilder<T>> configure)
+	{
+		if (configure is null)
+		{
+			throw new ArgumentNullException(nameof(configure));
+		}
+
+		return Feed.Create<T>(ct => FeedMockMessageSource.Single(configure, ct));
+	}
+}
+
+internal static class FeedMockMessageSource
+{
+	public static async IAsyncEnumerable<Message<T>> Single<T>(
+		Action<MessageBuilder<T>> configure,
+		[EnumeratorCancellation] CancellationToken ct)
+	{
+		ct.ThrowIfCancellationRequested();
+		var builder = Message<T>.Initial.With();
+		configure(builder);
+		yield return builder.Build();
+	}
+
+	public static async IAsyncEnumerable<Message<T>> Undefined<T>(
+		object identity,
+		[EnumeratorCancellation] CancellationToken ct)
+	{
+		GC.KeepAlive(identity);
+		ct.ThrowIfCancellationRequested();
+
+		// Initial already has Undefined data. Walking through None makes the final
+		// Undefined a real data-axis change which survives MessageManager replay.
+		var none = Message<T>.Initial.With().Data(Option<T>.None()).Build();
+		yield return none;
+		ct.ThrowIfCancellationRequested();
+		yield return none.With().Data(Option<T>.Undefined());
+	}
+}

--- a/src/Uno.HotTesting.Reactive/ListFeedMock.cs
+++ b/src/Uno.HotTesting.Reactive/ListFeedMock.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Uno.Extensions.Reactive;
+using Uno.Extensions.Reactive.Core;
+
+namespace Uno.HotTesting.Reactive;
+
+/// <summary>
+/// Creates finite <see cref="IListFeed{T}"/> instances pinned to common MVUX message states.
+/// </summary>
+public static class ListFeedMock
+{
+	/// <summary>Creates a list feed pinned before its first value.</summary>
+	/// <typeparam name="T">The list item type.</typeparam>
+	/// <returns>A list feed whose data axis is undefined.</returns>
+	public static IListFeed<T> Undefined<T>()
+		=> Wrap(FeedMock.Undefined<IImmutableList<T>>());
+
+	/// <summary>Creates a list feed pinned in an indefinite loading state.</summary>
+	/// <typeparam name="T">The list item type.</typeparam>
+	/// <returns>A transient list feed which completes after its loading message.</returns>
+	public static IListFeed<T> Loading<T>()
+		=> Wrap(FeedMock.Loading<IImmutableList<T>>());
+
+	/// <summary>Creates a list feed with a present, empty list.</summary>
+	/// <typeparam name="T">The list item type.</typeparam>
+	/// <returns>A list feed whose data axis is <c>Some(empty)</c>.</returns>
+	/// <remarks>
+	/// This intentionally differs from a scalar feed's <see cref="FeedMock.Empty{T}"/>.
+	/// List views need an empty collection value to render their empty state. The mock adapter
+	/// preserves that value instead of applying the normal Some(empty)-to-None coercion.
+	/// </remarks>
+	public static IListFeed<T> Empty<T>()
+		=> Wrap(FeedMock.Value<IImmutableList<T>>(ImmutableList<T>.Empty));
+
+	/// <summary>Creates a list feed pinned to the supplied items.</summary>
+	/// <typeparam name="T">The list item type.</typeparam>
+	/// <param name="items">The items to expose.</param>
+	/// <returns>A list feed whose data axis contains the supplied items.</returns>
+	/// <remarks>An empty array has the same <c>Some(empty)</c> semantics as <see cref="Empty{T}"/>.</remarks>
+	public static IListFeed<T> Value<T>(params T[] items)
+	{
+		if (items is null)
+		{
+			throw new ArgumentNullException(nameof(items));
+		}
+
+		return Wrap(FeedMock.Value<IImmutableList<T>>(items.ToImmutableList()));
+	}
+
+	/// <summary>Creates a list feed pinned to an error.</summary>
+	/// <typeparam name="T">The list item type.</typeparam>
+	/// <param name="error">The error to expose.</param>
+	/// <returns>A list feed whose error axis contains <paramref name="error"/>.</returns>
+	public static IListFeed<T> Error<T>(Exception error)
+		=> Wrap(FeedMock.Error<IImmutableList<T>>(error));
+
+	/// <summary>Creates a list feed pinned to stale items while a refresh is in progress.</summary>
+	/// <typeparam name="T">The list item type.</typeparam>
+	/// <param name="staleItems">The stale items to expose.</param>
+	/// <returns>A transient list feed with data.</returns>
+	/// <remarks>
+	/// An empty array remains <c>Some(empty)</c>. The internal refresh axis can only be
+	/// raised by a refreshable source feed.
+	/// </remarks>
+	public static IListFeed<T> Refreshing<T>(params T[] staleItems)
+	{
+		if (staleItems is null)
+		{
+			throw new ArgumentNullException(nameof(staleItems));
+		}
+
+		return Wrap(FeedMock.Refreshing<IImmutableList<T>>(staleItems.ToImmutableList()));
+	}
+
+	/// <summary>Creates a list feed pinned to an arbitrary message.</summary>
+	/// <typeparam name="T">The list item type.</typeparam>
+	/// <param name="configure">Configures the message axes.</param>
+	/// <returns>A list feed which emits the configured message and completes.</returns>
+	public static IListFeed<T> Message<T>(Action<MessageBuilder<IImmutableList<T>>> configure)
+		=> Wrap(FeedMock.Message(configure));
+
+	private static IListFeed<T> Wrap<T>(IFeed<IImmutableList<T>> source)
+		=> new Adapter<T>(source);
+
+	// AsListFeed normalizes Some(empty) to None. A mock must preserve the caller's
+	// explicit message so a list-empty visual state remains expressible.
+	private sealed class Adapter<T> : IListFeed<T>
+	{
+		private readonly IFeed<IImmutableList<T>> _source;
+
+		public Adapter(IFeed<IImmutableList<T>> source)
+		{
+			_source = source;
+		}
+
+		/// <inheritdoc />
+		public IAsyncEnumerable<Message<IImmutableList<T>>> GetSource(
+			SourceContext context,
+			CancellationToken ct = default)
+			=> _source.GetSource(context, ct);
+	}
+}

--- a/src/Uno.HotTesting.Reactive/Uno.HotTesting.Reactive.csproj
+++ b/src/Uno.HotTesting.Reactive/Uno.HotTesting.Reactive.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+	<Import Project="..\tfms-non-ui.props" />
+
+	<PropertyGroup>
+		<Description>MVUX feed mocks for previews and UI testing</Description>
+		<ImplicitUsings>false</ImplicitUsings>
+		<IsAotCompatible>true</IsAotCompatible>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="System.Collections.Immutable" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.Extensions.Reactive\Uno.Extensions.Reactive.csproj" />
+	</ItemGroup>
+</Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3149

## PR Type

- Feature
- Documentation content changes

## What is the current behavior?

Uno.Extensions has no runtime helper for hand-writing MVUX view-model mocks in tests or
design-time scenarios. Developers have to assemble MVUX feed states manually and there is
no documented, reusable vocabulary for pinned feed states.

## What is the new behavior?

Adds a deliberately small runtime assembly `Uno.HotTesting.Reactive` (assembly, package
and namespace identical) exposing `FeedMock` and `ListFeedMock` factories that build
cold, finite feeds pinned to a chosen MVUX state:

- Undefined, Loading, Empty, Value, Error, Refreshing, Message.
- Each subscription receives its pinned state and completes: no timers or background
  work, so Loading/Refreshing stay visually pinned and replay on re-subscription.
- Scalar `Empty` = `Option.None`; list `Empty` = `Some(empty)` preserved through a
  forwarding list adapter; `None` for a list is expressed explicitly via
  `ListFeedMock.Message`.
- `Undefined` replays a `None` data message then `Undefined` so the final undefined
  value stays an observable data-axis change through state replay.
- `Refreshing` sets data plus transient progress; it does not touch the internal
  refresh axis.

Usage is handwritten: the developer writes a record/class shaped like the page view
model, exposes `IFeed<T>`/`IListFeed<T>` properties matching the XAML bindings,
initialises them with these factories, and assigns the instance to `Page.DataContext`.
Property naming, feed-shape compatibility and DataContext injection remain explicit user
responsibilities; there is no generator and no generated code.

Docs: the MVUX testing reference page `doc/Reference/Reactive/testing.md` documents the
handwritten workflow with scalar and list examples. Design/scope is captured in
`specs/009-hot-testing-reactive-feed-mocks/spec.md`.

## PR Checklist

- [x] Tested code with current supported SDKs
- [x] Docs have been added/updated which fit the documentation template (for bug fixes / features)
- [x] Unit Tests and/or UI Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Wasm UI Tests are not showing unexpected differences — N/A, no UI/Wasm surface in this change
- [x] Contains **NO** breaking changes
- [ ] Updated the Release Notes — not done yet
- [x] Associated with an issue (GitHub or internal)

Focused tests: 22 passed, 0 failed (Release). The uno-dev image ships only the .NET 10
runtime, so the net9.0 test host was executed with DOTNET_ROLL_FORWARD=Major. Release
package creation for Uno.HotTesting.Reactive succeeded (net9.0 assembly, XML docs,
symbols, Uno.Extensions.Reactive dependency).

## Other information

Opened as a draft. This is the reusable runtime foundation for the broader Hot Testing
direction (spec 013). Intentionally out of scope: source generators / generated
view-model factories, generated records or automatic property-name matching,
MockCommand, timed scripts or selection helpers, and gallery/marketing docs.

Internal Issue (If applicable): n/a