### PR TITLE
fix(msal): stop re-probing the secure store on every launch

### DIFF
--- a/doc/Learn/Authentication/HowTo-MsalAuthentication.md
+++ b/doc/Learn/Authentication/HowTo-MsalAuthentication.md
@@ -356,6 +356,29 @@ On desktop targets, `MsalAuthenticationProvider` persists the MSAL token cache s
 
 - **Linux** — the cache is stored in the default keyring collection via `libsecret`.
 
+The provider checks once that the secure store can round-trip the cache, the first time it persists
+one at a given location. It does **not** re-check on every launch: on macOS the check probes with a keychain entry whose service name MSAL randomizes on
+every run, so re-checking asks the user to grant keychain access on every single start and there is
+no entry for "Always Allow" to be remembered against. A write the store silently rejects is caught
+instead — the provider notices the cache never reached disk, logs an error, and retries the setup.
+
+Set `VerifyCachePersistence` in the `Msal` configuration section to change when the check runs:
+
+| Value | Behavior |
+| --- | --- |
+| `Auto` (default) | Check only when nothing has been persisted at this location yet. |
+| `Always` | Check on every storage setup. Expect a keychain prompt on every launch on macOS. |
+| `Never` | Never check, not even on a first run. A store that cannot be written to is reported after the first real write is attempted. |
+
+```json
+{
+  "Msal": {
+    "ClientId": "161a9fb5-3b16-487a-81a2-ac45dcc0ad3b",
+    "VerifyCachePersistence": "Always"
+  }
+}
+```
+
 If the platform's secure storage isn't available (for example, a Linux session without a keyring), the provider logs an error and keeps the token cache in memory for the session — sign-in still works, but the user has to sign in again after an app restart. To persist the cache in an **unprotected (plaintext) file** in that situation instead, opt in explicitly:
 
 ```json

--- a/doc/Learn/UpdatingExtensions.md
+++ b/doc/Learn/UpdatingExtensions.md
@@ -43,6 +43,7 @@ The MSAL provider received a set of deliberate behavior corrections and platform
 - **Sign-out removes every MSAL account** and the serialized cache — previously only the first account was removed, leaving the rest silently renewable — and the token cache is cleared even when the provider throws.
 - **MSAL exceptions propagate untouched** (`MsalClientException`, `MsalServiceException`, …), so callers can inspect the MSAL error codes; they were previously flattened.
 - **Abandoned interactive sign-ins are cancelled** after 5 minutes by default — closing the system browser is undetectable on desktop — configurable via `InteractiveTimeout` in the `Msal` configuration section.
+- **The token-cache persistence check runs once per cache, not once per launch.** It used to probe the platform's secure store on every storage setup. On macOS that probe is a keychain entry whose service name MSAL randomizes each run, so the OS asked for keychain access on every single launch and "Always Allow" could never take effect. The check now runs only when nothing has been persisted yet, and a write that the store silently rejects is detected and reported instead. Restore the old behavior with `"VerifyCachePersistence": "Always"` in the `Msal` configuration section.
 
 ## Upgrading to Extensions 6.0
 

--- a/specs/015-msal-cache-persistence-check/spec.md
+++ b/specs/015-msal-cache-persistence-check/spec.md
@@ -1,0 +1,79 @@
+# 015 — MSAL token-cache persistence check
+
+## Problem
+
+`MsalAuthenticationProvider.SetupStorageCore` called `MsalCacheHelper.VerifyPersistence()` on every
+storage setup. The check writes, reads and deletes a probe entry in the platform's secure store, so
+it costs three round-trips per app start.
+
+On macOS it is worse than the count suggests. MSAL's validation accessor builds its probe entry as
+
+```csharp
+// MacKeychainAccessor.CreateForPersistenceValidation(), Microsoft.Identity.Client.Extensions.Msal
+new MacKeychainAccessor(_cacheFilePath + ".test", _service + Guid.NewGuid(), _account, _logger)
+```
+
+— a **different keychain service name on every run**. macOS gates keychain access with a per-item
+ACL, so a probe entry that never has the same name twice is a first-ever access every time. The user
+is prompted, answers "Always Allow", the entry is deleted at the end of the check, and the next
+launch asks again. There is no way for the grant to stick.
+
+Compounding it during development: a Skia desktop head is ad-hoc signed
+(`codesign -d -r-` reports `designated => cdhash H"…"`), so even the grant on the *real* cache entry
+is bound to the hash of that exact binary and is invalidated by the next rebuild.
+
+## Why the call could not simply be deleted
+
+`VerifyPersistence()` was the only thing reporting a broken store, because `MsalCacheHelper` handles
+the two directions differently:
+
+- **Read** — `Storage.ReadData()` rethrows, so a failure surfaces out of `GetAccountsAsync()`.
+- **Write** — `AfterAccessNotification` catches and logs `"Could not write the token cache.
+  Ignoring. See previous error message."`
+
+Dropping the check would therefore have converted a startup error into silent loss of the refresh
+token: the app looks signed in, and the user discovers otherwise after a restart.
+
+## Design
+
+Two facts about the MSAL extensions accessors make a cheaper equivalent possible:
+
+1. Every `ICacheAccessor.Write` ends in `FileIOWithRetries.TouchFile(_cacheFilePath)`, and `Clear`
+   begins with `DeleteCacheFile`. The cache file tracks whether a write landed — on macOS too, where
+   the payload itself lives in the keychain.
+2. `TokenCache.OnAfterAccessAsync` invokes the synchronous `TokenCacheCallback` and *then* the
+   asynchronous one. `RegisterCache` uses only the synchronous slots, so the provider can attach
+   `SetAfterAccessAsync` without displacing it.
+
+Hence:
+
+- **`MsalConfiguration.VerifyCachePersistence`** (`Auto` default, `Always`, `Never`). Note that
+  signing out does not re-arm `Auto`: `AfterAccessNotification` only calls `Storage.Clear()` when
+  serialization *throws*, so an emptied cache is rewritten and the file stays put.
+  `MsalStorageDefaults.ShouldVerifyPersistence(mode, cacheAlreadyPersisted)` holds the decision as a
+  pure function; the provider supplies `cacheAlreadyPersisted` from `File.Exists(cacheFilePath)`.
+- **`ArmWriteVerification` / `OnAfterCacheAccessAsync`** re-add the loud failure at no secure-store
+  cost: after the first state-changing write, the provider checks that the cache file exists. If it
+  does not, the write was rejected and swallowed — log an error and null `_setupStorageTask` so the
+  next `SetupStorage` rebuilds. That rebuild sees no cache file, so the probe runs even under `Auto`
+  and either recovers or takes the `AllowUnprotectedTokenCacheFallback` path.
+- The unprotected-file fallback still verifies unconditionally: it only runs because the protected
+  store already failed, and an ordinary file carries none of the cost that justifies skipping.
+
+Steady-state macOS launches now make **zero** extra secure-store round-trips.
+
+## Risks
+
+- `File.Exists` as the persistence signal depends on `TouchFile`-on-write, which is an MSAL
+  implementation detail rather than a contract. If a future version drops it, `Auto` degrades to
+  "never probe" and the write watchdog fires on every write — noisy, but not silent.
+- Two heads sharing a cache can race: one signs out (deleting the file) between the other's write
+  and its check, producing one spurious error and one redundant setup.
+- Under `Never`, a genuinely broken store surfaces as an exception out of `GetAccountsAsync()` in
+  `InternalRefreshAsync`, which the provider does not currently wrap. Wrapping that read is a
+  natural follow-up.
+
+## Tests
+
+`Given_MsalStorageDefaults` covers the decision table (`Auto` both ways, `Always`, `Never`) and pins
+`Auto` as both the configuration default and `default(MsalCachePersistenceCheck)`.

--- a/src/Uno.Extensions.Authentication.MSAL.Tests/Given_MsalStorageDefaults.cs
+++ b/src/Uno.Extensions.Authentication.MSAL.Tests/Given_MsalStorageDefaults.cs
@@ -113,4 +113,54 @@ public class Given_MsalStorageDefaults
 
 		first.Should().NotBe(second);
 	}
+
+	[TestMethod]
+	public void When_AutoAndNothingPersistedYet_Then_PersistenceVerified()
+	{
+		// A first run has no evidence the store works, so it is worth the probe.
+		MsalStorageDefaults
+			.ShouldVerifyPersistence(MsalCachePersistenceCheck.Auto, cacheAlreadyPersisted: false)
+			.Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void When_AutoAndCacheAlreadyPersisted_Then_PersistenceNotVerified()
+	{
+		// The whole point of Auto: a store that already accepted a write is not re-probed, so
+		// macOS stops asking for keychain access on every launch.
+		MsalStorageDefaults
+			.ShouldVerifyPersistence(MsalCachePersistenceCheck.Auto, cacheAlreadyPersisted: true)
+			.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void When_Always_Then_PersistenceVerifiedRegardlessOfExistingCache()
+	{
+		MsalStorageDefaults
+			.ShouldVerifyPersistence(MsalCachePersistenceCheck.Always, cacheAlreadyPersisted: true)
+			.Should().BeTrue();
+		MsalStorageDefaults
+			.ShouldVerifyPersistence(MsalCachePersistenceCheck.Always, cacheAlreadyPersisted: false)
+			.Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void When_Never_Then_PersistenceNeverVerified()
+	{
+		MsalStorageDefaults
+			.ShouldVerifyPersistence(MsalCachePersistenceCheck.Never, cacheAlreadyPersisted: false)
+			.Should().BeFalse();
+		MsalStorageDefaults
+			.ShouldVerifyPersistence(MsalCachePersistenceCheck.Never, cacheAlreadyPersisted: true)
+			.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void When_ModeUnset_Then_DefaultsToAuto()
+	{
+		// The provider reads this straight off configuration, so the default has to be the cheap
+		// mode rather than whatever `default(MsalCachePersistenceCheck)` happens to land on.
+		new MsalConfiguration().VerifyCachePersistence.Should().Be(MsalCachePersistenceCheck.Auto);
+		default(MsalCachePersistenceCheck).Should().Be(MsalCachePersistenceCheck.Auto);
+	}
 }

--- a/src/Uno.Extensions.Authentication.MSAL.Tests/Uno.Extensions.Authentication.MSAL.Tests.csproj
+++ b/src/Uno.Extensions.Authentication.MSAL.Tests/Uno.Extensions.Authentication.MSAL.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="..\Uno.Extensions.Authentication.MSAL\MsalStorageDefaults.cs" Link="MsalStorageDefaults.cs" />
     <Compile Include="..\Uno.Extensions.Authentication.MSAL\MsalRedirectDefaults.cs" Link="MsalRedirectDefaults.cs" />
     <Compile Include="..\Uno.Extensions.Authentication.MSAL\MsalConfiguration.cs" Link="MsalConfiguration.cs" />
+    <Compile Include="..\Uno.Extensions.Authentication.MSAL\MsalCachePersistenceCheck.cs" Link="MsalCachePersistenceCheck.cs" />
     <Compile Include="..\Uno.Extensions.Authentication.MSAL\MsalTokenCacheStore.cs" Link="MsalTokenCacheStore.cs" />
   </ItemGroup>
 

--- a/src/Uno.Extensions.Authentication.MSAL/MsalAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.MSAL/MsalAuthenticationProvider.cs
@@ -482,8 +482,9 @@ internal record MsalAuthenticationProvider(
 			try
 			{
 				var cacheHelper = await MsalCacheHelper.CreateAsync(storage).ConfigureAwait(false);
-				cacheHelper.VerifyPersistence();
+				VerifyPersistenceIfNeeded(cacheHelper, config, filePath);
 				cacheHelper.RegisterCache(_pca!.UserTokenCache);
+				ArmWriteVerification(filePath);
 			}
 			catch (MsalCachePersistenceException ex)
 			{
@@ -510,8 +511,12 @@ internal record MsalAuthenticationProvider(
 					.WithUnprotectedFile()
 					.Build();
 				var cacheHelper = await MsalCacheHelper.CreateAsync(fallback).ConfigureAwait(false);
+				// Always verified, whatever VerifyCachePersistence says: this path only runs because
+				// the protected store already failed, and an ordinary file carries none of the cost
+				// that makes the check worth skipping on the keychain.
 				cacheHelper.VerifyPersistence();
 				cacheHelper.RegisterCache(_pca!.UserTokenCache);
+				ArmWriteVerification(Path.Combine(folderPath, UnprotectedCacheFileName));
 			}
 
 			if (Logger.IsEnabled(LogLevel.Trace))
@@ -537,6 +542,122 @@ internal record MsalAuthenticationProvider(
 			return false;
 		}
 	}
+
+#if !UNO_EXT_MSAL_NOSTORAGE
+	/// <summary>
+	/// Runs <see cref="MsalCacheHelper.VerifyPersistence"/> when the configured
+	/// <see cref="MsalConfiguration.VerifyCachePersistence"/> mode calls for it.
+	/// </summary>
+	/// <remarks>
+	/// The check costs a write, a read and a delete against the platform's secure store. On macOS it
+	/// also cannot ever be granted once and for all: MSAL probes with a keychain entry whose service
+	/// name carries a fresh <see cref="Guid"/> every run
+	/// (<c>MacKeychainAccessor.CreateForPersistenceValidation</c>), so the OS treats each launch as a
+	/// first-ever access and re-prompts no matter how many times the user answers "Always Allow".
+	/// Skipping it once the store has demonstrably worked is what keeps a signed-in user from being
+	/// asked again on every start.
+	/// </remarks>
+	private void VerifyPersistenceIfNeeded(MsalCacheHelper cacheHelper, MsalConfiguration? config, string cacheFilePath)
+	{
+		var mode = config?.VerifyCachePersistence ?? MsalCachePersistenceCheck.Auto;
+		if (!MsalStorageDefaults.ShouldVerifyPersistence(mode, cacheAlreadyPersisted: File.Exists(cacheFilePath)))
+		{
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTraceMessage($"Skipping the token-cache persistence check ({mode}); {cacheFilePath} shows the store already accepted a write");
+			}
+
+			return;
+		}
+
+		cacheHelper.VerifyPersistence();
+	}
+
+	/// <summary>
+	/// Path of the cache whose first write has yet to be confirmed, or <c>null</c> when nothing is
+	/// owed. Taken atomically by <see cref="OnAfterCacheAccessAsync"/> so the check runs once per
+	/// storage setup.
+	/// </summary>
+	private string? _unverifiedCacheFilePath;
+
+	/// <summary>
+	/// 1 once <see cref="OnAfterCacheAccessAsync"/> has been attached to the token cache.
+	/// </summary>
+	private int _writeVerificationRegistered;
+
+	/// <summary>
+	/// Arms a one-shot check that the next cache write actually reaches
+	/// <paramref name="cacheFilePath"/>.
+	/// </summary>
+	/// <remarks>
+	/// This is what lets <see cref="MsalCachePersistenceCheck.Auto"/> skip the up-front probe without
+	/// trading a startup error for silent data loss: <c>MsalCacheHelper</c> logs and swallows write
+	/// failures ("Could not write the token cache. Ignoring."), so a store that rejects writes would
+	/// otherwise look healthy until the user found themselves signed out after a restart.
+	/// <para>
+	/// Safe alongside <c>RegisterCache</c>, which occupies the *synchronous*
+	/// <c>SetBeforeAccess</c>/<c>SetAfterAccess</c> slots: <c>TokenCache.OnAfterAccessAsync</c>
+	/// invokes the synchronous callback and then the asynchronous one, so this observes the state the
+	/// helper's own write left behind rather than displacing it.
+	/// </para>
+	/// </remarks>
+	private void ArmWriteVerification(string cacheFilePath)
+	{
+		Interlocked.Exchange(ref _unverifiedCacheFilePath, cacheFilePath);
+
+		// Registering again would only overwrite the same handler, but the exchange keeps the
+		// intent explicit: one handler, re-armed by the field above on every storage setup.
+		if (Interlocked.Exchange(ref _writeVerificationRegistered, 1) == 0)
+		{
+			_pca!.UserTokenCache.SetAfterAccessAsync(OnAfterCacheAccessAsync);
+		}
+	}
+
+	/// <summary>
+	/// Confirms that the first state-changing write reached the store, and schedules another storage
+	/// setup when it did not.
+	/// </summary>
+	private Task OnAfterCacheAccessAsync(TokenCacheNotificationArgs args)
+	{
+		// Plain read first: once the check is done this is the only cost on every later write.
+		if (!args.HasStateChanged || _unverifiedCacheFilePath is null)
+		{
+			return Task.CompletedTask;
+		}
+
+		if (Interlocked.Exchange(ref _unverifiedCacheFilePath, null) is not { } cacheFilePath)
+		{
+			// Another access won the race and already checked.
+			return Task.CompletedTask;
+		}
+
+		// Every accessor touches the cache file when it writes - including the macOS one, whose
+		// payload goes to the keychain - so the file's absence right after a write means the write
+		// was rejected and swallowed.
+		if (File.Exists(cacheFilePath))
+		{
+			if (Logger.IsEnabled(LogLevel.Trace))
+			{
+				Logger.LogTraceMessage($"Token-cache write confirmed at {cacheFilePath}");
+			}
+
+			return Task.CompletedTask;
+		}
+
+		if (Logger.IsEnabled(LogLevel.Error))
+		{
+			Logger.LogErrorMessage($"The token cache was serialized but nothing reached '{cacheFilePath}' - secure storage rejected the write and MsalCacheHelper swallowed the failure. Retrying storage setup; sign-in state won't survive an app restart until it succeeds");
+		}
+
+		// Deliberately racy with SetupStorage, which is already written to re-run whenever the
+		// latched task is missing or unsuccessful: the worst outcome is one redundant setup. That
+		// setup sees no cache file, so the persistence check runs even under Auto and either
+		// recovers or takes the AllowUnprotectedTokenCacheFallback path.
+		_setupStorageTask = null;
+
+		return Task.CompletedTask;
+	}
+#endif
 
 	private async Task<AuthenticationResult?> AcquireTokenAsync(IDispatcher dispatcher, CancellationToken cancellationToken)
 	{

--- a/src/Uno.Extensions.Authentication.MSAL/MsalCachePersistenceCheck.cs
+++ b/src/Uno.Extensions.Authentication.MSAL/MsalCachePersistenceCheck.cs
@@ -1,0 +1,34 @@
+namespace Uno.Extensions.Authentication.MSAL;
+
+/// <summary>
+/// Controls when <c>MsalAuthenticationProvider</c> runs <c>MsalCacheHelper.VerifyPersistence()</c>,
+/// the self-check that proves the platform's secure store can round-trip the token cache.
+/// </summary>
+/// <remarks>
+/// The check is not free: it writes, reads and deletes a probe entry in the secure store every time
+/// it runs. On macOS it is also unrepeatable by design - MSAL's validation accessor
+/// (<c>MacKeychainAccessor.CreateForPersistenceValidation</c>) appends a fresh <see cref="Guid"/> to
+/// the keychain service name, so the probe entry has a different name on every launch and macOS
+/// re-prompts for keychain access however many times the user answers "Always Allow".
+/// </remarks>
+internal enum MsalCachePersistenceCheck : byte
+{
+	/// <summary>
+	/// Run the check only when nothing has been persisted at this cache location yet. The default:
+	/// a first run is verified up front, and every launch after that makes no extra secure-store
+	/// round-trips. Signing out does not reset this - MSAL rewrites an emptied cache rather than
+	/// deleting it, so the cache file stays put.
+	/// </summary>
+	Auto,
+
+	/// <summary>
+	/// Run the check on every storage setup.
+	/// </summary>
+	Always,
+
+	/// <summary>
+	/// Never run the check, not even on a first run. A store that cannot be written to is then only
+	/// reported once the first real cache write has been attempted.
+	/// </summary>
+	Never,
+}

--- a/src/Uno.Extensions.Authentication.MSAL/MsalConfiguration.cs
+++ b/src/Uno.Extensions.Authentication.MSAL/MsalConfiguration.cs
@@ -56,4 +56,16 @@ internal class MsalConfiguration
 	/// the session instead of being written unprotected to disk.
 	/// </summary>
 	public bool AllowUnprotectedTokenCacheFallback { get; init; }
+
+	/// <summary>
+	/// Desktop only: when the provider runs MsalCacheHelper's persistence self-check. Defaults to
+	/// <see cref="MsalCachePersistenceCheck.Auto"/>, which checks only the first time a cache is
+	/// persisted at a given location.
+	/// </summary>
+	/// <remarks>
+	/// Mostly a macOS concern. The check probes the keychain with an entry whose service name MSAL
+	/// randomizes on every run, so under <see cref="MsalCachePersistenceCheck.Always"/> a user is
+	/// asked to grant keychain access on every single launch and can never make the prompt stick.
+	/// </remarks>
+	public MsalCachePersistenceCheck VerifyCachePersistence { get; init; } = MsalCachePersistenceCheck.Auto;
 }

--- a/src/Uno.Extensions.Authentication.MSAL/MsalStorageDefaults.cs
+++ b/src/Uno.Extensions.Authentication.MSAL/MsalStorageDefaults.cs
@@ -64,5 +64,25 @@ internal static class MsalStorageDefaults
 				new KeyValuePair<string, string>(LinuxKeyringProductAttributeKey, LinuxKeyringProductAttributeValue));
 		}
 	}
+
+	/// <summary>
+	/// Whether <c>MsalCacheHelper.VerifyPersistence()</c> should run for a cache whose secure store
+	/// has already accepted a write (<paramref name="cacheAlreadyPersisted"/>).
+	/// </summary>
+	/// <remarks>
+	/// Under <see cref="MsalCachePersistenceCheck.Auto"/> the check runs only when nothing has been
+	/// persisted at this location yet. The caller establishes that from the cache file: every
+	/// <c>ICacheAccessor</c> touches it when it writes (<c>FileIOWithRetries.TouchFile</c>) and
+	/// deletes it in <c>Clear</c>, so the file existing means a write already succeeded with this
+	/// configuration - on macOS too, where the payload itself lives in the keychain rather than in
+	/// that file.
+	/// </remarks>
+	internal static bool ShouldVerifyPersistence(MsalCachePersistenceCheck mode, bool cacheAlreadyPersisted) =>
+		mode switch
+		{
+			MsalCachePersistenceCheck.Always => true,
+			MsalCachePersistenceCheck.Never => false,
+			_ => !cacheAlreadyPersisted,
+		};
 }
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

Stacked on `dev/sb/auth-providers-fixes` — this fix builds on `MsalStorageDefaults` and `AllowUnprotectedTokenCacheFallback`, neither of which is on `main` yet.

## PR Type

- Bugfix

## What is the current behavior?

`MsalAuthenticationProvider.SetupStorageCore` calls `MsalCacheHelper.VerifyPersistence()` on every storage setup. The check writes, reads and deletes a probe entry in the platform's secure store, so it costs three round-trips per app start.

On macOS it can never be granted once and for all. MSAL's validation accessor builds its probe entry with a fresh `Guid` in the keychain service name:

```csharp
// MacKeychainAccessor.CreateForPersistenceValidation(), Microsoft.Identity.Client.Extensions.Msal
new MacKeychainAccessor(_cacheFilePath + ".test", _service + Guid.NewGuid(), _account, _logger)
```

macOS gates keychain access with a per-item ACL, so an entry that never has the same name twice is a first-ever access every time. The user is prompted, answers **Always Allow**, the entry is deleted at the end of the check, and the next launch asks again — three prompts on every single start, with no way to make them stop.

## What is the new behavior?

The check runs once per cache location instead of once per launch, and the guarantee it was providing is preserved by a cheaper mechanism.

It could not simply be deleted: it was the only thing reporting a broken store, because `MsalCacheHelper` handles the two directions differently. `Storage.ReadData()` rethrows, but `AfterAccessNotification` catches and logs `"Could not write the token cache. Ignoring."` Dropping the check would have traded a startup error for silent loss of the refresh token.

Two properties of the accessors make the replacement possible:

1. Every `ICacheAccessor.Write` ends in `FileIOWithRetries.TouchFile(_cacheFilePath)`, so the cache file tracks whether a write landed — on macOS too, where the payload lives in the keychain.
2. `TokenCache.OnAfterAccessAsync` invokes the synchronous `TokenCacheCallback` and *then* the asynchronous one. `RegisterCache` uses only the synchronous slots, so the provider can attach `SetAfterAccessAsync` without displacing it.

Hence:

- **`MsalConfiguration.VerifyCachePersistence`** — `Auto` (default), `Always`, `Never`. The decision lives in `MsalStorageDefaults.ShouldVerifyPersistence(mode, cacheAlreadyPersisted)` as a pure function; the provider supplies `cacheAlreadyPersisted` from `File.Exists`.
- **`ArmWriteVerification` / `OnAfterCacheAccessAsync`** — confirm the first state-changing write reached the store. If it did not, log an error and null `_setupStorageTask` so the next `SetupStorage` rebuilds; that rebuild sees no cache file, so it probes even under `Auto` and either recovers or takes the `AllowUnprotectedTokenCacheFallback` path.
- The unprotected-file fallback still verifies unconditionally — it only runs because the protected store already failed, and a plain file carries none of the cost that justifies skipping.

Steady-state macOS launches now make **zero** extra secure-store round-trips.

`specs/015-msal-cache-persistence-check/spec.md` records the design, the IL evidence behind each claim, and the risks (chiefly that `TouchFile`-on-write is an MSAL implementation detail rather than a contract; if it ever goes away, `Auto` degrades to "never probe" and the write watchdog fires loudly rather than silently).

### Verification

Measured on the `net10.0-desktop` head of `Uno.Samples/UI/Authentication.MsalExtensionsDemo` on macOS 26.5.2:

| | Before | After |
|---|---|---|
| Keychain prompts at startup | 3 | **0** |
| Keychain item `mdat` advances | yes | yes — cache still read and written |
| `SecurityAgent` (macOS prompt UI) spawned | yes | never |

Also confirms the change is inert where it should be: the packed `lib/net9.0-browserwasm1.0` assembly contains only the new enum, not the provider methods, so the `#if !UNO_EXT_MSAL_NOSTORAGE` guard keeps it out of the WebAssembly path.

## PR Checklist

- [x] Tested code with current supported SDKs
- [x] Docs have been added/updated which fit documentation template (for bug fixes / features)
- [x] Unit Tests and/or UI Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Wasm UI Tests are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the Release Notes

Notes on the checklist:

- **Tests** — `Given_MsalStorageDefaults` gains 5 cases covering the decision table (`Auto` both ways, `Always`, `Never`) and pinning `Auto` as both the configuration default and `default(MsalCachePersistenceCheck)`. `dotnet test` on `Uno.Extensions.Authentication.MSAL.Tests`: 44 passed, 0 failed. `MsalCachePersistenceCheck.cs` is linked into that project alongside the other MSAL sources.
- **Docs** — `HowTo-MsalAuthentication.md` documents the setting and its table; `UpdatingExtensions.md` carries the behavior-change entry alongside the other MSAL 7.0 changes.
- **No breaking changes** — additive configuration with a default that only *reduces* work. `Always` restores the previous behavior exactly.
- **Wasm UI Tests** — unchecked pending CI; the change is compiled out of the WebAssembly path, so no snapshot movement is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhtkcHHpbm6XiDagFY6VaS
