### PR TITLE
fix(web): name every callback source when a flow cannot start

### DIFF
--- a/specs/014-web-redirect-defaults/spec.md
+++ b/specs/014-web-redirect-defaults/spec.md
@@ -42,3 +42,22 @@ case had no working configuration to preserve.
 Web runtime suite (stub broker): placeholder substitution reaches the browser URL encoded and the
 broker is handed the derived callback; a config with no callback at all now signs in via the
 broker default. Red first, per AGENTS.
+
+## Diagnostics
+
+3. **The dead end names its cause.** When neither configuration nor the start URI nor the broker
+   yields a callback, the flow cannot start. The warning used to say only that `LoginCallbackUri`
+   was unset and `redirect_uri` was missing from `LoginStartUri` - which reads as a configuration
+   slip even when the start URI carries `{RedirectUri}` and the real cause is a platform with no
+   callback to derive. The broker's own failure message was logged at `Debug`, i.e. invisible at
+   the log level an app actually runs with, so the one line explaining the dead end never appeared.
+
+   The warning now names all three sources tried and carries the broker's message, plus what makes
+   a broker-derived callback possible (a custom scheme registered for the app: `CFBundleURLTypes`
+   in `Info.plist` on iOS/Mac Catalyst, an intent filter on Android). Found the hard way: an iOS
+   head whose `Info.plist` declared `CFBundleURLSchemes` at the root instead of inside
+   `CFBundleURLTypes` - so iOS ignored the scheme entirely - reported only "redirect_uri not set",
+   which is the one thing that was not wrong.
+
+   Guarded by `Given_WebAuthentication.When_BrokerCannotDeriveCallback_Then_WarningNamesBroker`
+   (stub broker throwing from `GetCurrentApplicationCallbackUri`).

--- a/src/Uno.Extensions.Authentication.UI.Tests/Given_WebAuthentication.cs
+++ b/src/Uno.Extensions.Authentication.UI.Tests/Given_WebAuthentication.cs
@@ -330,6 +330,49 @@ public class Given_WebAuthentication
 	}
 
 	/// <summary>
+	/// Spec 014 diagnostics: when nothing configures a callback and the broker cannot derive one
+	/// either, the warning must name the broker and carry its reason. The message this replaced
+	/// said only that LoginCallbackUri and redirect_uri were missing - which reads as a
+	/// configuration slip even when the start URI carries {RedirectUri} and the real cause is a
+	/// platform with no callback to derive (an iOS app with no CFBundleURLTypes entry, say).
+	/// </summary>
+	[TestMethod]
+	public async Task When_BrokerCannotDeriveCallback_Then_WarningNamesBroker()
+	{
+		StubWebAuthenticationBroker.EnsureRegistered();
+		var broker = StubWebAuthenticationBroker.Instance;
+		broker.Reset();
+		broker.CallbackUriError = "No custom scheme found for this application.";
+		var logs = new CapturingLoggerProvider();
+
+		using var host = UnoHost
+			.CreateDefaultBuilder(typeof(Given_WebAuthentication).Assembly)
+			.UseAuthentication(auth => auth
+				.AddWeb(web => web
+					.LoginStartUri($"{LoginStartUri}?client_id=demo&redirect_uri={{RedirectUri}}")))
+			.ConfigureServices(services => services
+				.AddLogging(logging => logging
+					.SetMinimumLevel(LogLevel.Trace)
+					.AddProvider(logs)))
+			.Build();
+
+		var authentication = host.Services.GetRequiredService<IAuthenticationService>();
+		var tokens = host.Services.GetRequiredService<ITokenCache>();
+		using var purge = Cts();
+		await tokens.ClearAsync(purge.Token);
+		using var cts = Cts();
+
+		var result = await authentication.LoginAsync(default, cancellationToken: cts.Token);
+
+		result.Should().BeFalse("no callback means no flow to start");
+		broker.InvocationCount.Should().Be(0, "the sign-in UI must not open without a callback");
+		logs.Text.Should().Contain("WebAuthenticationBroker",
+			"the warning must name the source that failed, not just the two configuration settings");
+		logs.Text.Should().Contain(broker.CallbackUriError,
+			"the broker's own reason is what tells the developer what to fix");
+	}
+
+	/// <summary>
 	/// Red test for spec 012 F4: no <see cref="CancellationToken"/> used to reach the broker call,
 	/// so an already-cancelled login still drove the whole interactive flow to completion.
 	/// </summary>

--- a/src/Uno.Extensions.Authentication.UI.Tests/StubWebAuthenticationBroker.cs
+++ b/src/Uno.Extensions.Authentication.UI.Tests/StubWebAuthenticationBroker.cs
@@ -41,6 +41,13 @@ internal sealed class StubWebAuthenticationBroker : IWebAuthenticationBrokerProv
 	/// </summary>
 	public WebAuthenticationStatus? NextStatus { get; set; }
 
+	/// <summary>
+	/// When set, <see cref="GetCurrentApplicationCallbackUri"/> throws with this message - what a
+	/// real broker does on a platform that has no callback to derive, such as an iOS app whose
+	/// Info.plist declares no custom scheme.
+	/// </summary>
+	public string? CallbackUriError { get; set; }
+
 	/// <summary>The most recently minted access token.</summary>
 	public string LastAccessToken => _lastAccessToken
 		?? throw new InvalidOperationException("No token has been issued yet.");
@@ -72,9 +79,13 @@ internal sealed class StubWebAuthenticationBroker : IWebAuthenticationBrokerProv
 		LastRequestUri = null;
 		LastCallbackUri = null;
 		NextStatus = null;
+		CallbackUriError = null;
 	}
 
-	public Uri GetCurrentApplicationCallbackUri() => new("web-tests://callback");
+	public Uri GetCurrentApplicationCallbackUri() =>
+		CallbackUriError is { Length: > 0 } error
+			? throw new InvalidOperationException(error)
+			: new Uri("web-tests://callback");
 
 	public Task<WebAuthenticationResult> AuthenticateAsync(WebAuthenticationOptions options, Uri requestUri, Uri callbackUri, CancellationToken ct)
 	{

--- a/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationProvider.cs
+++ b/src/Uno.Extensions.Authentication.UI/Web/WebAuthenticationProvider.cs
@@ -86,6 +86,7 @@ internal record WebAuthenticationProvider
 
 		loginCallbackUri = await PrepareLoginCallbackUri(credentials, loginCallbackUri, cancellationToken);
 
+		string? brokerError = null;
 #if !WINDOWS
 		// Nothing configured: fall back to the platform's own callback - the custom scheme on
 		// Android/iOS, the app origin on WebAssembly, the loopback listener on Skia Desktop. Not
@@ -93,7 +94,7 @@ internal record WebAuthenticationProvider
 		// protocol-activation flow (spec 014).
 		if (string.IsNullOrWhiteSpace(loginCallbackUri))
 		{
-			loginCallbackUri = GetBrokerCallbackUri();
+			(loginCallbackUri, brokerError) = TryGetBrokerCallbackUri();
 		}
 #endif
 
@@ -101,7 +102,9 @@ internal record WebAuthenticationProvider
 		{
 			if (ProviderLogger.IsEnabled(LogLevel.Warning))
 			{
-				ProviderLogger.LogWarning($"{nameof(InternalSettings.LoginCallbackUri)} not specified and {OAuthRedirectUriParameter} not set in {nameof(InternalSettings.LoginStartUri)}, unable to start login flow");
+				ProviderLogger.LogWarning(
+					"Unable to start login flow: {Reason}",
+					NoCallbackReason(nameof(InternalSettings.LoginCallbackUri), nameof(InternalSettings.LoginStartUri), brokerError));
 			}
 			return default;
 		}
@@ -163,26 +166,53 @@ internal record WebAuthenticationProvider
 	/// <summary>
 	/// The platform's own callback URI, used when configuration supplies none (spec 014): the
 	/// custom scheme on Android/iOS, the app origin on WebAssembly, the loopback listener on Skia
-	/// Desktop. Null when the broker cannot derive one (for example, no custom scheme registered),
-	/// which lands on the existing not-configured warning path.
+	/// Desktop. Returns a null URI plus the broker's own message when it cannot derive one (for
+	/// example, no custom scheme registered), which lands on the not-configured warning path.
 	/// </summary>
-	private string? GetBrokerCallbackUri()
+	/// <returns>
+	/// The callback URI, or the reason the broker could not supply one. The reason is carried back
+	/// rather than logged here because this is the last source tried: the caller reports it as the
+	/// cause of a flow that cannot start, where it is visible at Warning level (the flow is over)
+	/// instead of at Debug, where the one message explaining the dead end was invisible by default.
+	/// </returns>
+	private (string? CallbackUri, string? Error) TryGetBrokerCallbackUri()
 	{
 		try
 		{
-			return WebAuthenticationBroker.GetCurrentApplicationCallbackUri().OriginalString;
+			return (WebAuthenticationBroker.GetCurrentApplicationCallbackUri().OriginalString, null);
 		}
 		catch (Exception ex)
 		{
-			if (ProviderLogger.IsEnabled(LogLevel.Debug))
-			{
-				ProviderLogger.LogDebug("No broker-derived callback is available on this platform: {Error}", ex.Message);
-			}
-
-			return null;
+			return (null, ex.Message);
 		}
 	}
 #endif
+
+	/// <summary>
+	/// Why no callback URI could be resolved, naming every source that was tried: configuration,
+	/// the start URI's <c>redirect_uri</c>, and - off WinAppSDK - the platform broker (spec 014).
+	/// </summary>
+	/// <remarks>
+	/// Naming all three matters because the two-source message this replaced read as "you forgot
+	/// redirect_uri" even when the start URI carried <see cref="RedirectUriPlaceholder"/> and the
+	/// real cause was a platform with no callback to derive - an iOS <c>Info.plist</c> declaring no
+	/// <c>CFBundleURLTypes</c> entry, for instance, where the broker's own message says so.
+	/// </remarks>
+	private static string NoCallbackReason(string callbackSetting, string startUriSetting, string? brokerError)
+	{
+		var reason =
+			$"{callbackSetting} is not configured and {startUriSetting} carries no {OAuthRedirectUriParameter} value " +
+			$"(the {RedirectUriPlaceholder} placeholder is replaced with the callback, it is not one)";
+
+#if !WINDOWS
+		reason += brokerError is { Length: > 0 }
+			? $", and WebAuthenticationBroker could not derive one for this platform: {brokerError}"
+			: ", and WebAuthenticationBroker derived no callback for this platform";
+		reason += ". A broker-derived callback needs a custom scheme registered for the app - CFBundleURLTypes/CFBundleURLSchemes in Info.plist on iOS and Mac Catalyst, an intent filter on Android - or configure the callback explicitly";
+#endif
+
+		return reason;
+	}
 
 	/// <summary>
 	/// Applies <see cref="WebAuthenticationSettings.PrefersEphemeralWebBrowserSession"/> to Uno's
@@ -300,11 +330,12 @@ internal record WebAuthenticationProvider
 
 		logoutCallbackUri = await PrepareLogoutCallbackUri(await Tokens.GetAsync(cancellationToken), logoutCallbackUri, cancellationToken);
 
+		string? brokerError = null;
 #if !WINDOWS
 		// Same broker-derived default as sign-in (spec 014).
 		if (string.IsNullOrWhiteSpace(logoutCallbackUri))
 		{
-			logoutCallbackUri = GetBrokerCallbackUri();
+			(logoutCallbackUri, brokerError) = TryGetBrokerCallbackUri();
 		}
 #endif
 
@@ -312,7 +343,9 @@ internal record WebAuthenticationProvider
 		{
 			if (ProviderLogger.IsEnabled(LogLevel.Warning))
 			{
-				ProviderLogger.LogWarning($"{nameof(InternalSettings.LogoutCallbackUri)} not specified and {OAuthRedirectUriParameter} not set in {nameof(InternalSettings.LogoutStartUri)}, unable to start logout flow");
+				ProviderLogger.LogWarning(
+					"Unable to start logout flow: {Reason}",
+					NoCallbackReason(nameof(InternalSettings.LogoutCallbackUri), nameof(InternalSettings.LogoutStartUri), brokerError));
 			}
 			return false;
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

Stacked on `dev/sb/auth-providers-fixes` — this continues spec 014, which is not on `main` yet.

## PR Type

- Bugfix

## What is the current behavior?

When neither configuration nor the start URI nor the platform broker yields a callback URI, sign-in and sign-out cannot start. The warning named only the first two sources:

```
LoginCallbackUri not specified and redirect_uri not set in LoginStartUri, unable to start login flow
```

That reads as a configuration slip even when the start URI *does* carry `{RedirectUri}` and the real cause is a platform with no callback to derive. The broker's own failure message was logged at `Debug` — invisible at the level an app actually runs with — so the one line explaining the dead end never appeared.

Found the hard way on an iOS head whose `Info.plist` declared `CFBundleURLSchemes` at the root instead of inside `CFBundleURLTypes`, so iOS ignored the custom scheme entirely. The app reported "redirect_uri not set", which is the one thing that was not wrong.

## What is the new behavior?

`GetBrokerCallbackUri` becomes `TryGetBrokerCallbackUri`, returning the broker's message alongside the (null) URI instead of logging it at `Debug` and dropping it. The caller folds it into a single `Warning` that names all three sources tried and says what makes a broker-derived callback possible:

```
Unable to start login flow: LoginCallbackUri is not configured and LoginStartUri carries no
redirect_uri value (the {RedirectUri} placeholder is replaced with the callback, it is not one),
and WebAuthenticationBroker could not derive one for this platform: <broker's message>.
A broker-derived callback needs a custom scheme registered for the app -
CFBundleURLTypes/CFBundleURLSchemes in Info.plist on iOS and Mac Catalyst, an intent filter on
Android - or configure the callback explicitly
```

The reason travels back to the caller rather than being logged where it happens, because the broker is the *last* source tried: reported at the call site it is visible at `Warning` level, where the flow being over makes it worth saying. Both the login and logout paths get the same treatment.

Purely diagnostic — no change to which callback is chosen or how a flow runs.

`specs/014-web-redirect-defaults/spec.md` gains a Diagnostics section recording the cause and the guard.

### Verification

`StubWebAuthenticationBroker` gains a `CallbackUriError` that makes `GetCurrentApplicationCallbackUri` throw the way a real broker does on a platform with no callback. `When_BrokerCannotDeriveCallback_Then_WarningNamesBroker` asserts the flow does not start, the broker UI never opens, and the warning carries both the broker's name and its reason.

Executed locally on the Skia desktop runtime-test head, not just compiled:

```
UNO_RUNTIME_TESTS_RUN_TESTS='{"Filter":{"Value":"Given_WebAuthentication"}}' \
  dotnet Uno.Extensions.RuntimeTests.dll
```

`Given_WebAuthentication`: **10 total, 10 passed, 0 failed** — the 9 existing cases plus the new one.

## PR Checklist

- [x] Tested code with current supported SDKs
- [ ] Docs have been added/updated which fit documentation template (for bug fixes / features)
- [x] Unit Tests and/or UI Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Wasm UI Tests are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the Release Notes

Notes on the checklist:

- **Docs** unticked deliberately: this changes the text of a log message, not documented behavior or public API. The rationale lives in the spec and in the code comments. Happy to add a troubleshooting entry to the web-authentication how-to if reviewers would rather it were user-facing.
- **Release Notes** unticked for the same reason — no behavior to announce.
- **No breaking changes** — the only observable difference is the wording and log level at which an already-failing flow explains itself.
- **Wasm UI Tests** unchecked pending CI; nothing visual changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhtkcHHpbm6XiDagFY6VaS
