### PR TITLE
ci: Publish from servicing/* branches and bump main to 8.0-dev

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - servicing/*
       - release/* 
 
 env:

--- a/build/ci/.azure-pipelines.yml
+++ b/build/ci/.azure-pipelines.yml
@@ -2,6 +2,7 @@
   branches:
     include:
       - main
+      - servicing/*
       - feature/*
       - release/*
       - legacy/*
@@ -10,6 +11,7 @@ pr:
   branches:
     include:
       - main
+      - servicing/*
       - feature/*
       - release/*
       - legacy/*
@@ -129,7 +131,7 @@ stages:
 
 - stage: Publish_Dev
   displayName: 'Publish - Dev NuGet'
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature')), not(eq(variables['build.reason'], 'PullRequest')))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature')), not(eq(variables['build.reason'], 'PullRequest')))
   dependsOn: Packages
   jobs:
   - template: publish/publish-nuget-dev.yml

--- a/build/ci/.azure-pipelines.yml
+++ b/build/ci/.azure-pipelines.yml
@@ -129,6 +129,10 @@ stages:
 ## Publishing
 ##
 
+# A servicing/* branch continues a previous version line after main has moved on
+# to a newer one, so it publishes dev packages the same way main does. The same
+# pattern is added to the CI triggers, the dev-feed push step and version.json's
+# publicReleaseRefSpec.
 - stage: Publish_Dev
   displayName: 'Publish - Dev NuGet'
   condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature')), not(eq(variables['build.reason'], 'PullRequest')))

--- a/build/ci/templates/nuget-publish-dev.yml
+++ b/build/ci/templates/nuget-publish-dev.yml
@@ -1,7 +1,7 @@
 steps:
   - task: NuGetCommand@2
     displayName: 'Publish to Uno Dev Feed'
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))
     inputs:
       command: 'push'
       packagesToPush: '$(Pipeline.Workspace)/NuGet_Packages/**/*.nupkg'

--- a/build/ci/templates/nuget-publish-dev.yml
+++ b/build/ci/templates/nuget-publish-dev.yml
@@ -1,4 +1,6 @@
 steps:
+  # A servicing/* branch continues a previous version line after main has moved on
+  # to a newer one, so its packages reach the dev feed the same way main's do.
   - task: NuGetCommand@2
     displayName: 'Publish to Uno Dev Feed'
     condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/servicing/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))

--- a/version.json
+++ b/version.json
@@ -6,6 +6,7 @@
   },
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
+    "^refs/heads/servicing/.*$",
     "^refs/heads/release/stable/\\d+(?:\\.\\d+)?$"
   ],
   "cloudBuild": {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "7.4-dev.{height}",
+  "version": "8.0-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Release-process change, internal, as part of Uno 7.0 preparation. -->

## PR Type

- Build or CI related changes

## What is the current behavior?

`main` is the only branch that publishes an Extensions dev channel (`7.4.0-dev.*`). Once `main` retargets to Uno 7.0, those packages stop being consumable by apps still on Uno 6.x — which is what clients validate fixes against before we backport them to a service release.

`servicing/*` is not wired into this pipeline, so cutting such a branch today produces a branch that builds nothing.

## What is the new behavior?

Four commits that must land together.

**1. `ci: Build and publish from servicing/* branches`**

| Change | Why |
|---|---|
| `servicing/*` in `trigger.branches` and `pr.branches` (`build/ci/.azure-pipelines.yml`) | the branch builds at all, and PRs into it run |
| `servicing/` in the `Publish_Dev` stage condition | the dev publish stage runs for it |
| `servicing/` in the dev-feed push step (`build/ci/templates/nuget-publish-dev.yml`) | packages also reach the internal dev feed, matching `main` |
| `^refs/heads/servicing/.*$` in `publicReleaseRefSpec` (`version.json`) | NBGV emits `7.4.0-dev.30` rather than `7.4.0-dev.30.g8548c462cd` |

**2. `ci: Document the servicing/* branch pattern at the publish gates`** — the two generic comment blocks the other repos carry.

**3. `ci: Validate conventional commits on servicing/* branches`** — `Validate for conventional commits` is a **required status check** on `main`, but the workflow only listens for PRs to `main` and `release/*`. This is a prerequisite for giving `servicing/*` the same branch protection: a required check that never reports leaves the PR stuck at *"Expected — waiting for status"*.

**4. `chore!: Bump version to 8.0-dev for the Uno 7.0 line`**

### Why the bump is required

`main` is at `7.4.0-dev.29`. A `servicing/7.4` branch sits one commit above the same base, so **both would compute `7.4.0-dev.30`** from different code. The push runs with `allowPackageConflicts: true`, so the second is skipped **silently on a green pipeline**.

Verified with `nbgv get-version` after these commits:

| Branch | NuGetPackageVersion |
|---|---|
| `servicing/7.4` | `7.4.0-dev.30` — clean, no hash suffix, confirming the refspec entry works |
| `main` (this PR) | `8.0.0-dev.1` — height resets at the version change |

No `8.0` line exists on nuget.org today, so the space is free.

### Why a *major*

Unlike `Uno.Themes` and `uno.toolkit.ui` — both already on net10, where the bump rested on binary compatibility alone — every trigger applies here. Read from the published `7.4.0-dev.29` package:

```
net9.0, net9.0-android35.0, net9.0-browserwasm1.0, net9.0-desktop1.0,
net9.0-ios18.0, net9.0-maccatalyst18.0, net9.0-windows10.0.19041
```

- **Every shipped asset is net9**, which 7.0 drops. Removing a target framework is a breaking change by .NET convention regardless of API surface ([Microsoft](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/older-framework-versions-dropped)).
- **Mac Catalyst is removed in 7.0**, and `net9.0-maccatalyst18.0` is a shipped asset.
- Recompiled against 7.0, the `-android` / `-ios` assets become Skia binaries, unusable by 6.x consumers.

## 7.0 work still ahead on this repo (not in this PR)

- **TFM move** — `net9.0` is hardcoded in `src/tfms-non-ui.props`, `src/tfms-ui-maui.props` and siblings (22 references).
- **Mac Catalyst removal** — 6 references, including the shipped `Uno.Extensions.Maui.WinUI.csproj` platform condition and `src/Directory.Build.props`.
- **`Microsoft.Maui.Controls.Compatibility`** — referenced by two shipped projects, `Uno.Extensions.Maui.UI` and `Uno.Extensions.Maui.WinUI.Markup`. That package is [no longer built or shipped as of .NET 11 Preview 6](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview6/dotnetmaui.md), which is what [`unoplatform/uno#24360`](https://github.com/unoplatform/uno/pull/24360) addressed on the SDK side. Someone should confirm MAUI embedding behaves on net11 without the compatibility renderers.
- 1 × `Uno.UI.Toolkit` reference to remap.

No removed XAML prefixes, no SkiaSharp usage, no references to packages 7.0 deletes.

## PR Checklist

- [x] Tested with current supported SDKs — no product code changed
- [ ] Docs — n/a
- [ ] Tests — n/a, pipeline and version metadata only
- [x] Contains **NO** breaking changes to this repo's code — the `!` marks the version-line break for consumers of the 7.0 line
- [x] Commits follow Conventional Commits

## Other information

**`servicing/7.4` is deliberately not pushed yet.** It is cut at this PR's merge-base and stays local until this merges — pushing first opens the `7.4.0-dev.30` collision above. Its CI files are already byte-identical to this branch, so the two will not conflict on a later sync.

Sequence: merge this, confirm `main` publishes `8.0.0-dev.1`, push `servicing/7.4`, confirm `7.4.0-dev.30`, then apply the `servicing/*` branch protection mirroring `main`.

Same pattern already merged in [`unoplatform/uno#24361`](https://github.com/unoplatform/uno/pull/24361), [`uno.csharpmarkup#904`](https://github.com/unoplatform/uno.csharpmarkup/pull/904), [`uno.app-mcp#143`](https://github.com/unoplatform/uno.app-mcp/pull/143), [`Uno.Themes#1713`](https://github.com/unoplatform/Uno.Themes/pull/1713) and [`uno.toolkit.ui#1634`](https://github.com/unoplatform/uno.toolkit.ui/pull/1634).
