### PR TITLE
fix(reactive): treat a disposed dispatcher provider as no dispatcher

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Utils/Dispatching/Given_DispatcherLocal.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Utils/Dispatching/Given_DispatcherLocal.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -149,6 +150,55 @@ public class Given_DispatcherLocal
 		getValue.IsCompleted.Should().BeTrue();
 
 		enumeration.Result.Should().Be(1, because: "we should have got the value created for UI thread (on which we have waited on)");
+	}
+
+	[TestMethod]
+	public void When_ProviderDisposed_Then_ValueFallsBackToBackground()
+	{
+		// A provider whose backing state has been disposed. This is what
+		// DispatcherQueueProvider's static ThreadLocal<IDispatcher> does once the assembly owning it
+		// is unloaded with its collectible AssemblyLoadContext: ThreadLocal disposes itself from its
+		// own finalizer, and every later read throws.
+		var sut = new DispatcherLocal<string>(
+			factory: d => d is TestDispatcher ui ? ui.Name : "background",
+			schedulersProvider: () => throw new ObjectDisposedException(nameof(ThreadLocal<IDispatcher>)));
+
+		// Must NOT throw: callers reach this from their own finalizers (removing an event handler
+		// from a bindable collection resolves the current dispatcher), and an exception escaping a
+		// finalizer is unrecoverable -- it terminates the process rather than failing one operation.
+		sut.Value.Should().Be(
+			"background",
+			because: "a disposed provider means no dispatcher, which is also the truthful answer on a finalizer thread");
+	}
+
+	[TestMethod]
+	public void When_ProviderDisposed_Then_TryGetValueDoesNotThrow()
+	{
+		using var ui = new TestDispatcher("ui");
+		var sut = new DispatcherLocal<string>(
+			factory: d => d is TestDispatcher named ? named.Name : "background",
+			schedulersProvider: () => throw new ObjectDisposedException(nameof(ThreadLocal<IDispatcher>)),
+			allowCreationFromAnotherThread: true);
+
+		// TryGetValue resolves the CURRENT dispatcher to decide whether creation is permitted, so it
+		// reads the provider even though the owner is passed explicitly.
+		sut.TryGetValue(ui, out var value).Should().BeTrue();
+		value.Should().Be("ui");
+	}
+
+	[TestMethod]
+	public void When_ProviderThrowsOtherError_Then_ItPropagates()
+	{
+		// Only ObjectDisposedException is treated as "no dispatcher". Any other failure to resolve a
+		// dispatcher is a real fault and must not be swallowed, or a misconfigured provider would
+		// silently degrade every consumer to background values.
+		var sut = new DispatcherLocal<string>(
+			factory: _ => "background",
+			schedulersProvider: () => throw new InvalidOperationException("provider is misconfigured"));
+
+		var resolve = () => sut.Value;
+
+		resolve.Should().Throw<InvalidOperationException>().WithMessage("provider is misconfigured");
 	}
 
 	private int CountValues<T>(DispatcherLocal<T> sut, bool includeBackground = true)

--- a/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispatcherQueueProvider.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispatcherQueueProvider.cs
@@ -22,7 +22,7 @@ public static class DispatcherQueueProvider
 	/// <remarks>
 	/// Returns null rather than throwing once <see cref="_value"/> has been disposed. Nothing disposes
 	/// it explicitly -- <see cref="ThreadLocal{T}"/> disposes itself from its own finalizer, which
-	/// runs once this static becomes collectable. That happens when the assembly owning it is loaded
+	/// runs once this static becomes collectible. That happens when the assembly owning it is loaded
 	/// into a collectible <c>AssemblyLoadContext</c> and the context is unloaded: the ThreadLocal is
 	/// then finalized alongside the objects that still call in here, in no defined order, and those
 	/// calls can come from finalizers. Throwing from a finalizer is unrecoverable and terminates the

--- a/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispatcherQueueProvider.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispatcherQueueProvider.cs
@@ -19,8 +19,26 @@ public static class DispatcherQueueProvider
 	/// Gets a dispatcher queue instance that will execute tasks serially on the current thread, or null if no such queue exists.
 	/// </summary>
 	/// <returns>The dispatcher associated to the current thread if the thread is a UI thread.</returns>
+	/// <remarks>
+	/// Returns null rather than throwing once <see cref="_value"/> has been disposed. Nothing disposes
+	/// it explicitly -- <see cref="ThreadLocal{T}"/> disposes itself from its own finalizer, which
+	/// runs once this static becomes collectable. That happens when the assembly owning it is loaded
+	/// into a collectible <c>AssemblyLoadContext</c> and the context is unloaded: the ThreadLocal is
+	/// then finalized alongside the objects that still call in here, in no defined order, and those
+	/// calls can come from finalizers. Throwing from a finalizer is unrecoverable and terminates the
+	/// process, whereas null is the ordinary answer for a non-UI thread.
+	/// </remarks>
 	public static IDispatcher? GetForCurrentThread()
-		=> _value.Value;
+	{
+		try
+		{
+			return _value.Value;
+		}
+		catch (ObjectDisposedException)
+		{
+			return null;
+		}
+	}
 
 	private static IDispatcher? CreateForCurrentThread()
 		=> DispatcherQueue.GetForCurrentThread() is { } dispatcher ? new Dispatcher(dispatcher) : null;

--- a/src/Uno.Extensions.Reactive/Utils/Dispatching/DispatcherLocal.cs
+++ b/src/Uno.Extensions.Reactive/Utils/Dispatching/DispatcherLocal.cs
@@ -133,7 +133,7 @@ internal sealed class DispatcherLocal<T>
 	/// UI package's <c>DispatcherQueueProvider</c> resolves the dispatcher from a static
 	/// <see cref="ThreadLocal{T}"/>, and <see cref="ThreadLocal{T}"/> disposes itself from its own
 	/// finalizer. When the assembly owning that static lives in a collectible
-	/// <c>AssemblyLoadContext</c>, unloading the context makes the static collectable, so the
+	/// <c>AssemblyLoadContext</c>, unloading the context makes the static collectible, so the
 	/// ThreadLocal is finalized in the same pass as the objects that still hold a
 	/// <see cref="DispatcherLocal{T}"/> -- in no defined order.
 	///

--- a/src/Uno.Extensions.Reactive/Utils/Dispatching/DispatcherLocal.cs
+++ b/src/Uno.Extensions.Reactive/Utils/Dispatching/DispatcherLocal.cs
@@ -75,7 +75,7 @@ internal sealed class DispatcherLocal<T>
 	{
 		get
 		{
-			var current = _schedulersProvider();
+			var current = FindCurrentDispatcher();
 			var (hasValue, value, error) = GetValueCore(current, current);
 
 			if (hasValue)
@@ -87,7 +87,7 @@ internal sealed class DispatcherLocal<T>
 				throw new InvalidOperationException(error);
 			}
 		}
-		set => SetValueCore(_schedulersProvider(), value);
+		set => SetValueCore(FindCurrentDispatcher(), value);
 	}
 
 	/// <summary>
@@ -97,7 +97,7 @@ internal sealed class DispatcherLocal<T>
 	{
 		var (hasValue, value, error) = GetValueCore(
 			owner: scheduler,
-			current: _schedulersProvider());
+			current: FindCurrentDispatcher());
 
 		if (hasValue)
 		{
@@ -119,9 +119,44 @@ internal sealed class DispatcherLocal<T>
 	{
 		(var hasValue, value, _) = GetValueCore(
 			owner: scheduler,
-			current: _schedulersProvider());
+			current: FindCurrentDispatcher());
 
 		return hasValue;
+	}
+
+	/// <summary>
+	/// Resolves the dispatcher of the current thread, reporting "no dispatcher" instead of throwing
+	/// when the provider's backing state has already been disposed.
+	/// </summary>
+	/// <remarks>
+	/// A provider can legitimately be disposed while instances of this class are still reachable. The
+	/// UI package's <c>DispatcherQueueProvider</c> resolves the dispatcher from a static
+	/// <see cref="ThreadLocal{T}"/>, and <see cref="ThreadLocal{T}"/> disposes itself from its own
+	/// finalizer. When the assembly owning that static lives in a collectible
+	/// <c>AssemblyLoadContext</c>, unloading the context makes the static collectable, so the
+	/// ThreadLocal is finalized in the same pass as the objects that still hold a
+	/// <see cref="DispatcherLocal{T}"/> -- in no defined order.
+	///
+	/// Those objects reach this class from their own finalizers: removing an event handler from a
+	/// bindable collection resolves the current dispatcher to find the layer to unsubscribe from. If
+	/// the ThreadLocal was finalized first, that read threw <see cref="ObjectDisposedException"/> out
+	/// of a finalizer, which is unrecoverable and terminates the process.
+	///
+	/// Reporting null instead lets the caller take the background-value path, which is what a
+	/// finalizer thread would have got anyway -- it is not a UI thread, so there is no dispatcher to
+	/// find. Only <see cref="ObjectDisposedException"/> is treated this way: any other failure to
+	/// resolve a dispatcher is a real fault and still propagates.
+	/// </remarks>
+	private IDispatcher? FindCurrentDispatcher()
+	{
+		try
+		{
+			return _schedulersProvider();
+		}
+		catch (ObjectDisposedException)
+		{
+			return null;
+		}
 	}
 
 	private (bool hasValue, T? value, string? errorMessage) GetValueCore(IDispatcher? owner, IDispatcher? current)


### PR DESCRIPTION
Fixes #3174 — read that issue for the full mechanism; this is the fix and its evidence.

Draft because the reproduction that motivated it is an end-to-end collectible-`AssemblyLoadContext` host that lives downstream, so CI here can only prove the unit-level behaviour. See **Verification** for exactly what is and is not established.

## The bug in one paragraph

Removing an event handler from a `BindableCollection` resolves the current dispatcher so it can find that thread's `DataLayer` (`BindableCollection.cs:239` → `DispatcherLocal.Value` → `_schedulersProvider()`), and that resolution reads `DispatcherQueueProvider`'s static `ThreadLocal<IDispatcher>`. `ThreadLocal<T>` disposes itself from its own finalizer, so once the assembly owning that static is unloaded with a collectible ALC, the read throws `ObjectDisposedException`. Removal is reached **from** a finalizer — `~ItemsSourceView()` disposes its collection-changed listener, which unsubscribes — and an exception escaping a finalizer is unrecoverable: it terminates the process.

## The change

**`DispatcherLocal` (core)** — every current-dispatcher resolution now goes through `FindCurrentDispatcher()`, which reports `null` on `ObjectDisposedException`. All four call sites are covered: `Value` get, `Value` set, `GetValue`, `TryGetValue`. (`TryGetValue` matters even though the owner is passed explicitly — it still reads the *current* dispatcher to decide whether creation from another thread is permitted.)

Null is the truthful answer here, not a degraded one: a finalizer thread is not a UI thread, so there is genuinely no dispatcher to find. `DispatcherLocal` already has the background-value path for exactly that case, and `allowBackgroundValue` is **never overridden anywhere in this repo** (default `true`, `DispatcherLocal.cs:41`; the only production construction is `BindableCollection.cs:132`, which passes only `allowCreationFromAnotherThread: true`) — so that path is always available. Had it been `false`, this fix would merely have swapped a fatal `ObjectDisposedException` for a fatal `InvalidOperationException`, which is why it is called out rather than assumed.

**`DispatcherQueueProvider` (UI)** — `GetForCurrentThread()` guards the same way, so the provider cannot throw even for a consumer that resolves it directly rather than through `DispatcherLocal`. Defence in depth; the core fix is the load-bearing one.

**Only `ObjectDisposedException`** is treated this way. Any other resolution failure stays fatal — a misconfigured provider must not silently degrade every consumer to background values. There is a test for that specifically.

Chosen this way because `DispatcherLocal` is the layer that *depends* on "resolve the current dispatcher", it is reachable from every one of the eight removal paths in `BindableCollection` (lines 239, 245, 335, 338, 344, 347, 353, 356 — `VectorChanged` and the selection handlers resolve on removal too, so `CollectionChanged` is not the only exposure), and it takes an injectable provider, which makes the fix testable without disposing a process-wide static from a test.

## Deliberately not done here

Removal should arguably not resolve a dispatcher **at all**. `DispatcherLocal.ForEachValue` already iterates existing layers without resolving or creating anything, so the removal accessors could apply across all layers and be naturally idempotent — which would additionally fix removing a handler from a different thread than the one that added it, and would avoid constructing a `DataLayer` on a finalizer thread.

That is a behavioural change to event-removal semantics across eight accessors, including token-based overloads whose tolerance for unknown tokens I have not audited. It does not belong on a servicing branch. Happy to open it against `main` if you want it.

## Verification

**Red/green, run both ways:**

| Run | Result |
|---|---|
| 3 new tests with the fix | **6 passed / 0 failed** (`Given_DispatcherLocal`) |
| Same tests with `DispatcherLocal.cs` reverted, tests kept | **2 failed / 4 passed** — `When_ProviderDisposed_Then_ValueFallsBackToBackground`, `When_ProviderDisposed_Then_TryGetValueDoesNotThrow` |
| Full `Uno.Extensions.Reactive.Tests` | **1422 passed / 0 failed / 19 skipped** |
| `dotnet build` of the test project | 0 errors |

The third new test — `When_ProviderThrowsOtherError_Then_ItPropagates` — passes in *both* directions by design: it asserts the exception types that must **keep** throwing, so it guards the narrowness of the `catch` rather than the fix itself.

**Not established here, and worth being plain about:** no end-to-end proof that the process no longer dies. That needs a host loading `Uno.Extensions.Reactive.UI` into a collectible ALC, unloading it, and forcing finalizers — the setup described in the issue. The unit tests reproduce the *provider state* that causes it (a provider that throws `ObjectDisposedException`) and prove the resolution path now tolerates it; they do not reproduce the ALC teardown itself. I will confirm end-to-end against a downstream host once this is in a 7.4-dev package and report back on the issue.

One compile detail, in case it comes up in review: the XML doc on `FindCurrentDispatcher` refers to `DispatcherQueueProvider` in prose rather than with a `cref`, because it lives in the UI assembly and core does not reference it — a `cref` fails the build with CS1574.
