### PR TITLE
fix(reactive): do not resolve a dispatcher when removing a handler

### DIFF
--- a/src/Uno.Extensions.Reactive.Tests/Utils/Dispatching/Given_DispatcherLocal.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Utils/Dispatching/Given_DispatcherLocal.cs
@@ -151,6 +151,87 @@ public class Given_DispatcherLocal
 		enumeration.Result.Should().Be(1, because: "we should have got the value created for UI thread (on which we have waited on)");
 	}
 
+	[TestMethod]
+	public void When_TryGetCurrentValue_And_NotCreatedYet_Then_DoesNotCreate()
+	{
+		var current = default(IDispatcher?);
+		using var ui = new TestDispatcher("ui");
+		var factoryInvocations = 0;
+
+		var sut = new DispatcherLocal<string>(
+			factory: d =>
+			{
+				factoryInvocations++;
+				return d is TestDispatcher td ? td.Name : "background";
+			},
+			schedulersProvider: () => current);
+
+		current = ui;
+
+		sut.TryGetCurrentValue(out var value).Should().BeFalse();
+		value.Should().BeNull();
+		factoryInvocations.Should().Be(0, because: "a removal path must never materialize a value");
+		CountValues(sut).Should().Be(0);
+	}
+
+	[TestMethod]
+	public void When_TryGetCurrentValue_And_AlreadyCreated_Then_ReturnsIt()
+	{
+		var current = default(IDispatcher?);
+		using var ui = new TestDispatcher("ui");
+
+		var sut = new DispatcherLocal<string>(
+			factory: d => d is TestDispatcher td ? td.Name : "background",
+			schedulersProvider: () => current);
+
+		current = ui;
+		sut.Value.Should().Be("ui");
+
+		sut.TryGetCurrentValue(out var value).Should().BeTrue();
+		value.Should().Be("ui");
+		CountValues(sut).Should().Be(1, because: "no additional value should have been created");
+	}
+
+	[TestMethod]
+	public void When_TryGetCurrentValue_OnAnotherThread_Then_DoesNotCreate()
+	{
+		var current = default(IDispatcher?);
+		using var ui1 = new TestDispatcher("ui1");
+		using var ui2 = new TestDispatcher("ui2");
+
+		var sut = new DispatcherLocal<string>(
+			factory: d => d is TestDispatcher td ? td.Name : "background",
+			schedulersProvider: () => current);
+
+		current = ui1;
+		sut.Value.Should().Be("ui1");
+
+		current = ui2;
+
+		sut.TryGetCurrentValue(out var value).Should().BeFalse();
+		value.Should().BeNull();
+		CountValues(sut).Should().Be(1, because: "the value of another thread must not be returned, nor a new one created");
+	}
+
+	[TestMethod]
+	public void When_TryGetCurrentValue_OnBackgroundThread_Then_ReturnsExistingValueOnly()
+	{
+		var current = default(IDispatcher?);
+
+		var sut = new DispatcherLocal<string>(
+			factory: d => d is TestDispatcher td ? td.Name : "background",
+			schedulersProvider: () => current);
+
+		sut.TryGetCurrentValue(out _).Should().BeFalse();
+		CountValues(sut).Should().Be(0);
+
+		sut.Value.Should().Be("background");
+
+		sut.TryGetCurrentValue(out var value).Should().BeTrue();
+		value.Should().Be("background");
+		CountValues(sut).Should().Be(1);
+	}
+
 	private int CountValues<T>(DispatcherLocal<T> sut, bool includeBackground = true)
 	{
 		// note : This method MUST use ForEachValue for test When_EnumerateWhileCreatingValue_Then_Lock to be useful!

--- a/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
+++ b/src/Uno.Extensions.Reactive.UI/Presentation/Bindings/Collections/BindableCollection.cs
@@ -232,17 +232,31 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 			remove => RemoveVectorChangedHandler(value);
 		}
 
+		/// <summary>
+		/// Gets a facet of the current thread's data layer, but only if that layer has already been created.
+		/// </summary>
+		/// <remarks>
+		/// Used by ALL handler-removal paths, which must NOT create a data layer. A layer that was never materialized
+		/// cannot be holding the handler being removed, so there is nothing to do. This also keeps removal safe on the
+		/// finalizer thread: <c>ItemsSourceView.Finalize()</c> unsubscribes from the collection, and resolving a
+		/// dispatcher there can hit an already-finalized <see cref="System.Threading.ThreadLocal{T}"/>, whose
+		/// exception would escape the finalizer and terminate the process.
+		/// </remarks>
+		private TFacet? GetExistingFacet<TFacet>()
+			where TFacet : class
+			=> _holder.TryGetCurrentValue(out var layer) ? layer.GetFacet<TFacet>() : null;
+
 		/// <inheritdoc />
 		public event NotifyCollectionChangedEventHandler? CollectionChanged
 		{
 			add => _holder.Value.GetFacet<CollectionChangedFacet>().AddCollectionChangedHandler(value!);
-			remove => _holder.Value.GetFacet<CollectionChangedFacet>().RemoveCollectionChangedHandler(value!);
+			remove => GetExistingFacet<CollectionChangedFacet>()?.RemoveCollectionChangedHandler(value!);
 		}
 
 		public event PropertyChangedEventHandler? PropertyChanged
 		{
 			add => _holder.Value.GetFacet<CollectionChangedFacet>().AddPropertyChangedHandler(value!);
-			remove => _holder.Value.GetFacet<CollectionChangedFacet>().RemovePropertyChangedHandler(value!);
+			remove => GetExistingFacet<CollectionChangedFacet>()?.RemovePropertyChangedHandler(value!);
 		}
 
 		/// <inheritdoc />
@@ -332,28 +346,28 @@ namespace Uno.Extensions.Reactive.Bindings.Collections
 		internal EventRegistrationToken AddVectorChangedHandler(VectorChangedEventHandler<object?>? handler)
 			=> handler is null ? default : _holder.Value.GetFacet<CollectionChangedFacet>().AddVectorChangedHandler(handler);
 		internal void RemoveVectorChangedHandler(VectorChangedEventHandler<object?>? handler)
-			=> _holder.Value.GetFacet<CollectionChangedFacet>().RemoveVectorChangedHandler(handler!);
+			=> GetExistingFacet<CollectionChangedFacet>()?.RemoveVectorChangedHandler(handler!);
 #if USE_EVENT_TOKEN
 		internal void RemoveVectorChangedHandler(EventRegistrationToken token)
-			=> _holder.Value.GetFacet<CollectionChangedFacet>().RemoveVectorChangedHandler(token);
+			=> GetExistingFacet<CollectionChangedFacet>()?.RemoveVectorChangedHandler(token);
 #endif
 
 		internal EventRegistrationToken AddCurrentChangedHandler(CurrentChangedEventHandler? handler)
 			=> _holder.Value.GetFacet<SelectionFacet>().AddCurrentChangedHandler(handler!);
 		internal void RemoveCurrentChangedHandler(CurrentChangedEventHandler? handler)
-			=> _holder.Value.GetFacet<SelectionFacet>().RemoveCurrentChangedHandler(handler!);
+			=> GetExistingFacet<SelectionFacet>()?.RemoveCurrentChangedHandler(handler!);
 #if USE_EVENT_TOKEN
 		internal void RemoveCurrentChangedHandler(EventRegistrationToken token)
-			=> _holder.Value.GetFacet<SelectionFacet>().RemoveCurrentChangedHandler(token);
+			=> GetExistingFacet<SelectionFacet>()?.RemoveCurrentChangedHandler(token);
 #endif
 
 		internal EventRegistrationToken AddCurrentChangingHandler(CurrentChangingEventHandler? handler)
 			=> _holder.Value.GetFacet<SelectionFacet>().AddCurrentChangingHandler(handler!);
 		internal void RemoveCurrentChangingHandler(CurrentChangingEventHandler? handler)
-			=> _holder.Value.GetFacet<SelectionFacet>().RemoveCurrentChangingHandler(handler!);
+			=> GetExistingFacet<SelectionFacet>()?.RemoveCurrentChangingHandler(handler!);
 #if USE_EVENT_TOKEN
 		internal void RemoveCurrentChangingHandler(EventRegistrationToken token)
-			=> _holder.Value.GetFacet<SelectionFacet>().RemoveCurrentChangingHandler(token);
+			=> GetExistingFacet<SelectionFacet>()?.RemoveCurrentChangingHandler(token);
 #endif
 
 		/// <summary>

--- a/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispatcherQueueProvider.cs
+++ b/src/Uno.Extensions.Reactive.UI/Utils/Dispatching/DispatcherQueueProvider.cs
@@ -20,7 +20,21 @@ public static class DispatcherQueueProvider
 	/// </summary>
 	/// <returns>The dispatcher associated to the current thread if the thread is a UI thread.</returns>
 	public static IDispatcher? GetForCurrentThread()
-		=> _value.Value;
+	{
+		try
+		{
+			return _value.Value;
+		}
+		catch (ObjectDisposedException)
+		{
+			// _value is a static that is never disposed explicitly: it is reclaimed by its OWN finalizer once the
+			// AssemblyLoadContext holding it is collected. Finalization order is unspecified, so another finalizer
+			// running in the same pass can reach this after the ThreadLocal is gone. Throwing here would escape the
+			// finalizer thread and terminate the process; null is already a documented result of this method, and
+			// means the same thing in practice — there is no dispatcher for this thread any more.
+			return null;
+		}
+	}
 
 	private static IDispatcher? CreateForCurrentThread()
 		=> DispatcherQueue.GetForCurrentThread() is { } dispatcher ? new Dispatcher(dispatcher) : null;

--- a/src/Uno.Extensions.Reactive/Utils/Dispatching/DispatcherLocal.cs
+++ b/src/Uno.Extensions.Reactive/Utils/Dispatching/DispatcherLocal.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -122,6 +123,43 @@ internal sealed class DispatcherLocal<T>
 			current: _schedulersProvider());
 
 		return hasValue;
+	}
+
+	/// <summary>
+	/// Tries to get the value of the current thread, **without creating it** if it does not exist yet.
+	/// </summary>
+	/// <param name="value">The value already associated to the current thread, if any.</param>
+	/// <returns>True if a value had already been created for the current thread, false otherwise.</returns>
+	/// <remarks>
+	/// Unlike <see cref="Value"/> and <see cref="TryGetValue"/>, this never invokes the factory.
+	/// It is intended for tear-down paths (e.g. removing an event handler), which must not materialize state:
+	/// a value that was never created cannot be holding the state being removed. Those paths are also reachable
+	/// from the finalizer thread, where the dispatcher is unavailable and creating a value is unsafe.
+	/// </remarks>
+	public bool TryGetCurrentValue([MaybeNullWhen(false)] out T value)
+	{
+		var current = _schedulersProvider();
+		if (current is null)
+		{
+			if (_allowBackgroundValue && _backgroundValue is { } background)
+			{
+				value = background.Value;
+				return true;
+			}
+		}
+		else if (_mainUiValue is { } main && main.Scheduler == current)
+		{
+			value = main.Value;
+			return true;
+		}
+		else if (_otherUiValues is { } others && others.TryGetValue(current, out var existing))
+		{
+			value = existing.Value;
+			return true;
+		}
+
+		value = default;
+		return false;
 	}
 
 	private (bool hasValue, T? value, string? errorMessage) GetValueCore(IDispatcher? owner, IDispatcher? current)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3174

## PR Type

- Bugfix

## What is the current behavior?

`ItemsSourceView.Finalize()` unsubscribes from `BindableListFeed<T>.CollectionChanged`. That removal path went through `_holder.Value` (`BindableCollection.cs`), which resolves the current dispatcher via `DispatcherLocal.Value` → `DispatcherHelper.GetForCurrentThread` → `DispatcherQueueProvider.GetForCurrentThread()`.

`DispatcherQueueProvider` keeps the dispatcher in a `private static readonly ThreadLocal<IDispatcher?>` that is never disposed explicitly, so it is reclaimed by **its own finalizer** once the owning `AssemblyLoadContext` is collected. Finalization order is unspecified, so the unsubscribe could reach an already-finalized `ThreadLocal`:

```
[UNHANDLED_DOMAIN_EXCEPTION] IsTerminating=True ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Threading.ThreadLocal`1[[Uno.Extensions.IDispatcher, Uno.Extensions.Core, ...]]'.
   at System.Threading.ThreadLocal`1.GetValueSlow()
   at Uno.Extensions.Reactive.Bindings.BindableListFeed`1.remove_CollectionChanged(NotifyCollectionChangedEventHandler value)
   at Microsoft.UI.Xaml.Controls.ItemsSourceView.Finalize()
   at System.GC.RunFinalizers()
```

An unhandled exception on the finalizer thread is fatal by design, so **the process terminates**. Because it is a race between two finalizers it is intermittent — roughly one run in seven survived in the sampling that led to #3177.

A second, smaller problem on the same path: removing a handler could *create* a data layer via the factory, including a background one, purely as a side effect of unsubscribing.

## What is the new behavior?

Removal paths no longer resolve a dispatcher or create anything.

1. **`DispatcherLocal<T>.TryGetCurrentValue`** (new) returns the current thread's value only if it already exists, and never invokes the factory.
2. **`BindableCollection`** uses it for **all eight** handler-removal paths — collection-changed, property-changed, both `RemoveVectorChangedHandler` overloads and the four `SelectionFacet` ones (`CurrentChanged`/`CurrentChanging`) — through a shared `GetExistingFacet<TFacet>()` helper. A data layer that was never materialized cannot be holding the handler being removed, so removal is simply a no-op.
3. **`DispatcherQueueProvider.GetForCurrentThread()`** now tolerates a finalized `ThreadLocal` and returns `null` — already a documented result of that method, and semantically accurate: there is no dispatcher for this thread any more.

(3) is defence in depth: with (1) and (2) the reported stack no longer reaches it, but any *other* finalizer that resolves a dispatcher would hit the same fatal throw.

Behaviour is otherwise unchanged: the `Add`/read paths still use the creating accessor, exactly as before.

## PR Checklist

- [x] Tested code with current supported SDKs
- [ ] Docs have been added/updated — n/a, no public API surface change beyond an internal helper
- [x] Unit Tests and/or UI Tests for the changes have been added (see below)
- [ ] Wasm UI Tests are not showing unexpected differences — not run locally
- [x] Contains **NO** breaking changes
- [ ] Updated the Release Notes — happy to add if you'd like it there
- [x] Associated with an issue (#3177)

## Verification

- `dotnet test src/Uno.Extensions.Reactive.Tests` — **1435 passed, 0 failed**, 19 pre-existing skips.
- Four new tests in `Given_DispatcherLocal` covering `TryGetCurrentValue`: not-yet-created (asserts the factory is *not* invoked), already-created, another thread's value, and the background-thread case.
- Release builds of `Uno.Extensions.Reactive` and `Uno.Extensions.Reactive.WinUI`: 0 errors, and no warnings in any changed file.

**Where I would welcome direction:** the new tests pin the `TryGetCurrentValue` contract that the fix rests on, but they cannot fail against the old code because the method is new. A true regression test for the crash belongs in `Uno.Extensions.Reactive.UI.Tests` — asserting that removing a handler does not create a data layer — and I could not run that suite here (it needs an Uno UI host), so I did not want to commit a test I had not seen pass. Happy to add it if you can validate it, or if you would rather shape it yourselves.

## Other information

Opened as a **draft** for maintainer review — I am not a maintainer of this repository and the finalizer-safety reasoning deserves your eyes before this is considered ready. Observed against `7.4.0-dev.29`; the code involved appears unchanged for some time, so earlier versions are likely affected too.

Credit to #3174, whose analysis is the more complete one — in particular it enumerates **eight** reachable removal paths, not just the one in the stack trace. My first pass covered four; this PR now covers all eight. I had opened #3177 before spotting #3174 and have closed it as a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
