### PR TITLE
fix: ship the mock generator in the package and null-inject every constructor parameter

### DIFF
--- a/Uno.Extensions-packageonly.slnf
+++ b/Uno.Extensions-packageonly.slnf
@@ -50,6 +50,7 @@
       "src\\Uno.Extensions.Toolkit\\Uno.Extensions.Toolkit.csproj",
       "src\\Uno.Extensions.Validation.Fluent\\Uno.Extensions.Validation.Fluent.csproj",
       "src\\Uno.Extensions.Validation\\Uno.Extensions.Validation.csproj",
+      "src\\Uno.HotTesting.Reactive.Generator\\Uno.HotTesting.Reactive.Generator.csproj",
       "src\\Uno.HotTesting.Reactive.Tests\\Uno.HotTesting.Reactive.Tests.csproj",
       "src\\Uno.HotTesting.Reactive\\Uno.HotTesting.Reactive.csproj"
     ]

--- a/Uno.Extensions.Reactive.slnf
+++ b/Uno.Extensions.Reactive.slnf
@@ -21,6 +21,7 @@
       "src\\Uno.Extensions.RuntimeTests\\Uno.Extensions.RuntimeTests.Skia.Wpf\\Uno.Extensions.RuntimeTests.Skia.Wpf.csproj",
       "src\\Uno.Extensions.RuntimeTests\\Uno.Extensions.RuntimeTests.Wasm\\Uno.Extensions.RuntimeTests.Wasm.csproj",
       "src\\Uno.Extensions.RuntimeTests\\Uno.Extensions.RuntimeTests.Windows\\Uno.Extensions.RuntimeTests.Windows.csproj",
+      "src\\Uno.HotTesting.Reactive.Generator\\Uno.HotTesting.Reactive.Generator.csproj",
       "src\\Uno.HotTesting.Reactive.Tests\\Uno.HotTesting.Reactive.Tests.csproj",
       "src\\Uno.HotTesting.Reactive\\Uno.HotTesting.Reactive.csproj"
     ]

--- a/doc/Reference/Reactive/rules.md
+++ b/doc/Reference/Reactive/rules.md
@@ -26,3 +26,15 @@ but the property _property_name_ is not of type `IFeed<T>` (nor `IState<T>`).
 > [!NOTE]
 > If your property is synchronous (i.e. not a `Feed` nor a `State`), you don't need to use the `[FeedParameter]` attribute.
 > Remove the parameter from the method and get your value from the property directly.
+
+## Mock0001
+
+**No mock is generated for a model whose view-model has no public constructor.**
+
+`Uno.HotTesting.Reactive` builds the real view-model with every constructor parameter null-injected
+(`{Vm}Mock.Create`). The generated view-model mirrors the model's constructors, so a model whose constructors
+are all `internal` or `private` leaves nothing for `Create` to call: the generator reports this warning and
+emits no `{Model}Mock` / `{Vm}Mock` for that model.
+
+Make one of the model's constructors public to get the mock back, or suppress the warning for a model that is
+not meant to be mocked.

--- a/doc/Reference/Reactive/testing.md
+++ b/doc/Reference/Reactive/testing.md
@@ -126,7 +126,8 @@ emits, next to the model:
   service-dependent feeds, and whose **optional** members are the derived feeds
   (a `{Model}Mock.Empty` pins every input to its empty state);
 - a `partial class {Vm}Mock` with `Create(...)` factories that build the **real
-  view-model** with its services null-injected, then apply the mock;
+  view-model** with every constructor parameter null-injected (services,
+  navigator, ...), then apply the mock;
 - a `SetMock(this {Vm}, {Model}Mock)` extension that swaps each mocked feed.
 
 Given this model:

--- a/doc/Reference/Reactive/testing.md
+++ b/doc/Reference/Reactive/testing.md
@@ -130,6 +130,9 @@ emits, next to the model:
   navigator, ...), then apply the mock;
 - a `SetMock(this {Vm}, {Model}Mock)` extension that swaps each mocked feed.
 
+A view-model whose constructors are all non-public cannot be built this way:
+the generator reports the `MOCK0001` warning for that model and emits no mock.
+
 Given this model:
 
 ```csharp

--- a/specs/013-mvux-mocking-previews/history.md
+++ b/specs/013-mvux-mocking-previews/history.md
@@ -154,9 +154,15 @@ Propagated: documentation `doc/Reference/Reactive/testing.md`, spec §7/§8/§10
 The consumer generator emitted exactly one `default!`, so a model whose constructor takes more than one
 dependency (a service plus a navigator, a messenger, ...) produced a `Create` that did not compile. `Create`
 now targets the public view-model constructor with the fewest parameters (the generated VM mirrors the model's
-constructors; the protected model-wrapping constructor is never a candidate) and passes `default!` for each
-parameter. Fixture: `MenuModel` (two constructor parameters) in the two-project app; test
-`When_ModelHasSeveralCtorParameters_Then_CreateNullInjectsEachOne`.
+constructors; the protected model-wrapping constructor is never a candidate) and passes a typed
+`default({ParameterType})!` for each parameter: a bare `default!` fixes the arity but leaves two constructors
+of equal arity ambiguous (CS0121). Ties on arity are broken on the ordinal parameter type list, so the emitted
+code does not depend on the compiler's symbol order. A view-model with no public constructor reports the
+`MOCK0001` warning instead of silently emitting nothing. Fixture in the two-project app: `MenuModel` (two
+constructor parameters plus a second constructor of equal arity; its derived feed and independent state pin the
+record's member classification). Tests: `Given_GeneratedMock`
+(`..._Then_CreateCompilesAndInputFlows`, `..._Then_MockExposesOnlyTheDerivedOneAsOptional`) and the
+generator-driver tests of `Given_FeedsMockGenerator` (typed defaults, tie-break, `MOCK0001`).
 
 ---
 

--- a/specs/013-mvux-mocking-previews/history.md
+++ b/specs/013-mvux-mocking-previews/history.md
@@ -149,6 +149,17 @@ Propagated: documentation `doc/Reference/Reactive/testing.md`, spec §7/§8/§10
 
 ---
 
+## v13 — `Create` null-injects every constructor parameter
+
+The consumer generator emitted exactly one `default!`, so a model whose constructor takes more than one
+dependency (a service plus a navigator, a messenger, ...) produced a `Create` that did not compile. `Create`
+now targets the public view-model constructor with the fewest parameters (the generated VM mirrors the model's
+constructors; the protected model-wrapping constructor is never a candidate) and passes `default!` for each
+parameter. Fixture: `MenuModel` (two constructor parameters) in the two-project app; test
+`When_ModelHasSeveralCtorParameters_Then_CreateNullInjectsEachOne`.
+
+---
+
 ## Final decision register
 
 | # | Decision | Version |

--- a/specs/013-mvux-mocking-previews/implementation.md
+++ b/specs/013-mvux-mocking-previews/implementation.md
@@ -128,7 +128,9 @@ Rules:
 - **Command mocking is deferred to vNext**: the record carries no command member and `SetMock` wires none (the MVUX `__Mock_SetCommand` seam stays available for that future work).
 - `Create` opens the `MockingService.Enable()` scope around construction, so user code never opens it. `SetMock` callable repeatedly → live transitions (`vm.SetMock(RecipeModelMock.Empty with { Steps = ... })`).
 - Concrete generic types preserved throughout; **no tier-1 type or conversion path is emitted**.
-- Diagnostic `MOCK0001` when a VM is reachable but its assembly lacks hooks (opt-in missing).
+- Diagnostic `MOCK0001` (warning) when a model is reachable but its mock cannot be generated: its view-model
+  exposes no public constructor for `Create` to null-inject. (A model whose assembly lacks the hooks is not
+  enumerated at all, so that case cannot be reported.)
 
 ## 5. UI (`Uno.Extensions.Reactive.UI`) — tier 1
 

--- a/src/Uno.Extensions.Reactive.Tests.MockingApp/MenuModel.cs
+++ b/src/Uno.Extensions.Reactive.Tests.MockingApp/MenuModel.cs
@@ -1,0 +1,44 @@
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions.Reactive;
+
+namespace Uno.Extensions.Reactive.Tests.MockingApp;
+
+public interface IMenuService
+{
+	Task<IImmutableList<string>> GetItems(CancellationToken ct);
+}
+
+public interface IMenuNavigator
+{
+	ValueTask GoBack(CancellationToken ct);
+}
+
+/// <summary>
+/// Fixture for a model whose constructor takes more than one dependency: the generated Create must
+/// null-inject each parameter. Also carries a derived feed and an independent state for later coverage.
+/// </summary>
+public partial class MenuModel
+{
+	private readonly IMenuService _service;
+	private readonly IMenuNavigator _navigator;
+
+	public MenuModel(IMenuService service, IMenuNavigator navigator)
+	{
+		_service = service;
+		_navigator = navigator;
+	}
+
+	// service-dependent input (list)
+	public IListFeed<string> Items => ListFeed.Async(async ct => await _service.GetItems(ct));
+
+	// derived over the service-dependent list
+	public IFeed<int> ItemsCount => Items.AsFeed().Select(items => items.Count);
+
+	// independent state — not part of the mock
+	public IState<string> Filter => State<string>.Value(this, () => string.Empty);
+
+	// command → IAsyncCommand GoBack on the VM; the navigator is only reached when it executes
+	public ValueTask GoBack(CancellationToken ct) => _navigator.GoBack(ct);
+}

--- a/src/Uno.Extensions.Reactive.Tests.MockingApp/MenuModel.cs
+++ b/src/Uno.Extensions.Reactive.Tests.MockingApp/MenuModel.cs
@@ -15,9 +15,17 @@ public interface IMenuNavigator
 	ValueTask GoBack(CancellationToken ct);
 }
 
+public interface IMenuSnapshot
+{
+	IImmutableList<string> Items { get; }
+}
+
 /// <summary>
-/// Fixture for a model whose constructor takes more than one dependency: the generated Create must
-/// null-inject each parameter. Also carries a derived feed and an independent state for later coverage.
+/// Fixture for the constructor shapes the generated Create must handle: more than one dependency (each
+/// parameter null-injected) and two public constructors of equal arity (the parameter type must be spelled
+/// out, otherwise <c>new MenuViewModel(default!, default!)</c> is ambiguous, CS0121). The derived feed and
+/// the independent state pin the record's member classification: the derived feed is an optional override,
+/// the independent state is left out.
 /// </summary>
 public partial class MenuModel
 {
@@ -28,6 +36,11 @@ public partial class MenuModel
 	{
 		_service = service;
 		_navigator = navigator;
+	}
+
+	public MenuModel(IMenuSnapshot snapshot, IMenuNavigator navigator)
+		: this(new SnapshotMenuService(snapshot), navigator)
+	{
 	}
 
 	// service-dependent input (list)
@@ -41,4 +54,16 @@ public partial class MenuModel
 
 	// command → IAsyncCommand GoBack on the VM; the navigator is only reached when it executes
 	public ValueTask GoBack(CancellationToken ct) => _navigator.GoBack(ct);
+}
+
+internal sealed class SnapshotMenuService : IMenuService
+{
+	private readonly IMenuSnapshot _snapshot;
+
+	public SnapshotMenuService(IMenuSnapshot snapshot)
+	{
+		_snapshot = snapshot;
+	}
+
+	public Task<IImmutableList<string>> GetItems(CancellationToken ct) => Task.FromResult(_snapshot.Items);
 }

--- a/src/Uno.Extensions.Reactive.Tests/Mocking/Given_GeneratedMock.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Mocking/Given_GeneratedMock.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -83,14 +85,33 @@ public class Given_GeneratedMock : FeedUITests
 	}
 
 	[TestMethod]
-	public async Task When_ModelHasSeveralCtorParameters_Then_CreateNullInjectsEachOne()
+	public async Task When_ModelHasSeveralCtorParametersAndOverloads_Then_CreateCompilesAndInputFlows()
 	{
-		// MenuModel takes a service and a navigator: Create passes default for both, so it compiles and the
-		// mocked input flows without either dependency.
+		// MenuModel takes a service and a navigator, and offers a second constructor of the same arity. This file
+		// compiling is the proof that Create passes a typed default for each parameter (a bare `default!` leaves
+		// the call ambiguous, CS0121); the assertion checks that the mocked input flows without any dependency.
 		var vm = MenuViewModelMock.Create(new MenuModelMock { Items = ListFeedMock.Value("a", "b") });
 		using var _ = SourceContext.GetOrCreate(vm.Model).AsCurrent();
 
 		var items = await CurrentItems(SourceContext.GetOrCreate(vm.Model), vm.Model.Items);
 		items.Should().BeEquivalentTo(new[] { "a", "b" });
+	}
+
+	[TestMethod]
+	public void When_ModelHasDerivedAndIndependentMembers_Then_MockExposesOnlyTheDerivedOneAsOptional()
+	{
+		// MenuModel also declares a derived feed (ItemsCount) and an independent state (Filter): the record requires
+		// the input, offers the derived feed as an optional override and leaves the independent state out.
+		var mock = typeof(MenuModelMock);
+
+		IsRequired(mock.GetProperty(nameof(MenuModel.Items))).Should().BeTrue();
+		IsRequired(mock.GetProperty(nameof(MenuModel.ItemsCount))).Should().BeFalse();
+		mock.GetProperty(nameof(MenuModel.Filter)).Should().BeNull();
+	}
+
+	private static bool IsRequired(PropertyInfo? property)
+	{
+		property.Should().NotBeNull();
+		return property!.IsDefined(typeof(RequiredMemberAttribute), inherit: false);
 	}
 }

--- a/src/Uno.Extensions.Reactive.Tests/Mocking/Given_GeneratedMock.cs
+++ b/src/Uno.Extensions.Reactive.Tests/Mocking/Given_GeneratedMock.cs
@@ -20,18 +20,18 @@ namespace Uno.Extensions.Reactive.Tests.Mocking;
 [TestClass]
 public class Given_GeneratedMock : FeedUITests
 {
-	private static async Task<IImmutableList<int>?> CurrentItems(SourceContext ctx, IListFeed<int> feed)
+	private static async Task<IImmutableList<T>?> CurrentItems<T>(SourceContext ctx, IListFeed<T> feed)
 	{
 		var (result, _) = ctx.GetOrCreateListState(feed).Record();
 		for (var i = 0; i < 50; i++)
 		{
 			if (result.Count > 0 && result.Last().Current.Data.IsSome(out var v))
 			{
-				return (IImmutableList<int>)v!;
+				return (IImmutableList<T>)v!;
 			}
 			await Task.Delay(20);
 		}
-		return result.Count > 0 && result.Last().Current.Data.IsSome(out var last) ? (IImmutableList<int>)last! : null;
+		return result.Count > 0 && result.Last().Current.Data.IsSome(out var last) ? (IImmutableList<T>)last! : null;
 	}
 
 	[TestMethod]
@@ -80,5 +80,17 @@ public class Given_GeneratedMock : FeedUITests
 
 		var items = await CurrentItems(SourceContext.GetOrCreate(vm.Model), vm.Model.Steps);
 		items.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+	}
+
+	[TestMethod]
+	public async Task When_ModelHasSeveralCtorParameters_Then_CreateNullInjectsEachOne()
+	{
+		// MenuModel takes a service and a navigator: Create passes default for both, so it compiles and the
+		// mocked input flows without either dependency.
+		var vm = MenuViewModelMock.Create(new MenuModelMock { Items = ListFeedMock.Value("a", "b") });
+		using var _ = SourceContext.GetOrCreate(vm.Model).AsCurrent();
+
+		var items = await CurrentItems(SourceContext.GetOrCreate(vm.Model), vm.Model.Items);
+		items.Should().BeEquivalentTo(new[] { "a", "b" });
 	}
 }

--- a/src/Uno.HotTesting.Reactive.Generator/AnalyzerReleases.Unshipped.md
+++ b/src/Uno.HotTesting.Reactive.Generator/AnalyzerReleases.Unshipped.md
@@ -1,1 +1,8 @@
+; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
 ### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+MOCK0001 | Usage    | Warning  | No mock is generated for a model whose view-model exposes no public constructor.

--- a/src/Uno.HotTesting.Reactive.Generator/FeedsMockGenerator.cs
+++ b/src/Uno.HotTesting.Reactive.Generator/FeedsMockGenerator.cs
@@ -146,6 +146,18 @@ public sealed class FeedsMockGenerator : ISourceGenerator
 			return null;
 		}
 
+		// Create null-injects the public view-model constructor with the fewest parameters. The generated VM
+		// mirrors the model's constructors; its protected model-wrapping constructor is never a candidate.
+		var ctor = vm.Constructors
+			.Where(c => !c.IsStatic && c.DeclaredAccessibility == Accessibility.Public)
+			.OrderBy(c => c.Parameters.Length)
+			.FirstOrDefault();
+		if (ctor is null)
+		{
+			return null;
+		}
+
+		var ctorArguments = string.Join(", ", ctor.Parameters.Select(p => $"default! /* {p.Name} */"));
 		var vmFull = vm.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 		var mockName = $"{model.Name}Mock";
 		var vmMockName = $"{vm.Name}Mock";
@@ -205,7 +217,7 @@ public sealed class FeedsMockGenerator : ISourceGenerator
 					// (and lazy first subscriptions) still swap even after the scope is disposed.
 					using (global::Uno.HotTesting.Reactive.MockingService.Enable())
 					{
-						var vm = new {{vmFull}}(default!);
+						var vm = new {{vmFull}}({{ctorArguments}});
 						vm.SetMock(mock);
 						return vm;
 					}

--- a/src/Uno.HotTesting.Reactive.Generator/FeedsMockGenerator.cs
+++ b/src/Uno.HotTesting.Reactive.Generator/FeedsMockGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Uno.Extensions.Generators;
 
 namespace Uno.HotTesting.Reactive.Generator;
 
@@ -23,6 +24,16 @@ public sealed class FeedsMockGenerator : ISourceGenerator
 	private const string ModelAttribute = "Uno.Extensions.Reactive.Bindings.ModelAttribute";
 	private const string HotTesting = "global::Uno.HotTesting.Reactive";
 
+	// MOCK0001: a reachable model whose view-model Create cannot build. Reported, never silently skipped.
+	private static readonly DiagnosticDescriptor NoPublicConstructor = new DiagnosticDescriptor(
+		"MOCK0001",
+		"Mock not generated",
+		"No mock is generated for the model '{0}': its view-model '{1}' exposes no public constructor for Create to null-inject",
+		"Usage",
+		DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		helpLinkUri: "https://platform.uno/docs/articles/external/uno.extensions/doc/Reference/Reactive/rules.html#Mock0001");
+
 	/// <inheritdoc />
 	public void Initialize(GeneratorInitializationContext context) { }
 
@@ -39,7 +50,7 @@ public sealed class FeedsMockGenerator : ISourceGenerator
 
 		foreach (var model in EnumerateModels(compilation, feedDep))
 		{
-			if (GenerateFor(model, feedDep, modelAttr) is { } generated)
+			if (GenerateFor(context, model, feedDep, modelAttr) is { } generated)
 			{
 				context.AddSource($"{model.ToDisplayString().Replace('.', '_')}.Mock.g.cs", generated);
 			}
@@ -86,7 +97,7 @@ public sealed class FeedsMockGenerator : ISourceGenerator
 		public bool IsList;
 	}
 
-	private string? GenerateFor(INamedTypeSymbol model, INamedTypeSymbol feedDep, INamedTypeSymbol modelAttr)
+	private static string? GenerateFor(GeneratorExecutionContext context, INamedTypeSymbol model, INamedTypeSymbol feedDep, INamedTypeSymbol modelAttr)
 	{
 		var modelAttrData = model.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, modelAttr));
 		if (modelAttrData?.ConstructorArguments is not { Length: 1 } args || args[0].Value is not INamedTypeSymbol vm)
@@ -147,17 +158,25 @@ public sealed class FeedsMockGenerator : ISourceGenerator
 		}
 
 		// Create null-injects the public view-model constructor with the fewest parameters. The generated VM
-		// mirrors the model's constructors; its protected model-wrapping constructor is never a candidate.
+		// mirrors the model's constructors; its protected model-wrapping constructor is never a candidate. Ties on
+		// arity are broken on the parameter type list so the emitted code does not depend on symbol order.
 		var ctor = vm.Constructors
 			.Where(c => !c.IsStatic && c.DeclaredAccessibility == Accessibility.Public)
 			.OrderBy(c => c.Parameters.Length)
+			.ThenBy(ParameterTypes, StringComparer.Ordinal)
 			.FirstOrDefault();
 		if (ctor is null)
 		{
+			context.ReportDiagnostic(Diagnostic.Create(
+				NoPublicConstructor,
+				model.Locations.FirstOrDefault(location => location.IsInSource) ?? Location.None,
+				model.Name,
+				vm.Name));
 			return null;
 		}
 
-		var ctorArguments = string.Join(", ", ctor.Parameters.Select(p => $"default! /* {p.Name} */"));
+		// Typed defaults: a bare `default!` cannot pick between constructors of equal arity (CS0121).
+		var ctorArguments = string.Join(", ", ctor.Parameters.Select(p => $"default({FullName(p.Type)})! /* {p.Name} */"));
 		var vmFull = vm.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 		var mockName = $"{model.Name}Mock";
 		var vmMockName = $"{vm.Name}Mock";
@@ -257,6 +276,12 @@ public sealed class FeedsMockGenerator : ISourceGenerator
 		}
 		return false;
 	}
+
+	private static string ParameterTypes(IMethodSymbol ctor)
+		=> string.Join(",", ctor.Parameters.Select(p => FullName(p.Type)));
+
+	private static string FullName(ITypeSymbol type)
+		=> type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
 	private static string Camel(string name)
 		=> string.IsNullOrEmpty(name) ? name : char.ToLowerInvariant(name[0]) + name.Substring(1);

--- a/src/Uno.HotTesting.Reactive.Tests/Given_FeedsMockGenerator.cs
+++ b/src/Uno.HotTesting.Reactive.Tests/Given_FeedsMockGenerator.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.HotTesting.Reactive.Generator;
+
+namespace Uno.HotTesting.Reactive.Tests;
+
+/// <summary>
+/// Drives the consumer generator over hand-written metadata (the attributes and view-model the MVUX
+/// generator would have produced) to pin the emitted <c>Create</c> and the diagnostics. The two-project
+/// fixture app cannot host these cases: a warning fails its build and an ambiguous call never compiles.
+/// </summary>
+[TestClass]
+public class Given_FeedsMockGenerator
+{
+	private const string Preamble = """
+		using Uno.Extensions.Reactive;
+		using Uno.Extensions.Reactive.Bindings;
+		using Uno.Extensions.Reactive.Config;
+
+		namespace App;
+
+		public interface IService { }
+		public interface ISnapshot { }
+
+		""";
+
+	[TestMethod]
+	public void When_ViewModelHasPublicCtor_Then_CreateNullInjectsTypedDefaults()
+	{
+		var (sources, diagnostics) = Run(Preamble + """
+			[Model(typeof(ItemsViewModel))]
+			[FeedDependency("Items", OnParameter = "service")]
+			public class ItemsModel
+			{
+				public ItemsModel(IService service) { }
+				public IListFeed<string> Items => null!;
+			}
+
+			public class ItemsViewModel
+			{
+				public ItemsViewModel(IService service) { }
+				protected ItemsViewModel(ItemsModel model) { }
+				public ItemsModel Model => null!;
+			}
+			""");
+
+		diagnostics.Should().BeEmpty();
+		sources.Should().ContainSingle()
+			.Which.Should().Contain("new global::App.ItemsViewModel(default(global::App.IService)! /* service */)");
+	}
+
+	[TestMethod]
+	public void When_ViewModelHasSameArityCtors_Then_CreateTargetsOrdinalFirstParameterTypes()
+	{
+		// Two single-parameter constructors: the typed default makes the call unambiguous, and the ordinal
+		// tie-break on the parameter type list keeps the output stable whatever order the symbols come in.
+		var (sources, diagnostics) = Run(Preamble + """
+			[Model(typeof(ItemsViewModel))]
+			[FeedDependency("Items", OnParameter = "service")]
+			public class ItemsModel
+			{
+				public ItemsModel(IService service) { }
+				public ItemsModel(ISnapshot snapshot) { }
+				public IListFeed<string> Items => null!;
+			}
+
+			public class ItemsViewModel
+			{
+				public ItemsViewModel(ISnapshot snapshot) { }
+				public ItemsViewModel(IService service) { }
+				protected ItemsViewModel(ItemsModel model) { }
+				public ItemsModel Model => null!;
+			}
+			""");
+
+		diagnostics.Should().BeEmpty();
+		sources.Should().ContainSingle()
+			.Which.Should().Contain("new global::App.ItemsViewModel(default(global::App.IService)! /* service */)");
+	}
+
+	[TestMethod]
+	public void When_ViewModelHasNoPublicCtor_Then_ReportsMOCK0001AndEmitsNothing()
+	{
+		var (sources, diagnostics) = Run(Preamble + """
+			[Model(typeof(ItemsViewModel))]
+			[FeedDependency("Items", OnParameter = "service")]
+			public class ItemsModel
+			{
+				internal ItemsModel(IService service) { }
+				public IListFeed<string> Items => null!;
+			}
+
+			public class ItemsViewModel
+			{
+				internal ItemsViewModel(IService service) { }
+				protected ItemsViewModel(ItemsModel model) { }
+				public ItemsModel Model => null!;
+			}
+			""");
+
+		sources.Should().BeEmpty();
+		var diagnostic = diagnostics.Should().ContainSingle().Which;
+		diagnostic.Id.Should().Be("MOCK0001");
+		diagnostic.Severity.Should().Be(DiagnosticSeverity.Warning);
+		diagnostic.GetMessage().Should().Contain("ItemsModel").And.Contain("ItemsViewModel");
+	}
+
+	private static (string[] Sources, Diagnostic[] Diagnostics) Run(string source)
+	{
+		// The framework plus the Uno.Extensions assemblies of the test host: enough for the fixture source to
+		// compile, small enough for the generator's walk over referenced assemblies to stay quick.
+		var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+			.Split(Path.PathSeparator)
+			.Where(path => Path.GetFileName(path) is { } name
+				&& (name.StartsWith("System.", StringComparison.Ordinal)
+					|| name.StartsWith("netstandard", StringComparison.Ordinal)
+					|| name.StartsWith("Uno.Extensions.", StringComparison.Ordinal)))
+			.Select(path => MetadataReference.CreateFromFile(path));
+		var compilation = CSharpCompilation.Create(
+			"App",
+			new[] { CSharpSyntaxTree.ParseText(source) },
+			references,
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+		compilation.GetDiagnostics()
+			.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+			.Should().BeEmpty("the fixture source must compile before the generator runs");
+
+		var result = CSharpGeneratorDriver.Create(new FeedsMockGenerator())
+			.RunGenerators(compilation)
+			.GetRunResult()
+			.Results
+			.Single();
+
+		return (result.GeneratedSources.Select(generated => generated.SourceText.ToString()).ToArray(), result.Diagnostics.ToArray());
+	}
+}

--- a/src/Uno.HotTesting.Reactive.Tests/Uno.HotTesting.Reactive.Tests.csproj
+++ b/src/Uno.HotTesting.Reactive.Tests/Uno.HotTesting.Reactive.Tests.csproj
@@ -15,10 +15,13 @@
 		<PackageReference Include="MSTest.TestFramework" />
 		<PackageReference Include="coverlet.collector" />
 		<PackageReference Include="System.Collections.Immutable" />
+		<!-- Drives the consumer generator in-process (Given_FeedsMockGenerator) -->
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Extensions.Reactive.Testing\Uno.Extensions.Reactive.Testing.csproj" />
 		<ProjectReference Include="..\Uno.HotTesting.Reactive\Uno.HotTesting.Reactive.csproj" />
+		<ProjectReference Include="..\Uno.HotTesting.Reactive.Generator\Uno.HotTesting.Reactive.Generator.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.HotTesting.Reactive/Uno.HotTesting.Reactive.csproj
+++ b/src/Uno.HotTesting.Reactive/Uno.HotTesting.Reactive.csproj
@@ -14,4 +14,10 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Extensions.Reactive\Uno.Extensions.Reactive.csproj" />
 	</ItemGroup>
+
+	<ItemGroup>
+		<!-- The consumer generator (spec 013, tiers 2/3) ships as the analyzer of this package, the way the MVUX generator ships in Uno.Extensions.Reactive. -->
+		<ProjectReference Include="..\Uno.HotTesting.Reactive.Generator\Uno.HotTesting.Reactive.Generator.csproj" ReferenceOutputAssembly="false" />
+		<None Include="..\Uno.HotTesting.Reactive.Generator\bin\Uno.HotTesting.Reactive.Generator\$(Configuration)\netstandard2.0\Uno.HotTesting.Reactive.Generator.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): related to https://github.com/unoplatform/studio.live/issues/4074

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Build or CI related changes

## What is the current behavior?

`Uno.HotTesting.Reactive` (spec 013) is published with its runtime only: `Uno.HotTesting.Reactive.Generator` is never packed, so referencing the package generates no `{Model}Mock` / `{Vm}Mock` types.

The generator also emits `new {Vm}(default!)` with exactly one argument. A model whose constructor takes more than one dependency (a service plus a navigator or a messenger, the shape MVUX messaging produces) gets a `Create` factory that does not compile.

## What is the new behavior?

- The package ships the generator under `analyzers/dotnet/cs`, the way `Uno.Extensions.Reactive` ships the MVUX generator: a `ReferenceOutputAssembly="false"` project reference for build ordering and the generator DLL packed as a `None` item. The generator project joins the package-only and Reactive solution filters so package builds include it.
- `Create` targets the public view-model constructor with the fewest parameters (the protected model-wrapping constructor is never a candidate) and passes `default!` for each parameter. Output is unchanged for single-parameter models.
- Fixture `MenuModel` (two constructor parameters) in the two-project mocking app, test `When_ModelHasSeveralCtorParameters_Then_CreateNullInjectsEachOne`, one sentence in `doc/Reference/Reactive/testing.md`, and a spec 013 history note.

## Other information

Verified locally: a Release pack of `Uno.HotTesting.Reactive` contains `analyzers/dotnet/cs/Uno.HotTesting.Reactive.Generator.dll` next to the runtime; the `Uno.Extensions.Reactive.Tests` mocking tests and `Uno.HotTesting.Reactive.Tests` pass.